### PR TITLE
Add an install script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CC=gcc $(C99FLAGS)
 
 SRCS=src/*.mth src/prelude/*.mth src/mirth/*.mth src/mirth/data/*.mth src/mirth/elab/*.mth src/mirth/lexer/*.mth
 
-.PHONY: default show build update check update-mirth install-vim install-code profile play-snake test test-update
+.PHONY: default show build update check update-mirth install-vim install-code install profile play-snake test test-update
 
 default: show
 
@@ -37,6 +37,9 @@ install-code:
 
 install-atom:
 	apm link tools/mirth-atom
+
+install: bin/mirth0
+	./install.sh bin/mirth0
 
 profile: bin/mirth_prof
 	time bin/mirth_prof

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -euo pipefail
+
+rm -rf $HOME/.mirth
+mkdir -p $HOME/.mirth/bin
+cp $1 $HOME/.mirth/bin/mirth
+echo "Mirth installed at ~/.mirth"
+echo 'Please add mirth to your PATH:'
+echo
+echo '    export PATH=$HOME/.mirth/bin:$PATH'


### PR DESCRIPTION
Adds a `make install` rule that installs a `mirth` executable at `~/.mirth/bin`