### PR TITLE
Support for command-line arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,15 +56,15 @@ bin/mirth2: bin/mirth2.c
 	$(CC) -o bin/mirth2 bin/mirth2.c
 
 bin/mirth1.c: bin/mirth0 $(SRCS)
-	bin/mirth0
+	bin/mirth0 mirth.mth
 	mv bin/mirth.c bin/mirth1.c
 
 bin/mirth2.c: bin/mirth1 $(SRCS)
-	bin/mirth1
+	bin/mirth1 mirth.mth
 	mv bin/mirth.c bin/mirth2.c
 
 bin/mirth3.c: bin/mirth2 $(SRCS)
-	bin/mirth2
+	bin/mirth2 mirth.mth
 	mv bin/mirth.c bin/mirth3.c
 
 bin/mirth_prof.c: bin/mirth3.c
@@ -73,7 +73,7 @@ bin/mirth_prof: bin/mirth_prof.c
 	$(CC) -g -fprofile-instr-generate -o bin/mirth_prof bin/mirth_prof.c
 
 bin/snake.c: bin/mirth2 $(SRCS)
-	bin/mirth2
+	bin/mirth2 mirth.mth
 	rm -f bin/mirth.c
 
 bin/snake: bin/snake.c

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -34,7 +34,10 @@ extern void exit(int);
 static volatile usize sc = STACK_SIZE;
 static volatile i64 stack[STACK_SIZE] = {0};
 
-#define STRINGS_SIZE 10507
+int global_argc;
+char** global_argv;
+
+#define STRINGS_SIZE 10663
 static const char strings[STRINGS_SIZE] = { 
 109,105,114,116,104,46,109,116,104,0,
 66,117,105,108,100,105,110,103,46,0,
@@ -155,6 +158,8 @@ static const char strings[STRINGS_SIZE] = {
 124,124,0,
 116,97,98,108,101,0,
 102,105,101,108,100,0,
+97,114,103,99,0,
+97,114,103,118,0,
 99,111,109,112,105,108,101,114,32,101,114,114,111,114,58,32,78,85,77,95,80,82,73,77,83,32,97,110,100,32,110,117,109,45,110,97,109,101,115,64,32,100,111,32,110,111,116,32,109,97,116,99,104,0,
 99,111,109,112,105,108,101,114,32,101,114,114,111,114,58,32,97,116,116,101,109,112,116,101,100,32,116,111,32,103,101,116,32,110,97,109,101,45,115,105,103,32,102,111,114,32,110,111,110,45,119,111,114,100,44,32,110,111,110,45,101,120,116,101,114,110,97,108,32,110,97,109,101,0,
 99,111,109,112,105,108,101,114,32,101,114,114,111,114,58,32,97,116,116,101,109,112,116,101,100,32,116,111,32,103,101,116,32,116,121,112,101,32,100,101,102,105,110,105,116,105,111,110,32,102,111,114,32,110,111,110,45,116,121,112,101,32,110,97,109,101,0,
@@ -294,6 +299,8 @@ static const char strings[STRINGS_SIZE] = {
 35,100,101,102,105,110,101,32,83,84,65,67,75,95,83,73,90,69,32,50,48,48,48,0,
 115,116,97,116,105,99,32,118,111,108,97,116,105,108,101,32,117,115,105,122,101,32,115,99,32,61,32,83,84,65,67,75,95,83,73,90,69,59,0,
 115,116,97,116,105,99,32,118,111,108,97,116,105,108,101,32,105,54,52,32,115,116,97,99,107,91,83,84,65,67,75,95,83,73,90,69,93,32,61,32,123,48,125,59,0,
+105,110,116,32,103,108,111,98,97,108,95,97,114,103,99,59,0,
+99,104,97,114,42,42,32,103,108,111,98,97,108,95,97,114,103,118,59,0,
 35,100,101,102,105,110,101,32,83,84,82,73,78,71,83,95,83,73,90,69,32,0,
 0,
 115,116,97,116,105,99,32,99,111,110,115,116,32,99,104,97,114,32,115,116,114,105,110,103,115,91,83,84,82,73,78,71,83,95,83,73,90,69,93,32,61,32,123,32,0,
@@ -617,6 +624,12 @@ static const char strings[STRINGS_SIZE] = {
 32,32,32,32,98,111,111,108,32,121,32,61,32,112,111,112,40,41,59,0,
 32,32,32,32,112,117,115,104,40,121,32,124,124,32,120,41,59,0,
 125,0,
+32,123,0,
+32,32,32,32,112,117,115,104,40,103,108,111,98,97,108,95,97,114,103,99,41,59,0,
+125,0,
+32,123,0,
+32,32,32,32,112,117,115,104,40,40,105,54,52,41,103,108,111,98,97,108,95,97,114,103,118,41,59,0,
+125,0,
 99,97,110,39,116,32,100,101,99,108,97,114,101,32,101,120,116,101,114,110,97,108,32,119,105,116,104,32,109,117,108,116,105,112,108,101,32,114,101,116,117,114,110,32,118,97,108,117,101,115,0,
 105,54,52,32,0,
 118,111,105,100,32,0,
@@ -666,6 +679,8 @@ static const char strings[STRINGS_SIZE] = {
 123,0,
 125,0,
 105,110,116,32,109,97,105,110,32,40,105,110,116,32,97,114,103,99,44,32,99,104,97,114,42,42,32,97,114,103,118,41,32,123,0,
+32,32,32,32,103,108,111,98,97,108,95,97,114,103,99,32,61,32,97,114,103,99,59,0,
+32,32,32,32,103,108,111,98,97,108,95,97,114,103,118,32,61,32,97,114,103,118,59,0,
 32,32,32,32,114,101,116,117,114,110,32,48,59,0,
 125,0,
 69,120,112,101,99,116,101,100,32,116,121,112,101,44,32,103,111,116,32,117,110,107,110,111,119,110,32,116,111,107,101,110,46,0,
@@ -1075,6 +1090,13 @@ void mw_7C__7C_ (void) {
     push(y || x);
 }
 
+void mwargc (void) {
+    push(global_argc);
+}
+void mwargv (void) {
+    push((i64)global_argv);
+}
+
  volatile u8 bSTR_BUF_LEN[8] = {0};
  void mwSTR_BUF_LEN (void) { push((i64)bSTR_BUF_LEN); }
  volatile u8 bSTR_BUF[4096] = {0};
@@ -1299,9 +1321,12 @@ void mw_7C__7C_ (void) {
  void mwtest_prelude_21_ (void);
  void mwNEW_MIRTH_REVISION (void);
  void mwmain (void);
+ void mwint_trace_ln_21_ (void);
+ void mwptr_40__40_ (void);
+ void mwstr_trace_ln_21_ (void);
+ void mw1_2B_ (void);
  void mwStr__3E_Path (void);
  void mwrun_lexer_21_ (void);
- void mwstr_trace_ln_21_ (void);
  void mwelab_module_21_ (void);
  void mwtrip (void);
  void mwrotr (void);
@@ -1334,7 +1359,6 @@ void mw_7C__7C_ (void) {
  void mw_3E__3D_ (void);
  void mw0_3D_ (void);
  void mw0_3C_ (void);
- void mw1_2B_ (void);
  void mwmax (void);
  void mwsquare (void);
  void mwbool (void);
@@ -1344,6 +1368,9 @@ void mw_7C__7C_ (void) {
  void mwptr_2B_ (void);
  void mwptr_40_ (void);
  void mwptr_21_ (void);
+ void mwptr (void);
+ void mwptrs (void);
+ void mwptr_21__21_ (void);
  void mwu8 (void);
  void mwu8s (void);
  void mwu8_40__40_ (void);
@@ -1444,7 +1471,6 @@ void mw_7C__7C_ (void) {
  void mwint_print_sp_21_ (void);
  void mwint_trace_sp_21_ (void);
  void mwint_print_ln_21_ (void);
- void mwint_trace_ln_21_ (void);
  void mwopen_file_21_ (void);
  void mwcreate_file_21_ (void);
  void mwO_WRONLY_7C_O_CREAT_7C_O_TRUNC (void);
@@ -1752,6 +1778,8 @@ void mw_7C__7C_ (void) {
  void mwPRIM_BOOL_OR (void);
  void mwPRIM_TABLE (void);
  void mwPRIM_FIELD (void);
+ void mwPRIM_ARGC (void);
+ void mwPRIM_ARGV (void);
  void mwname_is_prim_3F_ (void);
  void mwdef_prim_21_ (void);
  void mwNameValue__3E_Int (void);
@@ -2538,10 +2566,10 @@ void mwinit_21_ (void){
 }
 
 void mwinit_paths_21_ (void){
-    push((i64)(strings + 3860));
+    push((i64)(strings + 3870));
     mwStr__3E_Path();
     mwsource_path_root_21_();
-    push((i64)(strings + 3864));
+    push((i64)(strings + 3874));
     mwStr__3E_Path();
     mwoutput_path_root_21_();
 }
@@ -2784,6 +2812,12 @@ void mwinit_names_21_ (void){
     mwPRIM_FIELD();
     push((i64)(strings + 1374));
     mwdef_prim_21_();
+    mwPRIM_ARGC();
+    push((i64)(strings + 1380));
+    mwdef_prim_21_();
+    mwPRIM_ARGV();
+    push((i64)(strings + 1385));
+    mwdef_prim_21_();
     mwNUM_PRIMS();
     mwnum_names_40_();
     mw1_2B_();
@@ -2791,7 +2825,7 @@ void mwinit_names_21_ (void){
     if (pop()) {
     mwid();
     } else {
-    push((i64)(strings + 1380));
+    push((i64)(strings + 1390));
     mwpanic_21_();
     }
 }
@@ -2878,6 +2912,21 @@ void mwNEW_MIRTH_REVISION (void){
 void mwmain (void){
     mwinit_21_();
     mwtest_21_();
+    mwargc();
+    mwint_trace_ln_21_();
+    push(0);
+    while(1) {
+    mwdup();
+    mwargc();
+    mw_3C_();
+    if (!pop()) break;
+    mwdup();
+    mwargv();
+    mwptr_40__40_();
+    mwstr_trace_ln_21_();
+    mw1_2B_();
+    }
+    mwdrop();
     push((i64)(strings + 0));
     mwStr__3E_Path();
     mwrun_lexer_21_();
@@ -2887,6 +2936,29 @@ void mwmain (void){
     mwdrop();
     push((i64)(strings + 20));
     mwstr_trace_ln_21_();
+}
+
+void mwint_trace_ln_21_ (void){
+    mwint_trace_21_();
+    mwtrace_ln_21_();
+}
+
+void mwptr_40__40_ (void){
+    { i64 d1 = pop();
+    mwptrs();
+      push(d1); }
+    mwptr_2B_();
+    mwptr_40_();
+}
+
+void mwstr_trace_ln_21_ (void){
+    mwstr_trace_21_();
+    mwtrace_ln_21_();
+}
+
+void mw1_2B_ (void){
+    push(1);
+    mw_2B_();
 }
 
 void mwStr__3E_Path (void){
@@ -2935,11 +3007,6 @@ void mwrun_lexer_21_ (void){
     mwlexer_module_40_();
     mwmodule_end_21_();
     mwlexer_module_40_();
-}
-
-void mwstr_trace_ln_21_ (void){
-    mwstr_trace_21_();
-    mwtrace_ln_21_();
 }
 
 void mwelab_module_21_ (void){
@@ -3120,11 +3187,6 @@ void mw0_3C_ (void){
     mw_3C_();
 }
 
-void mw1_2B_ (void){
-    push(1);
-    mw_2B_();
-}
-
 void mwmax (void){
     mwdup2();
     mw_3C_();
@@ -3171,6 +3233,23 @@ void mwptr_21_ (void){
     mwPtr__3E_Int();
       push(d1); }
     mw_21_();
+}
+
+void mwptr (void){
+    push(8);
+}
+
+void mwptrs (void){
+    mwptr();
+    mw_2A_();
+}
+
+void mwptr_21__21_ (void){
+    { i64 d1 = pop();
+    mwptrs();
+      push(d1); }
+    mwptr_2B_();
+    mwptr_21_();
 }
 
 void mwu8 (void){
@@ -3893,11 +3972,6 @@ void mwint_trace_sp_21_ (void){
 void mwint_print_ln_21_ (void){
     mwint_print_21_();
     mwprint_ln_21_();
-}
-
-void mwint_trace_ln_21_ (void){
-    mwint_trace_21_();
-    mwtrace_ln_21_();
 }
 
 void mwopen_file_21_ (void){
@@ -6222,7 +6296,7 @@ void mwemit_warning_at_21_ (void){
     { i64 d1 = pop();
     mwlocation_trace_21_();
       push(d1); }
-    push((i64)(strings + 3872));
+    push((i64)(strings + 3882));
     mwstr_trace_21_();
     mwstr_trace_ln_21_();
 }
@@ -6238,7 +6312,7 @@ void mwemit_error_at_21_ (void){
     { i64 d1 = pop();
     mwlocation_trace_21_();
       push(d1); }
-    push((i64)(strings + 3884));
+    push((i64)(strings + 3894));
     mwstr_trace_21_();
     mwstr_trace_ln_21_();
 }
@@ -6832,7 +6906,7 @@ void mwName__3E_Prim (void){
 }
 
 void mwNUM_PRIMS (void){
-    push(80);
+    push(82);
 }
 
 void mwInt__3E_Prim (void){
@@ -7240,6 +7314,16 @@ void mwPRIM_FIELD (void){
     mwInt__3E_Prim();
 }
 
+void mwPRIM_ARGC (void){
+    push(80);
+    mwInt__3E_Prim();
+}
+
+void mwPRIM_ARGV (void){
+    push(81);
+    mwInt__3E_Prim();
+}
+
 void mwname_is_prim_3F_ (void){
     mwdup();
     mwName__3E_Int();
@@ -7416,7 +7500,7 @@ void mwname_sig_40_ (void){
     mwname_external_40_();
     mwexternal_sig_40_();
     } else {
-    push((i64)(strings + 1434));
+    push((i64)(strings + 1444));
     mwpanic_21_();
     }
     }
@@ -7434,7 +7518,7 @@ void mwname_word_40_ (void){
     mwname_value_40_();
     mwNameValue__3E_Word();
     } else {
-    push((i64)(strings + 1575));
+    push((i64)(strings + 1585));
     mwpanic_21_();
     }
 }
@@ -7456,7 +7540,7 @@ void mwname_external_40_ (void){
     mwname_value_40_();
     mwNameValue__3E_External();
     } else {
-    push((i64)(strings + 1642));
+    push((i64)(strings + 1652));
     mwpanic_21_();
     }
 }
@@ -7532,7 +7616,7 @@ void mwname_type_40_ (void){
     mwname_value_40_();
     mwNameValue__3E_Type();
     } else {
-    push((i64)(strings + 1508));
+    push((i64)(strings + 1518));
     mwpanic_21_();
     }
 }
@@ -7578,7 +7662,7 @@ void mwname_buffer_40_ (void){
     mwname_value_40_();
     mwNameValue__3E_Buffer();
     } else {
-    push((i64)(strings + 1717));
+    push((i64)(strings + 1727));
     mwpanic_21_();
     }
 }
@@ -9113,7 +9197,7 @@ void mwtype_get_morphism (void){
     mwtype_is_morphism_3F_();
     mwnot();
     if (pop()) {
-    push((i64)(strings + 1961));
+    push((i64)(strings + 1971));
     mwpanic_21_();
     } else {
     mwtype_get_value();
@@ -9506,7 +9590,7 @@ void mwtype_get_var (void){
     mwtype_is_var_3F_();
     mwnot();
     if (pop()) {
-    push((i64)(strings + 1788));
+    push((i64)(strings + 1798));
     mwpanic_21_();
     } else {
     mwtype_get_value();
@@ -9533,7 +9617,7 @@ void mwtype_get_meta (void){
     mwtype_is_meta_3F_();
     mwnot();
     if (pop()) {
-    push((i64)(strings + 1843));
+    push((i64)(strings + 1853));
     mwpanic_21_();
     } else {
     mwtype_get_value();
@@ -9549,7 +9633,7 @@ void mwtype_get_tensor (void){
     mwtype_is_tensor_3F_();
     mwnot();
     if (pop()) {
-    push((i64)(strings + 1900));
+    push((i64)(strings + 1910));
     mwpanic_21_();
     } else {
     mwtype_get_value();
@@ -9569,7 +9653,7 @@ void mwtype_get_nominal (void){
     mwtype_is_nominal_3F_();
     mwnot();
     if (pop()) {
-    push((i64)(strings + 2026));
+    push((i64)(strings + 2036));
     mwpanic_21_();
     } else {
     mwtype_get_value();
@@ -9585,7 +9669,7 @@ void mwtype_get_table (void){
     mwtype_is_table_3F_();
     mwnot();
     if (pop()) {
-    push((i64)(strings + 2089));
+    push((i64)(strings + 2099));
     mwpanic_21_();
     } else {
     mwtype_get_value();
@@ -9672,7 +9756,7 @@ void mwmeta_alloc_21_ (void){
     mwMetaVar_2E_MAX();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 2335));
+    push((i64)(strings + 2345));
     mwpanic_21_();
     } else {
     mwid();
@@ -9811,12 +9895,12 @@ void mwtype_unify_failed_21_ (void){
     mwelab_token_40_();
     mwtoken_location();
     mwlocation_trace_21_();
-    push((i64)(strings + 2148));
+    push((i64)(strings + 2158));
     mwstr_trace_21_();
     { i64 d1 = pop();
     mwtype_trace_21_();
       push(d1); }
-    push((i64)(strings + 2174));
+    push((i64)(strings + 2184));
     mwstr_trace_21_();
     mwtype_trace_21_();
     mwtrace_ln_21_();
@@ -9841,11 +9925,11 @@ void mwlocation_trace_21_ (void){
     mwswap();
     mwload_module_source_path_21_();
     mwstr_buf_trace_21_();
-    push((i64)(strings + 3799));
+    push((i64)(strings + 3809));
     mwstr_trace_21_();
     mwRow__3E_Int();
     mwint_trace_21_();
-    push((i64)(strings + 3801));
+    push((i64)(strings + 3811));
     mwstr_trace_21_();
     mwCol__3E_Int();
     mwint_trace_21_();
@@ -9866,25 +9950,25 @@ void mwtype_trace_21_ (void){
     mwtype_is_meta_3F_();
     if (pop()) {
     mwtype_get_meta();
-    push((i64)(strings + 2229));
+    push((i64)(strings + 2239));
     mwstr_trace_21_();
     mwMetaVar__3E_Int();
     mwint_trace_21_();
     } else {
     mwtype_is_tensor_3F_();
     if (pop()) {
-    push((i64)(strings + 2231));
+    push((i64)(strings + 2241));
     mwstr_trace_21_();
     mwtype_trace_stack_21_();
-    push((i64)(strings + 2233));
+    push((i64)(strings + 2243));
     mwstr_trace_21_();
     } else {
     mwtype_is_morphism_3F_();
     if (pop()) {
-    push((i64)(strings + 2235));
+    push((i64)(strings + 2245));
     mwstr_trace_21_();
     mwtype_trace_sig_21_();
-    push((i64)(strings + 2237));
+    push((i64)(strings + 2247));
     mwstr_trace_21_();
     } else {
     mwtype_is_nominal_3F_();
@@ -9901,11 +9985,11 @@ void mwtype_trace_21_ (void){
     mwname_load_21_();
     mwstr_buf_trace_21_();
     } else {
-    push((i64)(strings + 2239));
+    push((i64)(strings + 2249));
     mwstr_trace_21_();
     mwType__3E_Int();
     mwint_trace_21_();
-    push((i64)(strings + 2254));
+    push((i64)(strings + 2264));
     mwstr_trace_21_();
     }
     }
@@ -9925,7 +10009,7 @@ void mwmeta_unify_21_ (void){
     mwswap();
     mwtype_has_meta_3F_();
     if (pop()) {
-    push((i64)(strings + 2435));
+    push((i64)(strings + 2445));
     mwelab_emit_error_21_();
     mwdrop();
     mwTYPE_ERROR();
@@ -10019,7 +10103,7 @@ void mwtype_has_meta (void){
     mwdrop2();
     mwfalse();
     } else {
-    push((i64)(strings + 2181));
+    push((i64)(strings + 2191));
     mwpanic_21_();
     }
     }
@@ -10063,7 +10147,7 @@ void mwtype_trace_sig_21_ (void){
     mwTYPE_ERROR();
     mw_3D_();
     if (pop()) {
-    push((i64)(strings + 2209));
+    push((i64)(strings + 2219));
     mwstr_trace_21_();
     mwdrop();
     } else {
@@ -10077,10 +10161,10 @@ void mwtype_trace_sig_21_ (void){
     mwdrop();
     } else {
     mwtype_trace_stack_21_();
-    push((i64)(strings + 2217));
+    push((i64)(strings + 2227));
     mwstr_trace_21_();
     }
-    push((i64)(strings + 2219));
+    push((i64)(strings + 2229));
     mwstr_trace_21_();
     mwmorphism_type_cod_40_();
     mwdup();
@@ -10089,7 +10173,7 @@ void mwtype_trace_sig_21_ (void){
     if (pop()) {
     mwdrop();
     } else {
-    push((i64)(strings + 2222));
+    push((i64)(strings + 2232));
     mwstr_trace_21_();
     mwtype_trace_stack_21_();
     }
@@ -10109,7 +10193,7 @@ void mwtype_trace_stack_21_ (void){
     mwdrop();
     } else {
     mwtype_trace_stack_21_();
-    push((i64)(strings + 2224));
+    push((i64)(strings + 2234));
     mwstr_trace_21_();
     }
     mwtensor_type_snd_40_();
@@ -10120,7 +10204,7 @@ void mwtype_trace_stack_21_ (void){
     mwtype_trace_21_();
     } else {
     mwtype_trace_21_();
-    push((i64)(strings + 2226));
+    push((i64)(strings + 2236));
     mwstr_trace_21_();
     }
     }
@@ -10132,7 +10216,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2256));
+    push((i64)(strings + 2266));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10140,7 +10224,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2262));
+    push((i64)(strings + 2272));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10148,7 +10232,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2265));
+    push((i64)(strings + 2275));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10156,7 +10240,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2270));
+    push((i64)(strings + 2280));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10164,7 +10248,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2274));
+    push((i64)(strings + 2284));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10172,7 +10256,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2278));
+    push((i64)(strings + 2288));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10180,7 +10264,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2281));
+    push((i64)(strings + 2291));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10188,7 +10272,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2285));
+    push((i64)(strings + 2295));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10196,7 +10280,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2289));
+    push((i64)(strings + 2299));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10204,7 +10288,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2293));
+    push((i64)(strings + 2303));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10212,7 +10296,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2296));
+    push((i64)(strings + 2306));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10220,7 +10304,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2300));
+    push((i64)(strings + 2310));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10228,14 +10312,14 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2304));
+    push((i64)(strings + 2314));
     mwstr_trace_21_();
     } else {
-    push((i64)(strings + 2308));
+    push((i64)(strings + 2318));
     mwstr_trace_21_();
     mwType__3E_Int();
     mwint_trace_21_();
-    push((i64)(strings + 2333));
+    push((i64)(strings + 2343));
     mwstr_trace_21_();
     }
     }
@@ -10408,7 +10492,7 @@ void mwmeta_type_40_ (void){
     mwmeta_is_defined_3F_();
     mwnot();
     if (pop()) {
-    push((i64)(strings + 2397));
+    push((i64)(strings + 2407));
     mwpanic_21_();
     } else {
     mwmeta_type_raw_40_();
@@ -10573,7 +10657,7 @@ void mwctx_trace_21_ (void){
     mwdrop();
     } else {
     mwctx_trace_21_();
-    push((i64)(strings + 2457));
+    push((i64)(strings + 2467));
     mwstr_trace_21_();
     }
     mwctx_var_40_();
@@ -10603,7 +10687,7 @@ void mwvar_trace_binding_21_ (void){
     if (pop()) {
     mwdrop();
     } else {
-    push((i64)(strings + 2495));
+    push((i64)(strings + 2505));
     mwstr_trace_21_();
     mwvar_type_40_();
     mwtype_trace_sig_21_();
@@ -10665,7 +10749,7 @@ void mwvar_alloc_21_ (void){
     mwVar_2E_MAX();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 2460));
+    push((i64)(strings + 2470));
     mwpanic_21_();
     } else {
     mwid();
@@ -10708,7 +10792,7 @@ void mwtable_alloc_21_ (void){
     mwTable_2E_MAX();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 2499));
+    push((i64)(strings + 2509));
     mwpanic_21_();
     } else {
     mwid();
@@ -10728,7 +10812,7 @@ void mwtable_new_21_ (void){
     mwtable_max_count_21_();
     mwtable_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2540));
+    push((i64)(strings + 2550));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     mwword_alloc_21_();
@@ -10755,7 +10839,7 @@ void mwtable_new_21_ (void){
     mwword_body_is_checked_21_();
     mwtable_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2545));
+    push((i64)(strings + 2555));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     push(8);
@@ -10764,7 +10848,7 @@ void mwtable_new_21_ (void){
     mwtable_num_buffer_21_();
     mwtable_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2550));
+    push((i64)(strings + 2560));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     mwword_alloc_21_();
@@ -10890,7 +10974,7 @@ void mwfield_alloc_21_ (void){
     mwField_2E_MAX();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 2558));
+    push((i64)(strings + 2568));
     mwpanic_21_();
     } else {
     mwid();
@@ -10907,7 +10991,7 @@ void mwfield_new_21_ (void){
     mwfield_name_21_();
     mwfield_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2599));
+    push((i64)(strings + 2609));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     mwover();
@@ -10920,7 +11004,7 @@ void mwfield_new_21_ (void){
     mwfield_buffer_21_();
     mwfield_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2607));
+    push((i64)(strings + 2617));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     mwword_alloc_21_();
@@ -10968,7 +11052,7 @@ void mwfield_new_21_ (void){
     mwfield_word_ptr_21_();
     mwfield_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2609));
+    push((i64)(strings + 2619));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     mwword_alloc_21_();
@@ -11009,7 +11093,7 @@ void mwfield_new_21_ (void){
     mwword_body_is_checked_21_();
     mwfield_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2611));
+    push((i64)(strings + 2621));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     mwword_alloc_21_();
@@ -11051,7 +11135,7 @@ void mwfield_new_21_ (void){
     mwword_body_is_checked_21_();
     mwfield_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2613));
+    push((i64)(strings + 2623));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     mwword_alloc_21_();
@@ -11217,7 +11301,7 @@ void mwarrow_alloc_21_ (void){
     mwMAX_ARROWS();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 2615));
+    push((i64)(strings + 2625));
     mwpanic_21_();
     } else {
     mwid();
@@ -11353,7 +11437,7 @@ void mwarrow_op_prim_40_ (void){
     mwarrow_op_value_40_();
     mwInt__3E_Prim();
     } else {
-    push((i64)(strings + 2671));
+    push((i64)(strings + 2681));
     mwpanic_21_();
     }
 }
@@ -11381,7 +11465,7 @@ void mwarrow_op_word_40_ (void){
     mwarrow_op_value_40_();
     mwInt__3E_Word();
     } else {
-    push((i64)(strings + 2740));
+    push((i64)(strings + 2750));
     mwpanic_21_();
     }
 }
@@ -11409,7 +11493,7 @@ void mwarrow_op_external_40_ (void){
     mwarrow_op_value_40_();
     mwInt__3E_External();
     } else {
-    push((i64)(strings + 2809));
+    push((i64)(strings + 2819));
     mwpanic_21_();
     }
 }
@@ -11437,7 +11521,7 @@ void mwarrow_op_buffer_40_ (void){
     mwarrow_op_value_40_();
     mwInt__3E_Buffer();
     } else {
-    push((i64)(strings + 2886));
+    push((i64)(strings + 2896));
     mwpanic_21_();
     }
 }
@@ -11461,7 +11545,7 @@ void mwarrow_op_int_40_ (void){
     if (pop()) {
     mwarrow_op_value_40_();
     } else {
-    push((i64)(strings + 2963));
+    push((i64)(strings + 2973));
     mwpanic_21_();
     }
 }
@@ -11489,7 +11573,7 @@ void mwarrow_op_str_40_ (void){
     mwarrow_op_value_40_();
     mwInt__3E_StrLit();
     } else {
-    push((i64)(strings + 3030));
+    push((i64)(strings + 3040));
     mwpanic_21_();
     }
 }
@@ -11596,7 +11680,7 @@ void mwarrow_args_0 (void){
     mwdrop();
     } else {
     mwarrow_token_40_();
-    push((i64)(strings + 3097));
+    push((i64)(strings + 3107));
     mwemit_fatal_error_21_();
     }
 }
@@ -11611,7 +11695,7 @@ void mwarrow_args_1 (void){
     mwargs_head_40_();
     } else {
     mwarrow_token_40_();
-    push((i64)(strings + 3139));
+    push((i64)(strings + 3149));
     mwemit_fatal_error_21_();
     }
 }
@@ -11629,7 +11713,7 @@ void mwarrow_args_2 (void){
     mwargs_head_40_();
     } else {
     mwarrow_token_40_();
-    push((i64)(strings + 3179));
+    push((i64)(strings + 3189));
     mwemit_fatal_error_21_();
     }
 }
@@ -11662,7 +11746,7 @@ void mwsubst_alloc_21_ (void){
     mwSubst_2E_MAX();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 3220));
+    push((i64)(strings + 3230));
     mwpanic_21_();
     } else {
     mwid();
@@ -11766,7 +11850,7 @@ void mwstrings_push_21_ (void){
     mwMAX_STRINGS();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 3243));
+    push((i64)(strings + 3253));
     mwpanic_21_();
     } else {
     mwstrings_size_40_();
@@ -11826,52 +11910,52 @@ void mwtoken_type_str (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 3267));
+    push((i64)(strings + 3277));
     } else {
     mwdup();
     mwTOKEN_LPAREN();
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 3272));
+    push((i64)(strings + 3282));
     } else {
     mwdup();
     mwTOKEN_RPAREN();
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 3279));
+    push((i64)(strings + 3289));
     } else {
     mwdup();
     mwTOKEN_COMMA();
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 3286));
+    push((i64)(strings + 3296));
     } else {
     mwdup();
     mwTOKEN_NAME();
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 3292));
+    push((i64)(strings + 3302));
     } else {
     mwdup();
     mwTOKEN_INT();
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 3297));
+    push((i64)(strings + 3307));
     } else {
     mwdup();
     mwTOKEN_STR();
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 3301));
+    push((i64)(strings + 3311));
     } else {
     mwdrop();
-    push((i64)(strings + 3305));
+    push((i64)(strings + 3315));
     }
     }
     }
@@ -11920,7 +12004,7 @@ void mwtoken_int_40_ (void){
     mwtoken_value_40_();
     mwTokenValue__3E_Int();
     } else {
-    push((i64)(strings + 3319));
+    push((i64)(strings + 3329));
     mwemit_fatal_error_21_();
     }
 }
@@ -11944,7 +12028,7 @@ void mwtoken_str_40_ (void){
     mwtoken_value_40_();
     mwTokenValue__3E_Str();
     } else {
-    push((i64)(strings + 3370));
+    push((i64)(strings + 3380));
     mwemit_fatal_error_21_();
     }
 }
@@ -11968,7 +12052,7 @@ void mwtoken_name_40_ (void){
     mwtoken_value_40_();
     mwTokenValue__3E_Name();
     } else {
-    push((i64)(strings + 3421));
+    push((i64)(strings + 3431));
     mwemit_fatal_error_21_();
     }
 }
@@ -11993,7 +12077,7 @@ void mwtoken_token_40_ (void){
     mwtoken_value_40_();
     mwTokenValue__3E_Token();
     } else {
-    push((i64)(strings + 3474));
+    push((i64)(strings + 3484));
     mwemit_fatal_error_21_();
     }
     }
@@ -12008,7 +12092,7 @@ void mwtoken_print_21_ (void){
     mwdup();
     mwtoken_location();
     mwlocation_print_21_();
-    push((i64)(strings + 3529));
+    push((i64)(strings + 3539));
     mwstr_print_21_();
     mwdup();
     mwToken__3E_Int();
@@ -12049,11 +12133,11 @@ void mwlocation_print_21_ (void){
     mwswap();
     mwload_module_source_path_21_();
     mwstr_buf_print_21_();
-    push((i64)(strings + 3803));
+    push((i64)(strings + 3813));
     mwstr_print_21_();
     mwRow__3E_Int();
     mwint_print_21_();
-    push((i64)(strings + 3805));
+    push((i64)(strings + 3815));
     mwstr_print_21_();
     mwCol__3E_Int();
     mwint_print_21_();
@@ -12148,7 +12232,7 @@ void mwtoken_has_args_3F_ (void){
 void mwtoken_args_0 (void){
     mwtoken_has_args_3F_();
     if (pop()) {
-    push((i64)(strings + 3532));
+    push((i64)(strings + 3542));
     mwemit_fatal_error_21_();
     } else {
     mwdrop();
@@ -12170,12 +12254,12 @@ void mwtoken_args_1 (void){
     mwdrop2();
     } else {
     mwdrop();
-    push((i64)(strings + 3549));
+    push((i64)(strings + 3559));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 3578));
+    push((i64)(strings + 3588));
     mwemit_fatal_error_21_();
     }
 }
@@ -12202,17 +12286,17 @@ void mwtoken_args_2 (void){
     mwdrop2();
     } else {
     mwdrop();
-    push((i64)(strings + 3603));
+    push((i64)(strings + 3613));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 3633));
+    push((i64)(strings + 3643));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 3661));
+    push((i64)(strings + 3671));
     mwemit_fatal_error_21_();
     }
 }
@@ -12246,22 +12330,22 @@ void mwtoken_args_3 (void){
     mwdrop2();
     } else {
     mwdrop();
-    push((i64)(strings + 3687));
+    push((i64)(strings + 3697));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 3717));
+    push((i64)(strings + 3727));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 3745));
+    push((i64)(strings + 3755));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 3773));
+    push((i64)(strings + 3783));
     mwemit_fatal_error_21_();
     }
 }
@@ -12303,7 +12387,7 @@ void mwmodule_alloc_21_ (void){
     mwMAX_MODULES();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 3807));
+    push((i64)(strings + 3817));
     mwpanic_21_();
     } else {
     mwid();
@@ -12317,7 +12401,7 @@ void mwmodule_path_21_ (void){
     mwMODULE_PATH_SIZE();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 3835));
