### PR TITLE
define comment syntax for atom

### DIFF
--- a/tools/mirth-atom/settings/language-mirth.cson
+++ b/tools/mirth-atom/settings/language-mirth.cson
@@ -1,0 +1,3 @@
+'.source.mirth':
+  'editor':
+    'commentStart': '# '


### PR DESCRIPTION
This enables `⌘-/` for toggling comments in atom.