### PR TITLE
Add ftplgun with commentstring

### DIFF
--- a/tools/mirth-vim/ftplugin/mirth.vim
+++ b/tools/mirth-vim/ftplugin/mirth.vim
@@ -1,0 +1,6 @@
+if exists('b:mirth_ftplugin')
+	finish
+endif
+let b:mirth_ftplugin = 1
+
+setlocal commentstring=#\ %s


### PR DESCRIPTION
This adds a vim plugin for mirth files. In particular, it defines a mirth-particular comment syntax.

This is useful for e.g. Nerdcommenter.