+    push((i64)(strings + 3845));
     mwpanic_21_();
     } else {
     mwmodule_path_40_();
@@ -12392,9 +12476,9 @@ void mwpath_separator (void){
     mwWIN32();
     mw_3D_();
     if (pop()) {
-    push((i64)(strings + 3868));
+    push((i64)(strings + 3878));
     } else {
-    push((i64)(strings + 3870));
+    push((i64)(strings + 3880));
     }
 }
 
@@ -12568,78 +12652,82 @@ void mwrun_output_c99_21_ (void){
 }
 
 void mwc99_emit_header_21_ (void){
-    push((i64)(strings + 3910));
+    push((i64)(strings + 3920));
     mw_3B_();
-    push((i64)(strings + 3949));
+    push((i64)(strings + 3959));
     mw_3B_();
-    push((i64)(strings + 4028));
+    push((i64)(strings + 4038));
     mw_3B_();
-    push((i64)(strings + 4050));
+    push((i64)(strings + 4060));
     mw_3B_();
-    push((i64)(strings + 4075));
+    push((i64)(strings + 4085));
     mw_3B_();
-    push((i64)(strings + 4097));
+    push((i64)(strings + 4107));
     mw_3B_();
-    push((i64)(strings + 4122));
+    push((i64)(strings + 4132));
     mw_3B_();
-    push((i64)(strings + 4144));
+    push((i64)(strings + 4154));
     mw_3B_();
-    push((i64)(strings + 4150));
+    push((i64)(strings + 4160));
     mw_3B_();
-    push((i64)(strings + 4183));
+    push((i64)(strings + 4193));
     mw_3B__3B_();
-    push((i64)(strings + 4190));
+    push((i64)(strings + 4200));
     mw_3B_();
-    push((i64)(strings + 4210));
+    push((i64)(strings + 4220));
     mw_3B__3B_();
-    push((i64)(strings + 4231));
+    push((i64)(strings + 4241));
     mw_3B_();
-    push((i64)(strings + 4251));
+    push((i64)(strings + 4261));
     mw_3B_();
-    push((i64)(strings + 4273));
+    push((i64)(strings + 4283));
     mw_3B_();
-    push((i64)(strings + 4295));
+    push((i64)(strings + 4305));
     mw_3B_();
-    push((i64)(strings + 4317));
+    push((i64)(strings + 4327));
     mw_3B_();
-    push((i64)(strings + 4336));
+    push((i64)(strings + 4346));
     mw_3B_();
-    push((i64)(strings + 4357));
+    push((i64)(strings + 4367));
     mw_3B_();
-    push((i64)(strings + 4378));
+    push((i64)(strings + 4388));
     mw_3B_();
-    push((i64)(strings + 4399));
+    push((i64)(strings + 4409));
     mw_3B__3B_();
-    push((i64)(strings + 4424));
+    push((i64)(strings + 4434));
     mw_3B_();
-    push((i64)(strings + 4475));
+    push((i64)(strings + 4485));
     mw_3B_();
-    push((i64)(strings + 4503));
+    push((i64)(strings + 4513));
     mw_3B_();
-    push((i64)(strings + 4539));
+    push((i64)(strings + 4549));
     mw_3B_();
-    push((i64)(strings + 4576));
+    push((i64)(strings + 4586));
     mw_3B_();
-    push((i64)(strings + 4599));
+    push((i64)(strings + 4609));
     mw_3B_();
-    push((i64)(strings + 4633));
+    push((i64)(strings + 4643));
     mw_3B__3B_();
-    push((i64)(strings + 4656));
+    push((i64)(strings + 4666));
     mw_3B_();
-    push((i64)(strings + 4680));
+    push((i64)(strings + 4690));
     mw_3B_();
-    push((i64)(strings + 4719));
+    push((i64)(strings + 4729));
+    mw_3B__3B_();
+    push((i64)(strings + 4774));
+    mw_3B_();
+    push((i64)(strings + 4791));
     mw_3B__3B_();
 }
 
 void mwc99_emit_strings_21_ (void){
-    push((i64)(strings + 4764));
+    push((i64)(strings + 4811));
     mw_2E_();
     mwstrings_size_40_();
     mw_2E_n();
-    push((i64)(strings + 4786));
+    push((i64)(strings + 4833));
     mw_3B_();
-    push((i64)(strings + 4787));
+    push((i64)(strings + 4834));
     mw_3B_();
     push(0);
     while(1) {
@@ -12653,7 +12741,7 @@ void mwc99_emit_strings_21_ (void){
     mwU8__3E_Int();
     mwdup();
     mw_2E_n();
-    push((i64)(strings + 4832));
+    push((i64)(strings + 4879));
     mw_2E_();
     mwnonzero();
     if (pop()) {
@@ -12664,494 +12752,484 @@ void mwc99_emit_strings_21_ (void){
     mw1_2B_();
     }
     mwdrop();
-    push((i64)(strings + 4834));
+    push((i64)(strings + 4881));
     mw_3B__3B_();
 }
 
 void mwc99_emit_prims_21_ (void){
-    push((i64)(strings + 4899));
+    push((i64)(strings + 4946));
     mw_3B_();
-    push((i64)(strings + 4917));
+    push((i64)(strings + 4964));
     mw_3B_();
-    push((i64)(strings + 4944));
+    push((i64)(strings + 4991));
     mw_3B_();
-    push((i64)(strings + 4972));
+    push((i64)(strings + 5019));
     mw_3B_();
-    push((i64)(strings + 4985));
+    push((i64)(strings + 5032));
     mw_3B_();
-    push((i64)(strings + 5028));
+    push((i64)(strings + 5075));
     mw_3B_();
-    push((i64)(strings + 5045));
+    push((i64)(strings + 5092));
     mw_3B_();
-    push((i64)(strings + 5063));
+    push((i64)(strings + 5110));
     mw_3B_();
-    push((i64)(strings + 5069));
+    push((i64)(strings + 5116));
     mw_3B__3B_();
-    push((i64)(strings + 5071));
+    push((i64)(strings + 5118));
     mw_3B_();
-    push((i64)(strings + 5095));
-    mw_3B_();
-    push((i64)(strings + 5119));
-    mw_3B_();
-    push((i64)(strings + 5140));
-    mw_3B__3B_();
     push((i64)(strings + 5142));
     mw_3B_();
-    push((i64)(strings + 5162));
+    push((i64)(strings + 5166));
     mw_3B_();
-    push((i64)(strings + 5181));
-    mw_3B_();
-    push((i64)(strings + 5199));
+    push((i64)(strings + 5187));
     mw_3B__3B_();
-    push((i64)(strings + 5201));
+    push((i64)(strings + 5189));
     mw_3B_();
-    push((i64)(strings + 5223));
+    push((i64)(strings + 5209));
     mw_3B_();
-    push((i64)(strings + 5242));
+    push((i64)(strings + 5228));
     mw_3B_();
-    push((i64)(strings + 5261));
+    push((i64)(strings + 5246));
     mw_3B__3B_();
-    push((i64)(strings + 5263));
+    push((i64)(strings + 5248));
     mw_3B_();
-    push((i64)(strings + 5285));
+    push((i64)(strings + 5270));
     mw_3B_();
-    push((i64)(strings + 5304));
+    push((i64)(strings + 5289));
     mw_3B_();
-    push((i64)(strings + 5323));
+    push((i64)(strings + 5308));
     mw_3B__3B_();
-    push((i64)(strings + 5325));
+    push((i64)(strings + 5310));
     mw_3B_();
-    push((i64)(strings + 5347));
+    push((i64)(strings + 5332));
     mw_3B_();
-    push((i64)(strings + 5366));
+    push((i64)(strings + 5351));
     mw_3B_();
-    push((i64)(strings + 5385));
+    push((i64)(strings + 5370));
     mw_3B__3B_();
-    push((i64)(strings + 5387));
+    push((i64)(strings + 5372));
     mw_3B_();
-    push((i64)(strings + 5407));
+    push((i64)(strings + 5394));
     mw_3B_();
-    push((i64)(strings + 5426));
+    push((i64)(strings + 5413));
     mw_3B_();
-    push((i64)(strings + 5444));
+    push((i64)(strings + 5432));
     mw_3B__3B_();
-    push((i64)(strings + 5446));
+    push((i64)(strings + 5434));
     mw_3B_();
-    push((i64)(strings + 5468));
+    push((i64)(strings + 5454));
     mw_3B_();
-    push((i64)(strings + 5487));
+    push((i64)(strings + 5473));
     mw_3B_();
-    push((i64)(strings + 5506));
+    push((i64)(strings + 5491));
     mw_3B__3B_();
-    push((i64)(strings + 5508));
+    push((i64)(strings + 5493));
     mw_3B_();
-    push((i64)(strings + 5530));
+    push((i64)(strings + 5515));
     mw_3B_();
-    push((i64)(strings + 5549));
+    push((i64)(strings + 5534));
     mw_3B_();
-    push((i64)(strings + 5568));
+    push((i64)(strings + 5553));
     mw_3B__3B_();
-    push((i64)(strings + 5570));
+    push((i64)(strings + 5555));
     mw_3B_();
-    push((i64)(strings + 5592));
+    push((i64)(strings + 5577));
     mw_3B_();
-    push((i64)(strings + 5610));
+    push((i64)(strings + 5596));
+    mw_3B_();
+    push((i64)(strings + 5615));
     mw_3B__3B_();
-    push((i64)(strings + 5612));
+    push((i64)(strings + 5617));
     mw_3B_();
-    push((i64)(strings + 5633));
+    push((i64)(strings + 5639));
     mw_3B_();
-    push((i64)(strings + 5651));
+    push((i64)(strings + 5657));
+    mw_3B__3B_();
+    push((i64)(strings + 5659));
     mw_3B_();
-    push((i64)(strings + 5676));
+    push((i64)(strings + 5680));
     mw_3B_();
-    push((i64)(strings + 5689));
+    push((i64)(strings + 5698));
     mw_3B_();
-    push((i64)(strings + 5731));
+    push((i64)(strings + 5723));
     mw_3B_();
-    push((i64)(strings + 5748));
+    push((i64)(strings + 5736));
     mw_3B_();
-    push((i64)(strings + 5754));
+    push((i64)(strings + 5778));
+    mw_3B_();
+    push((i64)(strings + 5795));
+    mw_3B_();
+    push((i64)(strings + 5801));
     mw_3B__3B_();
     mwPRIM_ID();
     mw_2E_p();
-    push((i64)(strings + 5756));
+    push((i64)(strings + 5803));
     mw_3B_();
-    push((i64)(strings + 5759));
+    push((i64)(strings + 5806));
     mw_3B__3B_();
     mwPRIM_DUP();
     mw_2E_p();
-    push((i64)(strings + 5761));
+    push((i64)(strings + 5808));
     mw_3B_();
-    push((i64)(strings + 5764));
+    push((i64)(strings + 5811));
     mw_3B_();
-    push((i64)(strings + 5783));
+    push((i64)(strings + 5830));
     mw_3B_();
-    push((i64)(strings + 5805));
+    push((i64)(strings + 5852));
     mw_3B__3B_();
     mwPRIM_DROP();
     mw_2E_p();
-    push((i64)(strings + 5807));
+    push((i64)(strings + 5854));
     mw_3B_();
-    push((i64)(strings + 5810));
+    push((i64)(strings + 5857));
     mw_3B_();
-    push((i64)(strings + 5821));
+    push((i64)(strings + 5868));
     mw_3B__3B_();
     mwPRIM_SWAP();
     mw_2E_p();
-    push((i64)(strings + 5823));
+    push((i64)(strings + 5870));
     mw_3B_();
-    push((i64)(strings + 5826));
+    push((i64)(strings + 5873));
     mw_3B_();
-    push((i64)(strings + 5845));
+    push((i64)(strings + 5892));
     mw_3B_();
-    push((i64)(strings + 5864));
+    push((i64)(strings + 5911));
     mw_3B_();
-    push((i64)(strings + 5886));
+    push((i64)(strings + 5933));
     mw_3B__3B_();
     mwPRIM_INT_ADD();
     mw_2E_p();
-    push((i64)(strings + 5888));
+    push((i64)(strings + 5935));
     mw_3B_();
-    push((i64)(strings + 5891));
+    push((i64)(strings + 5938));
     mw_3B_();
-    push((i64)(strings + 5910));
+    push((i64)(strings + 5957));
     mw_3B_();
-    push((i64)(strings + 5929));
+    push((i64)(strings + 5976));
     mw_3B_();
-    push((i64)(strings + 5946));
+    push((i64)(strings + 5993));
     mw_3B__3B_();
     mwPRIM_INT_SUB();
     mw_2E_p();
-    push((i64)(strings + 5948));
+    push((i64)(strings + 5995));
     mw_3B_();
-    push((i64)(strings + 5951));
+    push((i64)(strings + 5998));
     mw_3B_();
-    push((i64)(strings + 5970));
+    push((i64)(strings + 6017));
     mw_3B_();
-    push((i64)(strings + 5989));
+    push((i64)(strings + 6036));
     mw_3B_();
-    push((i64)(strings + 6006));
+    push((i64)(strings + 6053));
     mw_3B__3B_();
     mwPRIM_INT_MUL();
     mw_2E_p();
-    push((i64)(strings + 6008));
+    push((i64)(strings + 6055));
     mw_3B_();
-    push((i64)(strings + 6011));
+    push((i64)(strings + 6058));
     mw_3B_();
-    push((i64)(strings + 6030));
+    push((i64)(strings + 6077));
     mw_3B_();
-    push((i64)(strings + 6049));
+    push((i64)(strings + 6096));
     mw_3B_();
-    push((i64)(strings + 6066));
+    push((i64)(strings + 6113));
     mw_3B__3B_();
     mwPRIM_INT_DIV();
     mw_2E_p();
-    push((i64)(strings + 6068));
+    push((i64)(strings + 6115));
     mw_3B_();
-    push((i64)(strings + 6071));
+    push((i64)(strings + 6118));
     mw_3B_();
-    push((i64)(strings + 6090));
+    push((i64)(strings + 6137));
     mw_3B_();
-    push((i64)(strings + 6109));
+    push((i64)(strings + 6156));
     mw_3B_();
-    push((i64)(strings + 6126));
+    push((i64)(strings + 6173));
     mw_3B__3B_();
     mwPRIM_INT_MOD();
     mw_2E_p();
-    push((i64)(strings + 6128));
+    push((i64)(strings + 6175));
     mw_3B_();
-    push((i64)(strings + 6131));
+    push((i64)(strings + 6178));
     mw_3B_();
-    push((i64)(strings + 6150));
+    push((i64)(strings + 6197));
     mw_3B_();
-    push((i64)(strings + 6169));
+    push((i64)(strings + 6216));
     mw_3B_();
-    push((i64)(strings + 6186));
+    push((i64)(strings + 6233));
     mw_3B__3B_();
     mwPRIM_INT_EQ();
     mw_2E_p();
-    push((i64)(strings + 6188));
+    push((i64)(strings + 6235));
     mw_3B_();
-    push((i64)(strings + 6191));
+    push((i64)(strings + 6238));
     mw_3B_();
-    push((i64)(strings + 6210));
+    push((i64)(strings + 6257));
     mw_3B_();
-    push((i64)(strings + 6229));
+    push((i64)(strings + 6276));
     mw_3B_();
-    push((i64)(strings + 6247));
+    push((i64)(strings + 6294));
     mw_3B__3B_();
     mwPRIM_INT_LT();
     mw_2E_p();
-    push((i64)(strings + 6249));
+    push((i64)(strings + 6296));
     mw_3B_();
-    push((i64)(strings + 6252));
+    push((i64)(strings + 6299));
     mw_3B_();
-    push((i64)(strings + 6271));
+    push((i64)(strings + 6318));
     mw_3B_();
-    push((i64)(strings + 6290));
+    push((i64)(strings + 6337));
     mw_3B_();
-    push((i64)(strings + 6307));
+    push((i64)(strings + 6354));
     mw_3B__3B_();
     mwPRIM_INT_LE();
     mw_2E_p();
-    push((i64)(strings + 6309));
+    push((i64)(strings + 6356));
     mw_3B_();
-    push((i64)(strings + 6312));
+    push((i64)(strings + 6359));
     mw_3B_();
-    push((i64)(strings + 6331));
+    push((i64)(strings + 6378));
     mw_3B_();
-    push((i64)(strings + 6350));
+    push((i64)(strings + 6397));
     mw_3B_();
-    push((i64)(strings + 6368));
+    push((i64)(strings + 6415));
     mw_3B__3B_();
     mwPRIM_INT_AND();
     mw_2E_p();
-    push((i64)(strings + 6370));
+    push((i64)(strings + 6417));
     mw_3B_();
-    push((i64)(strings + 6373));
+    push((i64)(strings + 6420));
     mw_3B_();
-    push((i64)(strings + 6392));
+    push((i64)(strings + 6439));
     mw_3B_();
-    push((i64)(strings + 6411));
+    push((i64)(strings + 6458));
     mw_3B_();
-    push((i64)(strings + 6428));
+    push((i64)(strings + 6475));
     mw_3B__3B_();
     mwPRIM_INT_OR();
     mw_2E_p();
-    push((i64)(strings + 6430));
+    push((i64)(strings + 6477));
     mw_3B_();
-    push((i64)(strings + 6433));
+    push((i64)(strings + 6480));
     mw_3B_();
-    push((i64)(strings + 6452));
+    push((i64)(strings + 6499));
     mw_3B_();
-    push((i64)(strings + 6471));
+    push((i64)(strings + 6518));
     mw_3B_();
-    push((i64)(strings + 6488));
+    push((i64)(strings + 6535));
     mw_3B__3B_();
     mwPRIM_INT_XOR();
     mw_2E_p();
-    push((i64)(strings + 6490));
+    push((i64)(strings + 6537));
     mw_3B_();
-    push((i64)(strings + 6493));
+    push((i64)(strings + 6540));
     mw_3B_();
-    push((i64)(strings + 6512));
+    push((i64)(strings + 6559));
     mw_3B_();
-    push((i64)(strings + 6531));
+    push((i64)(strings + 6578));
     mw_3B_();
-    push((i64)(strings + 6548));
+    push((i64)(strings + 6595));
     mw_3B__3B_();
     mwPRIM_INT_SHL();
     mw_2E_p();
-    push((i64)(strings + 6550));
+    push((i64)(strings + 6597));
     mw_3B_();
-    push((i64)(strings + 6553));
+    push((i64)(strings + 6600));
     mw_3B_();
-    push((i64)(strings + 6572));
+    push((i64)(strings + 6619));
     mw_3B_();
-    push((i64)(strings + 6591));
+    push((i64)(strings + 6638));
     mw_3B_();
-    push((i64)(strings + 6609));
+    push((i64)(strings + 6656));
     mw_3B__3B_();
     mwPRIM_INT_SHR();
     mw_2E_p();
-    push((i64)(strings + 6611));
+    push((i64)(strings + 6658));
     mw_3B_();
-    push((i64)(strings + 6614));
+    push((i64)(strings + 6661));
     mw_3B_();
-    push((i64)(strings + 6633));
+    push((i64)(strings + 6680));
     mw_3B_();
-    push((i64)(strings + 6652));
+    push((i64)(strings + 6699));
     mw_3B_();
-    push((i64)(strings + 6670));
+    push((i64)(strings + 6717));
     mw_3B__3B_();
     mwPRIM_POSIX_WRITE();
     mw_2E_p();
-    push((i64)(strings + 6672));
+    push((i64)(strings + 6719));
     mw_3B_();
-    push((i64)(strings + 6675));
+    push((i64)(strings + 6722));
     mw_3B_();
-    push((i64)(strings + 6703));
+    push((i64)(strings + 6750));
     mw_3B_();
-    push((i64)(strings + 6728));
+    push((i64)(strings + 6775));
     mw_3B_();
-    push((i64)(strings + 6752));
+    push((i64)(strings + 6799));
     mw_3B_();
-    push((i64)(strings + 6772));
+    push((i64)(strings + 6819));
     mw_3B__3B_();
     mwPRIM_POSIX_READ();
     mw_2E_p();
-    push((i64)(strings + 6774));
+    push((i64)(strings + 6821));
     mw_3B_();
-    push((i64)(strings + 6777));
+    push((i64)(strings + 6824));
     mw_3B_();
-    push((i64)(strings + 6805));
-    mw_3B_();
-    push((i64)(strings + 6830));
-    mw_3B_();
-    push((i64)(strings + 6854));
+    push((i64)(strings + 6852));
     mw_3B_();
     push((i64)(strings + 6877));
+    mw_3B_();
+    push((i64)(strings + 6901));
+    mw_3B_();
+    push((i64)(strings + 6924));
     mw_3B__3B_();
     mwPRIM_POSIX_OPEN();
     mw_2E_p();
-    push((i64)(strings + 6879));
+    push((i64)(strings + 6926));
     mw_3B_();
-    push((i64)(strings + 6882));
+    push((i64)(strings + 6929));
     mw_3B_();
-    push((i64)(strings + 6906));
+    push((i64)(strings + 6953));
     mw_3B_();
-    push((i64)(strings + 6930));
+    push((i64)(strings + 6977));
     mw_3B_();
-    push((i64)(strings + 6955));
+    push((i64)(strings + 7002));
     mw_3B_();
-    push((i64)(strings + 6978));
+    push((i64)(strings + 7025));
     mw_3B__3B_();
     mwPRIM_POSIX_CLOSE();
     mw_2E_p();
-    push((i64)(strings + 6980));
-    mw_3B_();
-    push((i64)(strings + 6983));
-    mw_3B_();
-    push((i64)(strings + 7007));
-    mw_3B_();
     push((i64)(strings + 7027));
+    mw_3B_();
+    push((i64)(strings + 7030));
+    mw_3B_();
+    push((i64)(strings + 7054));
+    mw_3B_();
+    push((i64)(strings + 7074));
     mw_3B__3B_();
     mwPRIM_POSIX_EXIT();
     mw_2E_p();
-    push((i64)(strings + 7029));
+    push((i64)(strings + 7076));
     mw_3B_();
-    push((i64)(strings + 7032));
+    push((i64)(strings + 7079));
     mw_3B_();
-    push((i64)(strings + 7056));
+    push((i64)(strings + 7103));
     mw_3B_();
-    push((i64)(strings + 7069));
+    push((i64)(strings + 7116));
     mw_3B__3B_();
     mwPRIM_POSIX_MMAP();
     mw_2E_p();
-    push((i64)(strings + 7071));
+    push((i64)(strings + 7118));
     mw_3B_();
-    push((i64)(strings + 7074));
+    push((i64)(strings + 7121));
     mw_3B_();
-    push((i64)(strings + 7097));
+    push((i64)(strings + 7144));
     mw_3B_();
-    push((i64)(strings + 7129));
-    mw_3B_();
-    push((i64)(strings + 7157));
-    mw_3B_();
-    push((i64)(strings + 7168));
-    mw_3B_();
-    push((i64)(strings + 7194));
+    push((i64)(strings + 7176));
     mw_3B_();
     push((i64)(strings + 7204));
     mw_3B_();
-    push((i64)(strings + 7228));
+    push((i64)(strings + 7215));
     mw_3B_();
-    push((i64)(strings + 7252));
+    push((i64)(strings + 7241));
     mw_3B_();
-    push((i64)(strings + 7276));
+    push((i64)(strings + 7251));
     mw_3B_();
-    push((i64)(strings + 7300));
+    push((i64)(strings + 7275));
     mw_3B_();
-    push((i64)(strings + 7328));
+    push((i64)(strings + 7299));
     mw_3B_();
-    push((i64)(strings + 7353));
+    push((i64)(strings + 7323));
     mw_3B_();
-    push((i64)(strings + 7386));
+    push((i64)(strings + 7347));
     mw_3B_();
-    push((i64)(strings + 7404));
+    push((i64)(strings + 7375));
     mw_3B_();
-    push((i64)(strings + 7415));
+    push((i64)(strings + 7400));
+    mw_3B_();
+    push((i64)(strings + 7433));
+    mw_3B_();
+    push((i64)(strings + 7451));
+    mw_3B_();
+    push((i64)(strings + 7462));
     mw_3B__3B_();
     mwPRIM_DEBUG();
     mw_2E_p();
-    push((i64)(strings + 7417));
+    push((i64)(strings + 7464));
     mw_3B_();
-    push((i64)(strings + 7420));
+    push((i64)(strings + 7467));
     mw_3B_();
-    push((i64)(strings + 7443));
+    push((i64)(strings + 7490));
     mw_3B_();
-    push((i64)(strings + 7465));
+    push((i64)(strings + 7512));
     mw_3B_();
-    push((i64)(strings + 7479));
+    push((i64)(strings + 7526));
     mw_3B_();
-    push((i64)(strings + 7492));
+    push((i64)(strings + 7539));
     mw_3B_();
-    push((i64)(strings + 7510));
+    push((i64)(strings + 7557));
     mw_3B_();
-    push((i64)(strings + 7564));
+    push((i64)(strings + 7611));
     mw_3B_();
-    push((i64)(strings + 7583));
+    push((i64)(strings + 7630));
     mw_3B_();
-    push((i64)(strings + 7610));
+    push((i64)(strings + 7657));
     mw_3B_();
-    push((i64)(strings + 7625));
+    push((i64)(strings + 7672));
     mw_3B_();
-    push((i64)(strings + 7663));
+    push((i64)(strings + 7710));
     mw_3B_();
-    push((i64)(strings + 7726));
+    push((i64)(strings + 7773));
     mw_3B_();
-    push((i64)(strings + 7768));
+    push((i64)(strings + 7815));
     mw_3B_();
-    push((i64)(strings + 7787));
+    push((i64)(strings + 7834));
     mw_3B_();
-    push((i64)(strings + 7812));
+    push((i64)(strings + 7859));
     mw_3B_();
-    push((i64)(strings + 7818));
+    push((i64)(strings + 7865));
     mw_3B_();
-    push((i64)(strings + 7841));
+    push((i64)(strings + 7888));
     mw_3B__3B_();
     mwPRIM_MIRTH_REVISION();
     mw_2E_p();
-    push((i64)(strings + 7843));
+    push((i64)(strings + 7890));
     mw_3B_();
-    push((i64)(strings + 7846));
+    push((i64)(strings + 7893));
     mw_2E_();
     mwNEW_MIRTH_REVISION();
     mw_2E_n();
-    push((i64)(strings + 7856));
+    push((i64)(strings + 7903));
     mw_3B_();
-    push((i64)(strings + 7859));
+    push((i64)(strings + 7906));
     mw_3B__3B_();
     mwPRIM_MEM_GET();
     mw_2E_p();
-    push((i64)(strings + 7861));
+    push((i64)(strings + 7908));
     mw_3B_();
-    push((i64)(strings + 7864));
+    push((i64)(strings + 7911));
     mw_3B_();
-    push((i64)(strings + 7900));
+    push((i64)(strings + 7947));
     mw_3B__3B_();
     mwPRIM_MEM_SET();
     mw_2E_p();
-    push((i64)(strings + 7902));
+    push((i64)(strings + 7949));
     mw_3B_();
-    push((i64)(strings + 7905));
+    push((i64)(strings + 7952));
     mw_3B_();
-    push((i64)(strings + 7929));
+    push((i64)(strings + 7976));
     mw_3B_();
-    push((i64)(strings + 7950));
+    push((i64)(strings + 7997));
     mw_3B__3B_();
     mwPRIM_MEM_GET_BYTE();
     mw_2E_p();
-    push((i64)(strings + 7952));
+    push((i64)(strings + 7999));
     mw_3B_();
-    push((i64)(strings + 7955));
+    push((i64)(strings + 8002));
     mw_3B_();
-    push((i64)(strings + 7978));
-    mw_3B_();
-    push((i64)(strings + 7992));
-    mw_3B__3B_();
-    mwPRIM_MEM_SET_BYTE();
-    mw_2E_p();
-    push((i64)(strings + 7994));
-    mw_3B_();
-    push((i64)(strings + 7997));
-    mw_3B_();
-    push((i64)(strings + 8020));
+    push((i64)(strings + 8025));
     mw_3B_();
     push((i64)(strings + 8039));
     mw_3B__3B_();
-    mwPRIM_MEM_GET_U8();
+    mwPRIM_MEM_SET_BYTE();
     mw_2E_p();
     push((i64)(strings + 8041));
     mw_3B_();
@@ -13159,253 +13237,279 @@ void mwc99_emit_prims_21_ (void){
     mw_3B_();
     push((i64)(strings + 8067));
     mw_3B_();
-    push((i64)(strings + 8081));
-    mw_3B__3B_();
-    mwPRIM_MEM_SET_U8();
-    mw_2E_p();
-    push((i64)(strings + 8083));
-    mw_3B_();
     push((i64)(strings + 8086));
+    mw_3B__3B_();
+    mwPRIM_MEM_GET_U8();
+    mw_2E_p();
+    push((i64)(strings + 8088));
     mw_3B_();
-    push((i64)(strings + 8109));
+    push((i64)(strings + 8091));
+    mw_3B_();
+    push((i64)(strings + 8114));
     mw_3B_();
     push((i64)(strings + 8128));
     mw_3B__3B_();
-    mwPRIM_MEM_GET_U16();
+    mwPRIM_MEM_SET_U8();
     mw_2E_p();
     push((i64)(strings + 8130));
     mw_3B_();
     push((i64)(strings + 8133));
     mw_3B_();
-    push((i64)(strings + 8157));
+    push((i64)(strings + 8156));
     mw_3B_();
-    push((i64)(strings + 8171));
+    push((i64)(strings + 8175));
+    mw_3B__3B_();
+    mwPRIM_MEM_GET_U16();
+    mw_2E_p();
+    push((i64)(strings + 8177));
+    mw_3B_();
+    push((i64)(strings + 8180));
+    mw_3B_();
+    push((i64)(strings + 8204));
+    mw_3B_();
+    push((i64)(strings + 8218));
     mw_3B__3B_();
     mwPRIM_MEM_SET_U16();
     mw_2E_p();
-    push((i64)(strings + 8173));
-    mw_3B_();
-    push((i64)(strings + 8176));
-    mw_3B_();
-    push((i64)(strings + 8200));
-    mw_3B_();
     push((i64)(strings + 8220));
+    mw_3B_();
+    push((i64)(strings + 8223));
+    mw_3B_();
+    push((i64)(strings + 8247));
+    mw_3B_();
+    push((i64)(strings + 8267));
     mw_3B__3B_();
     mwPRIM_MEM_GET_U32();
     mw_2E_p();
-    push((i64)(strings + 8222));
+    push((i64)(strings + 8269));
     mw_3B_();
-    push((i64)(strings + 8225));
+    push((i64)(strings + 8272));
     mw_3B_();
-    push((i64)(strings + 8249));
+    push((i64)(strings + 8296));
     mw_3B_();
-    push((i64)(strings + 8263));
+    push((i64)(strings + 8310));
     mw_3B__3B_();
     mwPRIM_MEM_SET_U32();
     mw_2E_p();
-    push((i64)(strings + 8265));
-    mw_3B_();
-    push((i64)(strings + 8268));
-    mw_3B_();
-    push((i64)(strings + 8292));
-    mw_3B_();
     push((i64)(strings + 8312));
+    mw_3B_();
+    push((i64)(strings + 8315));
+    mw_3B_();
+    push((i64)(strings + 8339));
+    mw_3B_();
+    push((i64)(strings + 8359));
     mw_3B__3B_();
     mwPRIM_MEM_GET_U64();
     mw_2E_p();
-    push((i64)(strings + 8314));
+    push((i64)(strings + 8361));
     mw_3B_();
-    push((i64)(strings + 8317));
+    push((i64)(strings + 8364));
     mw_3B_();
-    push((i64)(strings + 8341));
+    push((i64)(strings + 8388));
     mw_3B_();
-    push((i64)(strings + 8355));
+    push((i64)(strings + 8402));
     mw_3B__3B_();
     mwPRIM_MEM_SET_U64();
     mw_2E_p();
-    push((i64)(strings + 8357));
-    mw_3B_();
-    push((i64)(strings + 8360));
-    mw_3B_();
-    push((i64)(strings + 8384));
-    mw_3B_();
     push((i64)(strings + 8404));
+    mw_3B_();
+    push((i64)(strings + 8407));
+    mw_3B_();
+    push((i64)(strings + 8431));
+    mw_3B_();
+    push((i64)(strings + 8451));
     mw_3B__3B_();
     mwPRIM_MEM_GET_I8();
     mw_2E_p();
-    push((i64)(strings + 8406));
+    push((i64)(strings + 8453));
     mw_3B_();
-    push((i64)(strings + 8409));
+    push((i64)(strings + 8456));
     mw_3B_();
-    push((i64)(strings + 8432));
-    mw_3B_();
-    push((i64)(strings + 8446));
-    mw_3B__3B_();
-    mwPRIM_MEM_SET_I8();
-    mw_2E_p();
-    push((i64)(strings + 8448));
-    mw_3B_();
-    push((i64)(strings + 8451));
-    mw_3B_();
-    push((i64)(strings + 8474));
+    push((i64)(strings + 8479));
     mw_3B_();
     push((i64)(strings + 8493));
     mw_3B__3B_();
-    mwPRIM_MEM_GET_I16();
+    mwPRIM_MEM_SET_I8();
     mw_2E_p();
     push((i64)(strings + 8495));
     mw_3B_();
     push((i64)(strings + 8498));
     mw_3B_();
-    push((i64)(strings + 8522));
+    push((i64)(strings + 8521));
     mw_3B_();
-    push((i64)(strings + 8536));
+    push((i64)(strings + 8540));
+    mw_3B__3B_();
+    mwPRIM_MEM_GET_I16();
+    mw_2E_p();
+    push((i64)(strings + 8542));
+    mw_3B_();
+    push((i64)(strings + 8545));
+    mw_3B_();
+    push((i64)(strings + 8569));
+    mw_3B_();
+    push((i64)(strings + 8583));
     mw_3B__3B_();
     mwPRIM_MEM_SET_I16();
     mw_2E_p();
-    push((i64)(strings + 8538));
-    mw_3B_();
-    push((i64)(strings + 8541));
-    mw_3B_();
-    push((i64)(strings + 8565));
-    mw_3B_();
     push((i64)(strings + 8585));
+    mw_3B_();
+    push((i64)(strings + 8588));
+    mw_3B_();
+    push((i64)(strings + 8612));
+    mw_3B_();
+    push((i64)(strings + 8632));
     mw_3B__3B_();
     mwPRIM_MEM_GET_I32();
     mw_2E_p();
-    push((i64)(strings + 8587));
+    push((i64)(strings + 8634));
     mw_3B_();
-    push((i64)(strings + 8590));
+    push((i64)(strings + 8637));
     mw_3B_();
-    push((i64)(strings + 8614));
+    push((i64)(strings + 8661));
     mw_3B_();
-    push((i64)(strings + 8628));
+    push((i64)(strings + 8675));
     mw_3B__3B_();
     mwPRIM_MEM_SET_I32();
     mw_2E_p();
-    push((i64)(strings + 8630));
-    mw_3B_();
-    push((i64)(strings + 8633));
-    mw_3B_();
-    push((i64)(strings + 8657));
-    mw_3B_();
     push((i64)(strings + 8677));
+    mw_3B_();
+    push((i64)(strings + 8680));
+    mw_3B_();
+    push((i64)(strings + 8704));
+    mw_3B_();
+    push((i64)(strings + 8724));
     mw_3B__3B_();
     mwPRIM_MEM_GET_I64();
     mw_2E_p();
-    push((i64)(strings + 8679));
+    push((i64)(strings + 8726));
     mw_3B_();
-    push((i64)(strings + 8682));
+    push((i64)(strings + 8729));
     mw_3B_();
-    push((i64)(strings + 8706));
+    push((i64)(strings + 8753));
     mw_3B_();
-    push((i64)(strings + 8720));
+    push((i64)(strings + 8767));
     mw_3B__3B_();
     mwPRIM_MEM_SET_I64();
     mw_2E_p();
-    push((i64)(strings + 8722));
-    mw_3B_();
-    push((i64)(strings + 8725));
-    mw_3B_();
-    push((i64)(strings + 8749));
-    mw_3B_();
     push((i64)(strings + 8769));
+    mw_3B_();
+    push((i64)(strings + 8772));
+    mw_3B_();
+    push((i64)(strings + 8796));
+    mw_3B_();
+    push((i64)(strings + 8816));
     mw_3B__3B_();
     mwPRIM_RUNNING_OS();
     mw_2E_p();
-    push((i64)(strings + 8771));
+    push((i64)(strings + 8818));
     mw_3B_();
-    push((i64)(strings + 8774));
+    push((i64)(strings + 8821));
     mw_3B_();
-    push((i64)(strings + 8799));
+    push((i64)(strings + 8846));
     mw_2E_();
     mwWIN32();
     mw_2E_n();
-    push((i64)(strings + 8809));
+    push((i64)(strings + 8856));
     mw_3B_();
-    push((i64)(strings + 8812));
+    push((i64)(strings + 8859));
     mw_3B_();
-    push((i64)(strings + 8839));
+    push((i64)(strings + 8886));
     mw_2E_();
     mwLINUX();
     mw_2E_n();
-    push((i64)(strings + 8849));
+    push((i64)(strings + 8896));
     mw_3B_();
-    push((i64)(strings + 8852));
+    push((i64)(strings + 8899));
     mw_3B_();
-    push((i64)(strings + 8879));
+    push((i64)(strings + 8926));
     mw_2E_();
     mwMACOS();
     mw_2E_n();
-    push((i64)(strings + 8889));
+    push((i64)(strings + 8936));
     mw_3B_();
-    push((i64)(strings + 8892));
+    push((i64)(strings + 8939));
     mw_3B_();
-    push((i64)(strings + 8898));
+    push((i64)(strings + 8945));
     mw_2E_();
     mwUNKNOWN();
     mw_2E_n();
-    push((i64)(strings + 8908));
+    push((i64)(strings + 8955));
     mw_3B_();
-    push((i64)(strings + 8911));
+    push((i64)(strings + 8958));
     mw_3B_();
-    push((i64)(strings + 8918));
+    push((i64)(strings + 8965));
     mw_3B__3B_();
     mwPRIM_CAST();
     mw_2E_p();
-    push((i64)(strings + 8920));
+    push((i64)(strings + 8967));
     mw_3B__3B_();
     mwPRIM_PTR_2B_();
     mw_2E_p();
-    push((i64)(strings + 8925));
+    push((i64)(strings + 8972));
     mw_3B_();
-    push((i64)(strings + 8928));
+    push((i64)(strings + 8975));
     mw_3B_();
-    push((i64)(strings + 8950));
+    push((i64)(strings + 8997));
     mw_3B_();
-    push((i64)(strings + 8968));
+    push((i64)(strings + 9015));
     mw_3B_();
-    push((i64)(strings + 8991));
+    push((i64)(strings + 9038));
     mw_3B__3B_();
     mwPRIM_TRUE();
     mw_2E_p();
-    push((i64)(strings + 8993));
+    push((i64)(strings + 9040));
     mw_3B_();
-    push((i64)(strings + 8996));
-    mw_3B_();
-    push((i64)(strings + 9012));
-    mw_3B_();
-    mwPRIM_FALSE();
-    mw_2E_p();
-    push((i64)(strings + 9014));
-    mw_3B_();
-    push((i64)(strings + 9017));
-    mw_3B_();
-    push((i64)(strings + 9034));
-    mw_3B__3B_();
-    mwPRIM_BOOL_AND();
-    mw_2E_p();
-    push((i64)(strings + 9036));
-    mw_3B_();
-    push((i64)(strings + 9039));
+    push((i64)(strings + 9043));
     mw_3B_();
     push((i64)(strings + 9059));
     mw_3B_();
-    push((i64)(strings + 9079));
+    mwPRIM_FALSE();
+    mw_2E_p();
+    push((i64)(strings + 9061));
     mw_3B_();
-    push((i64)(strings + 9097));
+    push((i64)(strings + 9064));
+    mw_3B_();
+    push((i64)(strings + 9081));
+    mw_3B__3B_();
+    mwPRIM_BOOL_AND();
+    mw_2E_p();
+    push((i64)(strings + 9083));
+    mw_3B_();
+    push((i64)(strings + 9086));
+    mw_3B_();
+    push((i64)(strings + 9106));
+    mw_3B_();
+    push((i64)(strings + 9126));
+    mw_3B_();
+    push((i64)(strings + 9144));
     mw_3B_();
     mwPRIM_BOOL_OR();
     mw_2E_p();
-    push((i64)(strings + 9099));
+    push((i64)(strings + 9146));
     mw_3B_();
-    push((i64)(strings + 9102));
+    push((i64)(strings + 9149));
     mw_3B_();
-    push((i64)(strings + 9122));
+    push((i64)(strings + 9169));
     mw_3B_();
-    push((i64)(strings + 9142));
+    push((i64)(strings + 9189));
     mw_3B_();
-    push((i64)(strings + 9160));
+    push((i64)(strings + 9207));
+    mw_3B__3B_();
+    mwPRIM_ARGC();
+    mw_2E_p();
+    push((i64)(strings + 9209));
+    mw_3B_();
+    push((i64)(strings + 9212));
+    mw_3B_();
+    push((i64)(strings + 9235));
+    mw_3B_();
+    mwPRIM_ARGV();
+    mw_2E_p();
+    push((i64)(strings + 9237));
+    mw_3B_();
+    push((i64)(strings + 9240));
+    mw_3B_();
+    push((i64)(strings + 9268));
     mw_3B__3B_();
 }
 
@@ -13453,7 +13557,7 @@ void mwc99_emit_word_sigs_21_ (void){
     mwc99_emit_word_sig_21_();
     mw1_2B_();
     }
-    push((i64)(strings + 9312));
+    push((i64)(strings + 9420));
     mw_3B_();
     mwdrop();
 }
@@ -13479,12 +13583,16 @@ void mwc99_emit_main_21_ (void){
     mwTYPE_UNIT();
     mwelab_stack_21_();
     mwelab_arrow_21_();
-    push((i64)(strings + 9597));
+    push((i64)(strings + 9705));
+    mw_3B_();
+    push((i64)(strings + 9740));
+    mw_3B_();
+    push((i64)(strings + 9764));
     mw_3B_();
     mwc99_emit_arrow_21_();
-    push((i64)(strings + 9632));
+    push((i64)(strings + 9788));
     mw_3B_();
-    push((i64)(strings + 9646));
+    push((i64)(strings + 9802));
     mw_3B_();
 }
 
@@ -13545,10 +13653,10 @@ void mw_2E_name (void){
 }
 
 void mw_2E_w (void){
-    push((i64)(strings + 3894));
+    push((i64)(strings + 3904));
     mw_2E_();
     mw_2E_name();
-    push((i64)(strings + 3902));
+    push((i64)(strings + 3912));
     mw_2E_();
 }
 
@@ -13560,26 +13668,26 @@ void mw_2E_p (void){
 void mwc99_emit_buffer_21_ (void){
     mwname_is_buffer_3F_();
     if (pop()) {
-    push((i64)(strings + 4837));
+    push((i64)(strings + 4884));
     mw_2E_();
     mwdup();
     mw_2E_name();
-    push((i64)(strings + 4852));
+    push((i64)(strings + 4899));
     mw_2E_();
     mwdup();
     mwname_buffer_40_();
     mwbuffer_size_40_();
     mw_2E_n();
-    push((i64)(strings + 4854));
+    push((i64)(strings + 4901));
     mw_3B_();
-    push((i64)(strings + 4863));
+    push((i64)(strings + 4910));
     mw_2E_();
     mwdup();
     mw_2E_name();
-    push((i64)(strings + 4872));
+    push((i64)(strings + 4919));
     mw_2E_();
     mw_2E_name();
-    push((i64)(strings + 4894));
+    push((i64)(strings + 4941));
     mw_3B_();
     } else {
     mwdrop();
@@ -13595,17 +13703,17 @@ void mwc99_emit_external_21_ (void){
     push(2);
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 9162));
+    push((i64)(strings + 9270));
     mwpanic_21_();
     } else {
     mwdup();
     push(1);
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 9213));
+    push((i64)(strings + 9321));
     mw_2E_();
     } else {
-    push((i64)(strings + 9218));
+    push((i64)(strings + 9326));
     mw_2E_();
     }
     }
@@ -13615,20 +13723,20 @@ void mwc99_emit_external_21_ (void){
     mw_2E_name();
       push(d3); }
       push(d2); }
-    push((i64)(strings + 9224));
+    push((i64)(strings + 9332));
     mw_2E_();
     mwover();
     mwdup();
     mwnonzero();
     if (pop()) {
-    push((i64)(strings + 9227));
+    push((i64)(strings + 9335));
     mw_2E_();
     mw1_();
     while(1) {
     mwdup();
     mwnonzero();
     if (!pop()) break;
-    push((i64)(strings + 9231));
+    push((i64)(strings + 9339));
     mw_2E_();
     mw1_();
     }
@@ -13636,9 +13744,9 @@ void mwc99_emit_external_21_ (void){
     } else {
     mwdrop();
     }
-    push((i64)(strings + 9237));
+    push((i64)(strings + 9345));
     mw_3B_();
-    push((i64)(strings + 9240));
+    push((i64)(strings + 9348));
     mw_2E_();
     { i64 d2 = pop();
     { i64 d3 = pop();
@@ -13646,18 +13754,18 @@ void mwc99_emit_external_21_ (void){
     mw_2E_name();
       push(d3); }
       push(d2); }
-    push((i64)(strings + 9249));
+    push((i64)(strings + 9357));
     mw_3B_();
     mwover();
     while(1) {
     mwdup();
     mwnonzero();
     if (!pop()) break;
-    push((i64)(strings + 9259));
+    push((i64)(strings + 9367));
     mw_2E_();
     mwdup();
     mw_2E_n();
-    push((i64)(strings + 9269));
+    push((i64)(strings + 9377));
     mw_3B_();
     mw1_();
     }
@@ -13665,9 +13773,9 @@ void mwc99_emit_external_21_ (void){
     mwdup();
     mwnonzero();
     if (pop()) {
-    push((i64)(strings + 9279));
+    push((i64)(strings + 9387));
     } else {
-    push((i64)(strings + 9289));
+    push((i64)(strings + 9397));
     }
     mw_2E_();
     { i64 d2 = pop();
@@ -13676,13 +13784,13 @@ void mwc99_emit_external_21_ (void){
     mw_2E_name();
       push(d3); }
       push(d2); }
-    push((i64)(strings + 9294));
+    push((i64)(strings + 9402));
     mw_2E_();
     { i64 d2 = pop();
     mwdup();
     mwnonzero();
     if (pop()) {
-    push((i64)(strings + 9296));
+    push((i64)(strings + 9404));
     mw_2E_();
     mwdup();
     mw1_();
@@ -13690,7 +13798,7 @@ void mwc99_emit_external_21_ (void){
     mwdup();
     mwnonzero();
     if (!pop()) break;
-    push((i64)(strings + 9299));
+    push((i64)(strings + 9407));
     mw_2E_();
     mwdup2();
     mw_();
@@ -13703,17 +13811,17 @@ void mwc99_emit_external_21_ (void){
     mwid();
     }
       push(d2); }
-    push((i64)(strings + 9303));
+    push((i64)(strings + 9411));
     mw_2E_();
     mwdup();
     mwnonzero();
     if (pop()) {
-    push((i64)(strings + 9305));
+    push((i64)(strings + 9413));
     } else {
-    push((i64)(strings + 9308));
+    push((i64)(strings + 9416));
     }
     mw_3B_();
-    push((i64)(strings + 9310));
+    push((i64)(strings + 9418));
     mw_3B_();
     mwdrop3();
     } else {
@@ -13740,10 +13848,10 @@ void mwsig_arity (void){
 void mwc99_emit_word_sig_21_ (void){
     mwname_is_word_3F_();
     if (pop()) {
-    push((i64)(strings + 9575));
+    push((i64)(strings + 9683));
     mw_2E_();
     mw_2E_name();
-    push((i64)(strings + 9584));
+    push((i64)(strings + 9692));
     mw_3B_();
     } else {
     mwdrop();
@@ -13772,50 +13880,50 @@ void mwc99_emit_arrow_op_21_ (void){
     mwarrow_op_is_int_3F_();
     if (pop()) {
     mwarrow_op_int_40_();
-    push((i64)(strings + 9313));
+    push((i64)(strings + 9421));
     mw_2E_();
     mw_2E_n();
-    push((i64)(strings + 9323));
+    push((i64)(strings + 9431));
     mw_3B_();
     } else {
     mwarrow_op_is_str_3F_();
     if (pop()) {
     mwarrow_op_str_40_();
     mwStrLit__3E_Int();
-    push((i64)(strings + 9326));
+    push((i64)(strings + 9434));
     mw_2E_();
     mw_2E_n();
-    push((i64)(strings + 9352));
+    push((i64)(strings + 9460));
     mw_3B_();
     } else {
     mwarrow_op_is_word_3F_();
     if (pop()) {
     mwarrow_op_word_40_();
     mwword_name_40_();
-    push((i64)(strings + 9356));
+    push((i64)(strings + 9464));
     mw_2E_();
     mw_2E_name();
-    push((i64)(strings + 9363));
+    push((i64)(strings + 9471));
     mw_3B_();
     } else {
     mwarrow_op_is_external_3F_();
     if (pop()) {
     mwarrow_op_external_40_();
     mwexternal_name_40_();
-    push((i64)(strings + 9367));
+    push((i64)(strings + 9475));
     mw_2E_();
     mw_2E_name();
-    push((i64)(strings + 9374));
+    push((i64)(strings + 9482));
     mw_3B_();
     } else {
     mwarrow_op_is_buffer_3F_();
     if (pop()) {
     mwarrow_op_buffer_40_();
     mwbuffer_name_40_();
-    push((i64)(strings + 9378));
+    push((i64)(strings + 9486));
     mw_2E_();
     mw_2E_name();
-    push((i64)(strings + 9385));
+    push((i64)(strings + 9493));
     mw_3B_();
     } else {
     mwarrow_op_is_prim_3F_();
@@ -13827,17 +13935,17 @@ void mwc99_emit_arrow_op_21_ (void){
     if (pop()) {
     mwdrop();
     mwarrow_args_1();
-    push((i64)(strings + 9389));
+    push((i64)(strings + 9497));
     mw_2E_();
     mw_2E_d();
-    push((i64)(strings + 9401));
+    push((i64)(strings + 9509));
     mw_3B_();
     mwArg__3E_Arrow();
     mwc99_emit_arrow_21_();
-    push((i64)(strings + 9411));
+    push((i64)(strings + 9519));
     mw_2E_();
     mw_2E_d();
-    push((i64)(strings + 9424));
+    push((i64)(strings + 9532));
     mw_3B_();
     } else {
     mwdup();
@@ -13846,17 +13954,17 @@ void mwc99_emit_arrow_op_21_ (void){
     if (pop()) {
     mwdrop();
     mwarrow_args_2();
-    push((i64)(strings + 9429));
+    push((i64)(strings + 9537));
     mw_3B_();
     { i64 d10 = pop();
     mwArg__3E_Arrow();
     mwc99_emit_arrow_21_();
       push(d10); }
-    push((i64)(strings + 9446));
+    push((i64)(strings + 9554));
     mw_3B_();
     mwArg__3E_Arrow();
     mwc99_emit_arrow_21_();
-    push((i64)(strings + 9459));
+    push((i64)(strings + 9567));
     mw_3B_();
     } else {
     mwdup();
@@ -13865,32 +13973,32 @@ void mwc99_emit_arrow_op_21_ (void){
     if (pop()) {
     mwdrop();
     mwarrow_args_2();
-    push((i64)(strings + 9465));
+    push((i64)(strings + 9573));
     mw_3B_();
     { i64 d11 = pop();
     mwArg__3E_Arrow();
     mwc99_emit_arrow_21_();
       push(d11); }
-    push((i64)(strings + 9480));
+    push((i64)(strings + 9588));
     mw_3B_();
     mwArg__3E_Arrow();
     mwc99_emit_arrow_21_();
-    push((i64)(strings + 9503));
+    push((i64)(strings + 9611));
     mw_3B_();
     } else {
     mwnip();
-    push((i64)(strings + 9509));
+    push((i64)(strings + 9617));
     mw_2E_();
     mwPrim__3E_Name();
     mw_2E_name();
-    push((i64)(strings + 9516));
+    push((i64)(strings + 9624));
     mw_3B_();
     }
     }
     }
     } else {
     mwarrow_token_40_();
-    push((i64)(strings + 9520));
+    push((i64)(strings + 9628));
     mwemit_fatal_error_21_();
     }
     }
@@ -13906,12 +14014,12 @@ void mwc99_emit_word_def_21_ (void){
     if (pop()) {
     mwdup();
     mw_2E_w();
-    push((i64)(strings + 9593));
+    push((i64)(strings + 9701));
     mw_3B_();
     mwname_word_40_();
     mwelab_word_body_21_();
     mwc99_emit_arrow_21_();
-    push((i64)(strings + 9595));
+    push((i64)(strings + 9703));
     mw_3B__3B_();
     } else {
     mwdrop();
@@ -14127,7 +14235,7 @@ void mwelab_type_atom_21_ (void){
     mwelab_type_con_21_();
     } else {
     mwdup();
-    push((i64)(strings + 9648));
+    push((i64)(strings + 9804));
     mwemit_error_21_();
     { i64 d3 = pop();
     mwTYPE_ERROR();
@@ -14191,7 +14299,7 @@ void mwelab_type_con_21_ (void){
     mwtoken_has_args_3F_();
     if (pop()) {
     mwdup();
-    push((i64)(strings + 9682));
+    push((i64)(strings + 9838));
     mwemit_error_21_();
     mwTYPE_ERROR();
     } else {
@@ -14204,13 +14312,13 @@ void mwelab_type_con_21_ (void){
     if (pop()) {
     mwdrop();
     mwdup();
-    push((i64)(strings + 9717));
+    push((i64)(strings + 9873));
     mwemit_error_21_();
     mwTYPE_ERROR();
     } else {
     mwdrop();
     mwdup();
-    push((i64)(strings + 9731));
+    push((i64)(strings + 9887));
     mwemit_error_21_();
     mwTYPE_ERROR();
     }
@@ -14358,7 +14466,7 @@ void mwelab_stack_pop_21_ (void){
     mwtype_get_tensor();
     mwtensor_type_unpack();
     } else {
-    push((i64)(strings + 9743));
+    push((i64)(strings + 9899));
     mwelab_emit_warning_21_();
     mwdrop();
     mwTYPE_ERROR();
@@ -14444,7 +14552,7 @@ void mwelab_arrow_step_21_ (void){
     mwelab_arrow_step_name_21_();
     } else {
     mwdrop();
-    push((i64)(strings + 9772));
+    push((i64)(strings + 9928));
     mwelab_emit_fatal_error_21_();
     }
     }
@@ -14488,7 +14596,7 @@ void mwelab_arrow_step_name_21_ (void){
     mwelab_arrow_step_prim_21_();
     } else {
     mwdrop();
-    push((i64)(strings + 9810));
+    push((i64)(strings + 9966));
     mwelab_emit_fatal_error_21_();
     mwTYPE_ERROR();
     mwelab_stack_21_();
@@ -15192,11 +15300,33 @@ void mwelab_arrow_step_prim_21_ (void){
     mwelab_26__26_();
     mwelab_stack_push_21_();
     } else {
+    mwdup();
+    mwPRIM_ARGC();
+    mw_3D_();
+    if (pop()) {
+    mwdrop();
+    mwelab_token_40_();
+    mwtoken_args_0();
+    mwTYPE_INT();
+    mwelab_stack_push_21_();
+    } else {
+    mwdup();
+    mwPRIM_ARGV();
+    mw_3D_();
+    if (pop()) {
+    mwdrop();
+    mwelab_token_40_();
+    mwtoken_args_0();
+    mwTYPE_PTR();
+    mwelab_stack_push_21_();
+    } else {
     mwdrop();
     mwTYPE_ERROR();
     mwelab_stack_21_();
-    push((i64)(strings + 9900));
+    push((i64)(strings + 10056));
     mwelab_emit_warning_21_();
+    }
+    }
     }
     }
     }
@@ -15338,7 +15468,7 @@ void mwstack_type_concat (void){
     mwtensor_type_new_21_();
     mwTTensor();
     } else {
-    push((i64)(strings + 9823));
+    push((i64)(strings + 9979));
     mwelab_emit_fatal_error_21_();
     }
     }
@@ -15349,7 +15479,7 @@ void mwelab_3F__3F_ (void){
     mwelab_token_40_();
     mwtoken_location();
     mwlocation_trace_21_();
-    push((i64)(strings + 9880));
+    push((i64)(strings + 10036));
     mwstr_trace_21_();
     mwelab_stack_40_();
     mwtype_trace_21_();
@@ -15713,7 +15843,7 @@ void mwelab_module_header_21_ (void){
     mwtoken_next();
     } else {
     mwdup();
-    push((i64)(strings + 9943));
+    push((i64)(strings + 10099));
     mwemit_error_21_();
     }
 }
@@ -15761,7 +15891,7 @@ void mwelab_module_name_21_ (void){
     mwname_defined_3F_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 9967));
+    push((i64)(strings + 10123));
     mwemit_fatal_error_21_();
     } else {
     mwnip();
@@ -15771,7 +15901,7 @@ void mwelab_module_name_21_ (void){
     mwmodule_name_21_();
     }
     } else {
-    push((i64)(strings + 9993));
+    push((i64)(strings + 10149));
     mwemit_fatal_error_21_();
     }
 }
@@ -15793,7 +15923,7 @@ void mwelab_module_import_21_ (void){
     if (pop()) {
     mwnip();
     mwname_load_21_();
-    push((i64)(strings + 10014));
+    push((i64)(strings + 10170));
     mwstr_buf_push_str_21_();
     mwSTR_BUF();
     mwStr__3E_Path();
@@ -15802,12 +15932,12 @@ void mwelab_module_import_21_ (void){
     mwdrop();
     } else {
     mwdrop();
-    push((i64)(strings + 10019));
+    push((i64)(strings + 10175));
     mwemit_fatal_error_21_();
     }
     }
     } else {
-    push((i64)(strings + 10045));
+    push((i64)(strings + 10201));
     mwemit_fatal_error_21_();
     }
 }
@@ -15854,7 +15984,7 @@ void mwelab_module_decl_21_ (void){
     if (pop()) {
     mwelab_target_c99_21_();
     } else {
-    push((i64)(strings + 10066));
+    push((i64)(strings + 10222));
     mwemit_fatal_error_21_();
     }
     }
@@ -15895,11 +16025,11 @@ void mwelab_def_21_ (void){
     mwword_sig_21_();
     } else {
     mwdrop();
-    push((i64)(strings + 10086));
+    push((i64)(strings + 10242));
     mwemit_fatal_error_21_();
     }
     } else {
-    push((i64)(strings + 10107));
+    push((i64)(strings + 10263));
     mwemit_fatal_error_21_();
     }
 }
@@ -15927,12 +16057,12 @@ void mwelab_def_type_21_ (void){
     mwnip();
     } else {
     mwdrop();
-    push((i64)(strings + 10126));
+    push((i64)(strings + 10282));
     mwemit_error_21_();
     mwTYPE_ERROR();
     }
     } else {
-    push((i64)(strings + 10140));
+    push((i64)(strings + 10296));
     mwemit_error_21_();
     mwTYPE_ERROR();
     }
@@ -15940,11 +16070,11 @@ void mwelab_def_type_21_ (void){
     mwname_type_21_();
     } else {
     mwdrop();
-    push((i64)(strings + 10157));
+    push((i64)(strings + 10313));
     mwemit_fatal_error_21_();
     }
     } else {
-    push((i64)(strings + 10178));
+    push((i64)(strings + 10334));
     mwemit_fatal_error_21_();
     }
 }
@@ -15972,12 +16102,12 @@ void mwelab_nominal_21_ (void){
     mwnip();
     } else {
     mwdrop();
-    push((i64)(strings + 10204));
+    push((i64)(strings + 10360));
     mwemit_error_21_();
     mwTYPE_ERROR();
     }
     } else {
-    push((i64)(strings + 10218));
+    push((i64)(strings + 10374));
     mwemit_error_21_();
     mwTYPE_ERROR();
     }
@@ -15989,11 +16119,11 @@ void mwelab_nominal_21_ (void){
     mwname_type_21_();
     } else {
     mwdrop();
-    push((i64)(strings + 10235));
+    push((i64)(strings + 10391));
     mwemit_fatal_error_21_();
     }
     } else {
-    push((i64)(strings + 10256));
+    push((i64)(strings + 10412));
     mwemit_fatal_error_21_();
     }
 }
@@ -16022,16 +16152,16 @@ void mwelab_buffer_21_ (void){
     mwbuffer_alloc_21_();
     mwdrop();
     } else {
-    push((i64)(strings + 10282));
+    push((i64)(strings + 10438));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 10303));
+    push((i64)(strings + 10459));
     mwemit_fatal_error_21_();
     }
     } else {
-    push((i64)(strings + 10326));
+    push((i64)(strings + 10482));
     mwemit_fatal_error_21_();
     }
 }
@@ -16048,7 +16178,7 @@ void mwelab_table_21_ (void){
     mwtable_new_21_();
     mwdrop();
     } else {
-    push((i64)(strings + 10347));
+    push((i64)(strings + 10503));
     mwemit_fatal_error_21_();
     }
 }
@@ -16088,24 +16218,24 @@ void mwelab_field_21_ (void){
     mwdrop();
     } else {
     mwdrop();
-    push((i64)(strings + 10367));
+    push((i64)(strings + 10523));
     mwemit_fatal_error_21_();
     }
     } else {
-    push((i64)(strings + 10386));
+    push((i64)(strings + 10542));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 10406));
+    push((i64)(strings + 10562));
     mwemit_fatal_error_21_();
     }
     } else {
-    push((i64)(strings + 10425));
+    push((i64)(strings + 10581));
     mwemit_fatal_error_21_();
     }
     } else {
-    push((i64)(strings + 10445));
+    push((i64)(strings + 10601));
     mwemit_fatal_error_21_();
     }
 }
