### PR TITLE
Remove mutable file variables and init-io!

### DIFF
--- a/mirth.mth
+++ b/mirth.mth
@@ -102,8 +102,8 @@ def(str-buf-push!, U8 -- +StrBuf,
         str-buf-length? 1+ str-buf-length!
     ))
 def(str-buf-write!, File -- +StrBuf, STR_BUF str-buf-length? posix-write!)
-def(str-buf-print!, +StrBuf, file-out@ str-buf-write!)
-def(str-buf-trace!, +StrBuf, file-err@ str-buf-write!)
+def(str-buf-print!, +StrBuf, stdout str-buf-write!)
+def(str-buf-trace!, +StrBuf, stderr str-buf-write!)
 
 def(str-buf-read!, File -- +IO,
     str-buf-clear!
@@ -112,7 +112,7 @@ def(str-buf-read!, File -- +IO,
         "str-buf-read! failed" panic! drop,
         str-buf-length!
     ))
-def(str-buf-input!, -- +IO, file-in@ str-buf-read!)
+def(str-buf-input!, -- +IO, stdin str-buf-read!)
 
 # Set the STR_BUF to a given string. If the string is
 # too large (> STR_BUF_SIZE - 1) it gets truncated.
@@ -296,36 +296,17 @@ def(stdout, File, 1)
 def(stderr, File, 2)
 
 def(init!, +IO,
-    init-io!
     0 strings-size!
     0 num-tokens!
     init-names!
     init-buffers!
     init-heap!)
 
-def(init-io!, +IO,
-    stdin file-in!
-    stdout file-out!
-    stderr file-err!
-    )
-
-quad def-static-buffer(FILE_IN)
-def(file-in!, File -- +IO, FILE_IN !)
-def(file-in@, -- File +IO, FILE_IN @)
-
-quad def-static-buffer(FILE_OUT)
-def(file-out!, File -- +IO, FILE_OUT !)
-def(file-out@, -- File +IO, FILE_OUT @)
-
-quad def-static-buffer(FILE_ERR)
-def(file-err!, File -- +IO, FILE_ERR !)
-def(file-err@, -- File +IO, FILE_ERR @)
-
 def(str-write!, Str File -- +IO,
     swap dup str-length posix-write!)
 
-def(str-print!, Str -- +IO, file-out@ str-write!)
-def(str-trace!, Str -- +IO, file-err@ str-write!)
+def(str-print!, Str -- +IO, stdout str-write!)
+def(str-trace!, Str -- +IO, stderr str-write!)
 def(str-print-sp!, Str -- +IO, str-print! print-sp!)
 def(str-trace-sp!, Str -- +IO, str-trace! trace-sp!)
 def(str-print-ln!, Str -- +IO, str-print! print-ln!)
@@ -422,8 +403,8 @@ def(str-buf-int!, Int --,
     ))
 
 def(int-write!, Int File -- +IO, dip(str-buf-int!) str-buf-write!)
-def(int-print!, Int -- +IO, file-out@ int-write!)
-def(int-trace!, Int -- +IO, file-err@ int-write!)
+def(int-print!, Int -- +IO, stdout int-write!)
+def(int-trace!, Int -- +IO, stderr int-write!)
 def(int-print-sp!, Int -- +IO, int-print! print-sp!)
 def(int-trace-sp!, Int -- +IO, int-trace! trace-sp!)
 def(int-print-ln!, Int -- +IO, int-print! print-ln!)

