### PR TITLE
Provide a default build task for vscode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,25 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "make",
+            "type": "shell",
+            "command": "make",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": "$gcc",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "clear": true
+            }
+        }
+    ]
+}

--- a/bootstrap/mirth.py
+++ b/bootstrap/mirth.py
@@ -198,7 +198,7 @@ def error(modpath, lineno, msg):
     p = os.path.relpath(modpath)
     if lineno is None:
         lineno = 1
-    print('%s:%d:' % (p, lineno), msg, file=sys.stderr)
+    print('%s:%d:1: error:' % (p, lineno), msg, file=sys.stderr)
     sys.exit(1)
 
 def handle_package_error(pkg, modpath, n, f):
@@ -2261,4 +2261,3 @@ if __name__ == '__main__':
         raise ValueError("Builtins are mismatched.")
 
     main()
-


### PR DESCRIPTION
Sligthly change format of error messages in bootstrap to improve the error reporting in vscode.