@@ -16125,12 +16255,14 @@ void mwelab_target_c99_21_ (void){
     mwStr__3E_Path();
     mwrun_output_c99_21_();
     } else {
-    push((i64)(strings + 10465));
+    push((i64)(strings + 10621));
     mwemit_fatal_error_21_();
     }
 }
 
 int main (int argc, char** argv) {
+    global_argc = argc;
+    global_argv = argv;
     mwmain();
     return 0;
 }

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -37,11 +37,12 @@ static volatile i64 stack[STACK_SIZE] = {0};
 int global_argc;
 char** global_argv;
 
-#define STRINGS_SIZE 10663
+#define STRINGS_SIZE 10695
 static const char strings[STRINGS_SIZE] = { 
-109,105,114,116,104,46,109,116,104,0,
+67,111,109,112,105,108,105,110,103,32,0,
 66,117,105,108,100,105,110,103,46,0,
 68,111,110,101,46,0,
+69,120,112,101,99,116,101,100,32,97,116,32,108,101,97,115,116,32,111,110,101,32,97,114,103,117,109,101,110,116,0,
 109,105,114,116,104,46,99,0,
 73,110,116,45,62,85,56,32,102,97,105,108,101,100,58,32,111,117,116,32,111,102,32,98,111,117,110,100,115,0,
 73,110,116,45,62,85,49,54,32,102,97,105,108,101,100,58,32,111,117,116,32,111,102,32,98,111,117,110,100,115,0,
@@ -1320,14 +1321,18 @@ void mwargv (void) {
  void mwtest_21_ (void);
  void mwtest_prelude_21_ (void);
  void mwNEW_MIRTH_REVISION (void);
+ void mwcompile_21_ (void);
+ void mwstr_trace_21_ (void);
+ void mwPath__3E_Str (void);
+ void mwstr_trace_ln_21_ (void);
+ void mwrun_lexer_21_ (void);
+ void mwelab_module_21_ (void);
  void mwmain (void);
  void mwint_trace_ln_21_ (void);
  void mwptr_40__40_ (void);
- void mwstr_trace_ln_21_ (void);
  void mw1_2B_ (void);
  void mwStr__3E_Path (void);
- void mwrun_lexer_21_ (void);
- void mwelab_module_21_ (void);
+ void mwpanic_21_ (void);
  void mwtrip (void);
  void mwrotr (void);
  void mwrotl (void);
@@ -1398,7 +1403,6 @@ void mwargv (void) {
  void mwquad_21__21_ (void);
  void mwInt__3E_U8 (void);
  void mwin_range (void);
- void mwpanic_21_ (void);
  void mwInt__3E_U16 (void);
  void mwInt__3E_U32 (void);
  void mwInt__3E_U64 (void);
@@ -1449,7 +1453,6 @@ void mwargv (void) {
  void mwstderr (void);
  void mwstr_write_21_ (void);
  void mwstr_print_21_ (void);
- void mwstr_trace_21_ (void);
  void mwstr_print_sp_21_ (void);
  void mwprint_sp_21_ (void);
  void mwstr_trace_sp_21_ (void);
@@ -2409,7 +2412,6 @@ void mwargv (void) {
  void mwmodule_path_21_ (void);
  void mwmodule_path_40_ (void);
  void mwmodule_path_3F_ (void);
- void mwPath__3E_Str (void);
  void mwload_source_path_21_ (void);
  void mwpath_40_ (void);
  void mwpath_21_ (void);
@@ -2566,257 +2568,257 @@ void mwinit_21_ (void){
 }
 
 void mwinit_paths_21_ (void){
-    push((i64)(strings + 3870));
+    push((i64)(strings + 3902));
     mwStr__3E_Path();
     mwsource_path_root_21_();
-    push((i64)(strings + 3874));
+    push((i64)(strings + 3906));
     mwStr__3E_Path();
     mwoutput_path_root_21_();
 }
 
 void mwinit_names_21_ (void){
     mwPRIM_ID();
-    push((i64)(strings + 937));
-    mwdef_prim_21_();
-    mwPRIM_DUP();
-    push((i64)(strings + 940));
-    mwdef_prim_21_();
-    mwPRIM_DROP();
-    push((i64)(strings + 944));
-    mwdef_prim_21_();
-    mwPRIM_SWAP();
-    push((i64)(strings + 949));
-    mwdef_prim_21_();
-    mwPRIM_DIP();
-    push((i64)(strings + 954));
-    mwdef_prim_21_();
-    mwPRIM_IF();
-    push((i64)(strings + 958));
-    mwdef_prim_21_();
-    mwPRIM_WHILE();
-    push((i64)(strings + 961));
-    mwdef_prim_21_();
-    mwPRIM_INT_ADD();
-    push((i64)(strings + 967));
-    mwdef_prim_21_();
-    mwPRIM_INT_SUB();
     push((i64)(strings + 969));
     mwdef_prim_21_();
-    mwPRIM_INT_MUL();
-    push((i64)(strings + 971));
+    mwPRIM_DUP();
+    push((i64)(strings + 972));
     mwdef_prim_21_();
-    mwPRIM_INT_DIV();
-    push((i64)(strings + 973));
+    mwPRIM_DROP();
+    push((i64)(strings + 976));
     mwdef_prim_21_();
-    mwPRIM_INT_MOD();
-    push((i64)(strings + 975));
-    mwdef_prim_21_();
-    mwPRIM_INT_EQ();
-    push((i64)(strings + 977));
-    mwdef_prim_21_();
-    mwPRIM_INT_LT();
-    push((i64)(strings + 979));
-    mwdef_prim_21_();
-    mwPRIM_INT_LE();
+    mwPRIM_SWAP();
     push((i64)(strings + 981));
     mwdef_prim_21_();
-    mwPRIM_INT_AND();
-    push((i64)(strings + 984));
-    mwdef_prim_21_();
-    mwPRIM_INT_OR();
+    mwPRIM_DIP();
     push((i64)(strings + 986));
     mwdef_prim_21_();
-    mwPRIM_INT_XOR();
-    push((i64)(strings + 988));
-    mwdef_prim_21_();
-    mwPRIM_INT_SHL();
+    mwPRIM_IF();
     push((i64)(strings + 990));
     mwdef_prim_21_();
-    mwPRIM_INT_SHR();
+    mwPRIM_WHILE();
     push((i64)(strings + 993));
     mwdef_prim_21_();
-    mwPRIM_MEM_GET();
-    push((i64)(strings + 996));
+    mwPRIM_INT_ADD();
+    push((i64)(strings + 999));
     mwdef_prim_21_();
-    mwPRIM_MEM_SET();
-    push((i64)(strings + 998));
+    mwPRIM_INT_SUB();
+    push((i64)(strings + 1001));
     mwdef_prim_21_();
-    mwPRIM_MEM_GET_BYTE();
-    push((i64)(strings + 1000));
+    mwPRIM_INT_MUL();
+    push((i64)(strings + 1003));
     mwdef_prim_21_();
-    mwPRIM_MEM_SET_BYTE();
-    push((i64)(strings + 1006));
+    mwPRIM_INT_DIV();
+    push((i64)(strings + 1005));
     mwdef_prim_21_();
-    mwPRIM_MEM_GET_U8();
-    push((i64)(strings + 1012));
+    mwPRIM_INT_MOD();
+    push((i64)(strings + 1007));
     mwdef_prim_21_();
-    mwPRIM_MEM_SET_U8();
+    mwPRIM_INT_EQ();
+    push((i64)(strings + 1009));
+    mwdef_prim_21_();
+    mwPRIM_INT_LT();
+    push((i64)(strings + 1011));
+    mwdef_prim_21_();
+    mwPRIM_INT_LE();
+    push((i64)(strings + 1013));
+    mwdef_prim_21_();
+    mwPRIM_INT_AND();
     push((i64)(strings + 1016));
     mwdef_prim_21_();
-    mwPRIM_MEM_GET_U16();
+    mwPRIM_INT_OR();
+    push((i64)(strings + 1018));
+    mwdef_prim_21_();
+    mwPRIM_INT_XOR();
     push((i64)(strings + 1020));
     mwdef_prim_21_();
-    mwPRIM_MEM_SET_U16();
+    mwPRIM_INT_SHL();
+    push((i64)(strings + 1022));
+    mwdef_prim_21_();
+    mwPRIM_INT_SHR();
     push((i64)(strings + 1025));
     mwdef_prim_21_();
-    mwPRIM_MEM_GET_U32();
+    mwPRIM_MEM_GET();
+    push((i64)(strings + 1028));
+    mwdef_prim_21_();
+    mwPRIM_MEM_SET();
     push((i64)(strings + 1030));
     mwdef_prim_21_();
+    mwPRIM_MEM_GET_BYTE();
+    push((i64)(strings + 1032));
+    mwdef_prim_21_();
+    mwPRIM_MEM_SET_BYTE();
+    push((i64)(strings + 1038));
+    mwdef_prim_21_();
+    mwPRIM_MEM_GET_U8();
+    push((i64)(strings + 1044));
+    mwdef_prim_21_();
+    mwPRIM_MEM_SET_U8();
+    push((i64)(strings + 1048));
+    mwdef_prim_21_();
+    mwPRIM_MEM_GET_U16();
+    push((i64)(strings + 1052));
+    mwdef_prim_21_();
+    mwPRIM_MEM_SET_U16();
+    push((i64)(strings + 1057));
+    mwdef_prim_21_();
+    mwPRIM_MEM_GET_U32();
+    push((i64)(strings + 1062));
+    mwdef_prim_21_();
     mwPRIM_MEM_SET_U32();
-    push((i64)(strings + 1035));
+    push((i64)(strings + 1067));
     mwdef_prim_21_();
     mwPRIM_MEM_GET_U64();
-    push((i64)(strings + 1040));
+    push((i64)(strings + 1072));
     mwdef_prim_21_();
     mwPRIM_MEM_SET_U64();
-    push((i64)(strings + 1045));
+    push((i64)(strings + 1077));
     mwdef_prim_21_();
     mwPRIM_MEM_GET_I8();
-    push((i64)(strings + 1050));
+    push((i64)(strings + 1082));
     mwdef_prim_21_();
     mwPRIM_MEM_SET_I8();
-    push((i64)(strings + 1054));
+    push((i64)(strings + 1086));
     mwdef_prim_21_();
     mwPRIM_MEM_GET_I16();
-    push((i64)(strings + 1058));
+    push((i64)(strings + 1090));
     mwdef_prim_21_();
     mwPRIM_MEM_SET_I16();
-    push((i64)(strings + 1063));
+    push((i64)(strings + 1095));
     mwdef_prim_21_();
     mwPRIM_MEM_GET_I32();
-    push((i64)(strings + 1068));
-    mwdef_prim_21_();
-    mwPRIM_MEM_SET_I32();
-    push((i64)(strings + 1073));
-    mwdef_prim_21_();
-    mwPRIM_MEM_GET_I64();
-    push((i64)(strings + 1078));
-    mwdef_prim_21_();
-    mwPRIM_MEM_SET_I64();
-    push((i64)(strings + 1083));
-    mwdef_prim_21_();
-    mwPRIM_POSIX_READ();
-    push((i64)(strings + 1088));
-    mwdef_prim_21_();
-    mwPRIM_POSIX_WRITE();
     push((i64)(strings + 1100));
     mwdef_prim_21_();
+    mwPRIM_MEM_SET_I32();
+    push((i64)(strings + 1105));
+    mwdef_prim_21_();
+    mwPRIM_MEM_GET_I64();
+    push((i64)(strings + 1110));
+    mwdef_prim_21_();
+    mwPRIM_MEM_SET_I64();
+    push((i64)(strings + 1115));
+    mwdef_prim_21_();
+    mwPRIM_POSIX_READ();
+    push((i64)(strings + 1120));
+    mwdef_prim_21_();
+    mwPRIM_POSIX_WRITE();
+    push((i64)(strings + 1132));
+    mwdef_prim_21_();
     mwPRIM_POSIX_OPEN();
-    push((i64)(strings + 1113));
+    push((i64)(strings + 1145));
     mwdef_prim_21_();
     mwPRIM_POSIX_CLOSE();
-    push((i64)(strings + 1125));
+    push((i64)(strings + 1157));
     mwdef_prim_21_();
     mwPRIM_POSIX_EXIT();
-    push((i64)(strings + 1138));
+    push((i64)(strings + 1170));
     mwdef_prim_21_();
     mwPRIM_POSIX_MMAP();
-    push((i64)(strings + 1150));
+    push((i64)(strings + 1182));
     mwdef_prim_21_();
     mwPRIM_DEBUG();
-    push((i64)(strings + 1162));
+    push((i64)(strings + 1194));
     mwdef_prim_21_();
     mwPRIM_MIRTH_REVISION();
-    push((i64)(strings + 1165));
+    push((i64)(strings + 1197));
     mwdef_prim_21_();
     mwPRIM_RUNNING_OS();
-    push((i64)(strings + 1180));
+    push((i64)(strings + 1212));
     mwdef_prim_21_();
     mwPRIM_DEF();
-    push((i64)(strings + 1191));
+    push((i64)(strings + 1223));
     mwdef_prim_21_();
     mwPRIM_DEF_TYPE();
-    push((i64)(strings + 1195));
+    push((i64)(strings + 1227));
     mwdef_prim_21_();
     mwPRIM_BUFFER();
-    push((i64)(strings + 1204));
+    push((i64)(strings + 1236));
     mwdef_prim_21_();
     mwPRIM_DEF_EXTERNAL();
-    push((i64)(strings + 1211));
+    push((i64)(strings + 1243));
     mwdef_prim_21_();
     mwPRIM_OUTPUT_ASM();
-    push((i64)(strings + 1224));
-    mwdef_prim_21_();
-    mwPRIM_TARGET_C99();
-    push((i64)(strings + 1235));
-    mwdef_prim_21_();
-    mwPRIM_DASHES();
-    push((i64)(strings + 1246));
-    mwdef_prim_21_();
-    mwPRIM_ARROW();
-    push((i64)(strings + 1249));
-    mwdef_prim_21_();
-    mwPRIM_INT();
-    push((i64)(strings + 1252));
-    mwdef_prim_21_();
-    mwPRIM_PTR();
     push((i64)(strings + 1256));
     mwdef_prim_21_();
-    mwPRIM_U8();
-    push((i64)(strings + 1260));
-    mwdef_prim_21_();
-    mwPRIM_U16();
-    push((i64)(strings + 1263));
-    mwdef_prim_21_();
-    mwPRIM_U32();
+    mwPRIM_TARGET_C99();
     push((i64)(strings + 1267));
     mwdef_prim_21_();
-    mwPRIM_U64();
-    push((i64)(strings + 1271));
-    mwdef_prim_21_();
-    mwPRIM_I8();
-    push((i64)(strings + 1275));
-    mwdef_prim_21_();
-    mwPRIM_I16();
+    mwPRIM_DASHES();
     push((i64)(strings + 1278));
     mwdef_prim_21_();
+    mwPRIM_ARROW();
+    push((i64)(strings + 1281));
+    mwdef_prim_21_();
+    mwPRIM_INT();
+    push((i64)(strings + 1284));
+    mwdef_prim_21_();
+    mwPRIM_PTR();
+    push((i64)(strings + 1288));
+    mwdef_prim_21_();
+    mwPRIM_U8();
+    push((i64)(strings + 1292));
+    mwdef_prim_21_();
+    mwPRIM_U16();
+    push((i64)(strings + 1295));
+    mwdef_prim_21_();
+    mwPRIM_U32();
+    push((i64)(strings + 1299));
+    mwdef_prim_21_();
+    mwPRIM_U64();
+    push((i64)(strings + 1303));
+    mwdef_prim_21_();
+    mwPRIM_I8();
+    push((i64)(strings + 1307));
+    mwdef_prim_21_();
+    mwPRIM_I16();
+    push((i64)(strings + 1310));
+    mwdef_prim_21_();
     mwPRIM_I32();
-    push((i64)(strings + 1282));
+    push((i64)(strings + 1314));
     mwdef_prim_21_();
     mwPRIM_I64();
-    push((i64)(strings + 1286));
+    push((i64)(strings + 1318));
     mwdef_prim_21_();
     mwPRIM_MODULE();
-    push((i64)(strings + 1290));
+    push((i64)(strings + 1322));
     mwdef_prim_21_();
     mwPRIM_IMPORT();
-    push((i64)(strings + 1297));
-    mwdef_prim_21_();
-    mwPRIM_NOMINAL();
-    push((i64)(strings + 1304));
-    mwdef_prim_21_();
-    mwPRIM_CAST();
-    push((i64)(strings + 1312));
-    mwdef_prim_21_();
-    mwPRIM_PTR_2B_();
     push((i64)(strings + 1329));
     mwdef_prim_21_();
+    mwPRIM_NOMINAL();
+    push((i64)(strings + 1336));
+    mwdef_prim_21_();
+    mwPRIM_CAST();
+    push((i64)(strings + 1344));
+    mwdef_prim_21_();
+    mwPRIM_PTR_2B_();
+    push((i64)(strings + 1361));
+    mwdef_prim_21_();
     mwPRIM_BOOL();
-    push((i64)(strings + 1346));
+    push((i64)(strings + 1378));
     mwdef_prim_21_();
     mwPRIM_TRUE();
-    push((i64)(strings + 1351));
+    push((i64)(strings + 1383));
     mwdef_prim_21_();
     mwPRIM_FALSE();
-    push((i64)(strings + 1356));
+    push((i64)(strings + 1388));
     mwdef_prim_21_();
     mwPRIM_BOOL_AND();
-    push((i64)(strings + 1362));
+    push((i64)(strings + 1394));
     mwdef_prim_21_();
     mwPRIM_BOOL_OR();
-    push((i64)(strings + 1365));
+    push((i64)(strings + 1397));
     mwdef_prim_21_();
     mwPRIM_TABLE();
-    push((i64)(strings + 1368));
+    push((i64)(strings + 1400));
     mwdef_prim_21_();
     mwPRIM_FIELD();
-    push((i64)(strings + 1374));
+    push((i64)(strings + 1406));
     mwdef_prim_21_();
     mwPRIM_ARGC();
-    push((i64)(strings + 1380));
+    push((i64)(strings + 1412));
     mwdef_prim_21_();
     mwPRIM_ARGV();
-    push((i64)(strings + 1385));
+    push((i64)(strings + 1417));
     mwdef_prim_21_();
     mwNUM_PRIMS();
     mwnum_names_40_();
@@ -2825,7 +2827,7 @@ void mwinit_names_21_ (void){
     if (pop()) {
     mwid();
     } else {
-    push((i64)(strings + 1390));
+    push((i64)(strings + 1422));
     mwpanic_21_();
     }
 }
@@ -2909,60 +2911,33 @@ void mwNEW_MIRTH_REVISION (void){
     push(0);
 }
 
-void mwmain (void){
-    mwinit_21_();
-    mwtest_21_();
-    mwargc();
-    mwint_trace_ln_21_();
-    push(0);
-    while(1) {
-    mwdup();
-    mwargc();
-    mw_3C_();
-    if (!pop()) break;
-    mwdup();
-    mwargv();
-    mwptr_40__40_();
-    mwstr_trace_ln_21_();
-    mw1_2B_();
-    }
-    mwdrop();
+void mwcompile_21_ (void){
     push((i64)(strings + 0));
-    mwStr__3E_Path();
+    mwstr_trace_21_();
+    mwdup();
+    mwPath__3E_Str();
+    mwstr_trace_ln_21_();
     mwrun_lexer_21_();
-    push((i64)(strings + 10));
+    push((i64)(strings + 11));
     mwstr_trace_ln_21_();
     mwelab_module_21_();
     mwdrop();
-    push((i64)(strings + 20));
+    push((i64)(strings + 21));
     mwstr_trace_ln_21_();
 }
 
-void mwint_trace_ln_21_ (void){
-    mwint_trace_21_();
-    mwtrace_ln_21_();
+void mwstr_trace_21_ (void){
+    mwstderr();
+    mwstr_write_21_();
 }
 
-void mwptr_40__40_ (void){
-    { i64 d1 = pop();
-    mwptrs();
-      push(d1); }
-    mwptr_2B_();
-    mwptr_40_();
+void mwPath__3E_Str (void){
+    mwcast();
 }
 
 void mwstr_trace_ln_21_ (void){
     mwstr_trace_21_();
     mwtrace_ln_21_();
-}
-
-void mw1_2B_ (void){
-    push(1);
-    mw_2B_();
-}
-
-void mwStr__3E_Path (void){
-    mwcast();
 }
 
 void mwrun_lexer_21_ (void){
@@ -2999,7 +2974,7 @@ void mwrun_lexer_21_ (void){
     mwlexer_emit_21_();
     } else {
     mwlexer_stack_pop_21_();
-    push((i64)(strings + 738));
+    push((i64)(strings + 770));
     mwemit_fatal_error_21_();
     }
     mwnum_tokens_40_();
@@ -3015,6 +2990,69 @@ void mwelab_module_21_ (void){
     mwelab_module_imports_21_();
     mwelab_module_decls_21_();
     mwdrop();
+}
+
+void mwmain (void){
+    mwinit_21_();
+    mwtest_21_();
+    mwargc();
+    mwint_trace_ln_21_();
+    push(0);
+    while(1) {
+    mwdup();
+    mwargc();
+    mw_3C_();
+    if (!pop()) break;
+    mwdup();
+    mwargv();
+    mwptr_40__40_();
+    mwstr_trace_ln_21_();
+    mw1_2B_();
+    }
+    mwdrop();
+    push(1);
+    mwargc();
+    mw_3C_();
+    if (pop()) {
+    push(1);
+    mwargv();
+    mwptr_40__40_();
+    mwStr__3E_Path();
+    mwcompile_21_();
+    } else {
+    push((i64)(strings + 27));
+    mwpanic_21_();
+    }
+}
+
+void mwint_trace_ln_21_ (void){
+    mwint_trace_21_();
+    mwtrace_ln_21_();
+}
+
+void mwptr_40__40_ (void){
+    { i64 d1 = pop();
+    mwptrs();
+      push(d1); }
+    mwptr_2B_();
+    mwptr_40_();
+}
+
+void mw1_2B_ (void){
+    push(1);
+    mw_2B_();
+}
+
+void mwStr__3E_Path (void){
+    mwcast();
+}
+
+void mwpanic_21_ (void){
+    push((i64)(strings + 315));
+    mwstr_trace_21_();
+    mwstr_trace_ln_21_();
+    push(1);
+    mwposix_exit_21_();
 }
 
 void mwtrip (void){
@@ -3407,7 +3445,7 @@ void mwInt__3E_U8 (void){
     if (pop()) {
     mwcast();
     } else {
-    push((i64)(strings + 34));
+    push((i64)(strings + 66));
     mwpanic_21_();
     }
 }
@@ -3423,14 +3461,6 @@ void mwin_range (void){
     mw_26__26_();
 }
 
-void mwpanic_21_ (void){
-    push((i64)(strings + 283));
-    mwstr_trace_21_();
-    mwstr_trace_ln_21_();
-    push(1);
-    mwposix_exit_21_();
-}
-
 void mwInt__3E_U16 (void){
     mwdup();
     mwU16_MIN();
@@ -3439,7 +3469,7 @@ void mwInt__3E_U16 (void){
     if (pop()) {
     mwcast();
     } else {
-    push((i64)(strings + 64));
+    push((i64)(strings + 96));
     mwpanic_21_();
     }
 }
@@ -3453,7 +3483,7 @@ void mwInt__3E_U32 (void){
     mwcast();
     } else {
     mw_3F__3F_();
-    push((i64)(strings + 95));
+    push((i64)(strings + 127));
     mwpanic_21_();
     }
 }
@@ -3470,7 +3500,7 @@ void mwInt__3E_I8 (void){
     if (pop()) {
     mwcast();
     } else {
-    push((i64)(strings + 126));
+    push((i64)(strings + 158));
     mwpanic_21_();
     }
 }
@@ -3483,7 +3513,7 @@ void mwInt__3E_I16 (void){
     if (pop()) {
     mwcast();
     } else {
-    push((i64)(strings + 156));
+    push((i64)(strings + 188));
     mwpanic_21_();
     }
 }
@@ -3496,7 +3526,7 @@ void mwInt__3E_I32 (void){
     if (pop()) {
     mwcast();
     } else {
-    push((i64)(strings + 187));
+    push((i64)(strings + 219));
     mwpanic_21_();
     }
 }
@@ -3667,7 +3697,7 @@ void mwstr_buf_clear_21_ (void){
 void mwstr_buf_push_21_ (void){
     mwstr_buf_full_3F_();
     if (pop()) {
-    push((i64)(strings + 218));
+    push((i64)(strings + 250));
     mwpanic_21_();
     } else {
     mwstr_buf_length_3F_();
@@ -3723,7 +3753,7 @@ void mwstr_buf_int_21_ (void){
     mw0_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 260));
+    push((i64)(strings + 292));
     mwstr_buf_21_();
     } else {
     mwdup();
@@ -3843,11 +3873,6 @@ void mwstr_print_21_ (void){
     mwstr_write_21_();
 }
 
-void mwstr_trace_21_ (void){
-    mwstderr();
-    mwstr_write_21_();
-}
-
 void mwstr_print_sp_21_ (void){
     mwstr_print_21_();
     mwprint_sp_21_();
@@ -3914,7 +3939,7 @@ void mwstr_buf_read_21_ (void){
     mwdup();
     mw0_3C_();
     if (pop()) {
-    push((i64)(strings + 262));
+    push((i64)(strings + 294));
     mwpanic_21_();
     } else {
     mwstr_buf_length_21_();
@@ -3982,7 +4007,7 @@ void mwopen_file_21_ (void){
     push(0);
     mw_3C_();
     if (pop()) {
-    push((i64)(strings + 291));
+    push((i64)(strings + 323));
     mwpanic_21_();
     } else {
     mwInt__3E_File();
@@ -3997,7 +4022,7 @@ void mwcreate_file_21_ (void){
     push(0);
     mw_3C_();
     if (pop()) {
-    push((i64)(strings + 312));
+    push((i64)(strings + 344));
     mwpanic_21_();
     } else {
     mwInt__3E_File();
@@ -4023,7 +4048,7 @@ void mwO_WRONLY_7C_O_CREAT_7C_O_TRUNC (void){
     if (pop()) {
     push(769);
     } else {
-    push((i64)(strings + 335));
+    push((i64)(strings + 367));
     mwpanic_21_();
     }
     }
@@ -4036,7 +4061,7 @@ void mwclose_file_21_ (void){
     push(0);
     mw_3C_();
     if (pop()) {
-    push((i64)(strings + 377));
+    push((i64)(strings + 409));
     mwpanic_21_();
     } else {
     mwid();
@@ -4047,7 +4072,7 @@ void mw_21__21_ (void){
     if (pop()) {
     mwid();
     } else {
-    push((i64)(strings + 398));
+    push((i64)(strings + 430));
     mwpanic_21_();
     }
 }
@@ -4614,7 +4639,7 @@ void mwtest_25_ (void){
 }
 
 void mwtest_str (void){
-    push((i64)(strings + 415));
+    push((i64)(strings + 447));
     mwdup();
     mwu8_40_();
     mwU8__3E_Int();
@@ -4651,15 +4676,15 @@ void mwtest_str (void){
     push(0);
     mw_21__21__3D_();
     mwdrop();
-    push((i64)(strings + 420));
+    push((i64)(strings + 452));
     mwstr_length();
     push(0);
     mw_21__21__3D_();
-    push((i64)(strings + 421));
+    push((i64)(strings + 453));
     mwstr_length();
     push(5);
     mw_21__21__3D_();
-    push((i64)(strings + 427));
+    push((i64)(strings + 459));
     mwstr_length();
     push(13);
     mw_21__21__3D_();
@@ -4862,7 +4887,7 @@ void mwheap_reserve_21_ (void){
     mwheap_length_21_();
     }
     } else {
-    push((i64)(strings + 441));
+    push((i64)(strings + 473));
     mwpanic_21_();
     }
     }
@@ -5011,11 +5036,11 @@ void mwinput_fill_buffer_21_ (void){
     }
     } else {
     mwdrop();
-    push((i64)(strings + 473));
+    push((i64)(strings + 505));
     mwpanic_21_();
     }
     } else {
-    push((i64)(strings + 505));
+    push((i64)(strings + 537));
     mwpanic_21_();
     }
 }
@@ -5050,7 +5075,7 @@ void mwinput_peek (void){
     mwINPUT_BUFFER();
     mwu8_40__40_();
     } else {
-    push((i64)(strings + 563));
+    push((i64)(strings + 595));
     mwpanic_21_();
     }
 }
@@ -5070,7 +5095,7 @@ void mwinput_move_21_ (void){
     mwid();
     }
     } else {
-    push((i64)(strings + 629));
+    push((i64)(strings + 661));
     mwpanic_21_();
     }
 }
@@ -5173,7 +5198,7 @@ void mwlexer_stack_full_3F_ (void){
 void mwlexer_stack_push_21_ (void){
     mwlexer_stack_full_3F_();
     if (pop()) {
-    push((i64)(strings + 695));
+    push((i64)(strings + 727));
     mwpanic_21_();
     } else {
     mwToken__3E_Int();
@@ -5193,7 +5218,7 @@ void mwToken__3E_Int (void){
 void mwlexer_stack_pop_21_ (void){
     mwlexer_stack_empty_3F_();
     if (pop()) {
-    push((i64)(strings + 716));
+    push((i64)(strings + 748));
     mwpanic_21_();
     } else {
     mwlexer_stack_length_40_();
@@ -5550,7 +5575,7 @@ void mwis_rparen_3F_ (void){
 void mwlexer_emit_rparen_21_ (void){
     mwlexer_stack_empty_3F_();
     if (pop()) {
-    push((i64)(strings + 767));
+    push((i64)(strings + 799));
     mwlexer_emit_fatal_error_21_();
     } else {
     mwTOKEN_RPAREN();
@@ -6089,7 +6114,7 @@ void mwlexer_push_string_char_21_ (void){
     mwstr_buf_push_21_();
     } else {
     mwstr_buf_push_21_();
-    push((i64)(strings + 797));
+    push((i64)(strings + 829));
     mwlexer_emit_warning_21_();
     }
     }
@@ -6272,17 +6297,17 @@ void mwlexer_trace_prefix_21_ (void){
     mwlexer_module_40_();
     mwload_module_source_path_21_();
     mwstr_buf_trace_21_();
-    push((i64)(strings + 832));
+    push((i64)(strings + 864));
     mwstr_trace_21_();
     mwlexer_row_40_();
     mwRow__3E_Int();
     mwint_trace_21_();
-    push((i64)(strings + 834));
+    push((i64)(strings + 866));
     mwstr_trace_21_();
     mwlexer_col_40_();
     mwCol__3E_Int();
     mwint_trace_21_();
-    push((i64)(strings + 836));
+    push((i64)(strings + 868));
     mwstr_trace_sp_21_();
 }
 
@@ -6296,7 +6321,7 @@ void mwemit_warning_at_21_ (void){
     { i64 d1 = pop();
     mwlocation_trace_21_();
       push(d1); }
-    push((i64)(strings + 3882));
+    push((i64)(strings + 3914));
     mwstr_trace_21_();
     mwstr_trace_ln_21_();
 }
@@ -6312,7 +6337,7 @@ void mwemit_error_at_21_ (void){
     { i64 d1 = pop();
     mwlocation_trace_21_();
       push(d1); }
-    push((i64)(strings + 3894));
+    push((i64)(strings + 3926));
     mwstr_trace_21_();
     mwstr_trace_ln_21_();
 }
@@ -6712,7 +6737,7 @@ void mwshow_names_table_21_ (void){
     if (!pop()) break;
     mwdup();
     mwint_print_21_();
-    push((i64)(strings + 838));
+    push((i64)(strings + 870));
     mwstr_print_21_();
     mwdup();
     mwInt__3E_Name();
@@ -6735,7 +6760,7 @@ void mwshow_names_table_21_ (void){
     mw1_2B_();
     }
     mwdrop();
-    push((i64)(strings + 841));
+    push((i64)(strings + 873));
     mwstr_print_21_();
     mwname_bytes();
     mw_40_();
@@ -6898,7 +6923,7 @@ void mwName__3E_Prim (void){
     mwNUM_PRIMS();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 855));
+    push((i64)(strings + 887));
     mwpanic_21_();
     } else {
     mwcast();
@@ -7341,7 +7366,7 @@ void mwdef_prim_21_ (void){
     if (pop()) {
     mwid();
     } else {
-    push((i64)(strings + 911));
+    push((i64)(strings + 943));
     mwpanic_21_();
     }
 }
@@ -7500,7 +7525,7 @@ void mwname_sig_40_ (void){
     mwname_external_40_();
     mwexternal_sig_40_();
     } else {
-    push((i64)(strings + 1444));
+    push((i64)(strings + 1476));
     mwpanic_21_();
     }
     }
@@ -7518,7 +7543,7 @@ void mwname_word_40_ (void){
     mwname_value_40_();
     mwNameValue__3E_Word();
     } else {
-    push((i64)(strings + 1585));
+    push((i64)(strings + 1617));
     mwpanic_21_();
     }
 }
@@ -7540,7 +7565,7 @@ void mwname_external_40_ (void){
     mwname_value_40_();
     mwNameValue__3E_External();
     } else {
-    push((i64)(strings + 1652));
+    push((i64)(strings + 1684));
     mwpanic_21_();
     }
 }
@@ -7616,7 +7641,7 @@ void mwname_type_40_ (void){
     mwname_value_40_();
     mwNameValue__3E_Type();
     } else {
-    push((i64)(strings + 1518));
+    push((i64)(strings + 1550));
     mwpanic_21_();
     }
 }
@@ -7662,7 +7687,7 @@ void mwname_buffer_40_ (void){
     mwname_value_40_();
     mwNameValue__3E_Buffer();
     } else {
-    push((i64)(strings + 1727));
+    push((i64)(strings + 1759));
     mwpanic_21_();
     }
 }
@@ -9197,7 +9222,7 @@ void mwtype_get_morphism (void){
     mwtype_is_morphism_3F_();
     mwnot();
     if (pop()) {
-    push((i64)(strings + 1971));
+    push((i64)(strings + 2003));
     mwpanic_21_();
     } else {
     mwtype_get_value();
@@ -9590,7 +9615,7 @@ void mwtype_get_var (void){
     mwtype_is_var_3F_();
     mwnot();
     if (pop()) {
-    push((i64)(strings + 1798));
+    push((i64)(strings + 1830));
     mwpanic_21_();
     } else {
     mwtype_get_value();
@@ -9617,7 +9642,7 @@ void mwtype_get_meta (void){
     mwtype_is_meta_3F_();
     mwnot();
     if (pop()) {
-    push((i64)(strings + 1853));
+    push((i64)(strings + 1885));
     mwpanic_21_();
     } else {
     mwtype_get_value();
@@ -9633,7 +9658,7 @@ void mwtype_get_tensor (void){
     mwtype_is_tensor_3F_();
     mwnot();
     if (pop()) {
-    push((i64)(strings + 1910));
+    push((i64)(strings + 1942));
     mwpanic_21_();
     } else {
     mwtype_get_value();
@@ -9653,7 +9678,7 @@ void mwtype_get_nominal (void){
     mwtype_is_nominal_3F_();
     mwnot();
     if (pop()) {
-    push((i64)(strings + 2036));
+    push((i64)(strings + 2068));
     mwpanic_21_();
     } else {
     mwtype_get_value();
@@ -9669,7 +9694,7 @@ void mwtype_get_table (void){
     mwtype_is_table_3F_();
     mwnot();
     if (pop()) {
-    push((i64)(strings + 2099));
+    push((i64)(strings + 2131));
     mwpanic_21_();
     } else {
     mwtype_get_value();
@@ -9756,7 +9781,7 @@ void mwmeta_alloc_21_ (void){
     mwMetaVar_2E_MAX();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 2345));
+    push((i64)(strings + 2377));
     mwpanic_21_();
     } else {
     mwid();
@@ -9895,12 +9920,12 @@ void mwtype_unify_failed_21_ (void){
     mwelab_token_40_();
     mwtoken_location();
     mwlocation_trace_21_();
-    push((i64)(strings + 2158));
+    push((i64)(strings + 2190));
     mwstr_trace_21_();
     { i64 d1 = pop();
     mwtype_trace_21_();
       push(d1); }
-    push((i64)(strings + 2184));
+    push((i64)(strings + 2216));
     mwstr_trace_21_();
     mwtype_trace_21_();
     mwtrace_ln_21_();
@@ -9925,11 +9950,11 @@ void mwlocation_trace_21_ (void){
     mwswap();
     mwload_module_source_path_21_();
     mwstr_buf_trace_21_();
-    push((i64)(strings + 3809));
+    push((i64)(strings + 3841));
     mwstr_trace_21_();
     mwRow__3E_Int();
     mwint_trace_21_();
-    push((i64)(strings + 3811));
+    push((i64)(strings + 3843));
     mwstr_trace_21_();
     mwCol__3E_Int();
     mwint_trace_21_();
@@ -9950,25 +9975,25 @@ void mwtype_trace_21_ (void){
     mwtype_is_meta_3F_();
     if (pop()) {
     mwtype_get_meta();
-    push((i64)(strings + 2239));
+    push((i64)(strings + 2271));
     mwstr_trace_21_();
     mwMetaVar__3E_Int();
     mwint_trace_21_();
     } else {
     mwtype_is_tensor_3F_();
     if (pop()) {
-    push((i64)(strings + 2241));
+    push((i64)(strings + 2273));
     mwstr_trace_21_();
     mwtype_trace_stack_21_();
-    push((i64)(strings + 2243));
+    push((i64)(strings + 2275));
     mwstr_trace_21_();
     } else {
     mwtype_is_morphism_3F_();
     if (pop()) {
-    push((i64)(strings + 2245));
+    push((i64)(strings + 2277));
     mwstr_trace_21_();
     mwtype_trace_sig_21_();
-    push((i64)(strings + 2247));
+    push((i64)(strings + 2279));
     mwstr_trace_21_();
     } else {
     mwtype_is_nominal_3F_();
@@ -9985,11 +10010,11 @@ void mwtype_trace_21_ (void){
     mwname_load_21_();
     mwstr_buf_trace_21_();
     } else {
-    push((i64)(strings + 2249));
+    push((i64)(strings + 2281));
     mwstr_trace_21_();
     mwType__3E_Int();
     mwint_trace_21_();
-    push((i64)(strings + 2264));
+    push((i64)(strings + 2296));
     mwstr_trace_21_();
     }
     }
@@ -10009,7 +10034,7 @@ void mwmeta_unify_21_ (void){
     mwswap();
     mwtype_has_meta_3F_();
     if (pop()) {
-    push((i64)(strings + 2445));
+    push((i64)(strings + 2477));
     mwelab_emit_error_21_();
     mwdrop();
     mwTYPE_ERROR();
@@ -10103,7 +10128,7 @@ void mwtype_has_meta (void){
     mwdrop2();
     mwfalse();
     } else {
-    push((i64)(strings + 2191));
+    push((i64)(strings + 2223));
     mwpanic_21_();
     }
     }
@@ -10147,7 +10172,7 @@ void mwtype_trace_sig_21_ (void){
     mwTYPE_ERROR();
     mw_3D_();
     if (pop()) {
-    push((i64)(strings + 2219));
+    push((i64)(strings + 2251));
     mwstr_trace_21_();
     mwdrop();
     } else {
@@ -10161,10 +10186,10 @@ void mwtype_trace_sig_21_ (void){
     mwdrop();
     } else {
     mwtype_trace_stack_21_();
-    push((i64)(strings + 2227));
+    push((i64)(strings + 2259));
     mwstr_trace_21_();
     }
-    push((i64)(strings + 2229));
+    push((i64)(strings + 2261));
     mwstr_trace_21_();
     mwmorphism_type_cod_40_();
     mwdup();
@@ -10173,7 +10198,7 @@ void mwtype_trace_sig_21_ (void){
     if (pop()) {
     mwdrop();
     } else {
-    push((i64)(strings + 2232));
+    push((i64)(strings + 2264));
     mwstr_trace_21_();
     mwtype_trace_stack_21_();
     }
@@ -10193,7 +10218,7 @@ void mwtype_trace_stack_21_ (void){
     mwdrop();
     } else {
     mwtype_trace_stack_21_();
-    push((i64)(strings + 2234));
+    push((i64)(strings + 2266));
     mwstr_trace_21_();
     }
     mwtensor_type_snd_40_();
@@ -10204,7 +10229,7 @@ void mwtype_trace_stack_21_ (void){
     mwtype_trace_21_();
     } else {
     mwtype_trace_21_();
-    push((i64)(strings + 2236));
+    push((i64)(strings + 2268));
     mwstr_trace_21_();
     }
     }
@@ -10216,7 +10241,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2266));
+    push((i64)(strings + 2298));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10224,7 +10249,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2272));
+    push((i64)(strings + 2304));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10232,7 +10257,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2275));
+    push((i64)(strings + 2307));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10240,7 +10265,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2280));
+    push((i64)(strings + 2312));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10248,7 +10273,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2284));
+    push((i64)(strings + 2316));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10256,7 +10281,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2288));
+    push((i64)(strings + 2320));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10264,7 +10289,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2291));
+    push((i64)(strings + 2323));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10272,7 +10297,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2295));
+    push((i64)(strings + 2327));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10280,7 +10305,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2299));
+    push((i64)(strings + 2331));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10288,7 +10313,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2303));
+    push((i64)(strings + 2335));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10296,7 +10321,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2306));
+    push((i64)(strings + 2338));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10304,7 +10329,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2310));
+    push((i64)(strings + 2342));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10312,14 +10337,14 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2314));
+    push((i64)(strings + 2346));
     mwstr_trace_21_();
     } else {
-    push((i64)(strings + 2318));
+    push((i64)(strings + 2350));
     mwstr_trace_21_();
     mwType__3E_Int();
     mwint_trace_21_();
-    push((i64)(strings + 2343));
+    push((i64)(strings + 2375));
     mwstr_trace_21_();
     }
     }
@@ -10492,7 +10517,7 @@ void mwmeta_type_40_ (void){
     mwmeta_is_defined_3F_();
     mwnot();
     if (pop()) {
-    push((i64)(strings + 2407));
+    push((i64)(strings + 2439));
     mwpanic_21_();
     } else {
     mwmeta_type_raw_40_();
@@ -10657,7 +10682,7 @@ void mwctx_trace_21_ (void){
     mwdrop();
     } else {
     mwctx_trace_21_();
-    push((i64)(strings + 2467));
+    push((i64)(strings + 2499));
     mwstr_trace_21_();
     }
     mwctx_var_40_();
@@ -10687,7 +10712,7 @@ void mwvar_trace_binding_21_ (void){
     if (pop()) {
     mwdrop();
     } else {
-    push((i64)(strings + 2505));
+    push((i64)(strings + 2537));
     mwstr_trace_21_();
     mwvar_type_40_();
     mwtype_trace_sig_21_();
@@ -10749,7 +10774,7 @@ void mwvar_alloc_21_ (void){
     mwVar_2E_MAX();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 2470));
+    push((i64)(strings + 2502));
     mwpanic_21_();
     } else {
     mwid();
@@ -10792,7 +10817,7 @@ void mwtable_alloc_21_ (void){
     mwTable_2E_MAX();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 2509));
+    push((i64)(strings + 2541));
     mwpanic_21_();
     } else {
     mwid();
@@ -10812,7 +10837,7 @@ void mwtable_new_21_ (void){
     mwtable_max_count_21_();
     mwtable_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2550));
+    push((i64)(strings + 2582));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     mwword_alloc_21_();
@@ -10839,7 +10864,7 @@ void mwtable_new_21_ (void){
     mwword_body_is_checked_21_();
     mwtable_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2555));
+    push((i64)(strings + 2587));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     push(8);
@@ -10848,7 +10873,7 @@ void mwtable_new_21_ (void){
     mwtable_num_buffer_21_();
     mwtable_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2560));
+    push((i64)(strings + 2592));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     mwword_alloc_21_();
@@ -10974,7 +10999,7 @@ void mwfield_alloc_21_ (void){
     mwField_2E_MAX();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 2568));
+    push((i64)(strings + 2600));
     mwpanic_21_();
     } else {
     mwid();
@@ -10991,7 +11016,7 @@ void mwfield_new_21_ (void){
     mwfield_name_21_();
     mwfield_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2609));
+    push((i64)(strings + 2641));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     mwover();
@@ -11004,7 +11029,7 @@ void mwfield_new_21_ (void){
     mwfield_buffer_21_();
     mwfield_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2617));
+    push((i64)(strings + 2649));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     mwword_alloc_21_();
@@ -11052,7 +11077,7 @@ void mwfield_new_21_ (void){
     mwfield_word_ptr_21_();
     mwfield_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2619));
+    push((i64)(strings + 2651));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     mwword_alloc_21_();
@@ -11093,7 +11118,7 @@ void mwfield_new_21_ (void){
     mwword_body_is_checked_21_();
     mwfield_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2621));
+    push((i64)(strings + 2653));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     mwword_alloc_21_();
@@ -11135,7 +11160,7 @@ void mwfield_new_21_ (void){
     mwword_body_is_checked_21_();
     mwfield_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2623));
+    push((i64)(strings + 2655));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     mwword_alloc_21_();
@@ -11301,7 +11326,7 @@ void mwarrow_alloc_21_ (void){
     mwMAX_ARROWS();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 2625));
+    push((i64)(strings + 2657));
     mwpanic_21_();
     } else {
     mwid();
@@ -11437,7 +11462,7 @@ void mwarrow_op_prim_40_ (void){
     mwarrow_op_value_40_();
     mwInt__3E_Prim();
     } else {
-    push((i64)(strings + 2681));
+    push((i64)(strings + 2713));
     mwpanic_21_();
     }
 }
@@ -11465,7 +11490,7 @@ void mwarrow_op_word_40_ (void){
     mwarrow_op_value_40_();
     mwInt__3E_Word();
     } else {
-    push((i64)(strings + 2750));
+    push((i64)(strings + 2782));
     mwpanic_21_();
     }
 }