--- a/mirth0.c
+++ b/mirth0.c
@@ -988,12 +988,6 @@ void mwRUNNING_OS (void) {
  void mwSTR_BUF (void) { push((i64)bSTR_BUF); }
  volatile u8 bTEST_BUF[16] = {0};
  void mwTEST_BUF (void) { push((i64)bTEST_BUF); }
- volatile u8 bFILE_IN[8] = {0};
- void mwFILE_IN (void) { push((i64)bFILE_IN); }
- volatile u8 bFILE_OUT[8] = {0};
- void mwFILE_OUT (void) { push((i64)bFILE_OUT); }
- volatile u8 bFILE_ERR[8] = {0};
- void mwFILE_ERR (void) { push((i64)bFILE_ERR); }
  volatile u8 bINPUT_ISOPEN[8] = {0};
  void mwINPUT_ISOPEN (void) { push((i64)bINPUT_ISOPEN); }
  volatile u8 bINPUT_LENGTH[8] = {0};
@@ -1143,12 +1137,12 @@ void mwRUNNING_OS (void) {
  void mwstr_buf_push_21_ (void);
  void mwstr_buf_write_21_ (void);
  void mwstr_buf_print_21_ (void);
- void mwfile_out_40_ (void);
+ void mwstdout (void);
  void mwstr_buf_trace_21_ (void);
- void mwfile_err_40_ (void);
+ void mwstderr (void);
  void mwstr_buf_read_21_ (void);
  void mwstr_buf_input_21_ (void);
- void mwfile_in_40_ (void);
+ void mwstdin (void);
  void mwstr_buf_21_ (void);
  void mwrun_tests (void);
  void mwtest_if (void);
@@ -1172,19 +1166,12 @@ void mwRUNNING_OS (void) {
  void mwtest_str (void);
  void mwtest_while (void);
  void mwtest_40__21_ (void);
- void mwstdin (void);
- void mwstdout (void);
- void mwstderr (void);
  void mwinit_21_ (void);
- void mwinit_io_21_ (void);
  void mwstrings_size_21_ (void);
  void mwnum_tokens_21_ (void);
  void mwinit_names_21_ (void);
  void mwinit_buffers_21_ (void);
  void mwinit_heap_21_ (void);
- void mwfile_in_21_ (void);
- void mwfile_out_21_ (void);
- void mwfile_err_21_ (void);
  void mwstr_write_21_ (void);
  void mwstr_print_21_ (void);
  void mwstr_trace_21_ (void);
@@ -2083,23 +2070,21 @@ void mwstr_buf_write_21_ (void){
 }
 
 void mwstr_buf_print_21_ (void){
-    mwfile_out_40_();
+    mwstdout();
     mwstr_buf_write_21_();
 }
 
-void mwfile_out_40_ (void){
-    mwFILE_OUT();
-    mw_40_();
+void mwstdout (void){
+    push(1);
 }
 
 void mwstr_buf_trace_21_ (void){
-    mwfile_err_40_();
+    mwstderr();
     mwstr_buf_write_21_();
 }
 
-void mwfile_err_40_ (void){
-    mwFILE_ERR();
-    mw_40_();
+void mwstderr (void){
+    push(2);
 }
 
 void mwstr_buf_read_21_ (void){
@@ -2120,13 +2105,12 @@ void mwstr_buf_read_21_ (void){
 }
 
 void mwstr_buf_input_21_ (void){
-    mwfile_in_40_();
+    mwstdin();
     mwstr_buf_read_21_();
 }
 
-void mwfile_in_40_ (void){
-    mwFILE_IN();
-    mw_40_();
+void mwstdin (void){
+    push(0);
 }
 
 void mwstr_buf_21_ (void){
@@ -2824,20 +2808,7 @@ void mwtest_40__21_ (void){
     mw_21__21__3D_();
 }
 
-void mwstdin (void){
-    push(0);
-}
-
-void mwstdout (void){
-    push(1);
-}
-
-void mwstderr (void){
-    push(2);
-}
-
 void mwinit_21_ (void){
-    mwinit_io_21_();
     push(0);
     mwstrings_size_21_();
     push(0);
@@ -2845,15 +2816,6 @@ void mwinit_21_ (void){
     mwinit_names_21_();
     mwinit_buffers_21_();
     mwinit_heap_21_();
-}
-
-void mwinit_io_21_ (void){
-    mwstdin();
-    mwfile_in_21_();
-    mwstdout();
-    mwfile_out_21_();
-    mwstderr();
-    mwfile_err_21_();
 }
 
 void mwstrings_size_21_ (void){
@@ -3177,21 +3139,6 @@ void mwinit_heap_21_ (void){
     mwheap_length_21_();
 }
 
-void mwfile_in_21_ (void){
-    mwFILE_IN();
-    mw_21_();
-}
-
-void mwfile_out_21_ (void){
-    mwFILE_OUT();
-    mw_21_();
-}
-
-void mwfile_err_21_ (void){
-    mwFILE_ERR();
-    mw_21_();
-}
-
 void mwstr_write_21_ (void){
     mwswap();
     mwdup();
@@ -3200,12 +3147,12 @@ void mwstr_write_21_ (void){
 }
 
 void mwstr_print_21_ (void){
-    mwfile_out_40_();
+    mwstdout();
     mwstr_write_21_();
 }
 
 void mwstr_trace_21_ (void){
-    mwfile_err_40_();
+    mwstderr();
     mwstr_write_21_();
 }
 
@@ -3564,12 +3511,12 @@ void mwint_write_21_ (void){
 }
 
 void mwint_print_21_ (void){
-    mwfile_out_40_();
+    mwstdout();
     mwint_write_21_();
 }
 
 void mwint_trace_21_ (void){
-    mwfile_err_40_();
+    mwstderr();
     mwint_write_21_();
 }
 


### PR DESCRIPTION
This design was not beneficial and was causing problems on Windows, which is less lenient about file descriptors. So now the `print!` and `trace!` words always print to stdout / stderr, rather than depending on mutable file descriptor variables.