### PR TITLE
c99: fix -Wstrict-prototypes error on clang 15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ check:
 
 clean:
 	cp bin/mirth0.c mirth0.c
-	rm -f bin/*
+	rm -rf bin/mirth{0,1,2,}{,.c,.dSYM}
 	mv mirth0.c bin/
 
 install-vim:

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -449,7 +449,7 @@ static value_t mkcell_freecdr (value_t car, value_t cdr) {
     return v;
 }
 
-static void do_pack_uncons() {
+static void do_pack_uncons(void) {
     value_t car, cdr, val;
     val = pop_value();
     value_uncons(val, &car, &cdr);
@@ -637,7 +637,7 @@ static void mwprim_2E_posix_2E_mmap (void) {
     #endif
 }
 
-static void do_debug() {
+static void do_debug(void) {
     write(2, "??", 2);
     char c[32] = {0};
     char* cp;
@@ -21218,7 +21218,7 @@ static void mwc99_emit_prims_21_ (void){
     mw_3B_();
     push_ptr("}\0\0\0");
     mw_3B__3B_();
-    push_ptr("static void do_pack_uncons() {\0\0\0");
+    push_ptr("static void do_pack_uncons(void) {\0\0\0");
     mw_3B_();
     push_ptr("    value_t car, cdr, val;\0\0\0");
     mw_3B_();
@@ -21606,7 +21606,7 @@ static void mwc99_emit_prims_21_ (void){
     mw_3B_();
     push_ptr("}\0\0\0");
     mw_3B__3B_();
-    push_ptr("static void do_debug() {\0\0\0");
+    push_ptr("static void do_debug(void) {\0\0\0");
     mw_3B_();
     push_ptr("    write(2, \"??\", 2);\0\0\0");
     mw_3B_();

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -20153,6 +20153,8 @@ static void mwc99_emit_external_21_ (void){
     mwdrop();
     } else {
     mwdrop();
+    push_ptr("void\0\0\0");
+    mw_2E_();
     }
     push_ptr(");\0\0\0");
     mw_3B_();

--- a/src/mirth/codegen.mth
+++ b/src/mirth/codegen.mth
@@ -697,7 +697,7 @@ def(c99-emit-prims!, +IO,
 
     # "#define do_pack_uncons() do{ value_t dpucar, dpucdr, dpuval=pop_value(); value_uncons(dpuval, &dpucar, &dpucdr); push_value(dpucar); push_value(dpucdr); if(dpuval.tag == VT_C64) { decref_for_uncons(dpuval); } }while(0)" ;
 
-    "static void do_pack_uncons() {" ;
+    "static void do_pack_uncons(void) {" ;
     "    value_t car, cdr, val;" ;
     "    val = pop_value();" ;
     "    value_uncons(val, &car, &cdr);" ;
@@ -947,7 +947,7 @@ def(c99-emit-prims!, +IO,
     "    #endif" ;
     "}" ;;
 
-    "static void do_debug() {" ;
+    "static void do_debug(void) {" ;
     "    write(2, \"??\", 2);" ;
     "    char c[32] = {0};" ;
     "    char* cp;" ;

--- a/src/mirth/codegen.mth
+++ b/src/mirth/codegen.mth
@@ -1176,7 +1176,7 @@ def(c99-emit-external!, External -- +IO,
             ", i64" .
             1-
         ) drop,
-        drop
+        drop "void" .
     ) ");" ;
 
     "static void mw" . dip2(external-name? .name) " (void) {" ;


### PR DESCRIPTION
Fixes the following error when building on macOS 14:

```
gcc -std=c99 -Wall -Wextra -Wno-unused-variable -Wno-unused-function -Wno-unused-parameter -Wno-unused-value -Wno-missing-braces -Werror -pedantic -O0 -g -o bin/mirth0 bin/mirth0.c
bin/mirth0.c:452:27: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
static void do_pack_uncons() {
                          ^
                           void
bin/mirth0.c:640:21: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
static void do_debug() {
                    ^
                     void
2 errors generated.
make: *** [bin/mirth0] Error 1
```