@@ -11493,7 +11518,7 @@ void mwarrow_op_external_40_ (void){
     mwarrow_op_value_40_();
     mwInt__3E_External();
     } else {
-    push((i64)(strings + 2819));
+    push((i64)(strings + 2851));
     mwpanic_21_();
     }
 }
@@ -11521,7 +11546,7 @@ void mwarrow_op_buffer_40_ (void){
     mwarrow_op_value_40_();
     mwInt__3E_Buffer();
     } else {
-    push((i64)(strings + 2896));
+    push((i64)(strings + 2928));
     mwpanic_21_();
     }
 }
@@ -11545,7 +11570,7 @@ void mwarrow_op_int_40_ (void){
     if (pop()) {
     mwarrow_op_value_40_();
     } else {
-    push((i64)(strings + 2973));
+    push((i64)(strings + 3005));
     mwpanic_21_();
     }
 }
@@ -11573,7 +11598,7 @@ void mwarrow_op_str_40_ (void){
     mwarrow_op_value_40_();
     mwInt__3E_StrLit();
     } else {
-    push((i64)(strings + 3040));
+    push((i64)(strings + 3072));
     mwpanic_21_();
     }
 }
@@ -11680,7 +11705,7 @@ void mwarrow_args_0 (void){
     mwdrop();
     } else {
     mwarrow_token_40_();
-    push((i64)(strings + 3107));
+    push((i64)(strings + 3139));
     mwemit_fatal_error_21_();
     }
 }
@@ -11695,7 +11720,7 @@ void mwarrow_args_1 (void){
     mwargs_head_40_();
     } else {
     mwarrow_token_40_();
-    push((i64)(strings + 3149));
+    push((i64)(strings + 3181));
     mwemit_fatal_error_21_();
     }
 }
@@ -11713,7 +11738,7 @@ void mwarrow_args_2 (void){
     mwargs_head_40_();
     } else {
     mwarrow_token_40_();
-    push((i64)(strings + 3189));
+    push((i64)(strings + 3221));
     mwemit_fatal_error_21_();
     }
 }
@@ -11746,7 +11771,7 @@ void mwsubst_alloc_21_ (void){
     mwSubst_2E_MAX();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 3230));
+    push((i64)(strings + 3262));
     mwpanic_21_();
     } else {
     mwid();
@@ -11850,7 +11875,7 @@ void mwstrings_push_21_ (void){
     mwMAX_STRINGS();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 3253));
+    push((i64)(strings + 3285));
     mwpanic_21_();
     } else {
     mwstrings_size_40_();
@@ -11910,52 +11935,52 @@ void mwtoken_type_str (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 3277));
+    push((i64)(strings + 3309));
     } else {
     mwdup();
     mwTOKEN_LPAREN();
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 3282));
+    push((i64)(strings + 3314));
     } else {
     mwdup();
     mwTOKEN_RPAREN();
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 3289));
+    push((i64)(strings + 3321));
     } else {
     mwdup();
     mwTOKEN_COMMA();
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 3296));
+    push((i64)(strings + 3328));
     } else {
     mwdup();
     mwTOKEN_NAME();
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 3302));
+    push((i64)(strings + 3334));
     } else {
     mwdup();
     mwTOKEN_INT();
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 3307));
+    push((i64)(strings + 3339));
     } else {
     mwdup();
     mwTOKEN_STR();
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 3311));
+    push((i64)(strings + 3343));
     } else {
     mwdrop();
-    push((i64)(strings + 3315));
+    push((i64)(strings + 3347));
     }
     }
     }
@@ -12004,7 +12029,7 @@ void mwtoken_int_40_ (void){
     mwtoken_value_40_();
     mwTokenValue__3E_Int();
     } else {
-    push((i64)(strings + 3329));
+    push((i64)(strings + 3361));
     mwemit_fatal_error_21_();
     }
 }
@@ -12028,7 +12053,7 @@ void mwtoken_str_40_ (void){
     mwtoken_value_40_();
     mwTokenValue__3E_Str();
     } else {
-    push((i64)(strings + 3380));
+    push((i64)(strings + 3412));
     mwemit_fatal_error_21_();
     }
 }
@@ -12052,7 +12077,7 @@ void mwtoken_name_40_ (void){
     mwtoken_value_40_();
     mwTokenValue__3E_Name();
     } else {
-    push((i64)(strings + 3431));
+    push((i64)(strings + 3463));
     mwemit_fatal_error_21_();
     }
 }
@@ -12077,7 +12102,7 @@ void mwtoken_token_40_ (void){
     mwtoken_value_40_();
     mwTokenValue__3E_Token();
     } else {
-    push((i64)(strings + 3484));
+    push((i64)(strings + 3516));
     mwemit_fatal_error_21_();
     }
     }
@@ -12092,7 +12117,7 @@ void mwtoken_print_21_ (void){
     mwdup();
     mwtoken_location();
     mwlocation_print_21_();
-    push((i64)(strings + 3539));
+    push((i64)(strings + 3571));
     mwstr_print_21_();
     mwdup();
     mwToken__3E_Int();
@@ -12133,11 +12158,11 @@ void mwlocation_print_21_ (void){
     mwswap();
     mwload_module_source_path_21_();
     mwstr_buf_print_21_();
-    push((i64)(strings + 3813));
+    push((i64)(strings + 3845));
     mwstr_print_21_();
     mwRow__3E_Int();
     mwint_print_21_();
-    push((i64)(strings + 3815));
+    push((i64)(strings + 3847));
     mwstr_print_21_();
     mwCol__3E_Int();
     mwint_print_21_();
@@ -12232,7 +12257,7 @@ void mwtoken_has_args_3F_ (void){
 void mwtoken_args_0 (void){
     mwtoken_has_args_3F_();
     if (pop()) {
-    push((i64)(strings + 3542));
+    push((i64)(strings + 3574));
     mwemit_fatal_error_21_();
     } else {
     mwdrop();
@@ -12254,12 +12279,12 @@ void mwtoken_args_1 (void){
     mwdrop2();
     } else {
     mwdrop();
-    push((i64)(strings + 3559));
+    push((i64)(strings + 3591));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 3588));
+    push((i64)(strings + 3620));
     mwemit_fatal_error_21_();
     }
 }
@@ -12286,17 +12311,17 @@ void mwtoken_args_2 (void){
     mwdrop2();
     } else {
     mwdrop();
-    push((i64)(strings + 3613));
+    push((i64)(strings + 3645));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 3643));
+    push((i64)(strings + 3675));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 3671));
+    push((i64)(strings + 3703));
     mwemit_fatal_error_21_();
     }
 }
@@ -12330,22 +12355,22 @@ void mwtoken_args_3 (void){
     mwdrop2();
     } else {
     mwdrop();
-    push((i64)(strings + 3697));
+    push((i64)(strings + 3729));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 3727));
+    push((i64)(strings + 3759));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 3755));
+    push((i64)(strings + 3787));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 3783));
+    push((i64)(strings + 3815));
     mwemit_fatal_error_21_();
     }
 }
@@ -12387,7 +12412,7 @@ void mwmodule_alloc_21_ (void){
     mwMAX_MODULES();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 3817));
+    push((i64)(strings + 3849));
     mwpanic_21_();
     } else {
     mwid();
@@ -12401,7 +12426,7 @@ void mwmodule_path_21_ (void){
     mwMODULE_PATH_SIZE();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 3845));
+    push((i64)(strings + 3877));
     mwpanic_21_();
     } else {
     mwmodule_path_40_();
@@ -12425,10 +12450,6 @@ void mwmodule_path_40_ (void){
 void mwmodule_path_3F_ (void){
     mwdup();
     mwmodule_path_40_();
-}
-
-void mwPath__3E_Str (void){
-    mwcast();
 }
 
 void mwload_source_path_21_ (void){
@@ -12476,9 +12497,9 @@ void mwpath_separator (void){
     mwWIN32();
     mw_3D_();
     if (pop()) {
-    push((i64)(strings + 3878));
+    push((i64)(strings + 3910));
     } else {
-    push((i64)(strings + 3880));
+    push((i64)(strings + 3912));
     }
 }
 
@@ -12652,82 +12673,82 @@ void mwrun_output_c99_21_ (void){
 }
 
 void mwc99_emit_header_21_ (void){
-    push((i64)(strings + 3920));
+    push((i64)(strings + 3952));
     mw_3B_();
-    push((i64)(strings + 3959));
+    push((i64)(strings + 3991));
     mw_3B_();
-    push((i64)(strings + 4038));
+    push((i64)(strings + 4070));
     mw_3B_();
-    push((i64)(strings + 4060));
+    push((i64)(strings + 4092));
     mw_3B_();
-    push((i64)(strings + 4085));
+    push((i64)(strings + 4117));
     mw_3B_();
-    push((i64)(strings + 4107));
+    push((i64)(strings + 4139));
     mw_3B_();
-    push((i64)(strings + 4132));
+    push((i64)(strings + 4164));
     mw_3B_();
-    push((i64)(strings + 4154));
+    push((i64)(strings + 4186));
     mw_3B_();
-    push((i64)(strings + 4160));
+    push((i64)(strings + 4192));
     mw_3B_();
-    push((i64)(strings + 4193));
+    push((i64)(strings + 4225));
     mw_3B__3B_();
-    push((i64)(strings + 4200));
+    push((i64)(strings + 4232));
     mw_3B_();
-    push((i64)(strings + 4220));
+    push((i64)(strings + 4252));
     mw_3B__3B_();
-    push((i64)(strings + 4241));
+    push((i64)(strings + 4273));
     mw_3B_();
-    push((i64)(strings + 4261));
+    push((i64)(strings + 4293));
     mw_3B_();
-    push((i64)(strings + 4283));
+    push((i64)(strings + 4315));
     mw_3B_();
-    push((i64)(strings + 4305));
+    push((i64)(strings + 4337));
     mw_3B_();
-    push((i64)(strings + 4327));
+    push((i64)(strings + 4359));
     mw_3B_();
-    push((i64)(strings + 4346));
+    push((i64)(strings + 4378));
     mw_3B_();
-    push((i64)(strings + 4367));
+    push((i64)(strings + 4399));
     mw_3B_();
-    push((i64)(strings + 4388));
+    push((i64)(strings + 4420));
     mw_3B_();
-    push((i64)(strings + 4409));
+    push((i64)(strings + 4441));
     mw_3B__3B_();
-    push((i64)(strings + 4434));
+    push((i64)(strings + 4466));
     mw_3B_();
-    push((i64)(strings + 4485));
+    push((i64)(strings + 4517));
     mw_3B_();
-    push((i64)(strings + 4513));
+    push((i64)(strings + 4545));
     mw_3B_();
-    push((i64)(strings + 4549));
+    push((i64)(strings + 4581));
     mw_3B_();
-    push((i64)(strings + 4586));
+    push((i64)(strings + 4618));
     mw_3B_();
-    push((i64)(strings + 4609));
+    push((i64)(strings + 4641));
     mw_3B_();
-    push((i64)(strings + 4643));
+    push((i64)(strings + 4675));
     mw_3B__3B_();
-    push((i64)(strings + 4666));
+    push((i64)(strings + 4698));
     mw_3B_();
-    push((i64)(strings + 4690));
+    push((i64)(strings + 4722));
     mw_3B_();
-    push((i64)(strings + 4729));
+    push((i64)(strings + 4761));
     mw_3B__3B_();
-    push((i64)(strings + 4774));
+    push((i64)(strings + 4806));
     mw_3B_();
-    push((i64)(strings + 4791));
+    push((i64)(strings + 4823));
     mw_3B__3B_();
 }
 
 void mwc99_emit_strings_21_ (void){
-    push((i64)(strings + 4811));
+    push((i64)(strings + 4843));
     mw_2E_();
     mwstrings_size_40_();
     mw_2E_n();
-    push((i64)(strings + 4833));
+    push((i64)(strings + 4865));
     mw_3B_();
-    push((i64)(strings + 4834));
+    push((i64)(strings + 4866));
     mw_3B_();
     push(0);
     while(1) {
@@ -12741,7 +12762,7 @@ void mwc99_emit_strings_21_ (void){
     mwU8__3E_Int();
     mwdup();
     mw_2E_n();
-    push((i64)(strings + 4879));
+    push((i64)(strings + 4911));
     mw_2E_();
     mwnonzero();
     if (pop()) {
@@ -12752,764 +12773,764 @@ void mwc99_emit_strings_21_ (void){
     mw1_2B_();
     }
     mwdrop();
-    push((i64)(strings + 4881));
+    push((i64)(strings + 4913));
     mw_3B__3B_();
 }
 
 void mwc99_emit_prims_21_ (void){
-    push((i64)(strings + 4946));
+    push((i64)(strings + 4978));
     mw_3B_();
-    push((i64)(strings + 4964));
+    push((i64)(strings + 4996));
     mw_3B_();
-    push((i64)(strings + 4991));
+    push((i64)(strings + 5023));
     mw_3B_();
-    push((i64)(strings + 5019));
+    push((i64)(strings + 5051));
     mw_3B_();
-    push((i64)(strings + 5032));
+    push((i64)(strings + 5064));
     mw_3B_();
-    push((i64)(strings + 5075));
+    push((i64)(strings + 5107));
     mw_3B_();
-    push((i64)(strings + 5092));
-    mw_3B_();
-    push((i64)(strings + 5110));
-    mw_3B_();
-    push((i64)(strings + 5116));
-    mw_3B__3B_();
-    push((i64)(strings + 5118));
+    push((i64)(strings + 5124));
     mw_3B_();
     push((i64)(strings + 5142));
     mw_3B_();
-    push((i64)(strings + 5166));
-    mw_3B_();
-    push((i64)(strings + 5187));
+    push((i64)(strings + 5148));
     mw_3B__3B_();
-    push((i64)(strings + 5189));
+    push((i64)(strings + 5150));
     mw_3B_();
-    push((i64)(strings + 5209));
+    push((i64)(strings + 5174));
     mw_3B_();
-    push((i64)(strings + 5228));
+    push((i64)(strings + 5198));
     mw_3B_();
-    push((i64)(strings + 5246));
+    push((i64)(strings + 5219));
     mw_3B__3B_();
-    push((i64)(strings + 5248));
+    push((i64)(strings + 5221));
     mw_3B_();
-    push((i64)(strings + 5270));
+    push((i64)(strings + 5241));
     mw_3B_();
-    push((i64)(strings + 5289));
+    push((i64)(strings + 5260));
     mw_3B_();
-    push((i64)(strings + 5308));
+    push((i64)(strings + 5278));
     mw_3B__3B_();
-    push((i64)(strings + 5310));
+    push((i64)(strings + 5280));
     mw_3B_();
-    push((i64)(strings + 5332));
+    push((i64)(strings + 5302));
     mw_3B_();
-    push((i64)(strings + 5351));
+    push((i64)(strings + 5321));
     mw_3B_();
-    push((i64)(strings + 5370));
+    push((i64)(strings + 5340));
     mw_3B__3B_();
-    push((i64)(strings + 5372));
+    push((i64)(strings + 5342));
     mw_3B_();
-    push((i64)(strings + 5394));
+    push((i64)(strings + 5364));
     mw_3B_();
-    push((i64)(strings + 5413));
+    push((i64)(strings + 5383));
     mw_3B_();
-    push((i64)(strings + 5432));
+    push((i64)(strings + 5402));
     mw_3B__3B_();
-    push((i64)(strings + 5434));
+    push((i64)(strings + 5404));
     mw_3B_();
-    push((i64)(strings + 5454));
+    push((i64)(strings + 5426));
     mw_3B_();
-    push((i64)(strings + 5473));
+    push((i64)(strings + 5445));
     mw_3B_();
-    push((i64)(strings + 5491));
+    push((i64)(strings + 5464));
     mw_3B__3B_();
-    push((i64)(strings + 5493));
+    push((i64)(strings + 5466));
     mw_3B_();
-    push((i64)(strings + 5515));
+    push((i64)(strings + 5486));
     mw_3B_();
-    push((i64)(strings + 5534));
+    push((i64)(strings + 5505));
     mw_3B_();
-    push((i64)(strings + 5553));
+    push((i64)(strings + 5523));
     mw_3B__3B_();
-    push((i64)(strings + 5555));
+    push((i64)(strings + 5525));
     mw_3B_();
-    push((i64)(strings + 5577));
+    push((i64)(strings + 5547));
     mw_3B_();
-    push((i64)(strings + 5596));
+    push((i64)(strings + 5566));
     mw_3B_();
-    push((i64)(strings + 5615));
+    push((i64)(strings + 5585));
     mw_3B__3B_();
-    push((i64)(strings + 5617));
+    push((i64)(strings + 5587));
     mw_3B_();
-    push((i64)(strings + 5639));
+    push((i64)(strings + 5609));
     mw_3B_();
-    push((i64)(strings + 5657));
+    push((i64)(strings + 5628));
+    mw_3B_();
+    push((i64)(strings + 5647));
     mw_3B__3B_();
-    push((i64)(strings + 5659));
+    push((i64)(strings + 5649));
     mw_3B_();
-    push((i64)(strings + 5680));
+    push((i64)(strings + 5671));
     mw_3B_();
-    push((i64)(strings + 5698));
+    push((i64)(strings + 5689));
+    mw_3B__3B_();
+    push((i64)(strings + 5691));
     mw_3B_();
-    push((i64)(strings + 5723));
+    push((i64)(strings + 5712));
     mw_3B_();
-    push((i64)(strings + 5736));
+    push((i64)(strings + 5730));
     mw_3B_();
-    push((i64)(strings + 5778));
+    push((i64)(strings + 5755));
     mw_3B_();
-    push((i64)(strings + 5795));
+    push((i64)(strings + 5768));
     mw_3B_();
-    push((i64)(strings + 5801));
+    push((i64)(strings + 5810));
+    mw_3B_();
+    push((i64)(strings + 5827));
+    mw_3B_();
+    push((i64)(strings + 5833));
     mw_3B__3B_();
     mwPRIM_ID();
     mw_2E_p();
-    push((i64)(strings + 5803));
+    push((i64)(strings + 5835));
     mw_3B_();
-    push((i64)(strings + 5806));
+    push((i64)(strings + 5838));
     mw_3B__3B_();
     mwPRIM_DUP();
     mw_2E_p();
-    push((i64)(strings + 5808));
+    push((i64)(strings + 5840));
     mw_3B_();
-    push((i64)(strings + 5811));
+    push((i64)(strings + 5843));
     mw_3B_();
-    push((i64)(strings + 5830));
+    push((i64)(strings + 5862));
     mw_3B_();
-    push((i64)(strings + 5852));
+    push((i64)(strings + 5884));
     mw_3B__3B_();
     mwPRIM_DROP();
     mw_2E_p();
-    push((i64)(strings + 5854));
+    push((i64)(strings + 5886));
     mw_3B_();
-    push((i64)(strings + 5857));
+    push((i64)(strings + 5889));
     mw_3B_();
-    push((i64)(strings + 5868));
+    push((i64)(strings + 5900));
     mw_3B__3B_();
     mwPRIM_SWAP();
     mw_2E_p();
-    push((i64)(strings + 5870));
+    push((i64)(strings + 5902));
     mw_3B_();
-    push((i64)(strings + 5873));
+    push((i64)(strings + 5905));
     mw_3B_();
-    push((i64)(strings + 5892));
+    push((i64)(strings + 5924));
     mw_3B_();
-    push((i64)(strings + 5911));
+    push((i64)(strings + 5943));
     mw_3B_();
-    push((i64)(strings + 5933));
+    push((i64)(strings + 5965));
     mw_3B__3B_();
     mwPRIM_INT_ADD();
     mw_2E_p();
-    push((i64)(strings + 5935));
+    push((i64)(strings + 5967));
     mw_3B_();
-    push((i64)(strings + 5938));
+    push((i64)(strings + 5970));
     mw_3B_();
-    push((i64)(strings + 5957));
+    push((i64)(strings + 5989));
     mw_3B_();
-    push((i64)(strings + 5976));
+    push((i64)(strings + 6008));
     mw_3B_();
-    push((i64)(strings + 5993));
+    push((i64)(strings + 6025));
     mw_3B__3B_();
     mwPRIM_INT_SUB();
     mw_2E_p();
-    push((i64)(strings + 5995));
+    push((i64)(strings + 6027));
     mw_3B_();
-    push((i64)(strings + 5998));
+    push((i64)(strings + 6030));
     mw_3B_();
-    push((i64)(strings + 6017));
+    push((i64)(strings + 6049));
     mw_3B_();
-    push((i64)(strings + 6036));
+    push((i64)(strings + 6068));
     mw_3B_();
-    push((i64)(strings + 6053));
+    push((i64)(strings + 6085));
     mw_3B__3B_();
     mwPRIM_INT_MUL();
     mw_2E_p();
-    push((i64)(strings + 6055));
+    push((i64)(strings + 6087));
     mw_3B_();
-    push((i64)(strings + 6058));
+    push((i64)(strings + 6090));
     mw_3B_();
-    push((i64)(strings + 6077));
+    push((i64)(strings + 6109));
     mw_3B_();
-    push((i64)(strings + 6096));
+    push((i64)(strings + 6128));
     mw_3B_();
-    push((i64)(strings + 6113));
+    push((i64)(strings + 6145));
     mw_3B__3B_();
     mwPRIM_INT_DIV();
     mw_2E_p();
-    push((i64)(strings + 6115));
+    push((i64)(strings + 6147));
     mw_3B_();
-    push((i64)(strings + 6118));
+    push((i64)(strings + 6150));
     mw_3B_();
-    push((i64)(strings + 6137));
+    push((i64)(strings + 6169));
     mw_3B_();
-    push((i64)(strings + 6156));
+    push((i64)(strings + 6188));
     mw_3B_();
-    push((i64)(strings + 6173));
+    push((i64)(strings + 6205));
     mw_3B__3B_();
     mwPRIM_INT_MOD();
     mw_2E_p();
-    push((i64)(strings + 6175));
+    push((i64)(strings + 6207));
     mw_3B_();
-    push((i64)(strings + 6178));
+    push((i64)(strings + 6210));
     mw_3B_();
-    push((i64)(strings + 6197));
+    push((i64)(strings + 6229));
     mw_3B_();
-    push((i64)(strings + 6216));
+    push((i64)(strings + 6248));
     mw_3B_();
-    push((i64)(strings + 6233));
+    push((i64)(strings + 6265));
     mw_3B__3B_();
     mwPRIM_INT_EQ();
     mw_2E_p();
-    push((i64)(strings + 6235));
+    push((i64)(strings + 6267));
     mw_3B_();
-    push((i64)(strings + 6238));
+    push((i64)(strings + 6270));
     mw_3B_();
-    push((i64)(strings + 6257));
+    push((i64)(strings + 6289));
     mw_3B_();
-    push((i64)(strings + 6276));
+    push((i64)(strings + 6308));
     mw_3B_();
-    push((i64)(strings + 6294));
+    push((i64)(strings + 6326));
     mw_3B__3B_();
     mwPRIM_INT_LT();
     mw_2E_p();
-    push((i64)(strings + 6296));
+    push((i64)(strings + 6328));
     mw_3B_();
-    push((i64)(strings + 6299));
+    push((i64)(strings + 6331));
     mw_3B_();
-    push((i64)(strings + 6318));
+    push((i64)(strings + 6350));
     mw_3B_();
-    push((i64)(strings + 6337));
+    push((i64)(strings + 6369));
     mw_3B_();
-    push((i64)(strings + 6354));
+    push((i64)(strings + 6386));
     mw_3B__3B_();
     mwPRIM_INT_LE();
     mw_2E_p();
-    push((i64)(strings + 6356));
+    push((i64)(strings + 6388));
     mw_3B_();
-    push((i64)(strings + 6359));
+    push((i64)(strings + 6391));
     mw_3B_();
-    push((i64)(strings + 6378));
+    push((i64)(strings + 6410));
     mw_3B_();
-    push((i64)(strings + 6397));
+    push((i64)(strings + 6429));
     mw_3B_();
-    push((i64)(strings + 6415));
+    push((i64)(strings + 6447));
     mw_3B__3B_();
     mwPRIM_INT_AND();
     mw_2E_p();
-    push((i64)(strings + 6417));
+    push((i64)(strings + 6449));
     mw_3B_();
-    push((i64)(strings + 6420));
+    push((i64)(strings + 6452));
     mw_3B_();
-    push((i64)(strings + 6439));
+    push((i64)(strings + 6471));
     mw_3B_();
-    push((i64)(strings + 6458));
+    push((i64)(strings + 6490));
     mw_3B_();
-    push((i64)(strings + 6475));
+    push((i64)(strings + 6507));
     mw_3B__3B_();
     mwPRIM_INT_OR();
     mw_2E_p();
-    push((i64)(strings + 6477));
+    push((i64)(strings + 6509));
     mw_3B_();
-    push((i64)(strings + 6480));
+    push((i64)(strings + 6512));
     mw_3B_();
-    push((i64)(strings + 6499));
+    push((i64)(strings + 6531));
     mw_3B_();
-    push((i64)(strings + 6518));
+    push((i64)(strings + 6550));
     mw_3B_();
-    push((i64)(strings + 6535));
+    push((i64)(strings + 6567));
     mw_3B__3B_();
     mwPRIM_INT_XOR();
     mw_2E_p();
-    push((i64)(strings + 6537));
+    push((i64)(strings + 6569));
     mw_3B_();
-    push((i64)(strings + 6540));
+    push((i64)(strings + 6572));
     mw_3B_();
-    push((i64)(strings + 6559));
+    push((i64)(strings + 6591));
     mw_3B_();
-    push((i64)(strings + 6578));
+    push((i64)(strings + 6610));
     mw_3B_();
-    push((i64)(strings + 6595));
+    push((i64)(strings + 6627));
     mw_3B__3B_();
     mwPRIM_INT_SHL();
     mw_2E_p();
-    push((i64)(strings + 6597));
+    push((i64)(strings + 6629));
     mw_3B_();
-    push((i64)(strings + 6600));
+    push((i64)(strings + 6632));
     mw_3B_();
-    push((i64)(strings + 6619));
+    push((i64)(strings + 6651));
     mw_3B_();
-    push((i64)(strings + 6638));
+    push((i64)(strings + 6670));
     mw_3B_();
-    push((i64)(strings + 6656));
+    push((i64)(strings + 6688));
     mw_3B__3B_();
     mwPRIM_INT_SHR();
     mw_2E_p();
-    push((i64)(strings + 6658));
+    push((i64)(strings + 6690));
     mw_3B_();
-    push((i64)(strings + 6661));
+    push((i64)(strings + 6693));
     mw_3B_();
-    push((i64)(strings + 6680));
+    push((i64)(strings + 6712));
     mw_3B_();
-    push((i64)(strings + 6699));
+    push((i64)(strings + 6731));
     mw_3B_();
-    push((i64)(strings + 6717));
+    push((i64)(strings + 6749));
     mw_3B__3B_();
     mwPRIM_POSIX_WRITE();
     mw_2E_p();
-    push((i64)(strings + 6719));
+    push((i64)(strings + 6751));
     mw_3B_();
-    push((i64)(strings + 6722));
+    push((i64)(strings + 6754));
     mw_3B_();
-    push((i64)(strings + 6750));
+    push((i64)(strings + 6782));
     mw_3B_();
-    push((i64)(strings + 6775));
+    push((i64)(strings + 6807));
     mw_3B_();
-    push((i64)(strings + 6799));
+    push((i64)(strings + 6831));
     mw_3B_();
-    push((i64)(strings + 6819));
+    push((i64)(strings + 6851));
     mw_3B__3B_();
     mwPRIM_POSIX_READ();
     mw_2E_p();
-    push((i64)(strings + 6821));
+    push((i64)(strings + 6853));
     mw_3B_();
-    push((i64)(strings + 6824));
+    push((i64)(strings + 6856));
     mw_3B_();
-    push((i64)(strings + 6852));
+    push((i64)(strings + 6884));
     mw_3B_();
-    push((i64)(strings + 6877));
+    push((i64)(strings + 6909));
     mw_3B_();
-    push((i64)(strings + 6901));
+    push((i64)(strings + 6933));
     mw_3B_();
-    push((i64)(strings + 6924));
+    push((i64)(strings + 6956));
     mw_3B__3B_();
     mwPRIM_POSIX_OPEN();
     mw_2E_p();
-    push((i64)(strings + 6926));
+    push((i64)(strings + 6958));
     mw_3B_();
-    push((i64)(strings + 6929));
+    push((i64)(strings + 6961));
     mw_3B_();
-    push((i64)(strings + 6953));
+    push((i64)(strings + 6985));
     mw_3B_();
-    push((i64)(strings + 6977));
+    push((i64)(strings + 7009));
     mw_3B_();
-    push((i64)(strings + 7002));
+    push((i64)(strings + 7034));
     mw_3B_();
-    push((i64)(strings + 7025));
+    push((i64)(strings + 7057));
     mw_3B__3B_();
     mwPRIM_POSIX_CLOSE();
     mw_2E_p();
-    push((i64)(strings + 7027));
+    push((i64)(strings + 7059));
     mw_3B_();
-    push((i64)(strings + 7030));
+    push((i64)(strings + 7062));
     mw_3B_();
-    push((i64)(strings + 7054));
+    push((i64)(strings + 7086));
     mw_3B_();
-    push((i64)(strings + 7074));
+    push((i64)(strings + 7106));
     mw_3B__3B_();
     mwPRIM_POSIX_EXIT();
     mw_2E_p();
-    push((i64)(strings + 7076));
+    push((i64)(strings + 7108));
     mw_3B_();
-    push((i64)(strings + 7079));
+    push((i64)(strings + 7111));
     mw_3B_();
-    push((i64)(strings + 7103));
+    push((i64)(strings + 7135));
     mw_3B_();
-    push((i64)(strings + 7116));
+    push((i64)(strings + 7148));
     mw_3B__3B_();
     mwPRIM_POSIX_MMAP();
     mw_2E_p();
-    push((i64)(strings + 7118));
+    push((i64)(strings + 7150));
     mw_3B_();
-    push((i64)(strings + 7121));
-    mw_3B_();
-    push((i64)(strings + 7144));
+    push((i64)(strings + 7153));
     mw_3B_();
     push((i64)(strings + 7176));
     mw_3B_();
-    push((i64)(strings + 7204));
+    push((i64)(strings + 7208));
     mw_3B_();
-    push((i64)(strings + 7215));
+    push((i64)(strings + 7236));
     mw_3B_();
-    push((i64)(strings + 7241));
+    push((i64)(strings + 7247));
     mw_3B_();
-    push((i64)(strings + 7251));
+    push((i64)(strings + 7273));
     mw_3B_();
-    push((i64)(strings + 7275));
+    push((i64)(strings + 7283));
     mw_3B_();
-    push((i64)(strings + 7299));
+    push((i64)(strings + 7307));
     mw_3B_();
-    push((i64)(strings + 7323));
+    push((i64)(strings + 7331));
     mw_3B_();
-    push((i64)(strings + 7347));
+    push((i64)(strings + 7355));
     mw_3B_();
-    push((i64)(strings + 7375));
+    push((i64)(strings + 7379));
     mw_3B_();
-    push((i64)(strings + 7400));
+    push((i64)(strings + 7407));
     mw_3B_();
-    push((i64)(strings + 7433));
+    push((i64)(strings + 7432));
     mw_3B_();
-    push((i64)(strings + 7451));
+    push((i64)(strings + 7465));
     mw_3B_();
-    push((i64)(strings + 7462));
+    push((i64)(strings + 7483));
+    mw_3B_();
+    push((i64)(strings + 7494));
     mw_3B__3B_();
     mwPRIM_DEBUG();
     mw_2E_p();
-    push((i64)(strings + 7464));
+    push((i64)(strings + 7496));
     mw_3B_();
-    push((i64)(strings + 7467));
+    push((i64)(strings + 7499));
     mw_3B_();
-    push((i64)(strings + 7490));
+    push((i64)(strings + 7522));
     mw_3B_();
-    push((i64)(strings + 7512));
+    push((i64)(strings + 7544));
     mw_3B_();
-    push((i64)(strings + 7526));
+    push((i64)(strings + 7558));
     mw_3B_();
-    push((i64)(strings + 7539));
+    push((i64)(strings + 7571));
     mw_3B_();
-    push((i64)(strings + 7557));
+    push((i64)(strings + 7589));
     mw_3B_();
-    push((i64)(strings + 7611));
+    push((i64)(strings + 7643));
     mw_3B_();
-    push((i64)(strings + 7630));
+    push((i64)(strings + 7662));
     mw_3B_();
-    push((i64)(strings + 7657));
+    push((i64)(strings + 7689));
     mw_3B_();
-    push((i64)(strings + 7672));
+    push((i64)(strings + 7704));
     mw_3B_();
-    push((i64)(strings + 7710));
+    push((i64)(strings + 7742));
     mw_3B_();
-    push((i64)(strings + 7773));
+    push((i64)(strings + 7805));
     mw_3B_();
-    push((i64)(strings + 7815));
+    push((i64)(strings + 7847));
     mw_3B_();
-    push((i64)(strings + 7834));
+    push((i64)(strings + 7866));
     mw_3B_();
-    push((i64)(strings + 7859));
+    push((i64)(strings + 7891));
     mw_3B_();
-    push((i64)(strings + 7865));
+    push((i64)(strings + 7897));
     mw_3B_();
-    push((i64)(strings + 7888));
+    push((i64)(strings + 7920));
     mw_3B__3B_();
     mwPRIM_MIRTH_REVISION();
     mw_2E_p();
-    push((i64)(strings + 7890));
+    push((i64)(strings + 7922));
     mw_3B_();
-    push((i64)(strings + 7893));
+    push((i64)(strings + 7925));
     mw_2E_();
     mwNEW_MIRTH_REVISION();
     mw_2E_n();
-    push((i64)(strings + 7903));
+    push((i64)(strings + 7935));
     mw_3B_();
-    push((i64)(strings + 7906));
+    push((i64)(strings + 7938));
     mw_3B__3B_();
     mwPRIM_MEM_GET();
     mw_2E_p();
-    push((i64)(strings + 7908));
+    push((i64)(strings + 7940));
     mw_3B_();
-    push((i64)(strings + 7911));
+    push((i64)(strings + 7943));
     mw_3B_();
-    push((i64)(strings + 7947));
+    push((i64)(strings + 7979));
     mw_3B__3B_();
     mwPRIM_MEM_SET();
     mw_2E_p();
-    push((i64)(strings + 7949));
+    push((i64)(strings + 7981));
     mw_3B_();
-    push((i64)(strings + 7952));
+    push((i64)(strings + 7984));
     mw_3B_();
-    push((i64)(strings + 7976));
+    push((i64)(strings + 8008));
     mw_3B_();
-    push((i64)(strings + 7997));
+    push((i64)(strings + 8029));
     mw_3B__3B_();
     mwPRIM_MEM_GET_BYTE();
     mw_2E_p();
-    push((i64)(strings + 7999));
+    push((i64)(strings + 8031));
     mw_3B_();
-    push((i64)(strings + 8002));
+    push((i64)(strings + 8034));
     mw_3B_();
-    push((i64)(strings + 8025));
+    push((i64)(strings + 8057));
     mw_3B_();
-    push((i64)(strings + 8039));
+    push((i64)(strings + 8071));
     mw_3B__3B_();
     mwPRIM_MEM_SET_BYTE();
     mw_2E_p();
-    push((i64)(strings + 8041));
+    push((i64)(strings + 8073));
     mw_3B_();
-    push((i64)(strings + 8044));
+    push((i64)(strings + 8076));
     mw_3B_();
-    push((i64)(strings + 8067));
+    push((i64)(strings + 8099));
     mw_3B_();
-    push((i64)(strings + 8086));
+    push((i64)(strings + 8118));
     mw_3B__3B_();
     mwPRIM_MEM_GET_U8();
     mw_2E_p();
-    push((i64)(strings + 8088));
+    push((i64)(strings + 8120));
     mw_3B_();
-    push((i64)(strings + 8091));
+    push((i64)(strings + 8123));
     mw_3B_();
-    push((i64)(strings + 8114));
+    push((i64)(strings + 8146));
     mw_3B_();
-    push((i64)(strings + 8128));
+    push((i64)(strings + 8160));
     mw_3B__3B_();
     mwPRIM_MEM_SET_U8();
     mw_2E_p();
-    push((i64)(strings + 8130));
+    push((i64)(strings + 8162));
     mw_3B_();
-    push((i64)(strings + 8133));
+    push((i64)(strings + 8165));
     mw_3B_();
-    push((i64)(strings + 8156));
+    push((i64)(strings + 8188));
     mw_3B_();
-    push((i64)(strings + 8175));
+    push((i64)(strings + 8207));
     mw_3B__3B_();
     mwPRIM_MEM_GET_U16();
     mw_2E_p();
-    push((i64)(strings + 8177));
+    push((i64)(strings + 8209));
     mw_3B_();
-    push((i64)(strings + 8180));
+    push((i64)(strings + 8212));
     mw_3B_();
-    push((i64)(strings + 8204));
+    push((i64)(strings + 8236));
     mw_3B_();
-    push((i64)(strings + 8218));
+    push((i64)(strings + 8250));
     mw_3B__3B_();
     mwPRIM_MEM_SET_U16();
     mw_2E_p();
-    push((i64)(strings + 8220));
+    push((i64)(strings + 8252));
     mw_3B_();
-    push((i64)(strings + 8223));
+    push((i64)(strings + 8255));
     mw_3B_();
-    push((i64)(strings + 8247));
+    push((i64)(strings + 8279));
     mw_3B_();
-    push((i64)(strings + 8267));
+    push((i64)(strings + 8299));
     mw_3B__3B_();
     mwPRIM_MEM_GET_U32();
     mw_2E_p();
-    push((i64)(strings + 8269));
+    push((i64)(strings + 8301));
     mw_3B_();
-    push((i64)(strings + 8272));
+    push((i64)(strings + 8304));
     mw_3B_();
-    push((i64)(strings + 8296));
+    push((i64)(strings + 8328));
     mw_3B_();
-    push((i64)(strings + 8310));
+    push((i64)(strings + 8342));
     mw_3B__3B_();
     mwPRIM_MEM_SET_U32();
     mw_2E_p();
-    push((i64)(strings + 8312));
+    push((i64)(strings + 8344));
     mw_3B_();
-    push((i64)(strings + 8315));
+    push((i64)(strings + 8347));
     mw_3B_();
-    push((i64)(strings + 8339));
+    push((i64)(strings + 8371));
     mw_3B_();
-    push((i64)(strings + 8359));
+    push((i64)(strings + 8391));
     mw_3B__3B_();
     mwPRIM_MEM_GET_U64();
     mw_2E_p();
-    push((i64)(strings + 8361));
+    push((i64)(strings + 8393));
     mw_3B_();
-    push((i64)(strings + 8364));
+    push((i64)(strings + 8396));
     mw_3B_();
-    push((i64)(strings + 8388));
+    push((i64)(strings + 8420));
     mw_3B_();
-    push((i64)(strings + 8402));
+    push((i64)(strings + 8434));
     mw_3B__3B_();
     mwPRIM_MEM_SET_U64();
     mw_2E_p();
-    push((i64)(strings + 8404));
+    push((i64)(strings + 8436));
     mw_3B_();
-    push((i64)(strings + 8407));
+    push((i64)(strings + 8439));
     mw_3B_();
-    push((i64)(strings + 8431));
+    push((i64)(strings + 8463));
     mw_3B_();
-    push((i64)(strings + 8451));
+    push((i64)(strings + 8483));
     mw_3B__3B_();
     mwPRIM_MEM_GET_I8();
     mw_2E_p();
-    push((i64)(strings + 8453));
+    push((i64)(strings + 8485));
     mw_3B_();
-    push((i64)(strings + 8456));
+    push((i64)(strings + 8488));
     mw_3B_();
-    push((i64)(strings + 8479));
+    push((i64)(strings + 8511));
     mw_3B_();
-    push((i64)(strings + 8493));
+    push((i64)(strings + 8525));
     mw_3B__3B_();
     mwPRIM_MEM_SET_I8();
     mw_2E_p();
-    push((i64)(strings + 8495));
+    push((i64)(strings + 8527));
     mw_3B_();
-    push((i64)(strings + 8498));
+    push((i64)(strings + 8530));
     mw_3B_();
-    push((i64)(strings + 8521));
+    push((i64)(strings + 8553));
     mw_3B_();
-    push((i64)(strings + 8540));
+    push((i64)(strings + 8572));
     mw_3B__3B_();
     mwPRIM_MEM_GET_I16();
     mw_2E_p();
-    push((i64)(strings + 8542));
+    push((i64)(strings + 8574));
     mw_3B_();
-    push((i64)(strings + 8545));
+    push((i64)(strings + 8577));
     mw_3B_();
-    push((i64)(strings + 8569));
+    push((i64)(strings + 8601));
     mw_3B_();
-    push((i64)(strings + 8583));
+    push((i64)(strings + 8615));
     mw_3B__3B_();
     mwPRIM_MEM_SET_I16();
     mw_2E_p();
-    push((i64)(strings + 8585));
+    push((i64)(strings + 8617));
     mw_3B_();
-    push((i64)(strings + 8588));
+    push((i64)(strings + 8620));
     mw_3B_();
-    push((i64)(strings + 8612));
+    push((i64)(strings + 8644));
     mw_3B_();
-    push((i64)(strings + 8632));
+    push((i64)(strings + 8664));
     mw_3B__3B_();
     mwPRIM_MEM_GET_I32();
     mw_2E_p();
-    push((i64)(strings + 8634));
+    push((i64)(strings + 8666));
     mw_3B_();
-    push((i64)(strings + 8637));
+    push((i64)(strings + 8669));
     mw_3B_();
-    push((i64)(strings + 8661));
+    push((i64)(strings + 8693));
     mw_3B_();
-    push((i64)(strings + 8675));
+    push((i64)(strings + 8707));
     mw_3B__3B_();
     mwPRIM_MEM_SET_I32();
     mw_2E_p();
-    push((i64)(strings + 8677));
+    push((i64)(strings + 8709));
     mw_3B_();
-    push((i64)(strings + 8680));
+    push((i64)(strings + 8712));
     mw_3B_();
-    push((i64)(strings + 8704));
+    push((i64)(strings + 8736));
     mw_3B_();
-    push((i64)(strings + 8724));
+    push((i64)(strings + 8756));
     mw_3B__3B_();
     mwPRIM_MEM_GET_I64();
     mw_2E_p();
-    push((i64)(strings + 8726));
+    push((i64)(strings + 8758));
     mw_3B_();
-    push((i64)(strings + 8729));
+    push((i64)(strings + 8761));
     mw_3B_();
-    push((i64)(strings + 8753));
+    push((i64)(strings + 8785));
     mw_3B_();
-    push((i64)(strings + 8767));
+    push((i64)(strings + 8799));
     mw_3B__3B_();
     mwPRIM_MEM_SET_I64();
     mw_2E_p();
-    push((i64)(strings + 8769));
+    push((i64)(strings + 8801));
     mw_3B_();
-    push((i64)(strings + 8772));
+    push((i64)(strings + 8804));
     mw_3B_();
-    push((i64)(strings + 8796));
+    push((i64)(strings + 8828));
     mw_3B_();
-    push((i64)(strings + 8816));
+    push((i64)(strings + 8848));
     mw_3B__3B_();
     mwPRIM_RUNNING_OS();
     mw_2E_p();
-    push((i64)(strings + 8818));
+    push((i64)(strings + 8850));
     mw_3B_();
-    push((i64)(strings + 8821));
+    push((i64)(strings + 8853));
     mw_3B_();
-    push((i64)(strings + 8846));
+    push((i64)(strings + 8878));
     mw_2E_();
     mwWIN32();
     mw_2E_n();
-    push((i64)(strings + 8856));
+    push((i64)(strings + 8888));
     mw_3B_();
-    push((i64)(strings + 8859));
+    push((i64)(strings + 8891));
     mw_3B_();
-    push((i64)(strings + 8886));
+    push((i64)(strings + 8918));
     mw_2E_();
     mwLINUX();
     mw_2E_n();
-    push((i64)(strings + 8896));
+    push((i64)(strings + 8928));
     mw_3B_();
-    push((i64)(strings + 8899));
+    push((i64)(strings + 8931));
     mw_3B_();
-    push((i64)(strings + 8926));
+    push((i64)(strings + 8958));
     mw_2E_();
     mwMACOS();
     mw_2E_n();
-    push((i64)(strings + 8936));
+    push((i64)(strings + 8968));
     mw_3B_();
-    push((i64)(strings + 8939));
+    push((i64)(strings + 8971));
     mw_3B_();
-    push((i64)(strings + 8945));
+    push((i64)(strings + 8977));
     mw_2E_();
     mwUNKNOWN();
     mw_2E_n();
-    push((i64)(strings + 8955));
+    push((i64)(strings + 8987));
     mw_3B_();
-    push((i64)(strings + 8958));
+    push((i64)(strings + 8990));
     mw_3B_();
-    push((i64)(strings + 8965));
+    push((i64)(strings + 8997));
     mw_3B__3B_();
     mwPRIM_CAST();
     mw_2E_p();
-    push((i64)(strings + 8967));
+    push((i64)(strings + 8999));
     mw_3B__3B_();
     mwPRIM_PTR_2B_();
     mw_2E_p();
-    push((i64)(strings + 8972));
+    push((i64)(strings + 9004));
     mw_3B_();
-    push((i64)(strings + 8975));
+    push((i64)(strings + 9007));
     mw_3B_();
-    push((i64)(strings + 8997));
+    push((i64)(strings + 9029));
     mw_3B_();
-    push((i64)(strings + 9015));
+    push((i64)(strings + 9047));
     mw_3B_();
-    push((i64)(strings + 9038));
+    push((i64)(strings + 9070));
     mw_3B__3B_();
     mwPRIM_TRUE();
     mw_2E_p();
-    push((i64)(strings + 9040));
+    push((i64)(strings + 9072));
     mw_3B_();
-    push((i64)(strings + 9043));
+    push((i64)(strings + 9075));
     mw_3B_();
-    push((i64)(strings + 9059));
+    push((i64)(strings + 9091));
     mw_3B_();
     mwPRIM_FALSE();
     mw_2E_p();
-    push((i64)(strings + 9061));
+    push((i64)(strings + 9093));
     mw_3B_();
-    push((i64)(strings + 9064));
+    push((i64)(strings + 9096));
     mw_3B_();
-    push((i64)(strings + 9081));
+    push((i64)(strings + 9113));
     mw_3B__3B_();
     mwPRIM_BOOL_AND();
     mw_2E_p();
-    push((i64)(strings + 9083));
+    push((i64)(strings + 9115));
     mw_3B_();
-    push((i64)(strings + 9086));
+    push((i64)(strings + 9118));
     mw_3B_();
-    push((i64)(strings + 9106));
+    push((i64)(strings + 9138));
     mw_3B_();
-    push((i64)(strings + 9126));
+    push((i64)(strings + 9158));
     mw_3B_();
-    push((i64)(strings + 9144));
+    push((i64)(strings + 9176));
     mw_3B_();
     mwPRIM_BOOL_OR();
     mw_2E_p();
-    push((i64)(strings + 9146));
+    push((i64)(strings + 9178));
     mw_3B_();
-    push((i64)(strings + 9149));
+    push((i64)(strings + 9181));
     mw_3B_();
-    push((i64)(strings + 9169));
+    push((i64)(strings + 9201));
     mw_3B_();
-    push((i64)(strings + 9189));
+    push((i64)(strings + 9221));
     mw_3B_();
-    push((i64)(strings + 9207));
+    push((i64)(strings + 9239));
     mw_3B__3B_();
     mwPRIM_ARGC();
     mw_2E_p();
-    push((i64)(strings + 9209));
+    push((i64)(strings + 9241));
     mw_3B_();
-    push((i64)(strings + 9212));
+    push((i64)(strings + 9244));
     mw_3B_();
-    push((i64)(strings + 9235));
+    push((i64)(strings + 9267));
     mw_3B_();
     mwPRIM_ARGV();
     mw_2E_p();
-    push((i64)(strings + 9237));
+    push((i64)(strings + 9269));
     mw_3B_();
-    push((i64)(strings + 9240));
+    push((i64)(strings + 9272));
     mw_3B_();
-    push((i64)(strings + 9268));
+    push((i64)(strings + 9300));
     mw_3B__3B_();
 }
 
@@ -13557,7 +13578,7 @@ void mwc99_emit_word_sigs_21_ (void){
     mwc99_emit_word_sig_21_();
     mw1_2B_();
     }
-    push((i64)(strings + 9420));
+    push((i64)(strings + 9452));
     mw_3B_();
     mwdrop();
 }
@@ -13583,16 +13604,16 @@ void mwc99_emit_main_21_ (void){
     mwTYPE_UNIT();
     mwelab_stack_21_();
     mwelab_arrow_21_();
-    push((i64)(strings + 9705));
+    push((i64)(strings + 9737));
     mw_3B_();
-    push((i64)(strings + 9740));
+    push((i64)(strings + 9772));
     mw_3B_();
-    push((i64)(strings + 9764));
+    push((i64)(strings + 9796));
     mw_3B_();
     mwc99_emit_arrow_21_();
-    push((i64)(strings + 9788));
+    push((i64)(strings + 9820));
     mw_3B_();
-    push((i64)(strings + 9802));
+    push((i64)(strings + 9834));
     mw_3B_();
 }
 
@@ -13653,10 +13674,10 @@ void mw_2E_name (void){
 }
 
 void mw_2E_w (void){
-    push((i64)(strings + 3904));
+    push((i64)(strings + 3936));
     mw_2E_();
     mw_2E_name();
-    push((i64)(strings + 3912));
+    push((i64)(strings + 3944));
     mw_2E_();
 }
 
@@ -13668,26 +13689,26 @@ void mw_2E_p (void){
 void mwc99_emit_buffer_21_ (void){
     mwname_is_buffer_3F_();
     if (pop()) {
-    push((i64)(strings + 4884));
+    push((i64)(strings + 4916));
     mw_2E_();
     mwdup();
     mw_2E_name();
-    push((i64)(strings + 4899));
+    push((i64)(strings + 4931));
     mw_2E_();
     mwdup();
     mwname_buffer_40_();
     mwbuffer_size_40_();
     mw_2E_n();
-    push((i64)(strings + 4901));
+    push((i64)(strings + 4933));
     mw_3B_();
-    push((i64)(strings + 4910));
+    push((i64)(strings + 4942));
     mw_2E_();
     mwdup();
     mw_2E_name();
-    push((i64)(strings + 4919));
+    push((i64)(strings + 4951));
     mw_2E_();
     mw_2E_name();
-    push((i64)(strings + 4941));
+    push((i64)(strings + 4973));
     mw_3B_();
     } else {
     mwdrop();
@@ -13703,17 +13724,17 @@ void mwc99_emit_external_21_ (void){
     push(2);
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 9270));
+    push((i64)(strings + 9302));
     mwpanic_21_();
     } else {
     mwdup();
     push(1);
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 9321));
+    push((i64)(strings + 9353));
     mw_2E_();
     } else {
-    push((i64)(strings + 9326));
+    push((i64)(strings + 9358));
     mw_2E_();
     }
     }
@@ -13723,20 +13744,20 @@ void mwc99_emit_external_21_ (void){
     mw_2E_name();
       push(d3); }
       push(d2); }
-    push((i64)(strings + 9332));
+    push((i64)(strings + 9364));
     mw_2E_();
     mwover();
     mwdup();
     mwnonzero();
     if (pop()) {
-    push((i64)(strings + 9335));
+    push((i64)(strings + 9367));
     mw_2E_();
     mw1_();
     while(1) {
     mwdup();
     mwnonzero();
     if (!pop()) break;
-    push((i64)(strings + 9339));
+    push((i64)(strings + 9371));
     mw_2E_();
     mw1_();
     }
@@ -13744,9 +13765,9 @@ void mwc99_emit_external_21_ (void){
     } else {
     mwdrop();
     }
-    push((i64)(strings + 9345));
+    push((i64)(strings + 9377));
     mw_3B_();
-    push((i64)(strings + 9348));
+    push((i64)(strings + 9380));
     mw_2E_();
     { i64 d2 = pop();
     { i64 d3 = pop();
@@ -13754,18 +13775,18 @@ void mwc99_emit_external_21_ (void){
     mw_2E_name();
       push(d3); }
       push(d2); }
-    push((i64)(strings + 9357));
+    push((i64)(strings + 9389));
     mw_3B_();
     mwover();
     while(1) {
     mwdup();
     mwnonzero();
     if (!pop()) break;
-    push((i64)(strings + 9367));
+    push((i64)(strings + 9399));
     mw_2E_();
     mwdup();
     mw_2E_n();
-    push((i64)(strings + 9377));
+    push((i64)(strings + 9409));
     mw_3B_();
     mw1_();
     }
@@ -13773,9 +13794,9 @@ void mwc99_emit_external_21_ (void){
     mwdup();
     mwnonzero();
     if (pop()) {
-    push((i64)(strings + 9387));
+    push((i64)(strings + 9419));
     } else {
-    push((i64)(strings + 9397));
+    push((i64)(strings + 9429));
     }
     mw_2E_();
     { i64 d2 = pop();
@@ -13784,13 +13805,13 @@ void mwc99_emit_external_21_ (void){
     mw_2E_name();
       push(d3); }
       push(d2); }
-    push((i64)(strings + 9402));
+    push((i64)(strings + 9434));
     mw_2E_();
     { i64 d2 = pop();
     mwdup();
     mwnonzero();
     if (pop()) {
-    push((i64)(strings + 9404));
+    push((i64)(strings + 9436));
     mw_2E_();
     mwdup();
     mw1_();
@@ -13798,7 +13819,7 @@ void mwc99_emit_external_21_ (void){
     mwdup();
     mwnonzero();
     if (!pop()) break;
-    push((i64)(strings + 9407));
+    push((i64)(strings + 9439));
     mw_2E_();
     mwdup2();
     mw_();
@@ -13811,17 +13832,17 @@ void mwc99_emit_external_21_ (void){
     mwid();
     }
       push(d2); }
-    push((i64)(strings + 9411));
+    push((i64)(strings + 9443));
     mw_2E_();
     mwdup();
     mwnonzero();
     if (pop()) {
-    push((i64)(strings + 9413));
+    push((i64)(strings + 9445));
     } else {
-    push((i64)(strings + 9416));
+    push((i64)(strings + 9448));
     }
     mw_3B_();
-    push((i64)(strings + 9418));
+    push((i64)(strings + 9450));
     mw_3B_();
     mwdrop3();
     } else {
@@ -13848,10 +13869,10 @@ void mwsig_arity (void){
 void mwc99_emit_word_sig_21_ (void){
     mwname_is_word_3F_();
     if (pop()) {
-    push((i64)(strings + 9683));
+    push((i64)(strings + 9715));
     mw_2E_();
     mw_2E_name();
-    push((i64)(strings + 9692));
+    push((i64)(strings + 9724));
     mw_3B_();
     } else {
     mwdrop();
@@ -13880,50 +13901,50 @@ void mwc99_emit_arrow_op_21_ (void){
     mwarrow_op_is_int_3F_();
     if (pop()) {
     mwarrow_op_int_40_();
-    push((i64)(strings + 9421));
+    push((i64)(strings + 9453));
     mw_2E_();
     mw_2E_n();
-    push((i64)(strings + 9431));
+    push((i64)(strings + 9463));
     mw_3B_();
     } else {
     mwarrow_op_is_str_3F_();
     if (pop()) {
     mwarrow_op_str_40_();
     mwStrLit__3E_Int();
-    push((i64)(strings + 9434));
+    push((i64)(strings + 9466));
     mw_2E_();
     mw_2E_n();
-    push((i64)(strings + 9460));
+    push((i64)(strings + 9492));
     mw_3B_();
     } else {
     mwarrow_op_is_word_3F_();
     if (pop()) {
     mwarrow_op_word_40_();
     mwword_name_40_();
-    push((i64)(strings + 9464));
+    push((i64)(strings + 9496));
     mw_2E_();
     mw_2E_name();
-    push((i64)(strings + 9471));
+    push((i64)(strings + 9503));
     mw_3B_();
     } else {
     mwarrow_op_is_external_3F_();
     if (pop()) {
     mwarrow_op_external_40_();
     mwexternal_name_40_();
-    push((i64)(strings + 9475));
+    push((i64)(strings + 9507));
     mw_2E_();
     mw_2E_name();
-    push((i64)(strings + 9482));
+    push((i64)(strings + 9514));
     mw_3B_();
     } else {
     mwarrow_op_is_buffer_3F_();
     if (pop()) {
     mwarrow_op_buffer_40_();
     mwbuffer_name_40_();
-    push((i64)(strings + 9486));
+    push((i64)(strings + 9518));
     mw_2E_();
     mw_2E_name();
-    push((i64)(strings + 9493));
+    push((i64)(strings + 9525));
     mw_3B_();
     } else {
     mwarrow_op_is_prim_3F_();
@@ -13935,17 +13956,17 @@ void mwc99_emit_arrow_op_21_ (void){
     if (pop()) {
     mwdrop();
     mwarrow_args_1();
-    push((i64)(strings + 9497));
+    push((i64)(strings + 9529));
     mw_2E_();
     mw_2E_d();
-    push((i64)(strings + 9509));
+    push((i64)(strings + 9541));
     mw_3B_();
     mwArg__3E_Arrow();
     mwc99_emit_arrow_21_();
-    push((i64)(strings + 9519));
+    push((i64)(strings + 9551));
     mw_2E_();
     mw_2E_d();
-    push((i64)(strings + 9532));
+    push((i64)(strings + 9564));
     mw_3B_();
     } else {
     mwdup();
@@ -13954,17 +13975,17 @@ void mwc99_emit_arrow_op_21_ (void){
     if (pop()) {
     mwdrop();
     mwarrow_args_2();
-    push((i64)(strings + 9537));
+    push((i64)(strings + 9569));
     mw_3B_();
     { i64 d10 = pop();
     mwArg__3E_Arrow();
     mwc99_emit_arrow_21_();
       push(d10); }
-    push((i64)(strings + 9554));
+    push((i64)(strings + 9586));
     mw_3B_();
     mwArg__3E_Arrow();
     mwc99_emit_arrow_21_();
-    push((i64)(strings + 9567));
+    push((i64)(strings + 9599));
     mw_3B_();
     } else {
     mwdup();
@@ -13973,32 +13994,32 @@ void mwc99_emit_arrow_op_21_ (void){
     if (pop()) {
     mwdrop();
     mwarrow_args_2();
-    push((i64)(strings + 9573));
+    push((i64)(strings + 9605));
     mw_3B_();
     { i64 d11 = pop();
     mwArg__3E_Arrow();
     mwc99_emit_arrow_21_();
       push(d11); }
-    push((i64)(strings + 9588));
+    push((i64)(strings + 9620));
     mw_3B_();
     mwArg__3E_Arrow();
     mwc99_emit_arrow_21_();
-    push((i64)(strings + 9611));
+    push((i64)(strings + 9643));
     mw_3B_();
     } else {
     mwnip();
-    push((i64)(strings + 9617));
+    push((i64)(strings + 9649));
     mw_2E_();
     mwPrim__3E_Name();
     mw_2E_name();
-    push((i64)(strings + 9624));
+    push((i64)(strings + 9656));
     mw_3B_();
     }
     }
     }
     } else {
     mwarrow_token_40_();
-    push((i64)(strings + 9628));
+    push((i64)(strings + 9660));
     mwemit_fatal_error_21_();
     }
     }
@@ -14014,12 +14035,12 @@ void mwc99_emit_word_def_21_ (void){
     if (pop()) {
     mwdup();
     mw_2E_w();
-    push((i64)(strings + 9701));
+    push((i64)(strings + 9733));
     mw_3B_();
     mwname_word_40_();
     mwelab_word_body_21_();
     mwc99_emit_arrow_21_();
-    push((i64)(strings + 9703));
+    push((i64)(strings + 9735));
     mw_3B__3B_();
     } else {
     mwdrop();
@@ -14235,7 +14256,7 @@ void mwelab_type_atom_21_ (void){
     mwelab_type_con_21_();
     } else {
     mwdup();
-    push((i64)(strings + 9804));
+    push((i64)(strings + 9836));
     mwemit_error_21_();
     { i64 d3 = pop();
     mwTYPE_ERROR();
@@ -14299,7 +14320,7 @@ void mwelab_type_con_21_ (void){
     mwtoken_has_args_3F_();
     if (pop()) {
     mwdup();
-    push((i64)(strings + 9838));
+    push((i64)(strings + 9870));
     mwemit_error_21_();
     mwTYPE_ERROR();
     } else {
@@ -14312,13 +14333,13 @@ void mwelab_type_con_21_ (void){
     if (pop()) {
     mwdrop();
     mwdup();
-    push((i64)(strings + 9873));
+    push((i64)(strings + 9905));
     mwemit_error_21_();
     mwTYPE_ERROR();
     } else {
     mwdrop();
     mwdup();
-    push((i64)(strings + 9887));
+    push((i64)(strings + 9919));
     mwemit_error_21_();
     mwTYPE_ERROR();
     }
@@ -14466,7 +14487,7 @@ void mwelab_stack_pop_21_ (void){
     mwtype_get_tensor();
     mwtensor_type_unpack();
     } else {
-    push((i64)(strings + 9899));
+    push((i64)(strings + 9931));
     mwelab_emit_warning_21_();
     mwdrop();
     mwTYPE_ERROR();
@@ -14552,7 +14573,7 @@ void mwelab_arrow_step_21_ (void){
     mwelab_arrow_step_name_21_();
     } else {
     mwdrop();
-    push((i64)(strings + 9928));
+    push((i64)(strings + 9960));
     mwelab_emit_fatal_error_21_();
     }
     }
@@ -14596,7 +14617,7 @@ void mwelab_arrow_step_name_21_ (void){
     mwelab_arrow_step_prim_21_();
     } else {
     mwdrop();
-    push((i64)(strings + 9966));
+    push((i64)(strings + 9998));
     mwelab_emit_fatal_error_21_();
     mwTYPE_ERROR();
     mwelab_stack_21_();
@@ -15323,7 +15344,7 @@ void mwelab_arrow_step_prim_21_ (void){
     mwdrop();
     mwTYPE_ERROR();
     mwelab_stack_21_();
-    push((i64)(strings + 10056));
+    push((i64)(strings + 10088));
     mwelab_emit_warning_21_();
     }
     }
@@ -15468,7 +15489,7 @@ void mwstack_type_concat (void){
     mwtensor_type_new_21_();
     mwTTensor();
     } else {
-    push((i64)(strings + 9979));
+    push((i64)(strings + 10011));
     mwelab_emit_fatal_error_21_();
     }
     }
@@ -15479,7 +15500,7 @@ void mwelab_3F__3F_ (void){
     mwelab_token_40_();
     mwtoken_location();
     mwlocation_trace_21_();
-    push((i64)(strings + 10036));
+    push((i64)(strings + 10068));
     mwstr_trace_21_();
     mwelab_stack_40_();
     mwtype_trace_21_();
@@ -15843,7 +15864,7 @@ void mwelab_module_header_21_ (void){
     mwtoken_next();
     } else {
     mwdup();
-    push((i64)(strings + 10099));
+    push((i64)(strings + 10131));
     mwemit_error_21_();
     }
 }
@@ -15891,7 +15912,7 @@ void mwelab_module_name_21_ (void){
     mwname_defined_3F_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 10123));
+    push((i64)(strings + 10155));
     mwemit_fatal_error_21_();
     } else {
     mwnip();
@@ -15901,7 +15922,7 @@ void mwelab_module_name_21_ (void){
     mwmodule_name_21_();
     }
     } else {
-    push((i64)(strings + 10149));
+    push((i64)(strings + 10181));
     mwemit_fatal_error_21_();
     }
 }
@@ -15923,7 +15944,7 @@ void mwelab_module_import_21_ (void){
     if (pop()) {
     mwnip();
     mwname_load_21_();
-    push((i64)(strings + 10170));
+    push((i64)(strings + 10202));
     mwstr_buf_push_str_21_();
     mwSTR_BUF();
     mwStr__3E_Path();
@@ -15932,12 +15953,12 @@ void mwelab_module_import_21_ (void){
     mwdrop();
     } else {
     mwdrop();
-    push((i64)(strings + 10175));
+    push((i64)(strings + 10207));
     mwemit_fatal_error_21_();
     }
     }
     } else {
-    push((i64)(strings + 10201));
+    push((i64)(strings + 10233));
     mwemit_fatal_error_21_();
     }
 }
@@ -15984,7 +16005,7 @@ void mwelab_module_decl_21_ (void){
     if (pop()) {
     mwelab_target_c99_21_();
     } else {
-    push((i64)(strings + 10222));
+    push((i64)(strings + 10254));
     mwemit_fatal_error_21_();
     }
     }
@@ -16025,11 +16046,11 @@ void mwelab_def_21_ (void){
     mwword_sig_21_();
     } else {
     mwdrop();
-    push((i64)(strings + 10242));
+    push((i64)(strings + 10274));
     mwemit_fatal_error_21_();
     }
     } else {
-    push((i64)(strings + 10263));
+    push((i64)(strings + 10295));
     mwemit_fatal_error_21_();
     }
 }
@@ -16057,12 +16078,12 @@ void mwelab_def_type_21_ (void){
     mwnip();
     } else {
     mwdrop();
-    push((i64)(strings + 10282));
+    push((i64)(strings + 10314));
     mwemit_error_21_();
     mwTYPE_ERROR();
     }
     } else {
-    push((i64)(strings + 10296));
+    push((i64)(strings + 10328));
     mwemit_error_21_();
     mwTYPE_ERROR();
     }
@@ -16070,11 +16091,11 @@ void mwelab_def_type_21_ (void){
     mwname_type_21_();
     } else {
     mwdrop();
-    push((i64)(strings + 10313));
+    push((i64)(strings + 10345));
     mwemit_fatal_error_21_();
     }
     } else {
-    push((i64)(strings + 10334));
+    push((i64)(strings + 10366));
     mwemit_fatal_error_21_();
     }
 }
@@ -16102,12 +16123,12 @@ void mwelab_nominal_21_ (void){
     mwnip();
     } else {
     mwdrop();
-    push((i64)(strings + 10360));
+    push((i64)(strings + 10392));
     mwemit_error_21_();
     mwTYPE_ERROR();
     }
     } else {
-    push((i64)(strings + 10374));
+    push((i64)(strings + 10406));
     mwemit_error_21_();
     mwTYPE_ERROR();
     }
@@ -16119,11 +16140,11 @@ void mwelab_nominal_21_ (void){
     mwname_type_21_();
     } else {
     mwdrop();
-    push((i64)(strings + 10391));
+    push((i64)(strings + 10423));
     mwemit_fatal_error_21_();
     }
     } else {
-    push((i64)(strings + 10412));
+    push((i64)(strings + 10444));
     mwemit_fatal_error_21_();
     }
 }
@@ -16152,16 +16173,16 @@ void mwelab_buffer_21_ (void){
     mwbuffer_alloc_21_();
     mwdrop();
     } else {
-    push((i64)(strings + 10438));
+    push((i64)(strings + 10470));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 10459));
+    push((i64)(strings + 10491));
     mwemit_fatal_error_21_();
     }
     } else {
-    push((i64)(strings + 10482));
+    push((i64)(strings + 10514));
     mwemit_fatal_error_21_();
     }
 }
@@ -16178,7 +16199,7 @@ void mwelab_table_21_ (void){
     mwtable_new_21_();
     mwdrop();
     } else {
-    push((i64)(strings + 10503));
+    push((i64)(strings + 10535));
     mwemit_fatal_error_21_();
     }
 }
@@ -16218,24 +16239,24 @@ void mwelab_field_21_ (void){
     mwdrop();
     } else {
     mwdrop();
-    push((i64)(strings + 10523));
+    push((i64)(strings + 10555));
     mwemit_fatal_error_21_();
     }
     } else {
-    push((i64)(strings + 10542));
+    push((i64)(strings + 10574));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 10562));
+    push((i64)(strings + 10594));
     mwemit_fatal_error_21_();
     }
     } else {
-    push((i64)(strings + 10581));
+    push((i64)(strings + 10613));
     mwemit_fatal_error_21_();
     }
     } else {
-    push((i64)(strings + 10601));
+    push((i64)(strings + 10633));
     mwemit_fatal_error_21_();
     }
 }
@@ -16255,7 +16276,7 @@ void mwelab_target_c99_21_ (void){
     mwStr__3E_Path();
     mwrun_output_c99_21_();
     } else {
-    push((i64)(strings + 10621));
+    push((i64)(strings + 10653));
     mwemit_fatal_error_21_();
     }
 }

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -37,7 +37,7 @@ static volatile i64 stack[STACK_SIZE] = {0};
 int global_argc;
 char** global_argv;
 
-#define STRINGS_SIZE 10695
+#define STRINGS_SIZE 10753
 static const char strings[STRINGS_SIZE] = { 
 67,111,109,112,105,108,105,110,103,32,0,
 66,117,105,108,100,105,110,103,46,0,
@@ -161,6 +161,8 @@ static const char strings[STRINGS_SIZE] = {
 102,105,101,108,100,0,
 97,114,103,99,0,
 97,114,103,118,0,
+97,114,103,118,0,
+112,114,105,109,46,117,110,115,97,102,101,46,124,112,116,114,124,0,
 99,111,109,112,105,108,101,114,32,101,114,114,111,114,58,32,78,85,77,95,80,82,73,77,83,32,97,110,100,32,110,117,109,45,110,97,109,101,115,64,32,100,111,32,110,111,116,32,109,97,116,99,104,0,
 99,111,109,112,105,108,101,114,32,101,114,114,111,114,58,32,97,116,116,101,109,112,116,101,100,32,116,111,32,103,101,116,32,110,97,109,101,45,115,105,103,32,102,111,114,32,110,111,110,45,119,111,114,100,44,32,110,111,110,45,101,120,116,101,114,110,97,108,32,110,97,109,101,0,
 99,111,109,112,105,108,101,114,32,101,114,114,111,114,58,32,97,116,116,101,109,112,116,101,100,32,116,111,32,103,101,116,32,116,121,112,101,32,100,101,102,105,110,105,116,105,111,110,32,102,111,114,32,110,111,110,45,116,121,112,101,32,110,97,109,101,0,
@@ -631,6 +633,9 @@ static const char strings[STRINGS_SIZE] = {
 32,123,0,
 32,32,32,32,112,117,115,104,40,40,105,54,52,41,103,108,111,98,97,108,95,97,114,103,118,41,59,0,
 125,0,
+32,123,0,
+32,32,32,32,112,117,115,104,40,40,105,54,52,41,115,105,122,101,111,102,40,118,111,105,100,42,41,41,59,0,
+125,0,
 99,97,110,39,116,32,100,101,99,108,97,114,101,32,101,120,116,101,114,110,97,108,32,119,105,116,104,32,109,117,108,116,105,112,108,101,32,114,101,116,117,114,110,32,118,97,108,117,101,115,0,
 105,54,52,32,0,
 118,111,105,100,32,0,
@@ -1096,6 +1101,10 @@ void mwargc (void) {
 }
 void mwargv (void) {
     push((i64)global_argv);
+}
+
+void mwprim_2E_unsafe_2E__7C_ptr_7C_ (void) {
+    push((i64)sizeof(void*));
 }
 
  volatile u8 bSTR_BUF_LEN[8] = {0};
@@ -1783,6 +1792,7 @@ void mwargv (void) {
  void mwPRIM_FIELD (void);
  void mwPRIM_ARGC (void);
  void mwPRIM_ARGV (void);
+ void mwPRIM_PTR_SIZE (void);
  void mwname_is_prim_3F_ (void);
  void mwdef_prim_21_ (void);
  void mwNameValue__3E_Int (void);
@@ -2568,10 +2578,10 @@ void mwinit_21_ (void){
 }
 
 void mwinit_paths_21_ (void){
-    push((i64)(strings + 3902));
+    push((i64)(strings + 3925));
     mwStr__3E_Path();
     mwsource_path_root_21_();
-    push((i64)(strings + 3906));
+    push((i64)(strings + 3929));
     mwStr__3E_Path();
     mwoutput_path_root_21_();
 }
@@ -2820,6 +2830,12 @@ void mwinit_names_21_ (void){
     mwPRIM_ARGV();
     push((i64)(strings + 1417));
     mwdef_prim_21_();
+    mwPRIM_ARGV();
+    push((i64)(strings + 1422));
+    mwdef_prim_21_();
+    mwPRIM_PTR_SIZE();
+    push((i64)(strings + 1427));
+    mwdef_prim_21_();
     mwNUM_PRIMS();
     mwnum_names_40_();
     mw1_2B_();
@@ -2827,7 +2843,7 @@ void mwinit_names_21_ (void){
     if (pop()) {
     mwid();
     } else {
-    push((i64)(strings + 1422));
+    push((i64)(strings + 1445));
     mwpanic_21_();
     }
 }
@@ -3274,7 +3290,7 @@ void mwptr_21_ (void){
 }
 
 void mwptr (void){
-    push(8);
+    mwprim_2E_unsafe_2E__7C_ptr_7C_();
 }
 
 void mwptrs (void){
@@ -6321,7 +6337,7 @@ void mwemit_warning_at_21_ (void){
     { i64 d1 = pop();
     mwlocation_trace_21_();
       push(d1); }
-    push((i64)(strings + 3914));
+    push((i64)(strings + 3937));
     mwstr_trace_21_();
     mwstr_trace_ln_21_();
 }
@@ -6337,7 +6353,7 @@ void mwemit_error_at_21_ (void){
     { i64 d1 = pop();
     mwlocation_trace_21_();
       push(d1); }
-    push((i64)(strings + 3926));
+    push((i64)(strings + 3949));
     mwstr_trace_21_();
     mwstr_trace_ln_21_();
 }
@@ -6931,7 +6947,7 @@ void mwName__3E_Prim (void){
 }
 
 void mwNUM_PRIMS (void){
-    push(82);
+    push(83);
 }
 
 void mwInt__3E_Prim (void){
@@ -7349,6 +7365,11 @@ void mwPRIM_ARGV (void){
     mwInt__3E_Prim();
 }
 
+void mwPRIM_PTR_SIZE (void){
+    push(82);
+    mwInt__3E_Prim();
+}
+
 void mwname_is_prim_3F_ (void){
     mwdup();
     mwName__3E_Int();
@@ -7525,7 +7546,7 @@ void mwname_sig_40_ (void){
     mwname_external_40_();
     mwexternal_sig_40_();
     } else {
-    push((i64)(strings + 1476));
+    push((i64)(strings + 1499));
     mwpanic_21_();
     }
     }
@@ -7543,7 +7564,7 @@ void mwname_word_40_ (void){
     mwname_value_40_();
     mwNameValue__3E_Word();
     } else {
-    push((i64)(strings + 1617));
+    push((i64)(strings + 1640));
     mwpanic_21_();
     }
 }
@@ -7565,7 +7586,7 @@ void mwname_external_40_ (void){
     mwname_value_40_();
     mwNameValue__3E_External();
     } else {
-    push((i64)(strings + 1684));
+    push((i64)(strings + 1707));
     mwpanic_21_();
     }
 }
@@ -7641,7 +7662,7 @@ void mwname_type_40_ (void){
     mwname_value_40_();
     mwNameValue__3E_Type();
     } else {
-    push((i64)(strings + 1550));
+    push((i64)(strings + 1573));
     mwpanic_21_();
     }
 }
@@ -7687,7 +7708,7 @@ void mwname_buffer_40_ (void){
     mwname_value_40_();
     mwNameValue__3E_Buffer();
     } else {
-    push((i64)(strings + 1759));
+    push((i64)(strings + 1782));
     mwpanic_21_();
     }
 }
@@ -9222,7 +9243,7 @@ void mwtype_get_morphism (void){
     mwtype_is_morphism_3F_();
     mwnot();
     if (pop()) {
-    push((i64)(strings + 2003));
+    push((i64)(strings + 2026));
     mwpanic_21_();
     } else {
     mwtype_get_value();
@@ -9615,7 +9636,7 @@ void mwtype_get_var (void){
     mwtype_is_var_3F_();
     mwnot();
     if (pop()) {
-    push((i64)(strings + 1830));
+    push((i64)(strings + 1853));
     mwpanic_21_();
     } else {
     mwtype_get_value();
@@ -9642,7 +9663,7 @@ void mwtype_get_meta (void){
     mwtype_is_meta_3F_();
     mwnot();
     if (pop()) {
-    push((i64)(strings + 1885));
+    push((i64)(strings + 1908));
     mwpanic_21_();
     } else {
     mwtype_get_value();
@@ -9658,7 +9679,7 @@ void mwtype_get_tensor (void){
     mwtype_is_tensor_3F_();
     mwnot();
     if (pop()) {
-    push((i64)(strings + 1942));
+    push((i64)(strings + 1965));
     mwpanic_21_();
     } else {
     mwtype_get_value();
@@ -9678,7 +9699,7 @@ void mwtype_get_nominal (void){
     mwtype_is_nominal_3F_();
     mwnot();
     if (pop()) {
-    push((i64)(strings + 2068));
+    push((i64)(strings + 2091));
     mwpanic_21_();
     } else {
     mwtype_get_value();
@@ -9694,7 +9715,7 @@ void mwtype_get_table (void){
     mwtype_is_table_3F_();
     mwnot();
     if (pop()) {
-    push((i64)(strings + 2131));
+    push((i64)(strings + 2154));
     mwpanic_21_();
     } else {
     mwtype_get_value();
@@ -9781,7 +9802,7 @@ void mwmeta_alloc_21_ (void){
     mwMetaVar_2E_MAX();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 2377));
+    push((i64)(strings + 2400));
     mwpanic_21_();
     } else {
     mwid();
@@ -9920,12 +9941,12 @@ void mwtype_unify_failed_21_ (void){
     mwelab_token_40_();
     mwtoken_location();
     mwlocation_trace_21_();
-    push((i64)(strings + 2190));
+    push((i64)(strings + 2213));
     mwstr_trace_21_();
     { i64 d1 = pop();
     mwtype_trace_21_();
       push(d1); }
-    push((i64)(strings + 2216));
+    push((i64)(strings + 2239));
     mwstr_trace_21_();
     mwtype_trace_21_();
     mwtrace_ln_21_();
@@ -9950,11 +9971,11 @@ void mwlocation_trace_21_ (void){
     mwswap();
     mwload_module_source_path_21_();
     mwstr_buf_trace_21_();
-    push((i64)(strings + 3841));
+    push((i64)(strings + 3864));
     mwstr_trace_21_();
     mwRow__3E_Int();
     mwint_trace_21_();
-    push((i64)(strings + 3843));
+    push((i64)(strings + 3866));
     mwstr_trace_21_();
     mwCol__3E_Int();
     mwint_trace_21_();
@@ -9975,25 +9996,25 @@ void mwtype_trace_21_ (void){
     mwtype_is_meta_3F_();
     if (pop()) {
     mwtype_get_meta();
-    push((i64)(strings + 2271));
+    push((i64)(strings + 2294));
     mwstr_trace_21_();
     mwMetaVar__3E_Int();
     mwint_trace_21_();
     } else {
     mwtype_is_tensor_3F_();
     if (pop()) {
-    push((i64)(strings + 2273));
+    push((i64)(strings + 2296));
     mwstr_trace_21_();
     mwtype_trace_stack_21_();
-    push((i64)(strings + 2275));
+    push((i64)(strings + 2298));
     mwstr_trace_21_();
     } else {
     mwtype_is_morphism_3F_();
     if (pop()) {
-    push((i64)(strings + 2277));
+    push((i64)(strings + 2300));
     mwstr_trace_21_();
     mwtype_trace_sig_21_();
-    push((i64)(strings + 2279));
+    push((i64)(strings + 2302));
     mwstr_trace_21_();
     } else {
     mwtype_is_nominal_3F_();
@@ -10010,11 +10031,11 @@ void mwtype_trace_21_ (void){
     mwname_load_21_();
     mwstr_buf_trace_21_();
     } else {
-    push((i64)(strings + 2281));
+    push((i64)(strings + 2304));
     mwstr_trace_21_();
     mwType__3E_Int();
     mwint_trace_21_();
-    push((i64)(strings + 2296));
+    push((i64)(strings + 2319));
     mwstr_trace_21_();
     }
     }
@@ -10034,7 +10055,7 @@ void mwmeta_unify_21_ (void){
     mwswap();
     mwtype_has_meta_3F_();
     if (pop()) {
-    push((i64)(strings + 2477));
+    push((i64)(strings + 2500));
     mwelab_emit_error_21_();
     mwdrop();
     mwTYPE_ERROR();
@@ -10128,7 +10149,7 @@ void mwtype_has_meta (void){
     mwdrop2();
     mwfalse();
     } else {
-    push((i64)(strings + 2223));
+    push((i64)(strings + 2246));
     mwpanic_21_();
     }
     }
@@ -10172,7 +10193,7 @@ void mwtype_trace_sig_21_ (void){
     mwTYPE_ERROR();
     mw_3D_();
     if (pop()) {
-    push((i64)(strings + 2251));
+    push((i64)(strings + 2274));
     mwstr_trace_21_();
     mwdrop();
     } else {
@@ -10186,10 +10207,10 @@ void mwtype_trace_sig_21_ (void){
     mwdrop();
     } else {
     mwtype_trace_stack_21_();
-    push((i64)(strings + 2259));
+    push((i64)(strings + 2282));
     mwstr_trace_21_();
     }
-    push((i64)(strings + 2261));
+    push((i64)(strings + 2284));
     mwstr_trace_21_();
     mwmorphism_type_cod_40_();
     mwdup();
@@ -10198,7 +10219,7 @@ void mwtype_trace_sig_21_ (void){
     if (pop()) {
     mwdrop();
     } else {
-    push((i64)(strings + 2264));
+    push((i64)(strings + 2287));
     mwstr_trace_21_();
     mwtype_trace_stack_21_();
     }
@@ -10218,7 +10239,7 @@ void mwtype_trace_stack_21_ (void){
     mwdrop();
     } else {
     mwtype_trace_stack_21_();
-    push((i64)(strings + 2266));
+    push((i64)(strings + 2289));
     mwstr_trace_21_();
     }
     mwtensor_type_snd_40_();
@@ -10229,7 +10250,7 @@ void mwtype_trace_stack_21_ (void){
     mwtype_trace_21_();
     } else {
     mwtype_trace_21_();
-    push((i64)(strings + 2268));
+    push((i64)(strings + 2291));
     mwstr_trace_21_();
     }
     }
@@ -10241,7 +10262,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2298));
+    push((i64)(strings + 2321));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10249,7 +10270,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2304));
+    push((i64)(strings + 2327));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10257,7 +10278,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2307));
+    push((i64)(strings + 2330));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10265,7 +10286,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2312));
+    push((i64)(strings + 2335));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10273,7 +10294,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2316));
+    push((i64)(strings + 2339));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10281,7 +10302,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2320));
+    push((i64)(strings + 2343));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10289,7 +10310,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2323));
+    push((i64)(strings + 2346));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10297,7 +10318,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2327));
+    push((i64)(strings + 2350));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10305,7 +10326,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2331));
+    push((i64)(strings + 2354));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10313,7 +10334,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2335));
+    push((i64)(strings + 2358));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10321,7 +10342,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2338));
+    push((i64)(strings + 2361));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10329,7 +10350,7 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2342));
+    push((i64)(strings + 2365));
     mwstr_trace_21_();
     } else {
     mwdup();
@@ -10337,14 +10358,14 @@ void mwtype_trace_prim_21_ (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 2346));
+    push((i64)(strings + 2369));
     mwstr_trace_21_();
     } else {
-    push((i64)(strings + 2350));
+    push((i64)(strings + 2373));
     mwstr_trace_21_();
     mwType__3E_Int();
     mwint_trace_21_();
-    push((i64)(strings + 2375));
+    push((i64)(strings + 2398));
     mwstr_trace_21_();
     }
     }
@@ -10517,7 +10538,7 @@ void mwmeta_type_40_ (void){
     mwmeta_is_defined_3F_();
     mwnot();
     if (pop()) {
-    push((i64)(strings + 2439));
+    push((i64)(strings + 2462));
     mwpanic_21_();
     } else {
     mwmeta_type_raw_40_();
@@ -10682,7 +10703,7 @@ void mwctx_trace_21_ (void){
     mwdrop();
     } else {
     mwctx_trace_21_();
-    push((i64)(strings + 2499));
+    push((i64)(strings + 2522));
     mwstr_trace_21_();
     }
     mwctx_var_40_();
@@ -10712,7 +10733,7 @@ void mwvar_trace_binding_21_ (void){
     if (pop()) {
     mwdrop();
     } else {
-    push((i64)(strings + 2537));
+    push((i64)(strings + 2560));
     mwstr_trace_21_();
     mwvar_type_40_();
     mwtype_trace_sig_21_();
@@ -10774,7 +10795,7 @@ void mwvar_alloc_21_ (void){
     mwVar_2E_MAX();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 2502));
+    push((i64)(strings + 2525));
     mwpanic_21_();
     } else {
     mwid();
@@ -10817,7 +10838,7 @@ void mwtable_alloc_21_ (void){
     mwTable_2E_MAX();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 2541));
+    push((i64)(strings + 2564));
     mwpanic_21_();
     } else {
     mwid();
@@ -10837,7 +10858,7 @@ void mwtable_new_21_ (void){
     mwtable_max_count_21_();
     mwtable_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2582));
+    push((i64)(strings + 2605));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     mwword_alloc_21_();
@@ -10864,7 +10885,7 @@ void mwtable_new_21_ (void){
     mwword_body_is_checked_21_();
     mwtable_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2587));
+    push((i64)(strings + 2610));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     push(8);
@@ -10873,7 +10894,7 @@ void mwtable_new_21_ (void){
     mwtable_num_buffer_21_();
     mwtable_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2592));
+    push((i64)(strings + 2615));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     mwword_alloc_21_();
@@ -10999,7 +11020,7 @@ void mwfield_alloc_21_ (void){
     mwField_2E_MAX();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 2600));
+    push((i64)(strings + 2623));
     mwpanic_21_();
     } else {
     mwid();
@@ -11016,7 +11037,7 @@ void mwfield_new_21_ (void){
     mwfield_name_21_();
     mwfield_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2641));
+    push((i64)(strings + 2664));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     mwover();
@@ -11029,7 +11050,7 @@ void mwfield_new_21_ (void){
     mwfield_buffer_21_();
     mwfield_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2649));
+    push((i64)(strings + 2672));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     mwword_alloc_21_();
@@ -11077,7 +11098,7 @@ void mwfield_new_21_ (void){
     mwfield_word_ptr_21_();
     mwfield_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2651));
+    push((i64)(strings + 2674));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     mwword_alloc_21_();
@@ -11118,7 +11139,7 @@ void mwfield_new_21_ (void){
     mwword_body_is_checked_21_();
     mwfield_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2653));
+    push((i64)(strings + 2676));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     mwword_alloc_21_();
@@ -11160,7 +11181,7 @@ void mwfield_new_21_ (void){
     mwword_body_is_checked_21_();
     mwfield_name_3F_();
     mwname_load_21_();
-    push((i64)(strings + 2655));
+    push((i64)(strings + 2678));
     mwstr_buf_push_str_21_();
     mwname_save_21_();
     mwword_alloc_21_();
@@ -11326,7 +11347,7 @@ void mwarrow_alloc_21_ (void){
     mwMAX_ARROWS();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 2657));
+    push((i64)(strings + 2680));
     mwpanic_21_();
     } else {
     mwid();
@@ -11462,7 +11483,7 @@ void mwarrow_op_prim_40_ (void){
     mwarrow_op_value_40_();
     mwInt__3E_Prim();
     } else {
-    push((i64)(strings + 2713));
+    push((i64)(strings + 2736));
     mwpanic_21_();
     }
 }
@@ -11490,7 +11511,7 @@ void mwarrow_op_word_40_ (void){
     mwarrow_op_value_40_();
     mwInt__3E_Word();
     } else {
-    push((i64)(strings + 2782));
+    push((i64)(strings + 2805));
     mwpanic_21_();
     }
 }
@@ -11518,7 +11539,7 @@ void mwarrow_op_external_40_ (void){
     mwarrow_op_value_40_();
     mwInt__3E_External();
     } else {
-    push((i64)(strings + 2851));
+    push((i64)(strings + 2874));
     mwpanic_21_();
     }
 }
@@ -11546,7 +11567,7 @@ void mwarrow_op_buffer_40_ (void){
     mwarrow_op_value_40_();
     mwInt__3E_Buffer();
     } else {
-    push((i64)(strings + 2928));
+    push((i64)(strings + 2951));
     mwpanic_21_();
     }
 }
@@ -11570,7 +11591,7 @@ void mwarrow_op_int_40_ (void){
     if (pop()) {
     mwarrow_op_value_40_();
     } else {
-    push((i64)(strings + 3005));
+    push((i64)(strings + 3028));
     mwpanic_21_();
     }
 }
@@ -11598,7 +11619,7 @@ void mwarrow_op_str_40_ (void){
     mwarrow_op_value_40_();
     mwInt__3E_StrLit();
     } else {
-    push((i64)(strings + 3072));
+    push((i64)(strings + 3095));
     mwpanic_21_();
     }
 }
@@ -11705,7 +11726,7 @@ void mwarrow_args_0 (void){
     mwdrop();
     } else {
     mwarrow_token_40_();
-    push((i64)(strings + 3139));
+    push((i64)(strings + 3162));
     mwemit_fatal_error_21_();
     }
 }
@@ -11720,7 +11741,7 @@ void mwarrow_args_1 (void){
     mwargs_head_40_();
     } else {
     mwarrow_token_40_();
-    push((i64)(strings + 3181));
+    push((i64)(strings + 3204));
     mwemit_fatal_error_21_();
     }
 }
@@ -11738,7 +11759,7 @@ void mwarrow_args_2 (void){
     mwargs_head_40_();
     } else {
     mwarrow_token_40_();
-    push((i64)(strings + 3221));
+    push((i64)(strings + 3244));
     mwemit_fatal_error_21_();
     }
 }
@@ -11771,7 +11792,7 @@ void mwsubst_alloc_21_ (void){
     mwSubst_2E_MAX();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 3262));
+    push((i64)(strings + 3285));
     mwpanic_21_();
     } else {
     mwid();
@@ -11875,7 +11896,7 @@ void mwstrings_push_21_ (void){
     mwMAX_STRINGS();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 3285));
+    push((i64)(strings + 3308));
     mwpanic_21_();
     } else {
     mwstrings_size_40_();
@@ -11935,52 +11956,52 @@ void mwtoken_type_str (void){
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 3309));
+    push((i64)(strings + 3332));
     } else {
     mwdup();
     mwTOKEN_LPAREN();
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 3314));
+    push((i64)(strings + 3337));
     } else {
     mwdup();
     mwTOKEN_RPAREN();
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 3321));
+    push((i64)(strings + 3344));
     } else {
     mwdup();
     mwTOKEN_COMMA();
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 3328));
+    push((i64)(strings + 3351));
     } else {
     mwdup();
     mwTOKEN_NAME();
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 3334));
+    push((i64)(strings + 3357));
     } else {
     mwdup();
     mwTOKEN_INT();
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 3339));
+    push((i64)(strings + 3362));
     } else {
     mwdup();
     mwTOKEN_STR();
     mw_3D_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 3343));
+    push((i64)(strings + 3366));
     } else {
     mwdrop();
-    push((i64)(strings + 3347));
+    push((i64)(strings + 3370));
     }
     }
     }
@@ -12029,7 +12050,7 @@ void mwtoken_int_40_ (void){
     mwtoken_value_40_();
     mwTokenValue__3E_Int();
     } else {
-    push((i64)(strings + 3361));
+    push((i64)(strings + 3384));
     mwemit_fatal_error_21_();
     }
 }
@@ -12053,7 +12074,7 @@ void mwtoken_str_40_ (void){
     mwtoken_value_40_();
     mwTokenValue__3E_Str();
     } else {
-    push((i64)(strings + 3412));
+    push((i64)(strings + 3435));
     mwemit_fatal_error_21_();
     }
 }
@@ -12077,7 +12098,7 @@ void mwtoken_name_40_ (void){
     mwtoken_value_40_();
     mwTokenValue__3E_Name();
     } else {
-    push((i64)(strings + 3463));
+    push((i64)(strings + 3486));
     mwemit_fatal_error_21_();
     }
 }
@@ -12102,7 +12123,7 @@ void mwtoken_token_40_ (void){
     mwtoken_value_40_();
     mwTokenValue__3E_Token();
     } else {
-    push((i64)(strings + 3516));
+    push((i64)(strings + 3539));
     mwemit_fatal_error_21_();
     }
     }
@@ -12117,7 +12138,7 @@ void mwtoken_print_21_ (void){
     mwdup();
     mwtoken_location();
     mwlocation_print_21_();
-    push((i64)(strings + 3571));
+    push((i64)(strings + 3594));
     mwstr_print_21_();
     mwdup();
     mwToken__3E_Int();
@@ -12158,11 +12179,11 @@ void mwlocation_print_21_ (void){
     mwswap();
     mwload_module_source_path_21_();
     mwstr_buf_print_21_();
-    push((i64)(strings + 3845));
+    push((i64)(strings + 3868));
     mwstr_print_21_();
     mwRow__3E_Int();
     mwint_print_21_();
-    push((i64)(strings + 3847));
+    push((i64)(strings + 3870));
     mwstr_print_21_();
     mwCol__3E_Int();
     mwint_print_21_();
@@ -12257,7 +12278,7 @@ void mwtoken_has_args_3F_ (void){
 void mwtoken_args_0 (void){
     mwtoken_has_args_3F_();
     if (pop()) {
-    push((i64)(strings + 3574));
+    push((i64)(strings + 3597));
     mwemit_fatal_error_21_();
     } else {
     mwdrop();
@@ -12279,12 +12300,12 @@ void mwtoken_args_1 (void){
     mwdrop2();
     } else {
     mwdrop();
-    push((i64)(strings + 3591));
+    push((i64)(strings + 3614));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 3620));
+    push((i64)(strings + 3643));
     mwemit_fatal_error_21_();
     }
 }
@@ -12311,17 +12332,17 @@ void mwtoken_args_2 (void){
     mwdrop2();
     } else {
     mwdrop();
-    push((i64)(strings + 3645));
+    push((i64)(strings + 3668));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 3675));
+    push((i64)(strings + 3698));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 3703));
+    push((i64)(strings + 3726));
     mwemit_fatal_error_21_();
     }
 }
@@ -12355,22 +12376,22 @@ void mwtoken_args_3 (void){
     mwdrop2();
     } else {
     mwdrop();
-    push((i64)(strings + 3729));
+    push((i64)(strings + 3752));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 3759));
+    push((i64)(strings + 3782));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 3787));
+    push((i64)(strings + 3810));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 3815));
+    push((i64)(strings + 3838));
     mwemit_fatal_error_21_();
     }
 }
@@ -12412,7 +12433,7 @@ void mwmodule_alloc_21_ (void){
     mwMAX_MODULES();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 3849));
+    push((i64)(strings + 3872));
     mwpanic_21_();
     } else {
     mwid();
@@ -12426,7 +12447,7 @@ void mwmodule_path_21_ (void){
     mwMODULE_PATH_SIZE();
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 3877));
+    push((i64)(strings + 3900));
     mwpanic_21_();
     } else {
     mwmodule_path_40_();
@@ -12497,9 +12518,9 @@ void mwpath_separator (void){
     mwWIN32();
     mw_3D_();
     if (pop()) {
-    push((i64)(strings + 3910));
+    push((i64)(strings + 3933));
     } else {
-    push((i64)(strings + 3912));
+    push((i64)(strings + 3935));
     }
 }
 
@@ -12673,82 +12694,82 @@ void mwrun_output_c99_21_ (void){
 }
 
 void mwc99_emit_header_21_ (void){
-    push((i64)(strings + 3952));
+    push((i64)(strings + 3975));
     mw_3B_();
-    push((i64)(strings + 3991));
+    push((i64)(strings + 4014));
     mw_3B_();
-    push((i64)(strings + 4070));
+    push((i64)(strings + 4093));
     mw_3B_();
-    push((i64)(strings + 4092));
+    push((i64)(strings + 4115));
     mw_3B_();
-    push((i64)(strings + 4117));
+    push((i64)(strings + 4140));
     mw_3B_();
-    push((i64)(strings + 4139));
+    push((i64)(strings + 4162));
     mw_3B_();
-    push((i64)(strings + 4164));
+    push((i64)(strings + 4187));
     mw_3B_();
-    push((i64)(strings + 4186));
+    push((i64)(strings + 4209));
     mw_3B_();
-    push((i64)(strings + 4192));
+    push((i64)(strings + 4215));
     mw_3B_();
-    push((i64)(strings + 4225));
+    push((i64)(strings + 4248));
     mw_3B__3B_();
-    push((i64)(strings + 4232));
+    push((i64)(strings + 4255));
     mw_3B_();
-    push((i64)(strings + 4252));
+    push((i64)(strings + 4275));
     mw_3B__3B_();
-    push((i64)(strings + 4273));
+    push((i64)(strings + 4296));
     mw_3B_();
-    push((i64)(strings + 4293));
+    push((i64)(strings + 4316));
     mw_3B_();
-    push((i64)(strings + 4315));
+    push((i64)(strings + 4338));
     mw_3B_();
-    push((i64)(strings + 4337));
+    push((i64)(strings + 4360));
     mw_3B_();
-    push((i64)(strings + 4359));
+    push((i64)(strings + 4382));
     mw_3B_();
-    push((i64)(strings + 4378));
+    push((i64)(strings + 4401));
     mw_3B_();
-    push((i64)(strings + 4399));
+    push((i64)(strings + 4422));
     mw_3B_();
-    push((i64)(strings + 4420));
+    push((i64)(strings + 4443));
     mw_3B_();
-    push((i64)(strings + 4441));
+    push((i64)(strings + 4464));
     mw_3B__3B_();
-    push((i64)(strings + 4466));
+    push((i64)(strings + 4489));
     mw_3B_();
-    push((i64)(strings + 4517));
+    push((i64)(strings + 4540));
     mw_3B_();
-    push((i64)(strings + 4545));
+    push((i64)(strings + 4568));
     mw_3B_();
-    push((i64)(strings + 4581));
-    mw_3B_();
-    push((i64)(strings + 4618));
+    push((i64)(strings + 4604));
     mw_3B_();
     push((i64)(strings + 4641));
     mw_3B_();
-    push((i64)(strings + 4675));
-    mw_3B__3B_();
+    push((i64)(strings + 4664));
+    mw_3B_();
     push((i64)(strings + 4698));
-    mw_3B_();
-    push((i64)(strings + 4722));
-    mw_3B_();
-    push((i64)(strings + 4761));
     mw_3B__3B_();
-    push((i64)(strings + 4806));
+    push((i64)(strings + 4721));
     mw_3B_();
-    push((i64)(strings + 4823));
+    push((i64)(strings + 4745));
+    mw_3B_();
+    push((i64)(strings + 4784));
+    mw_3B__3B_();
+    push((i64)(strings + 4829));
+    mw_3B_();
+    push((i64)(strings + 4846));
     mw_3B__3B_();
 }
 
 void mwc99_emit_strings_21_ (void){
-    push((i64)(strings + 4843));
+    push((i64)(strings + 4866));
     mw_2E_();
     mwstrings_size_40_();
     mw_2E_n();
-    push((i64)(strings + 4865));
+    push((i64)(strings + 4888));
     mw_3B_();
-    push((i64)(strings + 4866));
+    push((i64)(strings + 4889));
     mw_3B_();
     push(0);
     while(1) {
@@ -12762,7 +12783,7 @@ void mwc99_emit_strings_21_ (void){
     mwU8__3E_Int();
     mwdup();
     mw_2E_n();
-    push((i64)(strings + 4911));
+    push((i64)(strings + 4934));
     mw_2E_();
     mwnonzero();
     if (pop()) {
@@ -12773,764 +12794,772 @@ void mwc99_emit_strings_21_ (void){
     mw1_2B_();
     }
     mwdrop();
-    push((i64)(strings + 4913));
+    push((i64)(strings + 4936));
     mw_3B__3B_();
 }
 
 void mwc99_emit_prims_21_ (void){
-    push((i64)(strings + 4978));
+    push((i64)(strings + 5001));
     mw_3B_();
-    push((i64)(strings + 4996));
+    push((i64)(strings + 5019));
     mw_3B_();
-    push((i64)(strings + 5023));
+    push((i64)(strings + 5046));
     mw_3B_();
-    push((i64)(strings + 5051));
+    push((i64)(strings + 5074));
     mw_3B_();
-    push((i64)(strings + 5064));
+    push((i64)(strings + 5087));
     mw_3B_();
-    push((i64)(strings + 5107));
+    push((i64)(strings + 5130));
     mw_3B_();
-    push((i64)(strings + 5124));
+    push((i64)(strings + 5147));
     mw_3B_();
-    push((i64)(strings + 5142));
+    push((i64)(strings + 5165));
     mw_3B_();
-    push((i64)(strings + 5148));
+    push((i64)(strings + 5171));
     mw_3B__3B_();
-    push((i64)(strings + 5150));
+    push((i64)(strings + 5173));
     mw_3B_();
-    push((i64)(strings + 5174));
+    push((i64)(strings + 5197));
     mw_3B_();
-    push((i64)(strings + 5198));
-    mw_3B_();
-    push((i64)(strings + 5219));
-    mw_3B__3B_();
     push((i64)(strings + 5221));
     mw_3B_();
-    push((i64)(strings + 5241));
-    mw_3B_();
-    push((i64)(strings + 5260));
-    mw_3B_();
-    push((i64)(strings + 5278));
+    push((i64)(strings + 5242));
     mw_3B__3B_();
-    push((i64)(strings + 5280));
+    push((i64)(strings + 5244));
     mw_3B_();
-    push((i64)(strings + 5302));
+    push((i64)(strings + 5264));
     mw_3B_();
-    push((i64)(strings + 5321));
+    push((i64)(strings + 5283));
     mw_3B_();
-    push((i64)(strings + 5340));
+    push((i64)(strings + 5301));
     mw_3B__3B_();
-    push((i64)(strings + 5342));
+    push((i64)(strings + 5303));
     mw_3B_();
-    push((i64)(strings + 5364));
+    push((i64)(strings + 5325));
     mw_3B_();
-    push((i64)(strings + 5383));
+    push((i64)(strings + 5344));
     mw_3B_();
-    push((i64)(strings + 5402));
+    push((i64)(strings + 5363));
     mw_3B__3B_();
-    push((i64)(strings + 5404));
+    push((i64)(strings + 5365));
     mw_3B_();
-    push((i64)(strings + 5426));
+    push((i64)(strings + 5387));
     mw_3B_();
-    push((i64)(strings + 5445));
+    push((i64)(strings + 5406));
     mw_3B_();
-    push((i64)(strings + 5464));
+    push((i64)(strings + 5425));
     mw_3B__3B_();
-    push((i64)(strings + 5466));
+    push((i64)(strings + 5427));
     mw_3B_();
-    push((i64)(strings + 5486));
+    push((i64)(strings + 5449));
     mw_3B_();
-    push((i64)(strings + 5505));
+    push((i64)(strings + 5468));
     mw_3B_();
-    push((i64)(strings + 5523));
+    push((i64)(strings + 5487));
     mw_3B__3B_();
-    push((i64)(strings + 5525));
+    push((i64)(strings + 5489));
     mw_3B_();
-    push((i64)(strings + 5547));
+    push((i64)(strings + 5509));
     mw_3B_();
-    push((i64)(strings + 5566));
+    push((i64)(strings + 5528));
     mw_3B_();
-    push((i64)(strings + 5585));
+    push((i64)(strings + 5546));
     mw_3B__3B_();
-    push((i64)(strings + 5587));
+    push((i64)(strings + 5548));
     mw_3B_();
-    push((i64)(strings + 5609));
+    push((i64)(strings + 5570));
     mw_3B_();
-    push((i64)(strings + 5628));
+    push((i64)(strings + 5589));
     mw_3B_();
-    push((i64)(strings + 5647));
+    push((i64)(strings + 5608));
     mw_3B__3B_();
-    push((i64)(strings + 5649));
+    push((i64)(strings + 5610));
     mw_3B_();
-    push((i64)(strings + 5671));
+    push((i64)(strings + 5632));
     mw_3B_();
-    push((i64)(strings + 5689));
+    push((i64)(strings + 5651));
+    mw_3B_();
+    push((i64)(strings + 5670));
     mw_3B__3B_();
-    push((i64)(strings + 5691));
+    push((i64)(strings + 5672));
+    mw_3B_();
+    push((i64)(strings + 5694));
     mw_3B_();
     push((i64)(strings + 5712));
+    mw_3B__3B_();
+    push((i64)(strings + 5714));
     mw_3B_();
-    push((i64)(strings + 5730));
+    push((i64)(strings + 5735));
     mw_3B_();
-    push((i64)(strings + 5755));
+    push((i64)(strings + 5753));
     mw_3B_();
-    push((i64)(strings + 5768));
+    push((i64)(strings + 5778));
     mw_3B_();
-    push((i64)(strings + 5810));
-    mw_3B_();
-    push((i64)(strings + 5827));
+    push((i64)(strings + 5791));
     mw_3B_();
     push((i64)(strings + 5833));
+    mw_3B_();
+    push((i64)(strings + 5850));
+    mw_3B_();
+    push((i64)(strings + 5856));
     mw_3B__3B_();
     mwPRIM_ID();
     mw_2E_p();
-    push((i64)(strings + 5835));
+    push((i64)(strings + 5858));
     mw_3B_();
-    push((i64)(strings + 5838));
+    push((i64)(strings + 5861));
     mw_3B__3B_();
     mwPRIM_DUP();
     mw_2E_p();
-    push((i64)(strings + 5840));
+    push((i64)(strings + 5863));
     mw_3B_();
-    push((i64)(strings + 5843));
+    push((i64)(strings + 5866));
     mw_3B_();
-    push((i64)(strings + 5862));
+    push((i64)(strings + 5885));
     mw_3B_();
-    push((i64)(strings + 5884));
+    push((i64)(strings + 5907));
     mw_3B__3B_();
     mwPRIM_DROP();
     mw_2E_p();
-    push((i64)(strings + 5886));
+    push((i64)(strings + 5909));
     mw_3B_();
-    push((i64)(strings + 5889));
+    push((i64)(strings + 5912));
     mw_3B_();
-    push((i64)(strings + 5900));
+    push((i64)(strings + 5923));
     mw_3B__3B_();
     mwPRIM_SWAP();
     mw_2E_p();
-    push((i64)(strings + 5902));
+    push((i64)(strings + 5925));
     mw_3B_();
-    push((i64)(strings + 5905));
+    push((i64)(strings + 5928));
     mw_3B_();
-    push((i64)(strings + 5924));
+    push((i64)(strings + 5947));
     mw_3B_();
-    push((i64)(strings + 5943));
+    push((i64)(strings + 5966));
     mw_3B_();
-    push((i64)(strings + 5965));
+    push((i64)(strings + 5988));
     mw_3B__3B_();
     mwPRIM_INT_ADD();
     mw_2E_p();
-    push((i64)(strings + 5967));
+    push((i64)(strings + 5990));
     mw_3B_();
-    push((i64)(strings + 5970));
+    push((i64)(strings + 5993));
     mw_3B_();
-    push((i64)(strings + 5989));
+    push((i64)(strings + 6012));
     mw_3B_();
-    push((i64)(strings + 6008));
+    push((i64)(strings + 6031));
     mw_3B_();
-    push((i64)(strings + 6025));
+    push((i64)(strings + 6048));
     mw_3B__3B_();
     mwPRIM_INT_SUB();
     mw_2E_p();
-    push((i64)(strings + 6027));
+    push((i64)(strings + 6050));
     mw_3B_();
-    push((i64)(strings + 6030));
+    push((i64)(strings + 6053));
     mw_3B_();
-    push((i64)(strings + 6049));
+    push((i64)(strings + 6072));
     mw_3B_();
-    push((i64)(strings + 6068));
+    push((i64)(strings + 6091));
     mw_3B_();
-    push((i64)(strings + 6085));
+    push((i64)(strings + 6108));
     mw_3B__3B_();
     mwPRIM_INT_MUL();
     mw_2E_p();
-    push((i64)(strings + 6087));
+    push((i64)(strings + 6110));
     mw_3B_();
-    push((i64)(strings + 6090));
+    push((i64)(strings + 6113));
     mw_3B_();
-    push((i64)(strings + 6109));
+    push((i64)(strings + 6132));
     mw_3B_();
-    push((i64)(strings + 6128));
+    push((i64)(strings + 6151));
     mw_3B_();
-    push((i64)(strings + 6145));
+    push((i64)(strings + 6168));
     mw_3B__3B_();
     mwPRIM_INT_DIV();
     mw_2E_p();
-    push((i64)(strings + 6147));
+    push((i64)(strings + 6170));
     mw_3B_();
-    push((i64)(strings + 6150));
+    push((i64)(strings + 6173));
     mw_3B_();
-    push((i64)(strings + 6169));
+    push((i64)(strings + 6192));
     mw_3B_();
-    push((i64)(strings + 6188));
+    push((i64)(strings + 6211));
     mw_3B_();
-    push((i64)(strings + 6205));
+    push((i64)(strings + 6228));
     mw_3B__3B_();
     mwPRIM_INT_MOD();
     mw_2E_p();
-    push((i64)(strings + 6207));
+    push((i64)(strings + 6230));
     mw_3B_();
-    push((i64)(strings + 6210));
+    push((i64)(strings + 6233));
     mw_3B_();
-    push((i64)(strings + 6229));
+    push((i64)(strings + 6252));
     mw_3B_();
-    push((i64)(strings + 6248));
+    push((i64)(strings + 6271));
     mw_3B_();
-    push((i64)(strings + 6265));
+    push((i64)(strings + 6288));
     mw_3B__3B_();
     mwPRIM_INT_EQ();
     mw_2E_p();
-    push((i64)(strings + 6267));
+    push((i64)(strings + 6290));
     mw_3B_();
-    push((i64)(strings + 6270));
+    push((i64)(strings + 6293));
     mw_3B_();
-    push((i64)(strings + 6289));
-    mw_3B_();
-    push((i64)(strings + 6308));
-    mw_3B_();
-    push((i64)(strings + 6326));
-    mw_3B__3B_();
-    mwPRIM_INT_LT();
-    mw_2E_p();
-    push((i64)(strings + 6328));
+    push((i64)(strings + 6312));
     mw_3B_();
     push((i64)(strings + 6331));
     mw_3B_();
-    push((i64)(strings + 6350));
+    push((i64)(strings + 6349));
+    mw_3B__3B_();
+    mwPRIM_INT_LT();
+    mw_2E_p();
+    push((i64)(strings + 6351));
     mw_3B_();
-    push((i64)(strings + 6369));
+    push((i64)(strings + 6354));
     mw_3B_();
-    push((i64)(strings + 6386));
+    push((i64)(strings + 6373));
+    mw_3B_();
+    push((i64)(strings + 6392));
+    mw_3B_();
+    push((i64)(strings + 6409));
     mw_3B__3B_();
     mwPRIM_INT_LE();
     mw_2E_p();
-    push((i64)(strings + 6388));
+    push((i64)(strings + 6411));
     mw_3B_();
-    push((i64)(strings + 6391));
+    push((i64)(strings + 6414));
     mw_3B_();
-    push((i64)(strings + 6410));
-    mw_3B_();
-    push((i64)(strings + 6429));
-    mw_3B_();
-    push((i64)(strings + 6447));
-    mw_3B__3B_();
-    mwPRIM_INT_AND();
-    mw_2E_p();
-    push((i64)(strings + 6449));
+    push((i64)(strings + 6433));
     mw_3B_();
     push((i64)(strings + 6452));
     mw_3B_();
-    push((i64)(strings + 6471));
+    push((i64)(strings + 6470));
+    mw_3B__3B_();
+    mwPRIM_INT_AND();
+    mw_2E_p();
+    push((i64)(strings + 6472));
     mw_3B_();
-    push((i64)(strings + 6490));
+    push((i64)(strings + 6475));
     mw_3B_();
-    push((i64)(strings + 6507));
+    push((i64)(strings + 6494));
+    mw_3B_();
+    push((i64)(strings + 6513));
+    mw_3B_();
+    push((i64)(strings + 6530));
     mw_3B__3B_();
     mwPRIM_INT_OR();
     mw_2E_p();
-    push((i64)(strings + 6509));
+    push((i64)(strings + 6532));
     mw_3B_();
-    push((i64)(strings + 6512));
+    push((i64)(strings + 6535));
     mw_3B_();
-    push((i64)(strings + 6531));
+    push((i64)(strings + 6554));
     mw_3B_();
-    push((i64)(strings + 6550));
+    push((i64)(strings + 6573));
     mw_3B_();
-    push((i64)(strings + 6567));
+    push((i64)(strings + 6590));
     mw_3B__3B_();
     mwPRIM_INT_XOR();
     mw_2E_p();
-    push((i64)(strings + 6569));
+    push((i64)(strings + 6592));
     mw_3B_();
-    push((i64)(strings + 6572));
+    push((i64)(strings + 6595));
     mw_3B_();
-    push((i64)(strings + 6591));
+    push((i64)(strings + 6614));
     mw_3B_();
-    push((i64)(strings + 6610));
+    push((i64)(strings + 6633));
     mw_3B_();
-    push((i64)(strings + 6627));
+    push((i64)(strings + 6650));
     mw_3B__3B_();
     mwPRIM_INT_SHL();
     mw_2E_p();
-    push((i64)(strings + 6629));
+    push((i64)(strings + 6652));
     mw_3B_();
-    push((i64)(strings + 6632));
+    push((i64)(strings + 6655));
     mw_3B_();
-    push((i64)(strings + 6651));
-    mw_3B_();
-    push((i64)(strings + 6670));
-    mw_3B_();
-    push((i64)(strings + 6688));
-    mw_3B__3B_();
-    mwPRIM_INT_SHR();
-    mw_2E_p();
-    push((i64)(strings + 6690));
+    push((i64)(strings + 6674));
     mw_3B_();
     push((i64)(strings + 6693));
     mw_3B_();
-    push((i64)(strings + 6712));
-    mw_3B_();
-    push((i64)(strings + 6731));
-    mw_3B_();
-    push((i64)(strings + 6749));
+    push((i64)(strings + 6711));
     mw_3B__3B_();
-    mwPRIM_POSIX_WRITE();
+    mwPRIM_INT_SHR();
     mw_2E_p();
-    push((i64)(strings + 6751));
+    push((i64)(strings + 6713));
+    mw_3B_();
+    push((i64)(strings + 6716));
+    mw_3B_();
+    push((i64)(strings + 6735));
     mw_3B_();
     push((i64)(strings + 6754));
     mw_3B_();
-    push((i64)(strings + 6782));
+    push((i64)(strings + 6772));
+    mw_3B__3B_();
+    mwPRIM_POSIX_WRITE();
+    mw_2E_p();
+    push((i64)(strings + 6774));
     mw_3B_();
-    push((i64)(strings + 6807));
+    push((i64)(strings + 6777));
     mw_3B_();
-    push((i64)(strings + 6831));
+    push((i64)(strings + 6805));
     mw_3B_();
-    push((i64)(strings + 6851));
+    push((i64)(strings + 6830));
+    mw_3B_();
+    push((i64)(strings + 6854));
+    mw_3B_();
+    push((i64)(strings + 6874));
     mw_3B__3B_();
     mwPRIM_POSIX_READ();
     mw_2E_p();
-    push((i64)(strings + 6853));
+    push((i64)(strings + 6876));
     mw_3B_();
-    push((i64)(strings + 6856));
+    push((i64)(strings + 6879));
     mw_3B_();
-    push((i64)(strings + 6884));
+    push((i64)(strings + 6907));
     mw_3B_();
-    push((i64)(strings + 6909));
-    mw_3B_();
-    push((i64)(strings + 6933));
+    push((i64)(strings + 6932));
     mw_3B_();
     push((i64)(strings + 6956));
+    mw_3B_();
+    push((i64)(strings + 6979));
     mw_3B__3B_();
     mwPRIM_POSIX_OPEN();
     mw_2E_p();
-    push((i64)(strings + 6958));
+    push((i64)(strings + 6981));
     mw_3B_();
-    push((i64)(strings + 6961));
+    push((i64)(strings + 6984));
     mw_3B_();
-    push((i64)(strings + 6985));
+    push((i64)(strings + 7008));
     mw_3B_();
-    push((i64)(strings + 7009));
-    mw_3B_();
-    push((i64)(strings + 7034));
+    push((i64)(strings + 7032));
     mw_3B_();
     push((i64)(strings + 7057));
+    mw_3B_();
+    push((i64)(strings + 7080));
     mw_3B__3B_();
     mwPRIM_POSIX_CLOSE();
     mw_2E_p();
-    push((i64)(strings + 7059));
+    push((i64)(strings + 7082));
     mw_3B_();
-    push((i64)(strings + 7062));
+    push((i64)(strings + 7085));
     mw_3B_();
-    push((i64)(strings + 7086));
+    push((i64)(strings + 7109));
     mw_3B_();
-    push((i64)(strings + 7106));
+    push((i64)(strings + 7129));
     mw_3B__3B_();
     mwPRIM_POSIX_EXIT();
     mw_2E_p();
-    push((i64)(strings + 7108));
+    push((i64)(strings + 7131));
     mw_3B_();
-    push((i64)(strings + 7111));
+    push((i64)(strings + 7134));
     mw_3B_();
-    push((i64)(strings + 7135));
+    push((i64)(strings + 7158));
     mw_3B_();
-    push((i64)(strings + 7148));
+    push((i64)(strings + 7171));
     mw_3B__3B_();
     mwPRIM_POSIX_MMAP();
     mw_2E_p();
-    push((i64)(strings + 7150));
-    mw_3B_();
-    push((i64)(strings + 7153));
+    push((i64)(strings + 7173));
     mw_3B_();
     push((i64)(strings + 7176));
     mw_3B_();
-    push((i64)(strings + 7208));
+    push((i64)(strings + 7199));
     mw_3B_();
-    push((i64)(strings + 7236));
+    push((i64)(strings + 7231));
     mw_3B_();
-    push((i64)(strings + 7247));
+    push((i64)(strings + 7259));
     mw_3B_();
-    push((i64)(strings + 7273));
+    push((i64)(strings + 7270));
     mw_3B_();
-    push((i64)(strings + 7283));
+    push((i64)(strings + 7296));
     mw_3B_();
-    push((i64)(strings + 7307));
+    push((i64)(strings + 7306));
     mw_3B_();
-    push((i64)(strings + 7331));
+    push((i64)(strings + 7330));
     mw_3B_();
-    push((i64)(strings + 7355));
+    push((i64)(strings + 7354));
     mw_3B_();
-    push((i64)(strings + 7379));
+    push((i64)(strings + 7378));
     mw_3B_();
-    push((i64)(strings + 7407));
+    push((i64)(strings + 7402));
     mw_3B_();
-    push((i64)(strings + 7432));
+    push((i64)(strings + 7430));
     mw_3B_();
-    push((i64)(strings + 7465));
+    push((i64)(strings + 7455));
     mw_3B_();
-    push((i64)(strings + 7483));
+    push((i64)(strings + 7488));
     mw_3B_();
-    push((i64)(strings + 7494));
+    push((i64)(strings + 7506));
+    mw_3B_();
+    push((i64)(strings + 7517));
     mw_3B__3B_();
     mwPRIM_DEBUG();
     mw_2E_p();
-    push((i64)(strings + 7496));
-    mw_3B_();
-    push((i64)(strings + 7499));
+    push((i64)(strings + 7519));
     mw_3B_();
     push((i64)(strings + 7522));
     mw_3B_();
-    push((i64)(strings + 7544));
+    push((i64)(strings + 7545));
     mw_3B_();
-    push((i64)(strings + 7558));
+    push((i64)(strings + 7567));
     mw_3B_();
-    push((i64)(strings + 7571));
+    push((i64)(strings + 7581));
     mw_3B_();
-    push((i64)(strings + 7589));
+    push((i64)(strings + 7594));
     mw_3B_();
-    push((i64)(strings + 7643));
+    push((i64)(strings + 7612));
     mw_3B_();
-    push((i64)(strings + 7662));
+    push((i64)(strings + 7666));
     mw_3B_();
-    push((i64)(strings + 7689));
+    push((i64)(strings + 7685));
     mw_3B_();
-    push((i64)(strings + 7704));
+    push((i64)(strings + 7712));
     mw_3B_();
-    push((i64)(strings + 7742));
+    push((i64)(strings + 7727));
     mw_3B_();
-    push((i64)(strings + 7805));
+    push((i64)(strings + 7765));
     mw_3B_();
-    push((i64)(strings + 7847));
+    push((i64)(strings + 7828));
     mw_3B_();
-    push((i64)(strings + 7866));
+    push((i64)(strings + 7870));
     mw_3B_();
-    push((i64)(strings + 7891));
+    push((i64)(strings + 7889));
     mw_3B_();
-    push((i64)(strings + 7897));
+    push((i64)(strings + 7914));
     mw_3B_();
     push((i64)(strings + 7920));
+    mw_3B_();
+    push((i64)(strings + 7943));
     mw_3B__3B_();
     mwPRIM_MIRTH_REVISION();
     mw_2E_p();
-    push((i64)(strings + 7922));
+    push((i64)(strings + 7945));
     mw_3B_();
-    push((i64)(strings + 7925));
+    push((i64)(strings + 7948));
     mw_2E_();
     mwNEW_MIRTH_REVISION();
     mw_2E_n();
-    push((i64)(strings + 7935));
+    push((i64)(strings + 7958));
     mw_3B_();
-    push((i64)(strings + 7938));
+    push((i64)(strings + 7961));
     mw_3B__3B_();
     mwPRIM_MEM_GET();
     mw_2E_p();
-    push((i64)(strings + 7940));
+    push((i64)(strings + 7963));
     mw_3B_();
-    push((i64)(strings + 7943));
+    push((i64)(strings + 7966));
     mw_3B_();
-    push((i64)(strings + 7979));
+    push((i64)(strings + 8002));
     mw_3B__3B_();
     mwPRIM_MEM_SET();
     mw_2E_p();
-    push((i64)(strings + 7981));
+    push((i64)(strings + 8004));
     mw_3B_();
-    push((i64)(strings + 7984));
+    push((i64)(strings + 8007));
     mw_3B_();
-    push((i64)(strings + 8008));
+    push((i64)(strings + 8031));
     mw_3B_();
-    push((i64)(strings + 8029));
+    push((i64)(strings + 8052));
     mw_3B__3B_();
     mwPRIM_MEM_GET_BYTE();
     mw_2E_p();
-    push((i64)(strings + 8031));
-    mw_3B_();
-    push((i64)(strings + 8034));
+    push((i64)(strings + 8054));
     mw_3B_();
     push((i64)(strings + 8057));
     mw_3B_();
-    push((i64)(strings + 8071));
+    push((i64)(strings + 8080));
+    mw_3B_();
+    push((i64)(strings + 8094));
     mw_3B__3B_();
     mwPRIM_MEM_SET_BYTE();
     mw_2E_p();
-    push((i64)(strings + 8073));
-    mw_3B_();
-    push((i64)(strings + 8076));
+    push((i64)(strings + 8096));
     mw_3B_();
     push((i64)(strings + 8099));
     mw_3B_();
-    push((i64)(strings + 8118));
+    push((i64)(strings + 8122));
+    mw_3B_();
+    push((i64)(strings + 8141));
     mw_3B__3B_();
     mwPRIM_MEM_GET_U8();
     mw_2E_p();
-    push((i64)(strings + 8120));
-    mw_3B_();
-    push((i64)(strings + 8123));
+    push((i64)(strings + 8143));
     mw_3B_();
     push((i64)(strings + 8146));
     mw_3B_();
-    push((i64)(strings + 8160));
+    push((i64)(strings + 8169));
+    mw_3B_();
+    push((i64)(strings + 8183));
     mw_3B__3B_();
     mwPRIM_MEM_SET_U8();
     mw_2E_p();
-    push((i64)(strings + 8162));
-    mw_3B_();
-    push((i64)(strings + 8165));
+    push((i64)(strings + 8185));
     mw_3B_();
     push((i64)(strings + 8188));
     mw_3B_();
-    push((i64)(strings + 8207));
+    push((i64)(strings + 8211));
+    mw_3B_();
+    push((i64)(strings + 8230));
     mw_3B__3B_();
     mwPRIM_MEM_GET_U16();
     mw_2E_p();
-    push((i64)(strings + 8209));
+    push((i64)(strings + 8232));
     mw_3B_();
-    push((i64)(strings + 8212));
+    push((i64)(strings + 8235));
     mw_3B_();
-    push((i64)(strings + 8236));
+    push((i64)(strings + 8259));
     mw_3B_();
-    push((i64)(strings + 8250));
+    push((i64)(strings + 8273));
     mw_3B__3B_();
     mwPRIM_MEM_SET_U16();
     mw_2E_p();
-    push((i64)(strings + 8252));
+    push((i64)(strings + 8275));
     mw_3B_();
-    push((i64)(strings + 8255));
+    push((i64)(strings + 8278));
     mw_3B_();
-    push((i64)(strings + 8279));
+    push((i64)(strings + 8302));
     mw_3B_();
-    push((i64)(strings + 8299));
+    push((i64)(strings + 8322));
     mw_3B__3B_();
     mwPRIM_MEM_GET_U32();
     mw_2E_p();
-    push((i64)(strings + 8301));
+    push((i64)(strings + 8324));
     mw_3B_();
-    push((i64)(strings + 8304));
+    push((i64)(strings + 8327));
     mw_3B_();
-    push((i64)(strings + 8328));
+    push((i64)(strings + 8351));
     mw_3B_();
-    push((i64)(strings + 8342));
+    push((i64)(strings + 8365));
     mw_3B__3B_();
     mwPRIM_MEM_SET_U32();
     mw_2E_p();
-    push((i64)(strings + 8344));
+    push((i64)(strings + 8367));
     mw_3B_();
-    push((i64)(strings + 8347));
+    push((i64)(strings + 8370));
     mw_3B_();
-    push((i64)(strings + 8371));
+    push((i64)(strings + 8394));
     mw_3B_();
-    push((i64)(strings + 8391));
+    push((i64)(strings + 8414));
     mw_3B__3B_();
     mwPRIM_MEM_GET_U64();
     mw_2E_p();
-    push((i64)(strings + 8393));
+    push((i64)(strings + 8416));
     mw_3B_();
-    push((i64)(strings + 8396));
+    push((i64)(strings + 8419));
     mw_3B_();
-    push((i64)(strings + 8420));
+    push((i64)(strings + 8443));
     mw_3B_();
-    push((i64)(strings + 8434));
+    push((i64)(strings + 8457));
     mw_3B__3B_();
     mwPRIM_MEM_SET_U64();
     mw_2E_p();
-    push((i64)(strings + 8436));
+    push((i64)(strings + 8459));
     mw_3B_();
-    push((i64)(strings + 8439));
+    push((i64)(strings + 8462));
     mw_3B_();
-    push((i64)(strings + 8463));
+    push((i64)(strings + 8486));
     mw_3B_();
-    push((i64)(strings + 8483));
+    push((i64)(strings + 8506));
     mw_3B__3B_();
     mwPRIM_MEM_GET_I8();
     mw_2E_p();
-    push((i64)(strings + 8485));
-    mw_3B_();
-    push((i64)(strings + 8488));
+    push((i64)(strings + 8508));
     mw_3B_();
     push((i64)(strings + 8511));
     mw_3B_();
-    push((i64)(strings + 8525));
+    push((i64)(strings + 8534));
+    mw_3B_();
+    push((i64)(strings + 8548));
     mw_3B__3B_();
     mwPRIM_MEM_SET_I8();
     mw_2E_p();
-    push((i64)(strings + 8527));
-    mw_3B_();
-    push((i64)(strings + 8530));
+    push((i64)(strings + 8550));
     mw_3B_();
     push((i64)(strings + 8553));
     mw_3B_();
-    push((i64)(strings + 8572));
+    push((i64)(strings + 8576));
+    mw_3B_();
+    push((i64)(strings + 8595));
     mw_3B__3B_();
     mwPRIM_MEM_GET_I16();
     mw_2E_p();
-    push((i64)(strings + 8574));
+    push((i64)(strings + 8597));
     mw_3B_();
-    push((i64)(strings + 8577));
+    push((i64)(strings + 8600));
     mw_3B_();
-    push((i64)(strings + 8601));
+    push((i64)(strings + 8624));
     mw_3B_();
-    push((i64)(strings + 8615));
+    push((i64)(strings + 8638));
     mw_3B__3B_();
     mwPRIM_MEM_SET_I16();
     mw_2E_p();
-    push((i64)(strings + 8617));
+    push((i64)(strings + 8640));
     mw_3B_();
-    push((i64)(strings + 8620));
+    push((i64)(strings + 8643));
     mw_3B_();
-    push((i64)(strings + 8644));
+    push((i64)(strings + 8667));
     mw_3B_();
-    push((i64)(strings + 8664));
+    push((i64)(strings + 8687));
     mw_3B__3B_();
     mwPRIM_MEM_GET_I32();
     mw_2E_p();
-    push((i64)(strings + 8666));
+    push((i64)(strings + 8689));
     mw_3B_();
-    push((i64)(strings + 8669));
+    push((i64)(strings + 8692));
     mw_3B_();
-    push((i64)(strings + 8693));
+    push((i64)(strings + 8716));
     mw_3B_();
-    push((i64)(strings + 8707));
+    push((i64)(strings + 8730));
     mw_3B__3B_();
     mwPRIM_MEM_SET_I32();
     mw_2E_p();
-    push((i64)(strings + 8709));
+    push((i64)(strings + 8732));
     mw_3B_();
-    push((i64)(strings + 8712));
+    push((i64)(strings + 8735));
     mw_3B_();
-    push((i64)(strings + 8736));
+    push((i64)(strings + 8759));
     mw_3B_();
-    push((i64)(strings + 8756));
+    push((i64)(strings + 8779));
     mw_3B__3B_();
     mwPRIM_MEM_GET_I64();
     mw_2E_p();
-    push((i64)(strings + 8758));
+    push((i64)(strings + 8781));
     mw_3B_();
-    push((i64)(strings + 8761));
+    push((i64)(strings + 8784));
     mw_3B_();
-    push((i64)(strings + 8785));
+    push((i64)(strings + 8808));
     mw_3B_();
-    push((i64)(strings + 8799));
+    push((i64)(strings + 8822));
     mw_3B__3B_();
     mwPRIM_MEM_SET_I64();
     mw_2E_p();
-    push((i64)(strings + 8801));
+    push((i64)(strings + 8824));
     mw_3B_();
-    push((i64)(strings + 8804));
+    push((i64)(strings + 8827));
     mw_3B_();
-    push((i64)(strings + 8828));
+    push((i64)(strings + 8851));
     mw_3B_();
-    push((i64)(strings + 8848));
+    push((i64)(strings + 8871));
     mw_3B__3B_();
     mwPRIM_RUNNING_OS();
     mw_2E_p();
-    push((i64)(strings + 8850));
+    push((i64)(strings + 8873));
     mw_3B_();
-    push((i64)(strings + 8853));
+    push((i64)(strings + 8876));
     mw_3B_();
-    push((i64)(strings + 8878));
+    push((i64)(strings + 8901));
     mw_2E_();
     mwWIN32();
     mw_2E_n();
-    push((i64)(strings + 8888));
+    push((i64)(strings + 8911));
     mw_3B_();
-    push((i64)(strings + 8891));
+    push((i64)(strings + 8914));
     mw_3B_();
-    push((i64)(strings + 8918));
+    push((i64)(strings + 8941));
     mw_2E_();
     mwLINUX();
     mw_2E_n();
-    push((i64)(strings + 8928));
+    push((i64)(strings + 8951));
     mw_3B_();
-    push((i64)(strings + 8931));
+    push((i64)(strings + 8954));
     mw_3B_();
-    push((i64)(strings + 8958));
+    push((i64)(strings + 8981));
     mw_2E_();
     mwMACOS();
     mw_2E_n();
-    push((i64)(strings + 8968));
+    push((i64)(strings + 8991));
     mw_3B_();
-    push((i64)(strings + 8971));
+    push((i64)(strings + 8994));
     mw_3B_();
-    push((i64)(strings + 8977));
+    push((i64)(strings + 9000));
     mw_2E_();
     mwUNKNOWN();
     mw_2E_n();
-    push((i64)(strings + 8987));
+    push((i64)(strings + 9010));
     mw_3B_();
-    push((i64)(strings + 8990));
+    push((i64)(strings + 9013));
     mw_3B_();
-    push((i64)(strings + 8997));
+    push((i64)(strings + 9020));
     mw_3B__3B_();
     mwPRIM_CAST();
     mw_2E_p();
-    push((i64)(strings + 8999));
+    push((i64)(strings + 9022));
     mw_3B__3B_();
     mwPRIM_PTR_2B_();
     mw_2E_p();
-    push((i64)(strings + 9004));
+    push((i64)(strings + 9027));
     mw_3B_();
-    push((i64)(strings + 9007));
+    push((i64)(strings + 9030));
     mw_3B_();
-    push((i64)(strings + 9029));
-    mw_3B_();
-    push((i64)(strings + 9047));
+    push((i64)(strings + 9052));
     mw_3B_();
     push((i64)(strings + 9070));
+    mw_3B_();
+    push((i64)(strings + 9093));
     mw_3B__3B_();
     mwPRIM_TRUE();
     mw_2E_p();
-    push((i64)(strings + 9072));
+    push((i64)(strings + 9095));
     mw_3B_();
-    push((i64)(strings + 9075));
+    push((i64)(strings + 9098));
     mw_3B_();
-    push((i64)(strings + 9091));
+    push((i64)(strings + 9114));
     mw_3B_();
     mwPRIM_FALSE();
     mw_2E_p();
-    push((i64)(strings + 9093));
+    push((i64)(strings + 9116));
     mw_3B_();
-    push((i64)(strings + 9096));
+    push((i64)(strings + 9119));
     mw_3B_();
-    push((i64)(strings + 9113));
+    push((i64)(strings + 9136));
     mw_3B__3B_();
     mwPRIM_BOOL_AND();
     mw_2E_p();
-    push((i64)(strings + 9115));
-    mw_3B_();
-    push((i64)(strings + 9118));
-    mw_3B_();
     push((i64)(strings + 9138));
     mw_3B_();
-    push((i64)(strings + 9158));
+    push((i64)(strings + 9141));
     mw_3B_();
-    push((i64)(strings + 9176));
-    mw_3B_();
-    mwPRIM_BOOL_OR();
-    mw_2E_p();
-    push((i64)(strings + 9178));
+    push((i64)(strings + 9161));
     mw_3B_();
     push((i64)(strings + 9181));
     mw_3B_();
+    push((i64)(strings + 9199));
+    mw_3B_();
+    mwPRIM_BOOL_OR();
+    mw_2E_p();
     push((i64)(strings + 9201));
     mw_3B_();
-    push((i64)(strings + 9221));
+    push((i64)(strings + 9204));
     mw_3B_();
-    push((i64)(strings + 9239));
-    mw_3B__3B_();
-    mwPRIM_ARGC();
-    mw_2E_p();
-    push((i64)(strings + 9241));
+    push((i64)(strings + 9224));
     mw_3B_();
     push((i64)(strings + 9244));
     mw_3B_();
+    push((i64)(strings + 9262));
+    mw_3B__3B_();
+    mwPRIM_ARGC();
+    mw_2E_p();
+    push((i64)(strings + 9264));
+    mw_3B_();
     push((i64)(strings + 9267));
+    mw_3B_();
+    push((i64)(strings + 9290));
     mw_3B_();
     mwPRIM_ARGV();
     mw_2E_p();
-    push((i64)(strings + 9269));
+    push((i64)(strings + 9292));
     mw_3B_();
-    push((i64)(strings + 9272));
+    push((i64)(strings + 9295));
     mw_3B_();
-    push((i64)(strings + 9300));
+    push((i64)(strings + 9323));
+    mw_3B__3B_();
+    mwPRIM_PTR_SIZE();
+    mw_2E_p();
+    push((i64)(strings + 9325));
+    mw_3B_();
+    push((i64)(strings + 9328));
+    mw_3B_();
+    push((i64)(strings + 9358));
     mw_3B__3B_();
 }
 
@@ -13578,7 +13607,7 @@ void mwc99_emit_word_sigs_21_ (void){
     mwc99_emit_word_sig_21_();
     mw1_2B_();
     }
-    push((i64)(strings + 9452));
+    push((i64)(strings + 9510));
     mw_3B_();
     mwdrop();
 }
@@ -13604,16 +13633,16 @@ void mwc99_emit_main_21_ (void){
     mwTYPE_UNIT();
     mwelab_stack_21_();
     mwelab_arrow_21_();
-    push((i64)(strings + 9737));
+    push((i64)(strings + 9795));
     mw_3B_();
-    push((i64)(strings + 9772));
+    push((i64)(strings + 9830));
     mw_3B_();
-    push((i64)(strings + 9796));
+    push((i64)(strings + 9854));
     mw_3B_();
     mwc99_emit_arrow_21_();
-    push((i64)(strings + 9820));
+    push((i64)(strings + 9878));
     mw_3B_();
-    push((i64)(strings + 9834));
+    push((i64)(strings + 9892));
     mw_3B_();
 }
 
@@ -13674,10 +13703,10 @@ void mw_2E_name (void){
 }
 
 void mw_2E_w (void){
-    push((i64)(strings + 3936));
+    push((i64)(strings + 3959));
     mw_2E_();
     mw_2E_name();
-    push((i64)(strings + 3944));
+    push((i64)(strings + 3967));
     mw_2E_();
 }
 
@@ -13689,26 +13718,26 @@ void mw_2E_p (void){
 void mwc99_emit_buffer_21_ (void){
     mwname_is_buffer_3F_();
     if (pop()) {
-    push((i64)(strings + 4916));
+    push((i64)(strings + 4939));
     mw_2E_();
     mwdup();
     mw_2E_name();
-    push((i64)(strings + 4931));
+    push((i64)(strings + 4954));
     mw_2E_();
     mwdup();
     mwname_buffer_40_();
     mwbuffer_size_40_();
     mw_2E_n();
-    push((i64)(strings + 4933));
+    push((i64)(strings + 4956));
     mw_3B_();
-    push((i64)(strings + 4942));
+    push((i64)(strings + 4965));
     mw_2E_();
     mwdup();
     mw_2E_name();
-    push((i64)(strings + 4951));
+    push((i64)(strings + 4974));
     mw_2E_();
     mw_2E_name();
-    push((i64)(strings + 4973));
+    push((i64)(strings + 4996));
     mw_3B_();
     } else {
     mwdrop();
@@ -13724,17 +13753,17 @@ void mwc99_emit_external_21_ (void){
     push(2);
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 9302));
+    push((i64)(strings + 9360));
     mwpanic_21_();
     } else {
     mwdup();
     push(1);
     mw_3E__3D_();
     if (pop()) {
-    push((i64)(strings + 9353));
+    push((i64)(strings + 9411));
     mw_2E_();
     } else {
-    push((i64)(strings + 9358));
+    push((i64)(strings + 9416));
     mw_2E_();
     }
     }
@@ -13744,20 +13773,20 @@ void mwc99_emit_external_21_ (void){
     mw_2E_name();
       push(d3); }
       push(d2); }
-    push((i64)(strings + 9364));
+    push((i64)(strings + 9422));
     mw_2E_();
     mwover();
     mwdup();
     mwnonzero();
     if (pop()) {
-    push((i64)(strings + 9367));
+    push((i64)(strings + 9425));
     mw_2E_();
     mw1_();
     while(1) {
     mwdup();
     mwnonzero();
     if (!pop()) break;
-    push((i64)(strings + 9371));
+    push((i64)(strings + 9429));
     mw_2E_();
     mw1_();
     }
@@ -13765,9 +13794,9 @@ void mwc99_emit_external_21_ (void){
     } else {
     mwdrop();
     }
-    push((i64)(strings + 9377));
+    push((i64)(strings + 9435));
     mw_3B_();
-    push((i64)(strings + 9380));
+    push((i64)(strings + 9438));
     mw_2E_();
     { i64 d2 = pop();
     { i64 d3 = pop();
@@ -13775,18 +13804,18 @@ void mwc99_emit_external_21_ (void){
     mw_2E_name();
       push(d3); }
       push(d2); }
-    push((i64)(strings + 9389));
+    push((i64)(strings + 9447));
     mw_3B_();
     mwover();
     while(1) {
     mwdup();
     mwnonzero();
     if (!pop()) break;
-    push((i64)(strings + 9399));
+    push((i64)(strings + 9457));
     mw_2E_();
     mwdup();
     mw_2E_n();
-    push((i64)(strings + 9409));
+    push((i64)(strings + 9467));
     mw_3B_();
     mw1_();
     }
@@ -13794,9 +13823,9 @@ void mwc99_emit_external_21_ (void){
     mwdup();
     mwnonzero();
     if (pop()) {
-    push((i64)(strings + 9419));
+    push((i64)(strings + 9477));
     } else {
-    push((i64)(strings + 9429));
+    push((i64)(strings + 9487));
     }
     mw_2E_();
     { i64 d2 = pop();
@@ -13805,13 +13834,13 @@ void mwc99_emit_external_21_ (void){
     mw_2E_name();
       push(d3); }
       push(d2); }
-    push((i64)(strings + 9434));
+    push((i64)(strings + 9492));
     mw_2E_();
     { i64 d2 = pop();
     mwdup();
     mwnonzero();
     if (pop()) {
-    push((i64)(strings + 9436));
+    push((i64)(strings + 9494));
     mw_2E_();
     mwdup();
     mw1_();
@@ -13819,7 +13848,7 @@ void mwc99_emit_external_21_ (void){
     mwdup();
     mwnonzero();
     if (!pop()) break;
-    push((i64)(strings + 9439));
+    push((i64)(strings + 9497));
     mw_2E_();
     mwdup2();
     mw_();
@@ -13832,17 +13861,17 @@ void mwc99_emit_external_21_ (void){
     mwid();
     }
       push(d2); }
-    push((i64)(strings + 9443));
+    push((i64)(strings + 9501));
     mw_2E_();
     mwdup();
     mwnonzero();
     if (pop()) {
-    push((i64)(strings + 9445));
+    push((i64)(strings + 9503));
     } else {
-    push((i64)(strings + 9448));
+    push((i64)(strings + 9506));
     }
     mw_3B_();
-    push((i64)(strings + 9450));
+    push((i64)(strings + 9508));
     mw_3B_();
     mwdrop3();
     } else {
@@ -13869,10 +13898,10 @@ void mwsig_arity (void){
 void mwc99_emit_word_sig_21_ (void){
     mwname_is_word_3F_();
     if (pop()) {
-    push((i64)(strings + 9715));
+    push((i64)(strings + 9773));
     mw_2E_();
     mw_2E_name();
-    push((i64)(strings + 9724));
+    push((i64)(strings + 9782));
     mw_3B_();
     } else {
     mwdrop();
@@ -13901,50 +13930,50 @@ void mwc99_emit_arrow_op_21_ (void){
     mwarrow_op_is_int_3F_();
     if (pop()) {
     mwarrow_op_int_40_();
-    push((i64)(strings + 9453));
+    push((i64)(strings + 9511));
     mw_2E_();
     mw_2E_n();
-    push((i64)(strings + 9463));
+    push((i64)(strings + 9521));
     mw_3B_();
     } else {
     mwarrow_op_is_str_3F_();
     if (pop()) {
     mwarrow_op_str_40_();
     mwStrLit__3E_Int();
-    push((i64)(strings + 9466));
+    push((i64)(strings + 9524));
     mw_2E_();
     mw_2E_n();
-    push((i64)(strings + 9492));
+    push((i64)(strings + 9550));
     mw_3B_();
     } else {
     mwarrow_op_is_word_3F_();
     if (pop()) {
     mwarrow_op_word_40_();
     mwword_name_40_();
-    push((i64)(strings + 9496));
+    push((i64)(strings + 9554));
     mw_2E_();
     mw_2E_name();
-    push((i64)(strings + 9503));
+    push((i64)(strings + 9561));
     mw_3B_();
     } else {
     mwarrow_op_is_external_3F_();
     if (pop()) {
     mwarrow_op_external_40_();
     mwexternal_name_40_();
-    push((i64)(strings + 9507));
+    push((i64)(strings + 9565));
     mw_2E_();
     mw_2E_name();
-    push((i64)(strings + 9514));
+    push((i64)(strings + 9572));
     mw_3B_();
     } else {
     mwarrow_op_is_buffer_3F_();
     if (pop()) {
     mwarrow_op_buffer_40_();
     mwbuffer_name_40_();
-    push((i64)(strings + 9518));
+    push((i64)(strings + 9576));
     mw_2E_();
     mw_2E_name();
-    push((i64)(strings + 9525));
+    push((i64)(strings + 9583));
     mw_3B_();
     } else {
     mwarrow_op_is_prim_3F_();
@@ -13956,17 +13985,17 @@ void mwc99_emit_arrow_op_21_ (void){
     if (pop()) {
     mwdrop();
     mwarrow_args_1();
-    push((i64)(strings + 9529));
+    push((i64)(strings + 9587));
     mw_2E_();
     mw_2E_d();
-    push((i64)(strings + 9541));
+    push((i64)(strings + 9599));
     mw_3B_();
     mwArg__3E_Arrow();
     mwc99_emit_arrow_21_();
-    push((i64)(strings + 9551));
+    push((i64)(strings + 9609));
     mw_2E_();
     mw_2E_d();
-    push((i64)(strings + 9564));
+    push((i64)(strings + 9622));
     mw_3B_();
     } else {
     mwdup();
@@ -13975,17 +14004,17 @@ void mwc99_emit_arrow_op_21_ (void){
     if (pop()) {
     mwdrop();
     mwarrow_args_2();
-    push((i64)(strings + 9569));
+    push((i64)(strings + 9627));
     mw_3B_();
     { i64 d10 = pop();
     mwArg__3E_Arrow();
     mwc99_emit_arrow_21_();
       push(d10); }
-    push((i64)(strings + 9586));
+    push((i64)(strings + 9644));
     mw_3B_();
     mwArg__3E_Arrow();
     mwc99_emit_arrow_21_();
-    push((i64)(strings + 9599));
+    push((i64)(strings + 9657));
     mw_3B_();
     } else {
     mwdup();
@@ -13994,32 +14023,32 @@ void mwc99_emit_arrow_op_21_ (void){
     if (pop()) {
     mwdrop();
     mwarrow_args_2();
-    push((i64)(strings + 9605));
+    push((i64)(strings + 9663));
     mw_3B_();
     { i64 d11 = pop();
     mwArg__3E_Arrow();
     mwc99_emit_arrow_21_();
       push(d11); }
-    push((i64)(strings + 9620));
+    push((i64)(strings + 9678));
     mw_3B_();
     mwArg__3E_Arrow();
     mwc99_emit_arrow_21_();
-    push((i64)(strings + 9643));
+    push((i64)(strings + 9701));
     mw_3B_();
     } else {
     mwnip();
-    push((i64)(strings + 9649));
+    push((i64)(strings + 9707));
     mw_2E_();
     mwPrim__3E_Name();
     mw_2E_name();
-    push((i64)(strings + 9656));
+    push((i64)(strings + 9714));
     mw_3B_();
     }
     }
     }
     } else {
     mwarrow_token_40_();
-    push((i64)(strings + 9660));
+    push((i64)(strings + 9718));
     mwemit_fatal_error_21_();
     }
     }
@@ -14035,12 +14064,12 @@ void mwc99_emit_word_def_21_ (void){
     if (pop()) {
     mwdup();
     mw_2E_w();
-    push((i64)(strings + 9733));
+    push((i64)(strings + 9791));
     mw_3B_();
     mwname_word_40_();
     mwelab_word_body_21_();
     mwc99_emit_arrow_21_();
-    push((i64)(strings + 9735));
+    push((i64)(strings + 9793));
     mw_3B__3B_();
     } else {
     mwdrop();
@@ -14256,7 +14285,7 @@ void mwelab_type_atom_21_ (void){
     mwelab_type_con_21_();
     } else {
     mwdup();
-    push((i64)(strings + 9836));
+    push((i64)(strings + 9894));
     mwemit_error_21_();
     { i64 d3 = pop();
     mwTYPE_ERROR();
@@ -14320,7 +14349,7 @@ void mwelab_type_con_21_ (void){
     mwtoken_has_args_3F_();
     if (pop()) {
     mwdup();
-    push((i64)(strings + 9870));
+    push((i64)(strings + 9928));
     mwemit_error_21_();
     mwTYPE_ERROR();
     } else {
@@ -14333,13 +14362,13 @@ void mwelab_type_con_21_ (void){
     if (pop()) {
     mwdrop();
     mwdup();
-    push((i64)(strings + 9905));
+    push((i64)(strings + 9963));
     mwemit_error_21_();
     mwTYPE_ERROR();
     } else {
     mwdrop();
     mwdup();
-    push((i64)(strings + 9919));
+    push((i64)(strings + 9977));
     mwemit_error_21_();
     mwTYPE_ERROR();
     }
@@ -14487,7 +14516,7 @@ void mwelab_stack_pop_21_ (void){
     mwtype_get_tensor();
     mwtensor_type_unpack();
     } else {
-    push((i64)(strings + 9931));
+    push((i64)(strings + 9989));
     mwelab_emit_warning_21_();
     mwdrop();
     mwTYPE_ERROR();
@@ -14573,7 +14602,7 @@ void mwelab_arrow_step_21_ (void){
     mwelab_arrow_step_name_21_();
     } else {
     mwdrop();
-    push((i64)(strings + 9960));
+    push((i64)(strings + 10018));
     mwelab_emit_fatal_error_21_();
     }
     }
@@ -14617,7 +14646,7 @@ void mwelab_arrow_step_name_21_ (void){
     mwelab_arrow_step_prim_21_();
     } else {
     mwdrop();
-    push((i64)(strings + 9998));
+    push((i64)(strings + 10056));
     mwelab_emit_fatal_error_21_();
     mwTYPE_ERROR();
     mwelab_stack_21_();
@@ -15341,11 +15370,22 @@ void mwelab_arrow_step_prim_21_ (void){
     mwTYPE_PTR();
     mwelab_stack_push_21_();
     } else {
+    mwdup();
+    mwPRIM_PTR_SIZE();
+    mw_3D_();
+    if (pop()) {
+    mwdrop();
+    mwelab_token_40_();
+    mwtoken_args_0();
+    mwTYPE_INT();
+    mwelab_stack_push_21_();
+    } else {
     mwdrop();
     mwTYPE_ERROR();
     mwelab_stack_21_();
-    push((i64)(strings + 10088));
+    push((i64)(strings + 10146));
     mwelab_emit_warning_21_();
+    }
     }
     }
     }
@@ -15489,7 +15529,7 @@ void mwstack_type_concat (void){
     mwtensor_type_new_21_();
     mwTTensor();
     } else {
-    push((i64)(strings + 10011));
+    push((i64)(strings + 10069));
     mwelab_emit_fatal_error_21_();
     }
     }
@@ -15500,7 +15540,7 @@ void mwelab_3F__3F_ (void){
     mwelab_token_40_();
     mwtoken_location();
     mwlocation_trace_21_();
-    push((i64)(strings + 10068));
+    push((i64)(strings + 10126));
     mwstr_trace_21_();
     mwelab_stack_40_();
     mwtype_trace_21_();
@@ -15864,7 +15904,7 @@ void mwelab_module_header_21_ (void){
     mwtoken_next();
     } else {
     mwdup();
-    push((i64)(strings + 10131));
+    push((i64)(strings + 10189));
     mwemit_error_21_();
     }
 }
@@ -15912,7 +15952,7 @@ void mwelab_module_name_21_ (void){
     mwname_defined_3F_();
     if (pop()) {
     mwdrop();
-    push((i64)(strings + 10155));
+    push((i64)(strings + 10213));
     mwemit_fatal_error_21_();
     } else {
     mwnip();
@@ -15922,7 +15962,7 @@ void mwelab_module_name_21_ (void){
     mwmodule_name_21_();
     }
     } else {
-    push((i64)(strings + 10181));
+    push((i64)(strings + 10239));
     mwemit_fatal_error_21_();
     }
 }
@@ -15944,7 +15984,7 @@ void mwelab_module_import_21_ (void){
     if (pop()) {
     mwnip();
     mwname_load_21_();
-    push((i64)(strings + 10202));
+    push((i64)(strings + 10260));
     mwstr_buf_push_str_21_();
     mwSTR_BUF();
     mwStr__3E_Path();
@@ -15953,12 +15993,12 @@ void mwelab_module_import_21_ (void){
     mwdrop();
     } else {
     mwdrop();
-    push((i64)(strings + 10207));
+    push((i64)(strings + 10265));
     mwemit_fatal_error_21_();
     }
     }
     } else {
-    push((i64)(strings + 10233));
+    push((i64)(strings + 10291));
     mwemit_fatal_error_21_();
     }
 }
@@ -16005,7 +16045,7 @@ void mwelab_module_decl_21_ (void){
     if (pop()) {
     mwelab_target_c99_21_();
     } else {
-    push((i64)(strings + 10254));
+    push((i64)(strings + 10312));
     mwemit_fatal_error_21_();
     }
     }
@@ -16046,11 +16086,11 @@ void mwelab_def_21_ (void){
     mwword_sig_21_();
     } else {
     mwdrop();
-    push((i64)(strings + 10274));
+    push((i64)(strings + 10332));
     mwemit_fatal_error_21_();
     }
     } else {
-    push((i64)(strings + 10295));
+    push((i64)(strings + 10353));
     mwemit_fatal_error_21_();
     }
 }
@@ -16078,12 +16118,12 @@ void mwelab_def_type_21_ (void){
     mwnip();
     } else {
     mwdrop();
-    push((i64)(strings + 10314));
+    push((i64)(strings + 10372));
     mwemit_error_21_();
     mwTYPE_ERROR();
     }
     } else {
-    push((i64)(strings + 10328));
+    push((i64)(strings + 10386));
     mwemit_error_21_();
     mwTYPE_ERROR();
     }
@@ -16091,11 +16131,11 @@ void mwelab_def_type_21_ (void){
     mwname_type_21_();
     } else {
     mwdrop();
-    push((i64)(strings + 10345));
+    push((i64)(strings + 10403));
     mwemit_fatal_error_21_();
     }
     } else {
-    push((i64)(strings + 10366));
+    push((i64)(strings + 10424));
     mwemit_fatal_error_21_();
     }
 }
@@ -16123,12 +16163,12 @@ void mwelab_nominal_21_ (void){
     mwnip();
     } else {
     mwdrop();
-    push((i64)(strings + 10392));
+    push((i64)(strings + 10450));
     mwemit_error_21_();
     mwTYPE_ERROR();
     }
     } else {
-    push((i64)(strings + 10406));
+    push((i64)(strings + 10464));
     mwemit_error_21_();
     mwTYPE_ERROR();
     }
@@ -16140,11 +16180,11 @@ void mwelab_nominal_21_ (void){
     mwname_type_21_();
     } else {
     mwdrop();
-    push((i64)(strings + 10423));
+    push((i64)(strings + 10481));
     mwemit_fatal_error_21_();
     }
     } else {
-    push((i64)(strings + 10444));
+    push((i64)(strings + 10502));
     mwemit_fatal_error_21_();
     }
 }
@@ -16173,16 +16213,16 @@ void mwelab_buffer_21_ (void){
     mwbuffer_alloc_21_();
     mwdrop();
     } else {
-    push((i64)(strings + 10470));
+    push((i64)(strings + 10528));
     mwemit_fatal_error_21_();
     }
     } else {
     mwdrop();
-    push((i64)(strings + 10491));
+    push((i64)(strings + 10549));
     mwemit_fatal_error_21_();
     }
     } else {
-    push((i64)(strings + 10514));
+    push((i64)(strings + 10572));
     mwemit_fatal_error_21_();
     }
 }
@@ -16199,7 +16239,7 @@ void mwelab_table_21_ (void){
     mwtable_new_21_();
     mwdrop();
     } else {
-    push((i64)(strings + 10535));
+    push((i64)(strings + 10593));
     mwemit_fatal_error_21_();
     }
 }
@@ -16239,24 +16279,24 @@ void mwelab_field_21_ (void){
     mwdrop();
     } else {
     mwdrop();
-    push((i64)(strings + 10555));
-    mwemit_fatal_error_21_();
-    }
-    } else {
-    push((i64)(strings + 10574));
-    mwemit_fatal_error_21_();
-    }
-    } else {
-    mwdrop();
-    push((i64)(strings + 10594));
-    mwemit_fatal_error_21_();
-    }
-    } else {
     push((i64)(strings + 10613));
     mwemit_fatal_error_21_();
     }
     } else {
-    push((i64)(strings + 10633));
+    push((i64)(strings + 10632));
+    mwemit_fatal_error_21_();
+    }
+    } else {
+    mwdrop();
+    push((i64)(strings + 10652));
+    mwemit_fatal_error_21_();
+    }
+    } else {
+    push((i64)(strings + 10671));
+    mwemit_fatal_error_21_();
+    }
+    } else {
+    push((i64)(strings + 10691));
     mwemit_fatal_error_21_();
     }
 }
@@ -16276,7 +16316,7 @@ void mwelab_target_c99_21_ (void){
     mwStr__3E_Path();
     mwrun_output_c99_21_();
     } else {
-    push((i64)(strings + 10653));
+    push((i64)(strings + 10711));
     mwemit_fatal_error_21_();
     }
 }

--- a/build.bat
+++ b/build.bat
@@ -1,17 +1,17 @@
 @echo off
 
 cl /WX /MD /TC bin\mirth0.c /link /WX  || goto :error
-mirth0.exe || goto :error
+mirth0.exe mirth.mth || goto :error
 if exist bin\mirth1.c del bin\mirth1.c
 rename bin\mirth.c mirth1.c || goto :error
 
 cl /WX /MD /TC bin\mirth1.c /link /WX  || goto :error
-mirth1.exe || goto :error
+mirth1.exe mirth.mth || goto :error
 if exist bin\mirth2.c del bin\mirth2.c
 rename bin\mirth.c mirth2.c || goto :error
 
 cl /WX /W3 /MD /TC bin\mirth2.c /link /WX  || goto :error
-mirth2.exe || goto :error
+mirth2.exe mirth.mth || goto :error
 if exist bin\mirth3.c del bin\mirth3.c
 rename bin\mirth.c mirth3.c || goto :error
 

--- a/src/mirth.mth
+++ b/src/mirth.mth
@@ -24,6 +24,12 @@ def(main, +IO,
     init!
     test!
 
+    argc int-trace-ln!
+    0 while(dup argc <,
+      dup argv ptr@@ str-trace-ln!
+      1+
+    ) drop
+
     "mirth.mth" Str->Path run-lexer!
 
     # show-names-table!

--- a/src/mirth.mth
+++ b/src/mirth.mth
@@ -20,6 +20,20 @@ def(test!, +IO,
 
 def(NEW_MIRTH_REVISION, Int, 0)
 
+def(compile!, Path -- +IO,
+  "Compiling " str-trace!
+  dup Path->Str str-trace-ln!
+
+  run-lexer!
+
+  # show-names-table!
+  # show-tokens!
+
+  "Building." str-trace-ln!
+
+  elab-module! drop
+  "Done." str-trace-ln!)
+
 def(main, +IO,
     init!
     test!
@@ -30,15 +44,10 @@ def(main, +IO,
       1+
     ) drop
 
-    "mirth.mth" Str->Path run-lexer!
-
-    # show-names-table!
-    # show-tokens!
-
-    "Building." str-trace-ln!
-
-    elab-module! drop
-    "Done." str-trace-ln!)
+    1 argc < if(
+      1 argv ptr@@ Str->Path compile!,
+      "Expected at least one argument" panic!)
+    )
 
 #########
 # Build #

--- a/src/mirth/codegen.mth
+++ b/src/mirth/codegen.mth
@@ -113,6 +113,9 @@ def(c99-emit-header!, +IO,
     "#define STACK_SIZE 2000" ;
     "static volatile usize sc = STACK_SIZE;" ;
     "static volatile i64 stack[STACK_SIZE] = {0};" ;;
+
+    "int global_argc;" ;
+    "char** global_argv;" ;;
     )
 
 def(c99-emit-strings!, +IO,
@@ -502,6 +505,14 @@ def(c99-emit-prims!, +IO,
     "    push(y || x);" ;
     "}" ;;
 
+    PRIM_ARGC .p " {" ;
+    "    push(global_argc);";
+    "}" ;
+
+    PRIM_ARGV .p " {" ;
+    "    push((i64)global_argv);";
+    "}" ;;
+
     )
 
 def(c99-emit-externals!, +IO,
@@ -660,6 +671,8 @@ def(c99-emit-main!, Token -- +IO,
     elab-arrow!
 
     "int main (int argc, char** argv) {" ;
+    "    global_argc = argc;";
+    "    global_argv = argv;";
     c99-emit-arrow!
     "    return 0;" ;
     "}" ;

--- a/src/mirth/codegen.mth
+++ b/src/mirth/codegen.mth
@@ -513,6 +513,10 @@ def(c99-emit-prims!, +IO,
     "    push((i64)global_argv);";
     "}" ;;
 
+    PRIM_PTR_SIZE .p " {" ;
+    "    push((i64)sizeof(void*));";
+    "}" ;;
+
     )
 
 def(c99-emit-externals!, +IO,

--- a/src/mirth/data/name.mth
+++ b/src/mirth/data/name.mth
@@ -312,7 +312,9 @@ def(PRIM_BOOL_AND, Prim, 76 Int->Prim)
 def(PRIM_BOOL_OR, Prim, 77 Int->Prim)
 def(PRIM_TABLE, Prim, 78 Int->Prim)
 def(PRIM_FIELD, Prim, 79 Int->Prim)
-def(NUM_PRIMS, Size, 80)
+def(PRIM_ARGC, Prim, 80 Int->Prim)
+def(PRIM_ARGV, Prim, 81 Int->Prim)
+def(NUM_PRIMS, Size, 82)
 
 def(name-is-prim?, Name -- Name Bool, dup Name->Int NUM_PRIMS <)
 
@@ -404,6 +406,8 @@ def(init-names!, +Names,
     PRIM_BOOL_OR "||" def-prim!
     PRIM_TABLE "table" def-prim!
     PRIM_FIELD "field" def-prim!
+    PRIM_ARGC "argc" def-prim!
+    PRIM_ARGV "argv" def-prim!
     NUM_PRIMS num-names@ 1+ = if(id,
         "compiler error: NUM_PRIMS and num-names@ do not match" panic!)
     )

--- a/src/mirth/data/name.mth
+++ b/src/mirth/data/name.mth
@@ -314,7 +314,8 @@ def(PRIM_TABLE, Prim, 78 Int->Prim)
 def(PRIM_FIELD, Prim, 79 Int->Prim)
 def(PRIM_ARGC, Prim, 80 Int->Prim)
 def(PRIM_ARGV, Prim, 81 Int->Prim)
-def(NUM_PRIMS, Size, 82)
+def(PRIM_PTR_SIZE, Prim, 82 Int->Prim)
+def(NUM_PRIMS, Size, 83)
 
 def(name-is-prim?, Name -- Name Bool, dup Name->Int NUM_PRIMS <)
 
@@ -408,6 +409,8 @@ def(init-names!, +Names,
     PRIM_FIELD "field" def-prim!
     PRIM_ARGC "argc" def-prim!
     PRIM_ARGV "argv" def-prim!
+    PRIM_ARGV "argv" def-prim!
+    PRIM_PTR_SIZE "prim.unsafe.|ptr|" def-prim!
     NUM_PRIMS num-names@ 1+ = if(id,
         "compiler error: NUM_PRIMS and num-names@ do not match" panic!)
     )

--- a/src/mirth/elab.mth
+++ b/src/mirth/elab.mth
@@ -516,9 +516,13 @@ def(elab-arrow-step-prim!, Arrow Prim -- Arrow +Elab,
         drop elab-token@ token-args-0
         TYPE_PTR elab-stack-push!,
 
+    dup PRIM_PTR_SIZE = if (
+        drop elab-token@ token-args-0
+        TYPE_INT elab-stack-push!,
+
         drop TYPE_ERROR elab-stack!
         "compiler error: unknown prim in elaborator" elab-emit-warning!
-    ))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+    )))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
 
 def(elab-arrow-step-dip!, Arrow -- Arrow +Elab,
     elab-token@ dip(

--- a/src/mirth/elab.mth
+++ b/src/mirth/elab.mth
@@ -509,9 +509,16 @@ def(elab-arrow-step-prim!, Arrow Prim -- Arrow +Elab,
         drop elab-token@ token-args-0
         elab-stack-pop2! elab&& elab-stack-push!,
 
+    dup PRIM_ARGC = if (
+        drop elab-token@ token-args-0
+        TYPE_INT elab-stack-push!,
+    dup PRIM_ARGV = if (
+        drop elab-token@ token-args-0
+        TYPE_PTR elab-stack-push!,
+
         drop TYPE_ERROR elab-stack!
         "compiler error: unknown prim in elaborator" elab-emit-warning!
-    ))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+    ))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
 
 def(elab-arrow-step-dip!, Arrow -- Arrow +Elab,
     elab-token@ dip(

--- a/src/prelude/common.mth
+++ b/src/prelude/common.mth
@@ -58,6 +58,11 @@ def(ptr+, Int Ptr -- Ptr, prim.unsafe.ptr+)
 def(ptr@, Ptr -- Ptr, @ Int->Ptr)
 def(ptr!, Ptr Ptr --, dip(Ptr->Int) !)
 
+def(ptr, Size, 8)
+def(ptrs, Size -- Size, ptr *)
+def(ptr@@, Offset Ptr -- Ptr, dip(ptrs) ptr+ ptr@)
+def(ptr!!, Ptr Offset Ptr --, dip(ptrs) ptr+ ptr!)
+
 def(u8, Size, 1)
 def(u8s, Size -- Size, id)
 def(u8@@, Offset Ptr -- Byte, ptr+ u8@)

--- a/src/prelude/common.mth
+++ b/src/prelude/common.mth
@@ -58,7 +58,7 @@ def(ptr+, Int Ptr -- Ptr, prim.unsafe.ptr+)
 def(ptr@, Ptr -- Ptr, @ Int->Ptr)
 def(ptr!, Ptr Ptr --, dip(Ptr->Int) !)
 
-def(ptr, Size, 8)
+def(ptr, Size, prim.unsafe.|ptr|)
 def(ptrs, Size -- Size, ptr *)
 def(ptr@@, Offset Ptr -- Ptr, dip(ptrs) ptr+ ptr@)
 def(ptr!!, Ptr Offset Ptr --, dip(ptrs) ptr+ ptr!)


### PR DESCRIPTION
This PR defines two primitives, `argc` (an `Int`) and `argv` (a `Ptr`). These are implemented as global variables which are set to the value of the standard C `argc` and `argv` parameters to `main`, and are simply pushed to the stack when needed.