### PR TITLE
Make block names more stable in the codegen.

### DIFF
--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -1473,6 +1473,8 @@ static u8 bC99_NEED_STACK[16] = {0};
 #define mwC99_NEED_STACK() push_ptr((void*)bC99_NEED_STACK)
 static u8 bExternal_2E_NUM[8] = {0};
 #define mwExternal_2E_NUM() push_ptr((void*)bExternal_2E_NUM)
+static u8 bAB_HOME[16] = {0};
+#define mwAB_HOME() push_ptr((void*)bAB_HOME)
 static u8 bAB_ARROW[16] = {0};
 #define mwAB_ARROW() push_ptr((void*)bAB_ARROW)
 
@@ -2503,6 +2505,8 @@ static void mwstat (void) {
  static void mwelab_type_quote_21_ (void);
  static void mwelab_type_unify_21_ (void);
  static void mwelab_simple_type_arg_21_ (void);
+ static void mwab_home_40_ (void);
+ static void mwab_home_21_ (void);
  static void mwab_arrow_40_ (void);
  static void mwab_arrow_21_ (void);
  static void mwab_ctx_40_ (void);
@@ -2706,1274 +2710,1277 @@ static void mwstat (void) {
  static void mb_88 (void);
  static void mb_89 (void);
  static void mb_90 (void);
- static void mb_mirth_2E_data_2E_prim_254_7 (void);
- static void mb_mirth_2E_data_2E_prim_255_7 (void);
- static void mb_mirth_2E_data_2E_prim_256_7 (void);
- static void mb_mirth_2E_data_2E_prim_257_7 (void);
- static void mb_mirth_2E_data_2E_prim_258_7 (void);
- static void mb_mirth_2E_data_2E_prim_259_7 (void);
- static void mb_mirth_2E_data_2E_prim_260_7 (void);
- static void mb_mirth_2E_data_2E_prim_261_7 (void);
- static void mb_mirth_2E_data_2E_prim_262_7 (void);
- static void mb_mirth_2E_data_2E_prim_416_9 (void);
- static void mb_mirth_2E_data_2E_prim_425_9 (void);
- static void mb_mirth_2E_data_2E_prim_433_9 (void);
- static void mb_mirth_2E_data_2E_prim_434_23 (void);
- static void mb_mirth_2E_data_2E_prim_442_9 (void);
- static void mb_mirth_2E_data_2E_prim_443_9 (void);
- static void mb_mirth_2E_data_2E_prim_452_9 (void);
- static void mb_mirth_2E_data_2E_prim_452_13 (void);
- static void mb_mirth_2E_data_2E_prim_453_9 (void);
- static void mb_mirth_2E_data_2E_prim_453_27 (void);
- static void mb_mirth_2E_data_2E_prim_454_9 (void);
- static void mb_mirth_2E_data_2E_prim_454_13 (void);
- static void mb_mirth_2E_data_2E_prim_462_9 (void);
- static void mb_mirth_2E_data_2E_prim_464_9 (void);
- static void mb_mirth_2E_data_2E_prim_464_13 (void);
- static void mb_mirth_2E_data_2E_prim_464_35 (void);
- static void mb_mirth_2E_data_2E_prim_473_13 (void);
- static void mb_mirth_2E_data_2E_prim_474_13 (void);
- static void mb_mirth_2E_data_2E_prim_483_9 (void);
- static void mb_mirth_2E_data_2E_prim_492_9 (void);
- static void mb_mirth_2E_data_2E_prim_501_9 (void);
- static void mb_mirth_2E_data_2E_prim_520_18 (void);
- static void mb_mirth_2E_data_2E_prim_524_13 (void);
- static void mb_mirth_2E_data_2E_prim_528_22 (void);
- static void mb_mirth_42_9 (void);
- static void mb_mirth_38_9 (void);
- static void mb_mirth_2E_lexer_68_28 (void);
- static void mb_mirth_2E_lexer_68_11 (void);
- static void mb_mirth_2E_lexer_75_9 (void);
- static void mb_mirth_2E_lexer_73_9 (void);
- static void mb_mirth_2E_elab_736_37 (void);
- static void mb_mirth_2E_elab_736_11 (void);
- static void mb_mirth_2E_elab_935_14 (void);
- static void mb_mirth_56_9 (void);
- static void mb_mirth_55_9 (void);
- static void mb_prelude_203_35 (void);
- static void mb_prelude_58_43 (void);
- static void mb_prelude_95_5 (void);
- static void mb_prelude_94_9 (void);
- static void mb_prelude_97_5 (void);
- static void mb_prelude_96_9 (void);
- static void mb_prelude_99_9 (void);
- static void mb_prelude_98_9 (void);
- static void mb_prelude_108_43 (void);
- static void mb_prelude_134_18 (void);
- static void mb_prelude_134_22 (void);
- static void mb_prelude_113_36 (void);
- static void mb_prelude_114_31 (void);
- static void mb_prelude_116_29 (void);
- static void mb_prelude_117_38 (void);
- static void mb_prelude_118_44 (void);
- static void mb_prelude_120_33 (void);
- static void mb_prelude_122_24 (void);
- static void mb_prelude_125_42 (void);
- static void mb_prelude_125_46 (void);
- static void mb_prelude_128_18 (void);
- static void mb_prelude_131_23 (void);
- static void mb_prelude_137_18 (void);
- static void mb_prelude_137_22 (void);
- static void mb_prelude_137_26 (void);
- static void mb_prelude_143_41 (void);
- static void mb_prelude_144_36 (void);
- static void mb_prelude_147_23 (void);
- static void mb_prelude_147_17 (void);
- static void mb_prelude_151_20 (void);
- static void mb_prelude_151_17 (void);
- static void mb_prelude_184_9 (void);
- static void mb_prelude_183_9 (void);
- static void mb_prelude_186_13 (void);
- static void mb_prelude_185_13 (void);
- static void mb_prelude_199_35 (void);
- static void mb_prelude_199_30 (void);
- static void mb_prelude_200_36 (void);
- static void mb_prelude_200_30 (void);
- static void mb_prelude_204_35 (void);
- static void mb_prelude_210_35 (void);
- static void mb_prelude_211_35 (void);
- static void mb_prelude_214_35 (void);
- static void mb_prelude_215_35 (void);
- static void mb_prelude_217_40 (void);
- static void mb_prelude_217_49 (void);
- static void mb_prelude_273_40 (void);
- static void mb_prelude_273_32 (void);
- static void mb_prelude_324_26 (void);
- static void mb_prelude_325_30 (void);
- static void mb_prelude_326_34 (void);
- static void mb_prelude_327_38 (void);
- static void mb_prelude_328_42 (void);
- static void mb_prelude_332_44 (void);
- static void mb_prelude_333_48 (void);
- static void mb_prelude_334_52 (void);
- static void mb_prelude_335_56 (void);
- static void mb_platform_2E_posix_14_29 (void);
- static void mb_platform_2E_posix_22_9 (void);
- static void mb_platform_2E_posix_22_13 (void);
- static void mb_platform_2E_posix_25_9 (void);
- static void mb_platform_2E_posix_24_9 (void);
- static void mb_platform_2E_posix_27_13 (void);
- static void mb_platform_2E_posix_26_13 (void);
- static void mb_data_2E_str_16_23 (void);
- static void mb_platform_2E_posix_44_9 (void);
- static void mb_platform_2E_posix_43_9 (void);
- static void mb_platform_2E_posix_46_13 (void);
- static void mb_platform_2E_posix_45_13 (void);
- static void mb_platform_2E_posix_57_9 (void);
- static void mb_platform_2E_posix_56_9 (void);
- static void mb_data_2E_str_70_9 (void);
- static void mb_platform_2E_posix_61_38 (void);
- static void mb_data_2E_str_57_13 (void);
- static void mb_platform_2E_posix_62_38 (void);
- static void mb_platform_2E_posix_64_34 (void);
- static void mb_data_2E_str_126_9 (void);
- static void mb_data_2E_str_125_9 (void);
- static void mb_data_2E_str_127_13 (void);
- static void mb_data_2E_str_129_27 (void);
- static void mb_data_2E_str_129_19 (void);
- static void mb_data_2E_str_130_51 (void);
- static void mb_data_2E_str_130_18 (void);
- static void mb_platform_2E_posix_74_9 (void);
- static void mb_platform_2E_posix_73_9 (void);
- static void mb_platform_2E_posix_87_9 (void);
- static void mb_platform_2E_posix_86_9 (void);
- static void mb_platform_2E_posix_102_9 (void);
- static void mb_platform_2E_posix_101_9 (void);
- static void mb_platform_2E_posix_112_46 (void);
- static void mb_platform_2E_posix_116_9 (void);
- static void mb_platform_2E_posix_116_41 (void);
- static void mb_platform_2E_posix_119_13 (void);
- static void mb_platform_2E_posix_118_13 (void);
- static void mb_data_2E_char_148_13 (void);
- static void mb_data_2E_char_149_9 (void);
- static void mb_data_2E_str_10_13 (void);
- static void mb_data_2E_str_21_9 (void);
- static void mb_data_2E_str_20_9 (void);
- static void mb_data_2E_str_21_13 (void);
- static void mb_data_2E_str_28_20 (void);
- static void mb_data_2E_str_30_9 (void);
- static void mb_data_2E_str_31_18 (void);
- static void mb_data_2E_list_268_19 (void);
- static void mb_data_2E_list_269_19 (void);
- static void mb_data_2E_list_269_23 (void);
- static void mb_data_2E_list_270_26 (void);
- static void mb_data_2E_list_270_31 (void);
- static void mb_data_2E_list_270_40 (void);
- static void mb_data_2E_str_47_9 (void);
- static void mb_data_2E_str_48_19 (void);
- static void mb_data_2E_str_39_27 (void);
- static void mb_data_2E_str_39_16 (void);
- static void mb_data_2E_str_63_13 (void);
- static void mb_data_2E_char_113_29 (void);
- static void mb_data_2E_char_155_19 (void);
- static void mb_data_2E_str_148_9 (void);
- static void mb_data_2E_str_147_11 (void);
- static void mb_data_2E_str_149_13 (void);
- static void mb_data_2E_str_135_16 (void);
- static void mb_data_2E_str_140_10 (void);
- static void mb_data_2E_str_141_9 (void);
- static void mb_data_2E_str_162_9 (void);
- static void mb_data_2E_str_161_20 (void);
- static void mb_data_2E_str_163_13 (void);
- static void mb_data_2E_str_175_9 (void);
- static void mb_data_2E_str_176_13 (void);
- static void mb_data_2E_str_175_15 (void);
- static void mb_data_2E_str_176_21 (void);
- static void mb_data_2E_str_181_32 (void);
- static void mb_data_2E_str_188_9 (void);
- static void mb_data_2E_str_188_21 (void);
- static void mb_data_2E_str_191_9 (void);
- static void mb_data_2E_str_191_21 (void);
- static void mb_data_2E_char_85_5 (void);
- static void mb_data_2E_char_84_9 (void);
- static void mb_data_2E_char_87_5 (void);
- static void mb_data_2E_char_86_9 (void);
- static void mb_data_2E_char_89_9 (void);
- static void mb_data_2E_char_88_9 (void);
- static void mb_data_2E_str_198_9 (void);
- static void mb_data_2E_str_197_9 (void);
- static void mb_data_2E_str_198_16 (void);
- static void mb_data_2E_str_198_24 (void);
- static void mb_data_2E_list_28_58 (void);
- static void mb_data_2E_list_29_58 (void);
- static void mb_data_2E_list_30_58 (void);
- static void mb_data_2E_list_31_58 (void);
- static void mb_data_2E_list_32_58 (void);
- static void mb_data_2E_list_33_58 (void);
- static void mb_data_2E_list_34_58 (void);
- static void mb_data_2E_list_35_58 (void);
- static void mb_data_2E_list_36_58 (void);
- static void mb_data_2E_list_61_21 (void);
- static void mb_data_2E_list_69_22 (void);
- static void mb_data_2E_list_81_24 (void);
- static void mb_data_2E_list_81_28 (void);
- static void mb_data_2E_list_164_14 (void);
- static void mb_data_2E_list_166_9 (void);
- static void mb_data_2E_list_165_9 (void);
- static void mb_data_2E_list_166_13 (void);
- static void mb_data_2E_list_168_13 (void);
- static void mb_data_2E_list_167_13 (void);
- static void mb_data_2E_list_167_34 (void);
- static void mb_data_2E_list_165_19 (void);
- static void mb_data_2E_list_90_24 (void);
- static void mb_data_2E_list_94_41 (void);
- static void mb_data_2E_list_103_27 (void);
- static void mb_data_2E_list_108_20 (void);
- static void mb_data_2E_list_109_20 (void);
- static void mb_data_2E_list_110_20 (void);
- static void mb_data_2E_list_111_34 (void);
- static void mb_data_2E_list_144_26 (void);
- static void mb_data_2E_list_151_26 (void);
- static void mb_data_2E_list_161_25 (void);
- static void mb_data_2E_list_174_23 (void);
- static void mb_data_2E_list_175_23 (void);
- static void mb_data_2E_list_176_23 (void);
- static void mb_data_2E_list_182_24 (void);
- static void mb_data_2E_list_183_24 (void);
- static void mb_data_2E_list_184_24 (void);
- static void mb_data_2E_list_185_27 (void);
- static void mb_data_2E_list_191_22 (void);
- static void mb_data_2E_list_192_22 (void);
- static void mb_data_2E_list_193_22 (void);
- static void mb_data_2E_list_194_26 (void);
- static void mb_data_2E_list_197_55 (void);
- static void mb_data_2E_list_198_54 (void);
- static void mb_data_2E_list_212_20 (void);
- static void mb_data_2E_list_213_20 (void);
- static void mb_data_2E_list_199_56 (void);
- static void mb_data_2E_list_232_21 (void);
- static void mb_data_2E_list_241_22 (void);
- static void mb_data_2E_list_249_19 (void);
- static void mb_data_2E_list_249_31 (void);
- static void mb_data_2E_list_250_19 (void);
- static void mb_data_2E_list_250_23 (void);
- static void mb_data_2E_list_250_36 (void);
- static void mb_data_2E_list_250_40 (void);
- static void mb_data_2E_list_250_53 (void);
- static void mb_data_2E_list_250_57 (void);
- static void mb_data_2E_list_251_21 (void);
- static void mb_data_2E_list_251_25 (void);
- static void mb_data_2E_list_251_30 (void);
- static void mb_data_2E_list_251_43 (void);
- static void mb_data_2E_list_251_48 (void);
- static void mb_data_2E_list_258_20 (void);
- static void mb_data_2E_list_258_32 (void);
- static void mb_data_2E_list_259_20 (void);
- static void mb_data_2E_list_259_24 (void);
- static void mb_data_2E_list_259_37 (void);
- static void mb_data_2E_list_259_41 (void);
- static void mb_data_2E_list_259_54 (void);
- static void mb_data_2E_list_259_58 (void);
- static void mb_data_2E_list_260_22 (void);
- static void mb_data_2E_list_260_26 (void);
- static void mb_data_2E_list_260_31 (void);
- static void mb_data_2E_list_260_44 (void);
- static void mb_data_2E_list_260_49 (void);
- static void mb_data_2E_list_277_20 (void);
- static void mb_data_2E_list_278_20 (void);
- static void mb_data_2E_list_278_24 (void);
- static void mb_data_2E_list_279_27 (void);
- static void mb_data_2E_list_279_32 (void);
- static void mb_data_2E_list_279_41 (void);
- static void mb_data_2E_list_287_24 (void);
- static void mb_data_2E_list_288_25 (void);
- static void mb_data_2E_list_288_37 (void);
- static void mb_data_2E_list_289_31 (void);
- static void mb_data_2E_list_289_44 (void);
- static void mb_data_2E_list_289_61 (void);
- static void mb_data_2E_list_296_25 (void);
- static void mb_data_2E_list_297_26 (void);
- static void mb_data_2E_list_297_38 (void);
- static void mb_data_2E_list_298_32 (void);
- static void mb_data_2E_list_298_45 (void);
- static void mb_data_2E_list_298_62 (void);
- static void mb_data_2E_list_303_36 (void);
- static void mb_data_2E_list_303_44 (void);
- static void mb_data_2E_list_311_27 (void);
- static void mb_data_2E_list_311_35 (void);
- static void mb_data_2E_list_311_47 (void);
- static void mb_data_2E_list_316_22 (void);
- static void mb_data_2E_list_316_32 (void);
- static void mb_data_2E_list_320_23 (void);
- static void mb_data_2E_list_320_34 (void);
- static void mb_data_2E_list_326_25 (void);
- static void mb_data_2E_list_332_27 (void);
- static void mb_data_2E_list_332_35 (void);
- static void mb_data_2E_list_332_44 (void);
- static void mb_data_2E_list_332_52 (void);
- static void mb_data_2E_list_334_24 (void);
- static void mb_data_2E_list_336_17 (void);
- static void mb_data_2E_list_335_17 (void);
- static void mb_data_2E_list_336_28 (void);
- static void mb_data_2E_list_335_22 (void);
- static void mb_data_2E_list_335_29 (void);
- static void mb_data_2E_list_344_23 (void);
- static void mb_data_2E_list_351_22 (void);
- static void mb_data_2E_list_351_28 (void);
- static void mb_data_2E_list_354_31 (void);
- static void mb_data_2E_list_357_24 (void);
- static void mb_data_2E_list_359_17 (void);
- static void mb_data_2E_list_358_17 (void);
- static void mb_data_2E_list_359_26 (void);
- static void mb_data_2E_list_365_22 (void);
- static void mb_data_2E_list_365_27 (void);
- static void mb_data_2E_list_369_27 (void);
- static void mb_data_2E_list_373_22 (void);
- static void mb_data_2E_list_373_35 (void);
- static void mb_data_2E_list_377_19 (void);
- static void mb_data_2E_list_381_20 (void);
- static void mb_data_2E_list_385_19 (void);
- static void mb_data_2E_list_389_20 (void);
- static void mb_data_2E_list_396_13 (void);
- static void mb_data_2E_list_395_13 (void);
- static void mb_data_2E_list_397_17 (void);
- static void mb_data_2E_maybe_38_28 (void);
- static void mb_data_2E_maybe_38_22 (void);
- static void mb_data_2E_char_11_5 (void);
- static void mb_data_2E_char_8_9 (void);
- static void mb_data_2E_char_16_5 (void);
- static void mb_data_2E_char_12_9 (void);
- static void mb_data_2E_char_22_9 (void);
- static void mb_data_2E_char_17_9 (void);
- static void mb_data_2E_char_24_13 (void);
- static void mb_data_2E_char_25_13 (void);
- static void mb_data_2E_char_26_13 (void);
- static void mb_data_2E_char_19_13 (void);
- static void mb_data_2E_char_20_13 (void);
- static void mb_data_2E_char_14_13 (void);
- static void mb_data_2E_char_35_5 (void);
- static void mb_data_2E_char_34_9 (void);
- static void mb_data_2E_char_37_5 (void);
- static void mb_data_2E_char_36_9 (void);
- static void mb_data_2E_char_39_9 (void);
- static void mb_data_2E_char_38_9 (void);
- static void mb_data_2E_char_100_9 (void);
- static void mb_data_2E_char_101_9 (void);
- static void mb_data_2E_char_55_5 (void);
- static void mb_data_2E_char_54_9 (void);
- static void mb_data_2E_char_57_5 (void);
- static void mb_data_2E_char_56_9 (void);
- static void mb_data_2E_char_59_9 (void);
- static void mb_data_2E_char_58_9 (void);
- static void mb_data_2E_char_105_9 (void);
- static void mb_data_2E_char_106_9 (void);
- static void mb_data_2E_char_107_9 (void);
- static void mb_data_2E_char_96_9 (void);
- static void mb_data_2E_char_119_9 (void);
- static void mb_data_2E_char_122_5 (void);
- static void mb_data_2E_char_121_9 (void);
- static void mb_data_2E_char_124_5 (void);
- static void mb_data_2E_char_123_9 (void);
- static void mb_data_2E_char_128_9 (void);
- static void mb_data_2E_char_125_9 (void);
- static void mb_data_2E_char_128_18 (void);
- static void mb_data_2E_char_126_13 (void);
- static void mb_data_2E_char_127_13 (void);
- static void mb_data_2E_char_123_18 (void);
- static void mb_data_2E_char_121_18 (void);
- static void mb_data_2E_char_133_20 (void);
- static void mb_data_2E_char_137_32 (void);
- static void mb_data_2E_char_205_9 (void);
- static void mb_data_2E_char_205_13 (void);
- static void mb_data_2E_char_211_9 (void);
- static void mb_data_2E_char_212_9 (void);
- static void mb_data_2E_char_215_18 (void);
- static void mb_data_2E_char_221_9 (void);
- static void mb_data_2E_char_221_13 (void);
- static void mb_data_2E_char_233_21 (void);
- static void mb_data_2E_char_238_9 (void);
- static void mb_data_2E_char_237_9 (void);
- static void mb_data_2E_path_9_29 (void);
- static void mb_data_2E_path_23_60 (void);
- static void mb_data_2E_path_23_54 (void);
- static void mb_data_2E_path_28_9 (void);
- static void mb_data_2E_path_27_9 (void);
- static void mb_mirth_2E_input_19_41 (void);
- static void mb_mirth_2E_input_19_39 (void);
- static void mb_mirth_2E_input_59_9 (void);
- static void mb_mirth_2E_input_46_9 (void);
- static void mb_mirth_2E_input_57_13 (void);
- static void mb_mirth_2E_input_51_13 (void);
- static void mb_mirth_2E_input_54_17 (void);
- static void mb_mirth_2E_input_52_17 (void);
- static void mb_mirth_2E_input_34_9 (void);
- static void mb_mirth_2E_input_33_9 (void);
- static void mb_mirth_2E_input_67_9 (void);
- static void mb_mirth_2E_input_66_9 (void);
- static void mb_mirth_2E_input_77_9 (void);
- static void mb_mirth_2E_input_74_9 (void);
- static void mb_mirth_2E_input_96_9 (void);
- static void mb_mirth_2E_input_86_9 (void);
- static void mb_mirth_2E_input_90_9 (void);
- static void mb_mirth_2E_input_87_13 (void);
- static void mb_mirth_2E_input_93_13 (void);
- static void mb_mirth_2E_input_91_13 (void);
- static void mb_mirth_2E_input_119_9 (void);
- static void mb_mirth_2E_input_108_9 (void);
- static void mb_mirth_2E_input_117_13 (void);
- static void mb_mirth_2E_input_113_13 (void);
- static void mb_mirth_2E_input_115_17 (void);
- static void mb_mirth_2E_input_114_17 (void);
- static void mb_mirth_2E_lexer_44_9 (void);
- static void mb_mirth_2E_lexer_43_9 (void);
- static void mb_mirth_2E_lexer_52_9 (void);
- static void mb_mirth_2E_lexer_51_9 (void);
- static void mb_mirth_2E_data_2E_module_26_9 (void);
- static void mb_mirth_2E_data_2E_module_25_9 (void);
- static void mb_mirth_2E_lexer_108_5 (void);
- static void mb_mirth_2E_lexer_106_9 (void);
- static void mb_mirth_2E_lexer_112_5 (void);
- static void mb_mirth_2E_lexer_109_9 (void);
- static void mb_mirth_2E_lexer_116_5 (void);
- static void mb_mirth_2E_lexer_113_9 (void);
- static void mb_mirth_2E_lexer_119_5 (void);
- static void mb_mirth_2E_lexer_117_9 (void);
- static void mb_mirth_2E_lexer_123_5 (void);
- static void mb_mirth_2E_lexer_120_9 (void);
- static void mb_mirth_2E_lexer_127_5 (void);
- static void mb_mirth_2E_lexer_124_9 (void);
- static void mb_mirth_2E_lexer_131_5 (void);
- static void mb_mirth_2E_lexer_128_9 (void);
- static void mb_mirth_2E_lexer_135_5 (void);
- static void mb_mirth_2E_lexer_132_9 (void);
- static void mb_mirth_2E_lexer_139_5 (void);
- static void mb_mirth_2E_lexer_136_9 (void);
- static void mb_mirth_2E_lexer_143_5 (void);
- static void mb_mirth_2E_lexer_140_9 (void);
- static void mb_mirth_2E_lexer_147_5 (void);
- static void mb_mirth_2E_lexer_144_9 (void);
- static void mb_mirth_2E_lexer_151_5 (void);
- static void mb_mirth_2E_lexer_148_9 (void);
- static void mb_mirth_2E_lexer_155_9 (void);
- static void mb_mirth_2E_lexer_152_9 (void);
- static void mb_mirth_2E_data_2E_token_266_9 (void);
- static void mb_mirth_2E_lexer_94_9 (void);
- static void mb_mirth_2E_lexer_94_32 (void);
- static void mb_mirth_2E_lexer_95_9 (void);
- static void mb_mirth_2E_lexer_95_29 (void);
- static void mb_mirth_2E_lexer_96_9 (void);
- static void mb_mirth_2E_lexer_96_29 (void);
- static void mb_mirth_2E_lexer_436_52 (void);
- static void mb_mirth_2E_lexer_211_9 (void);
- static void mb_mirth_2E_lexer_210_22 (void);
- static void mb_mirth_2E_lexer_216_13 (void);
- static void mb_mirth_2E_lexer_212_13 (void);
- static void mb_mirth_2E_lexer_226_9 (void);
- static void mb_mirth_2E_lexer_222_9 (void);
- static void mb_mirth_2E_lexer_228_13 (void);
- static void mb_mirth_2E_lexer_227_13 (void);
- static void mb_mirth_2E_lexer_416_35 (void);
- static void mb_mirth_2E_lexer_416_11 (void);
- static void mb_mirth_2E_lexer_417_47 (void);
- static void mb_mirth_2E_lexer_417_31 (void);
- static void mb_mirth_2E_lexer_170_9 (void);
- static void mb_mirth_2E_lexer_169_9 (void);
- static void mb_mirth_2E_lexer_173_13 (void);
- static void mb_mirth_2E_lexer_171_13 (void);
- static void mb_mirth_2E_lexer_183_9 (void);
- static void mb_mirth_2E_lexer_182_9 (void);
- static void mb_mirth_2E_lexer_186_13 (void);
- static void mb_mirth_2E_lexer_184_13 (void);
- static void mb_mirth_2E_lexer_196_9 (void);
- static void mb_mirth_2E_lexer_195_9 (void);
- static void mb_mirth_2E_lexer_199_13 (void);
- static void mb_mirth_2E_lexer_197_13 (void);
- static void mb_mirth_2E_lexer_370_9 (void);
- static void mb_mirth_2E_lexer_369_22 (void);
- static void mb_mirth_2E_lexer_375_13 (void);
- static void mb_mirth_2E_lexer_371_13 (void);
- static void mb_mirth_2E_lexer_240_9 (void);
- static void mb_mirth_2E_lexer_241_13 (void);
- static void mb_mirth_2E_lexer_242_13 (void);
- static void mb_mirth_2E_lexer_419_60 (void);
- static void mb_mirth_2E_lexer_419_36 (void);
- static void mb_mirth_2E_lexer_266_34 (void);
- static void mb_mirth_2E_lexer_266_28 (void);
- static void mb_mirth_2E_lexer_311_9 (void);
- static void mb_mirth_2E_lexer_310_9 (void);
- static void mb_mirth_2E_data_2E_name_55_29 (void);
- static void mb_mirth_2E_data_2E_name_55_11 (void);
- static void mb_mirth_2E_data_2E_name_60_9 (void);
- static void mb_mirth_2E_data_2E_name_57_9 (void);
- static void mb_mirth_2E_lexer_247_9 (void);
- static void mb_mirth_2E_lexer_255_9 (void);
- static void mb_mirth_2E_lexer_253_9 (void);
- static void mb_mirth_2E_lexer_261_9 (void);
- static void mb_mirth_2E_lexer_260_9 (void);
- static void mb_mirth_2E_lexer_273_9 (void);
- static void mb_mirth_2E_lexer_272_9 (void);
- static void mb_mirth_2E_lexer_276_9 (void);
- static void mb_mirth_2E_lexer_275_11 (void);
- static void mb_mirth_2E_lexer_276_13 (void);
- static void mb_mirth_2E_lexer_279_9 (void);
- static void mb_mirth_2E_lexer_278_9 (void);
- static void mb_mirth_2E_lexer_290_9 (void);
- static void mb_mirth_2E_lexer_289_9 (void);
- static void mb_mirth_2E_lexer_305_9 (void);
- static void mb_mirth_2E_lexer_293_9 (void);
- static void mb_mirth_2E_lexer_302_13 (void);
- static void mb_mirth_2E_lexer_295_13 (void);
- static void mb_mirth_2E_lexer_296_55 (void);
- static void mb_mirth_2E_lexer_296_19 (void);
- static void mb_mirth_2E_lexer_296_59 (void);
- static void mb_mirth_2E_lexer_299_17 (void);
- static void mb_mirth_2E_lexer_298_17 (void);
- static void mb_mirth_2E_lexer_283_55 (void);
- static void mb_mirth_2E_lexer_324_9 (void);
- static void mb_mirth_2E_lexer_319_9 (void);
- static void mb_mirth_2E_lexer_321_13 (void);
- static void mb_mirth_2E_lexer_320_13 (void);
- static void mb_mirth_2E_lexer_320_18 (void);
- static void mb_mirth_2E_lexer_327_9 (void);
- static void mb_mirth_2E_lexer_326_11 (void);
- static void mb_mirth_2E_lexer_328_13 (void);
- static void mb_mirth_2E_lexer_329_17 (void);
- static void mb_mirth_2E_lexer_344_9 (void);
- static void mb_mirth_2E_lexer_339_9 (void);
- static void mb_mirth_2E_lexer_341_13 (void);
- static void mb_mirth_2E_lexer_340_13 (void);
- static void mb_mirth_2E_lexer_340_18 (void);
- static void mb_mirth_2E_lexer_348_9 (void);
- static void mb_mirth_2E_lexer_347_11 (void);
- static void mb_mirth_2E_lexer_349_13 (void);
- static void mb_mirth_2E_lexer_350_17 (void);
- static void mb_mirth_2E_lexer_358_9 (void);
- static void mb_mirth_2E_lexer_357_9 (void);
- static void mb_mirth_2E_lexer_360_13 (void);
- static void mb_mirth_2E_lexer_359_13 (void);
- static void mb_mirth_2E_lexer_412_9 (void);
- static void mb_mirth_2E_lexer_385_9 (void);
- static void mb_mirth_2E_lexer_390_9 (void);
- static void mb_mirth_2E_lexer_388_13 (void);
- static void mb_mirth_2E_lexer_393_9 (void);
- static void mb_mirth_2E_lexer_391_13 (void);
- static void mb_mirth_2E_lexer_396_9 (void);
- static void mb_mirth_2E_lexer_394_13 (void);
- static void mb_mirth_2E_lexer_399_9 (void);
- static void mb_mirth_2E_lexer_397_13 (void);
- static void mb_mirth_2E_lexer_402_9 (void);
- static void mb_mirth_2E_lexer_400_13 (void);
- static void mb_mirth_2E_lexer_405_13 (void);
- static void mb_mirth_2E_lexer_403_13 (void);
- static void mb_mirth_2E_lexer_434_42 (void);
- static void mb_mirth_2E_lexer_424_9 (void);
- static void mb_mirth_2E_lexer_423_9 (void);
- static void mb_mirth_2E_data_2E_error_14_9 (void);
- static void mb_mirth_2E_lexer_435_40 (void);
- static void mb_mirth_2E_data_2E_error_24_9 (void);
- static void mb_mirth_2E_data_2E_name_38_9 (void);
- static void mb_mirth_2E_data_2E_name_37_11 (void);
- static void mb_mirth_2E_data_2E_name_39_13 (void);
- static void mb_mirth_2E_data_2E_name_50_9 (void);
- static void mb_mirth_2E_data_2E_name_49_9 (void);
- static void mb_mirth_2E_data_2E_name_50_13 (void);
- static void mb_mirth_2E_data_2E_name_65_9 (void);
- static void mb_mirth_2E_data_2E_name_90_9 (void);
- static void mb_mirth_2E_data_2E_name_87_9 (void);
- static void mb_mirth_2E_data_2E_name_89_13 (void);
- static void mb_mirth_2E_data_2E_name_88_13 (void);
- static void mb_mirth_2E_data_2E_name_96_9 (void);
- static void mb_mirth_2E_data_2E_name_95_9 (void);
- static void mb_mirth_2E_data_2E_name_102_9 (void);
- static void mb_mirth_2E_data_2E_name_101_9 (void);
- static void mb_mirth_2E_data_2E_name_108_9 (void);
- static void mb_mirth_2E_data_2E_name_107_9 (void);
- static void mb_mirth_2E_data_2E_name_117_9 (void);
- static void mb_mirth_2E_data_2E_name_116_9 (void);
- static void mb_mirth_2E_data_2E_name_116_22 (void);
- static void mb_mirth_2E_data_2E_name_122_9 (void);
- static void mb_mirth_2E_data_2E_name_123_9 (void);
- static void mb_mirth_2E_data_2E_name_122_23 (void);
- static void mb_mirth_2E_data_2E_name_124_9 (void);
- static void mb_mirth_2E_data_2E_name_123_23 (void);
- static void mb_mirth_2E_data_2E_name_125_9 (void);
- static void mb_mirth_2E_data_2E_name_124_28 (void);
- static void mb_mirth_2E_data_2E_name_126_13 (void);
- static void mb_mirth_2E_data_2E_name_125_22 (void);
- static void mb_mirth_2E_data_2E_name_135_20 (void);
- static void mb_mirth_2E_data_2E_name_135_11 (void);
- static void mb_mirth_2E_data_2E_name_139_9 (void);
- static void mb_mirth_2E_data_2E_name_142_13 (void);
- static void mb_mirth_2E_data_2E_name_143_13 (void);
- static void mb_mirth_2E_data_2E_name_144_9 (void);
- static void mb_mirth_2E_data_2E_name_144_18 (void);
- static void mb_mirth_2E_data_2E_name_149_9 (void);
- static void mb_mirth_2E_data_2E_name_148_9 (void);
- static void mb_mirth_2E_data_2E_prim_121_9 (void);
- static void mb_mirth_2E_data_2E_token_154_17 (void);
- static void mb_mirth_2E_data_2E_token_153_17 (void);
- static void mb_mirth_2E_data_2E_token_162_34 (void);
- static void mb_mirth_2E_data_2E_token_162_11 (void);
- static void mb_mirth_2E_data_2E_token_168_9 (void);
- static void mb_mirth_2E_data_2E_token_167_9 (void);
- static void mb_mirth_2E_data_2E_token_174_59 (void);
- static void mb_mirth_2E_data_2E_token_174_23 (void);
- static void mb_mirth_2E_data_2E_token_174_54 (void);
- static void mb_mirth_2E_data_2E_token_174_42 (void);
- static void mb_mirth_2E_data_2E_token_180_9 (void);
- static void mb_mirth_2E_data_2E_token_176_9 (void);
- static void mb_mirth_2E_data_2E_token_176_13 (void);
- static void mb_mirth_2E_data_2E_token_178_13 (void);
- static void mb_mirth_2E_data_2E_token_177_15 (void);
- static void mb_mirth_2E_data_2E_token_178_17 (void);
- static void mb_mirth_2E_data_2E_token_191_9 (void);
- static void mb_mirth_2E_data_2E_token_190_9 (void);
- static void mb_mirth_2E_data_2E_token_200_9 (void);
- static void mb_mirth_2E_data_2E_token_198_9 (void);
- static void mb_mirth_2E_data_2E_token_202_13 (void);
- static void mb_mirth_2E_data_2E_token_201_13 (void);
- static void mb_mirth_2E_data_2E_token_198_39 (void);
- static void mb_mirth_2E_data_2E_token_198_27 (void);
- static void mb_mirth_2E_data_2E_token_214_9 (void);
- static void mb_mirth_2E_data_2E_token_210_9 (void);
- static void mb_mirth_2E_data_2E_token_216_13 (void);
- static void mb_mirth_2E_data_2E_token_215_13 (void);
- static void mb_mirth_2E_data_2E_token_210_39 (void);
- static void mb_mirth_2E_data_2E_token_210_27 (void);
- static void mb_mirth_2E_data_2E_token_229_9 (void);
- static void mb_mirth_2E_data_2E_token_224_9 (void);
- static void mb_mirth_2E_data_2E_token_231_13 (void);
- static void mb_mirth_2E_data_2E_token_230_13 (void);
- static void mb_mirth_2E_data_2E_token_224_39 (void);
- static void mb_mirth_2E_data_2E_token_224_27 (void);
- static void mb_mirth_2E_data_2E_token_244_9 (void);
- static void mb_mirth_2E_data_2E_token_238_9 (void);
- static void mb_mirth_2E_data_2E_token_238_39 (void);
- static void mb_mirth_2E_data_2E_token_238_27 (void);
- static void mb_mirth_2E_data_2E_token_241_13 (void);
- static void mb_mirth_2E_data_2E_token_240_13 (void);
- static void mb_mirth_2E_data_2E_token_241_32 (void);
- static void mb_mirth_2E_data_2E_token_250_39 (void);
- static void mb_mirth_2E_data_2E_token_250_28 (void);
- static void mb_mirth_2E_data_2E_token_262_9 (void);
- static void mb_mirth_2E_data_2E_token_264_9 (void);
- static void mb_mirth_2E_data_2E_token_297_9 (void);
- static void mb_mirth_2E_data_2E_token_296_9 (void);
- static void mb_mirth_2E_data_2E_token_303_9 (void);
- static void mb_mirth_2E_data_2E_token_302_9 (void);
- static void mb_mirth_2E_data_2E_token_307_34 (void);
- static void mb_mirth_2E_data_2E_token_307_11 (void);
- static void mb_mirth_2E_data_2E_token_322_9 (void);
- static void mb_mirth_2E_data_2E_token_317_9 (void);
- static void mb_mirth_2E_data_2E_token_328_9 (void);
- static void mb_mirth_2E_data_2E_token_327_18 (void);
- static void mb_mirth_2E_data_2E_token_328_40 (void);
- static void mb_mirth_2E_data_2E_token_328_31 (void);
- static void mb_mirth_2E_data_2E_token_328_35 (void);
- static void mb_mirth_2E_data_2E_token_377_9 (void);
- static void mb_mirth_2E_data_2E_token_376_9 (void);
- static void mb_mirth_2E_data_2E_module_20_9 (void);
- static void mb_data_2E_set_8_41 (void);
- static void mb_mirth_2E_data_2E_module_32_9 (void);
- static void mb_mirth_2E_data_2E_module_35_9 (void);
- static void mb_mirth_2E_data_2E_module_33_13 (void);
- static void mb_mirth_2E_data_2E_module_37_13 (void);
- static void mb_mirth_2E_data_2E_module_36_13 (void);
- static void mb_data_2E_bag_117_23 (void);
- static void mb_data_2E_bag_117_17 (void);
- static void mb_mirth_2E_codegen_39_9 (void);
- static void mb_mirth_2E_codegen_31_9 (void);
- static void mb_mirth_2E_codegen_34_13 (void);
- static void mb_mirth_2E_codegen_33_13 (void);
- static void mb_mirth_2E_codegen_36_17 (void);
- static void mb_mirth_2E_codegen_35_17 (void);
- static void mb_mirth_2E_codegen_43_38 (void);
- static void mb_mirth_2E_codegen_43_22 (void);
- static void mb_mirth_2E_codegen_47_38 (void);
- static void mb_mirth_2E_codegen_47_22 (void);
- static void mb_mirth_2E_codegen_64_9 (void);
- static void mb_mirth_2E_codegen_54_9 (void);
- static void mb_mirth_2E_codegen_64_17 (void);
- static void mb_mirth_2E_codegen_56_13 (void);
- static void mb_mirth_2E_codegen_55_15 (void);
- static void mb_mirth_2E_codegen_59_17 (void);
- static void mb_mirth_2E_codegen_81_9 (void);
- static void mb_mirth_2E_codegen_79_9 (void);
- static void mb_mirth_2E_codegen_216_13 (void);
- static void mb_mirth_2E_codegen_209_16 (void);
- static void mb_mirth_2E_codegen_1157_18 (void);
- static void mb_mirth_2E_codegen_1484_14 (void);
- static void mb_mirth_2E_codegen_1492_15 (void);
- static void mb_mirth_2E_codegen_1500_15 (void);
- static void mb_mirth_2E_codegen_1401_9 (void);
- static void mb_mirth_2E_codegen_1400_11 (void);
- static void mb_mirth_2E_codegen_222_5 (void);
- static void mb_mirth_2E_codegen_220_9 (void);
- static void mb_mirth_2E_codegen_225_9 (void);
- static void mb_mirth_2E_codegen_223_9 (void);
- static void mb_mirth_2E_codegen_228_24 (void);
- static void mb_mirth_2E_codegen_228_15 (void);
- static void mb_mirth_2E_data_2E_type_726_9 (void);
- static void mb_mirth_2E_data_2E_type_724_9 (void);
- static void mb_mirth_2E_data_2E_type_725_35 (void);
- static void mb_mirth_2E_data_2E_type_725_15 (void);
- static void mb_mirth_2E_data_2E_type_725_50 (void);
- static void mb_mirth_2E_codegen_1164_9 (void);
- static void mb_mirth_2E_codegen_1162_9 (void);
- static void mb_mirth_2E_codegen_1166_13 (void);
- static void mb_mirth_2E_codegen_1165_13 (void);
- static void mb_mirth_2E_codegen_1170_10 (void);
- static void mb_mirth_2E_codegen_1179_9 (void);
- static void mb_mirth_2E_codegen_1174_9 (void);
- static void mb_mirth_2E_codegen_1176_13 (void);
- static void mb_mirth_2E_codegen_1175_18 (void);
- static void mb_mirth_2E_codegen_1182_29 (void);
- static void mb_mirth_2E_codegen_1184_9 (void);
- static void mb_mirth_2E_codegen_1183_16 (void);
- static void mb_mirth_2E_codegen_1187_32 (void);
- static void mb_mirth_2E_codegen_1187_15 (void);
- static void mb_mirth_2E_codegen_1188_10 (void);
- static void mb_mirth_2E_codegen_1190_9 (void);
- static void mb_mirth_2E_codegen_1198_9 (void);
- static void mb_mirth_2E_codegen_1191_9 (void);
- static void mb_mirth_2E_codegen_1194_13 (void);
- static void mb_mirth_2E_codegen_1193_15 (void);
- static void mb_mirth_2E_codegen_1201_21 (void);
- static void mb_mirth_2E_codegen_1201_15 (void);
- static void mb_mirth_2E_codegen_1208_22 (void);
- static void mb_mirth_2E_codegen_1221_17 (void);
- static void mb_mirth_2E_codegen_1229_17 (void);
- static void mb_mirth_2E_codegen_1238_17 (void);
- static void mb_mirth_2E_codegen_1251_13 (void);
- static void mb_mirth_2E_codegen_1378_9 (void);
- static void mb_mirth_2E_codegen_1377_9 (void);
- static void mb_mirth_2E_codegen_1322_17 (void);
- static void mb_mirth_2E_data_2E_table_32_21 (void);
- static void mb_mirth_2E_codegen_1293_25 (void);
- static void mb_mirth_2E_codegen_1305_25 (void);
- static void mb_mirth_2E_codegen_1450_9 (void);
- static void mb_mirth_2E_codegen_1443_9 (void);
- static void mb_mirth_2E_codegen_1451_26 (void);
- static void mb_mirth_2E_codegen_1454_13 (void);
- static void mb_mirth_2E_codegen_1453_13 (void);
- static void mb_mirth_2E_codegen_1433_9 (void);
- static void mb_mirth_2E_codegen_1437_9 (void);
- static void mb_mirth_2E_codegen_1422_23 (void);
- static void mb_mirth_2E_codegen_1423_27 (void);
- static void mb_mirth_2E_codegen_1423_8 (void);
- static void mb_mirth_2E_codegen_1258_5 (void);
- static void mb_mirth_2E_codegen_1257_9 (void);
- static void mb_mirth_2E_codegen_1260_5 (void);
- static void mb_mirth_2E_codegen_1259_9 (void);
- static void mb_mirth_2E_codegen_1262_5 (void);
- static void mb_mirth_2E_codegen_1261_9 (void);
- static void mb_mirth_2E_codegen_1264_5 (void);
- static void mb_mirth_2E_codegen_1263_9 (void);
- static void mb_mirth_2E_codegen_1266_5 (void);
- static void mb_mirth_2E_codegen_1265_9 (void);
- static void mb_mirth_2E_codegen_1269_9 (void);
- static void mb_mirth_2E_codegen_1267_9 (void);
- static void mb_mirth_2E_codegen_1270_13 (void);
- static void mb_mirth_2E_codegen_1318_9 (void);
- static void mb_mirth_2E_codegen_1341_9 (void);
- static void mb_mirth_2E_data_2E_ctx_17_21 (void);
- static void mb_mirth_2E_codegen_1347_9 (void);
- static void mb_mirth_2E_codegen_1355_9 (void);
- static void mb_mirth_2E_codegen_1385_9 (void);
- static void mb_mirth_2E_codegen_1384_9 (void);
- static void mb_mirth_2E_codegen_1393_9 (void);
- static void mb_mirth_2E_codegen_1392_9 (void);
- static void mb_mirth_2E_codegen_1551_9 (void);
- static void mb_mirth_2E_codegen_1543_9 (void);
- static void mb_mirth_2E_codegen_1546_13 (void);
- static void mb_mirth_2E_codegen_1544_13 (void);
- static void mb_mirth_2E_codegen_1526_9 (void);
- static void mb_mirth_2E_codegen_1515_9 (void);
- static void mb_mirth_2E_codegen_1518_13 (void);
- static void mb_mirth_2E_codegen_1516_13 (void);
- static void mb_mirth_2E_codegen_1596_9 (void);
- static void mb_mirth_2E_codegen_1557_9 (void);
- static void mb_mirth_2E_codegen_1560_13 (void);
- static void mb_mirth_2E_codegen_1558_13 (void);
- static void mb_mirth_2E_codegen_1534_9 (void);
- static void mb_mirth_2E_codegen_1533_9 (void);
- static void mb_mirth_2E_codegen_1479_17 (void);
- static void mb_mirth_2E_codegen_1474_17 (void);
- static void mb_mirth_2E_codegen_1476_21 (void);
- static void mb_mirth_2E_codegen_1475_23 (void);
- static void mb_mirth_2E_codegen_1510_15 (void);
- static void mb_data_2E_lazy_30_21 (void);
- static void mb_mirth_2E_data_2E_arrow_94_9 (void);
- static void mb_mirth_2E_data_2E_arrow_106_9 (void);
- static void mb_mirth_2E_data_2E_arrow_146_9 (void);
- static void mb_mirth_2E_data_2E_arrow_133_9 (void);
- static void mb_mirth_2E_data_2E_arrow_138_13 (void);
- static void mb_mirth_2E_data_2E_arrow_134_13 (void);
- static void mb_mirth_2E_data_2E_arrow_141_17 (void);
- static void mb_mirth_2E_data_2E_arrow_142_23 (void);
- static void mb_mirth_2E_elab_188_9 (void);
- static void mb_mirth_2E_elab_491_9 (void);
- static void mb_mirth_2E_elab_490_9 (void);
- static void mb_mirth_2E_data_2E_arrow_158_9 (void);
- static void mb_mirth_2E_data_2E_arrow_151_9 (void);
- static void mb_mirth_2E_data_2E_arrow_156_13 (void);
- static void mb_mirth_2E_data_2E_arrow_152_13 (void);
- static void mb_mirth_2E_data_2E_arrow_163_9 (void);
- static void mb_mirth_2E_data_2E_arrow_165_9 (void);
- static void mb_mirth_2E_data_2E_arrow_165_13 (void);
- static void mb_mirth_2E_data_2E_arrow_166_19 (void);
- static void mb_mirth_2E_data_2E_arrow_169_13 (void);
- static void mb_mirth_2E_data_2E_type_177_30 (void);
- static void mb_mirth_2E_data_2E_type_184_30 (void);
- static void mb_mirth_2E_data_2E_type_185_30 (void);
- static void mb_mirth_2E_data_2E_type_187_26 (void);
- static void mb_mirth_2E_data_2E_type_193_30 (void);
- static void mb_mirth_2E_data_2E_type_194_30 (void);
- static void mb_mirth_2E_data_2E_type_195_31 (void);
- static void mb_mirth_2E_data_2E_type_197_26 (void);
- static void mb_mirth_2E_data_2E_type_203_30 (void);
- static void mb_mirth_2E_data_2E_type_204_30 (void);
- static void mb_mirth_2E_data_2E_type_205_31 (void);
- static void mb_mirth_2E_data_2E_type_207_26 (void);
- static void mb_mirth_2E_data_2E_type_213_30 (void);
- static void mb_mirth_2E_data_2E_type_214_30 (void);
- static void mb_mirth_2E_data_2E_type_215_31 (void);
- static void mb_mirth_2E_data_2E_type_217_26 (void);
- static void mb_mirth_2E_data_2E_type_223_30 (void);
- static void mb_mirth_2E_data_2E_type_224_30 (void);
- static void mb_mirth_2E_data_2E_type_225_31 (void);
- static void mb_mirth_2E_data_2E_type_227_26 (void);
- static void mb_mirth_2E_data_2E_type_233_30 (void);
- static void mb_mirth_2E_data_2E_type_234_30 (void);
- static void mb_mirth_2E_data_2E_type_235_31 (void);
- static void mb_mirth_2E_data_2E_type_237_26 (void);
- static void mb_mirth_2E_data_2E_type_243_30 (void);
- static void mb_mirth_2E_data_2E_type_244_30 (void);
- static void mb_mirth_2E_data_2E_type_245_31 (void);
- static void mb_mirth_2E_data_2E_type_247_26 (void);
- static void mb_mirth_2E_data_2E_type_253_30 (void);
- static void mb_mirth_2E_data_2E_type_254_30 (void);
- static void mb_mirth_2E_elab_583_27 (void);
- static void mb_mirth_2E_elab_586_17 (void);
- static void mb_mirth_2E_elab_592_17 (void);
- static void mb_mirth_2E_data_2E_arrow_205_9 (void);
- static void mb_mirth_2E_data_2E_arrow_207_9 (void);
- static void mb_mirth_2E_data_2E_arrow_206_9 (void);
- static void mb_mirth_2E_data_2E_arrow_213_9 (void);
- static void mb_mirth_2E_data_2E_arrow_212_9 (void);
- static void mb_mirth_2E_data_2E_arrow_235_9 (void);
- static void mb_mirth_2E_data_2E_arrow_262_9 (void);
- static void mb_mirth_2E_data_2E_arrow_255_14 (void);
- static void mb_mirth_2E_data_2E_arrow_259_9 (void);
- static void mb_mirth_2E_data_2E_arrow_274_46 (void);
- static void mb_mirth_2E_data_2E_arrow_274_34 (void);
- static void mb_mirth_2E_data_2E_type_68_33 (void);
- static void mb_mirth_2E_data_2E_type_95_27 (void);
- static void mb_mirth_2E_data_2E_type_96_32 (void);
- static void mb_mirth_2E_data_2E_type_97_37 (void);
- static void mb_mirth_2E_data_2E_type_98_42 (void);
- static void mb_mirth_2E_data_2E_type_99_47 (void);
- static void mb_mirth_2E_data_2E_type_100_52 (void);
- static void mb_mirth_2E_data_2E_type_615_9 (void);
- static void mb_mirth_2E_data_2E_type_614_9 (void);
- static void mb_mirth_2E_data_2E_type_614_17 (void);
- static void mb_mirth_2E_data_2E_type_158_10 (void);
- static void mb_mirth_2E_data_2E_type_160_9 (void);
- static void mb_mirth_2E_data_2E_type_640_9 (void);
- static void mb_mirth_2E_data_2E_type_639_9 (void);
- static void mb_mirth_2E_data_2E_type_622_5 (void);
- static void mb_mirth_2E_data_2E_type_620_9 (void);
- static void mb_mirth_2E_data_2E_type_625_5 (void);
- static void mb_mirth_2E_data_2E_type_623_9 (void);
- static void mb_mirth_2E_data_2E_type_629_9 (void);
- static void mb_mirth_2E_data_2E_type_627_9 (void);
- static void mb_mirth_2E_data_2E_type_629_18 (void);
- static void mb_mirth_2E_data_2E_type_346_9 (void);
- static void mb_mirth_2E_data_2E_type_345_9 (void);
- static void mb_mirth_2E_data_2E_type_346_13 (void);
- static void mb_mirth_2E_data_2E_type_331_9 (void);
- static void mb_mirth_2E_data_2E_type_330_9 (void);
- static void mb_mirth_2E_data_2E_type_331_13 (void);
- static void mb_mirth_2E_data_2E_type_336_9 (void);
- static void mb_mirth_2E_data_2E_type_335_9 (void);
- static void mb_mirth_2E_data_2E_type_336_13 (void);
- static void mb_mirth_2E_data_2E_type_341_9 (void);
- static void mb_mirth_2E_data_2E_type_340_9 (void);
- static void mb_mirth_2E_data_2E_type_341_13 (void);
- static void mb_mirth_2E_data_2E_type_326_9 (void);
- static void mb_mirth_2E_data_2E_type_326_18 (void);
- static void mb_mirth_2E_data_2E_type_326_53 (void);
- static void mb_mirth_2E_data_2E_type_263_60 (void);
- static void mb_mirth_2E_data_2E_type_263_37 (void);
- static void mb_mirth_2E_data_2E_type_275_60 (void);
- static void mb_mirth_2E_data_2E_type_275_37 (void);
- static void mb_mirth_2E_data_2E_type_290_21 (void);
- static void mb_mirth_2E_data_2E_type_289_21 (void);
- static void mb_mirth_2E_data_2E_type_360_24 (void);
- static void mb_mirth_2E_data_2E_type_360_64 (void);
- static void mb_mirth_2E_data_2E_type_360_52 (void);
- static void mb_mirth_2E_data_2E_type_361_26 (void);
- static void mb_mirth_2E_data_2E_type_361_66 (void);
- static void mb_mirth_2E_data_2E_type_361_54 (void);
- static void mb_mirth_2E_data_2E_type_362_21 (void);
- static void mb_mirth_2E_data_2E_type_362_61 (void);
- static void mb_mirth_2E_data_2E_type_362_49 (void);
- static void mb_mirth_2E_data_2E_type_387_9 (void);
- static void mb_mirth_2E_data_2E_type_386_9 (void);
- static void mb_mirth_2E_data_2E_type_394_9 (void);
- static void mb_mirth_2E_data_2E_type_393_9 (void);
- static void mb_mirth_2E_data_2E_type_406_20 (void);
- static void mb_mirth_2E_data_2E_type_406_16 (void);
- static void mb_mirth_2E_data_2E_type_460_9 (void);
- static void mb_mirth_2E_data_2E_type_459_9 (void);
- static void mb_mirth_2E_data_2E_type_504_17 (void);
- static void mb_mirth_2E_data_2E_type_503_17 (void);
- static void mb_mirth_2E_data_2E_type_467_17 (void);
- static void mb_mirth_2E_data_2E_type_468_17 (void);
- static void mb_mirth_2E_data_2E_type_476_24 (void);
- static void mb_mirth_2E_data_2E_type_490_9 (void);
- static void mb_mirth_2E_data_2E_type_488_9 (void);
- static void mb_mirth_2E_data_2E_type_513_17 (void);
- static void mb_mirth_2E_data_2E_type_514_17 (void);
- static void mb_mirth_2E_data_2E_type_515_27 (void);
- static void mb_mirth_2E_data_2E_type_523_17 (void);
- static void mb_mirth_2E_data_2E_type_524_17 (void);
- static void mb_mirth_2E_data_2E_type_563_9 (void);
- static void mb_mirth_2E_data_2E_type_562_9 (void);
- static void mb_mirth_2E_data_2E_type_564_13 (void);
- static void mb_mirth_2E_data_2E_type_557_9 (void);
- static void mb_mirth_2E_data_2E_type_556_9 (void);
- static void mb_mirth_2E_data_2E_type_552_9 (void);
- static void mb_mirth_2E_data_2E_type_552_45 (void);
- static void mb_mirth_2E_data_2E_type_600_17 (void);
- static void mb_mirth_2E_data_2E_type_599_17 (void);
- static void mb_mirth_2E_data_2E_type_744_21 (void);
- static void mb_data_2E_map_21_49 (void);
- static void mb_data_2E_map_19_45 (void);
- static void mb_mirth_2E_data_2E_type_714_9 (void);
- static void mb_mirth_2E_data_2E_type_713_9 (void);
- static void mb_mirth_2E_data_2E_type_713_17 (void);
- static void mb_mirth_2E_data_2E_type_741_25 (void);
- static void mb_data_2E_map_25_50 (void);
- static void mb_data_2E_map_26_52 (void);
- static void mb_data_2E_bag_135_20 (void);
- static void mb_data_2E_bag_135_16 (void);
- static void mb_data_2E_bag_139_9 (void);
- static void mb_data_2E_bag_139_32 (void);
- static void mb_data_2E_bag_139_28 (void);
- static void mb_data_2E_bag_139_41 (void);
- static void mb_data_2E_bag_26_70 (void);
- static void mb_data_2E_bag_47_32 (void);
- static void mb_data_2E_bag_49_33 (void);
- static void mb_data_2E_bag_51_26 (void);
- static void mb_data_2E_bag_54_56 (void);
- static void mb_data_2E_bag_104_9 (void);
- static void mb_data_2E_bag_102_9 (void);
- static void mb_data_2E_bag_104_13 (void);
- static void mb_data_2E_bag_108_13 (void);
- static void mb_data_2E_bag_107_13 (void);
- static void mb_data_2E_bag_108_27 (void);
- static void mb_data_2E_bag_102_13 (void);
- static void mb_data_2E_bag_75_9 (void);
- static void mb_data_2E_bag_73_9 (void);
- static void mb_data_2E_bag_75_13 (void);
- static void mb_data_2E_bag_80_28 (void);
- static void mb_data_2E_bag_73_13 (void);
- static void mb_data_2E_bag_128_9 (void);
- static void mb_data_2E_bag_131_9 (void);
- static void mb_data_2E_bag_125_9 (void);
- static void mb_data_2E_bag_157_9 (void);
- static void mb_data_2E_bag_155_9 (void);
- static void mb_data_2E_bag_157_13 (void);
- static void mb_data_2E_bag_159_34 (void);
- static void mb_data_2E_bag_160_23 (void);
- static void mb_data_2E_bag_161_23 (void);
- static void mb_data_2E_bag_155_13 (void);
- static void mb_data_2E_bag_155_45 (void);
- static void mb_data_2E_bag_155_39 (void);
- static void mb_data_2E_bag_189_9 (void);
- static void mb_data_2E_bag_184_9 (void);
- static void mb_data_2E_bag_189_13 (void);
- static void mb_data_2E_bag_192_13 (void);
- static void mb_data_2E_bag_191_13 (void);
- static void mb_data_2E_bag_192_26 (void);
- static void mb_data_2E_bag_184_13 (void);
- static void mb_data_2E_bag_186_13 (void);
- static void mb_data_2E_bag_185_13 (void);
- static void mb_data_2E_bag_197_37 (void);
- static void mb_data_2E_bag_200_37 (void);
- static void mb_data_2E_lazy_16_11 (void);
- static void mb_data_2E_lazy_18_17 (void);
- static void mb_data_2E_lazy_20_17 (void);
- static void mb_data_2E_lazy_22_17 (void);
- static void mb_data_2E_lazy_44_12 (void);
- static void mb_data_2E_lazy_44_16 (void);
- static void mb_data_2E_lazy_46_12 (void);
- static void mb_data_2E_lazy_46_16 (void);
- static void mb_data_2E_lazy_46_20 (void);
- static void mb_data_2E_lazy_48_12 (void);
- static void mb_data_2E_lazy_48_16 (void);
- static void mb_mirth_2E_data_2E_var_25_9 (void);
- static void mb_mirth_2E_data_2E_var_26_9 (void);
- static void mb_mirth_2E_data_2E_var_27_9 (void);
- static void mb_mirth_2E_elab_25_53 (void);
- static void mb_mirth_2E_elab_39_9 (void);
- static void mb_mirth_2E_elab_37_9 (void);
- static void mb_mirth_2E_elab_39_13 (void);
- static void mb_mirth_2E_elab_38_18 (void);
- static void mb_mirth_2E_elab_40_37 (void);
- static void mb_mirth_2E_elab_40_11 (void);
- static void mb_mirth_2E_elab_41_9 (void);
- static void mb_mirth_2E_elab_46_9 (void);
- static void mb_mirth_2E_elab_45_9 (void);
- static void mb_mirth_2E_elab_46_13 (void);
- static void mb_mirth_2E_elab_45_29 (void);
- static void mb_mirth_2E_elab_52_9 (void);
- static void mb_mirth_2E_elab_51_11 (void);
- static void mb_mirth_2E_elab_52_18 (void);
- static void mb_mirth_2E_elab_53_13 (void);
- static void mb_mirth_2E_elab_67_5 (void);
- static void mb_mirth_2E_elab_65_9 (void);
- static void mb_mirth_2E_elab_70_5 (void);
- static void mb_mirth_2E_elab_68_9 (void);
- static void mb_mirth_2E_elab_73_5 (void);
- static void mb_mirth_2E_elab_71_9 (void);
- static void mb_mirth_2E_elab_76_5 (void);
- static void mb_mirth_2E_elab_74_9 (void);
- static void mb_mirth_2E_elab_79_9 (void);
- static void mb_mirth_2E_elab_77_9 (void);
- static void mb_mirth_2E_elab_80_13 (void);
- static void mb_mirth_2E_elab_65_28 (void);
- static void mb_mirth_2E_elab_60_9 (void);
- static void mb_mirth_2E_elab_59_9 (void);
- static void mb_mirth_2E_elab_113_17 (void);
- static void mb_mirth_2E_elab_111_17 (void);
- static void mb_mirth_2E_elab_146_9 (void);
- static void mb_mirth_2E_elab_151_9 (void);
- static void mb_mirth_2E_elab_147_9 (void);
- static void mb_mirth_2E_elab_149_13 (void);
- static void mb_mirth_2E_elab_148_13 (void);
- static void mb_mirth_2E_elab_137_9 (void);
- static void mb_mirth_2E_elab_142_9 (void);
- static void mb_mirth_2E_elab_138_9 (void);
- static void mb_mirth_2E_elab_140_13 (void);
- static void mb_mirth_2E_elab_139_13 (void);
- static void mb_mirth_2E_elab_158_9 (void);
- static void mb_mirth_2E_elab_157_9 (void);
- static void mb_mirth_2E_elab_90_10 (void);
- static void mb_mirth_2E_elab_91_10 (void);
- static void mb_mirth_2E_elab_94_23 (void);
- static void mb_mirth_2E_elab_98_17 (void);
- static void mb_mirth_2E_elab_98_21 (void);
- static void mb_mirth_2E_elab_100_25 (void);
- static void mb_mirth_2E_elab_104_10 (void);
- static void mb_mirth_2E_data_2E_ctx_19_24 (void);
- static void mb_mirth_2E_elab_163_13 (void);
- static void mb_mirth_2E_data_2E_ctx_14_35 (void);
- static void mb_mirth_2E_elab_125_9 (void);
- static void mb_mirth_2E_elab_133_9 (void);
- static void mb_mirth_2E_elab_126_9 (void);
- static void mb_mirth_2E_elab_126_13 (void);
- static void mb_mirth_2E_elab_128_13 (void);
- static void mb_mirth_2E_elab_127_15 (void);
- static void mb_mirth_2E_elab_129_17 (void);
- static void mb_mirth_2E_elab_130_17 (void);
- static void mb_mirth_2E_elab_131_18 (void);
- static void mb_mirth_2E_elab_166_9 (void);
- static void mb_mirth_2E_elab_184_28 (void);
- static void mb_mirth_2E_elab_199_17 (void);
- static void mb_mirth_2E_elab_201_13 (void);
- static void mb_mirth_2E_elab_205_13 (void);
- static void mb_mirth_2E_elab_205_17 (void);
- static void mb_mirth_2E_elab_205_27 (void);
- static void mb_mirth_2E_elab_214_9 (void);
- static void mb_mirth_2E_elab_222_9 (void);
- static void mb_mirth_2E_elab_229_9 (void);
- static void mb_mirth_2E_elab_228_11 (void);
- static void mb_mirth_2E_elab_228_16 (void);
- static void mb_mirth_2E_elab_228_43 (void);
- static void mb_mirth_2E_elab_234_24 (void);
- static void mb_mirth_2E_elab_263_25 (void);
- static void mb_mirth_2E_elab_285_42 (void);
- static void mb_mirth_2E_elab_285_36 (void);
- static void mb_mirth_2E_elab_295_9 (void);
- static void mb_mirth_2E_elab_297_9 (void);
- static void mb_mirth_2E_elab_303_27 (void);
- static void mb_mirth_2E_elab_305_17 (void);
- static void mb_mirth_2E_elab_307_22 (void);
- static void mb_mirth_2E_elab_318_9 (void);
- static void mb_mirth_2E_elab_317_9 (void);
- static void mb_mirth_2E_elab_327_13 (void);
- static void mb_mirth_2E_elab_327_54 (void);
- static void mb_mirth_2E_elab_332_37 (void);
- static void mb_mirth_2E_elab_335_24 (void);
- static void mb_mirth_2E_elab_338_9 (void);
- static void mb_mirth_2E_elab_342_9 (void);
- static void mb_mirth_2E_elab_353_13 (void);
- static void mb_mirth_2E_elab_354_13 (void);
- static void mb_mirth_2E_elab_354_22 (void);
- static void mb_mirth_2E_elab_366_13 (void);
- static void mb_mirth_2E_elab_366_17 (void);
- static void mb_mirth_2E_elab_569_27 (void);
- static void mb_mirth_2E_elab_572_17 (void);
- static void mb_mirth_2E_elab_578_17 (void);
- static void mb_mirth_2E_elab_1166_21 (void);
- static void mb_mirth_2E_elab_1168_23 (void);
- static void mb_mirth_2E_elab_1169_23 (void);
- static void mb_mirth_2E_elab_407_9 (void);
- static void mb_mirth_2E_elab_406_9 (void);
- static void mb_mirth_2E_elab_420_9 (void);
- static void mb_mirth_2E_elab_418_9 (void);
- static void mb_mirth_2E_elab_426_13 (void);
- static void mb_mirth_2E_elab_431_17 (void);
- static void mb_mirth_2E_elab_428_17 (void);
- static void mb_mirth_2E_elab_429_41 (void);
- static void mb_mirth_2E_elab_429_35 (void);
- static void mb_mirth_2E_elab_435_17 (void);
- static void mb_mirth_2E_elab_438_13 (void);
- static void mb_mirth_2E_elab_418_27 (void);
- static void mb_mirth_2E_elab_456_9 (void);
- static void mb_mirth_2E_elab_454_9 (void);
- static void mb_mirth_2E_elab_457_13 (void);
- static void mb_mirth_2E_elab_458_33 (void);
- static void mb_mirth_2E_elab_460_13 (void);
- static void mb_mirth_2E_elab_454_28 (void);
- static void mb_mirth_2E_elab_479_9 (void);
- static void mb_mirth_2E_elab_486_15 (void);
- static void mb_mirth_2E_elab_514_38 (void);
- static void mb_mirth_2E_elab_615_35 (void);
- static void mb_mirth_2E_elab_615_11 (void);
- static void mb_mirth_2E_elab_618_9 (void);
- static void mb_mirth_2E_elab_617_11 (void);
- static void mb_mirth_2E_elab_619_13 (void);
- static void mb_mirth_2E_elab_622_17 (void);
- static void mb_mirth_2E_elab_620_17 (void);
- static void mb_mirth_2E_elab_622_32 (void);
- static void mb_mirth_2E_elab_627_21 (void);
- static void mb_mirth_2E_elab_623_21 (void);
- static void mb_mirth_2E_elab_630_17 (void);
- static void mb_mirth_2E_elab_630_41 (void);
- static void mb_mirth_2E_elab_631_17 (void);
- static void mb_mirth_2E_elab_638_35 (void);
- static void mb_mirth_2E_elab_638_11 (void);
- static void mb_mirth_2E_elab_639_9 (void);
- static void mb_mirth_2E_elab_639_25 (void);
- static void mb_mirth_2E_elab_596_9 (void);
- static void mb_mirth_2E_elab_598_10 (void);
- static void mb_mirth_2E_elab_603_5 (void);
- static void mb_mirth_2E_elab_602_9 (void);
- static void mb_mirth_2E_elab_608_9 (void);
- static void mb_mirth_2E_elab_604_9 (void);
- static void mb_mirth_2E_elab_605_13 (void);
- static void mb_mirth_2E_elab_606_13 (void);
- static void mb_mirth_2E_elab_850_28 (void);
- static void mb_mirth_2E_elab_850_24 (void);
- static void mb_mirth_2E_elab_662_9 (void);
- static void mb_mirth_2E_elab_659_9 (void);
- static void mb_mirth_2E_elab_660_37 (void);
- static void mb_mirth_2E_elab_660_15 (void);
- static void mb_mirth_2E_elab_653_9 (void);
- static void mb_mirth_2E_elab_652_9 (void);
- static void mb_mirth_2E_elab_669_14 (void);
- static void mb_mirth_2E_elab_673_9 (void);
- static void mb_mirth_2E_elab_674_36 (void);
- static void mb_mirth_2E_elab_674_24 (void);
- static void mb_mirth_2E_elab_689_5 (void);
- static void mb_mirth_2E_elab_680_9 (void);
- static void mb_mirth_2E_elab_718_9 (void);
- static void mb_mirth_2E_elab_690_9 (void);
- static void mb_mirth_2E_elab_695_22 (void);
- static void mb_mirth_2E_elab_698_22 (void);
- static void mb_mirth_2E_elab_702_21 (void);
- static void mb_mirth_2E_elab_703_26 (void);
- static void mb_mirth_2E_elab_704_25 (void);
- static void mb_mirth_2E_elab_706_26 (void);
- static void mb_mirth_2E_elab_680_13 (void);
- static void mb_mirth_2E_elab_683_13 (void);
- static void mb_mirth_2E_elab_684_30 (void);
- static void mb_mirth_2E_elab_723_9 (void);
- static void mb_mirth_2E_elab_723_23 (void);
- static void mb_mirth_2E_elab_724_26 (void);
- static void mb_mirth_2E_elab_725_10 (void);
- static void mb_mirth_2E_elab_726_10 (void);
- static void mb_mirth_2E_elab_753_9 (void);
- static void mb_mirth_2E_elab_742_9 (void);
- static void mb_mirth_2E_elab_743_31 (void);
- static void mb_mirth_2E_elab_743_27 (void);
- static void mb_mirth_2E_elab_745_65 (void);
- static void mb_mirth_2E_elab_745_12 (void);
- static void mb_mirth_2E_elab_751_13 (void);
- static void mb_mirth_2E_elab_750_51 (void);
- static void mb_mirth_2E_elab_762_17 (void);
- static void mb_mirth_2E_elab_761_17 (void);
- static void mb_mirth_2E_elab_771_13 (void);
- static void mb_mirth_2E_elab_776_25 (void);
- static void mb_mirth_2E_elab_783_25 (void);
- static void mb_mirth_2E_elab_798_9 (void);
- static void mb_mirth_2E_elab_799_20 (void);
- static void mb_mirth_2E_elab_800_13 (void);
- static void mb_mirth_2E_elab_808_9 (void);
- static void mb_mirth_2E_elab_807_31 (void);
- static void mb_mirth_2E_elab_811_9 (void);
- static void mb_mirth_2E_elab_810_24 (void);
- static void mb_mirth_2E_elab_820_27 (void);
- static void mb_mirth_2E_elab_820_23 (void);
- static void mb_mirth_2E_elab_822_9 (void);
- static void mb_mirth_2E_elab_821_36 (void);
- static void mb_mirth_2E_elab_828_9 (void);
- static void mb_mirth_2E_elab_829_14 (void);
- static void mb_mirth_2E_elab_836_5 (void);
- static void mb_mirth_2E_elab_833_9 (void);
- static void mb_mirth_2E_elab_838_9 (void);
- static void mb_mirth_2E_elab_837_9 (void);
- static void mb_mirth_2E_elab_833_13 (void);
- static void mb_mirth_2E_elab_834_29 (void);
- static void mb_mirth_2E_elab_835_35 (void);
- static void mb_mirth_2E_elab_835_15 (void);
- static void mb_mirth_2E_elab_844_28 (void);
- static void mb_mirth_2E_elab_844_24 (void);
- static void mb_mirth_2E_elab_847_29 (void);
- static void mb_mirth_2E_elab_847_25 (void);
- static void mb_mirth_2E_elab_854_13 (void);
- static void mb_mirth_2E_elab_855_32 (void);
- static void mb_mirth_2E_elab_855_28 (void);
- static void mb_mirth_2E_elab_857_28 (void);
- static void mb_mirth_2E_elab_857_24 (void);
- static void mb_mirth_2E_elab_861_13 (void);
- static void mb_mirth_2E_elab_862_13 (void);
- static void mb_mirth_2E_elab_863_13 (void);
- static void mb_mirth_2E_elab_866_9 (void);
- static void mb_mirth_2E_elab_868_18 (void);
- static void mb_mirth_2E_elab_871_17 (void);
- static void mb_mirth_2E_elab_871_21 (void);
- static void mb_mirth_2E_elab_875_13 (void);
- static void mb_mirth_2E_elab_886_9 (void);
- static void mb_mirth_2E_elab_877_9 (void);
- static void mb_mirth_2E_elab_884_13 (void);
- static void mb_mirth_2E_elab_878_13 (void);
- static void mb_mirth_2E_elab_891_13 (void);
- static void mb_mirth_2E_elab_900_9 (void);
- static void mb_mirth_2E_elab_893_9 (void);
- static void mb_mirth_2E_elab_898_13 (void);
- static void mb_mirth_2E_elab_894_13 (void);
- static void mb_mirth_2E_elab_905_13 (void);
- static void mb_mirth_2E_elab_912_9 (void);
- static void mb_mirth_2E_elab_907_9 (void);
- static void mb_mirth_2E_elab_910_13 (void);
- static void mb_mirth_2E_elab_908_13 (void);
- static void mb_mirth_2E_elab_917_13 (void);
- static void mb_mirth_2E_elab_920_9 (void);
- static void mb_mirth_2E_elab_919_9 (void);
- static void mb_mirth_2E_elab_975_9 (void);
- static void mb_mirth_2E_elab_994_9 (void);
- static void mb_mirth_2E_elab_1008_9 (void);
- static void mb_mirth_2E_elab_1030_9 (void);
- static void mb_mirth_2E_elab_1036_13 (void);
- static void mb_mirth_2E_elab_1035_13 (void);
- static void mb_mirth_2E_elab_1064_13 (void);
- static void mb_mirth_2E_elab_1065_17 (void);
- static void mb_mirth_2E_elab_1072_21 (void);
- static void mb_mirth_2E_elab_1067_21 (void);
- static void mb_mirth_2E_elab_1074_25 (void);
- static void mb_mirth_2E_elab_1097_9 (void);
- static void mb_mirth_2E_elab_927_13 (void);
- static void mb_mirth_2E_elab_928_9 (void);
- static void mb_mirth_2E_elab_929_9 (void);
- static void mb_mirth_2E_elab_1115_13 (void);
- static void mb_mirth_2E_elab_1147_9 (void);
- static void mb_mirth_2E_elab_1145_9 (void);
- static void mb_mirth_2E_data_2E_prim_117_9 (void);
- static void mb_mirth_2E_data_2E_prim_135_14 (void);
+ static void mb_init_prims_21__283 (void);
+ static void mb_init_prims_21__288 (void);
+ static void mb_init_prims_21__293 (void);
+ static void mb_init_prims_21__298 (void);
+ static void mb_init_prims_21__303 (void);
+ static void mb_init_prims_21__308 (void);
+ static void mb_init_prims_21__313 (void);
+ static void mb_init_prims_21__318 (void);
+ static void mb_init_prims_21__323 (void);
+ static void mb_init_prims_21__788 (void);
+ static void mb_init_prims_21__821 (void);
+ static void mb_init_prims_21__851 (void);
+ static void mb_init_prims_21__859 (void);
+ static void mb_init_prims_21__886 (void);
+ static void mb_init_prims_21__891 (void);
+ static void mb_init_prims_21__927 (void);
+ static void mb_init_prims_21__929 (void);
+ static void mb_init_prims_21__936 (void);
+ static void mb_init_prims_21__942 (void);
+ static void mb_init_prims_21__946 (void);
+ static void mb_init_prims_21__948 (void);
+ static void mb_init_prims_21__978 (void);
+ static void mb_init_prims_21__986 (void);
+ static void mb_init_prims_21__988 (void);
+ static void mb_init_prims_21__994 (void);
+ static void mb_init_prims_21__1018 (void);
+ static void mb_init_prims_21__1025 (void);
+ static void mb_init_prims_21__1056 (void);
+ static void mb_init_prims_21__1089 (void);
+ static void mb_init_prims_21__1115 (void);
+ static void mb_init_prims_21__1167 (void);
+ static void mb_init_prims_21__1178 (void);
+ static void mb_init_prims_21__1191 (void);
+ static void mb_compile_21__23 (void);
+ static void mb_compile_21__16 (void);
+ static void mb_run_lexer_21__19 (void);
+ static void mb_run_lexer_21__16 (void);
+ static void mb_run_lexer_21__28 (void);
+ static void mb_run_lexer_21__25 (void);
+ static void mb_elab_module_21__7 (void);
+ static void mb_elab_module_21__4 (void);
+ static void mb_typecheck_everything_21__2 (void);
+ static void mb_main_13 (void);
+ static void mb_main_6 (void);
+ static void mb_ptr_40__40__2 (void);
+ static void mb_with_raw_ptr_11 (void);
+ static void mb_Int__3E_OS_8 (void);
+ static void mb_Int__3E_OS_5 (void);
+ static void mb_Int__3E_OS_16 (void);
+ static void mb_Int__3E_OS_13 (void);
+ static void mb_Int__3E_OS_24 (void);
+ static void mb_Int__3E_OS_21 (void);
+ static void mb_posix_open_21__2 (void);
+ static void mb_dip2_8 (void);
+ static void mb_dip2_10 (void);
+ static void mb_rotr_3 (void);
+ static void mb_rotl_2 (void);
+ static void mb_over_2 (void);
+ static void mb_over2_2 (void);
+ static void mb_over3_2 (void);
+ static void mb_tuck_3 (void);
+ static void mb_nip_2 (void);
+ static void mb_dup3_3 (void);
+ static void mb_dup3_5 (void);
+ static void mb_dip_3F__8 (void);
+ static void mb_dip_27__9 (void);
+ static void mb_dip3_8 (void);
+ static void mb_dip3_10 (void);
+ static void mb_dip3_12 (void);
+ static void mb_rot4r_3 (void);
+ static void mb_rot4l_2 (void);
+ static void mb_or_10 (void);
+ static void mb_or_8 (void);
+ static void mb_and_10 (void);
+ static void mb_and_8 (void);
+ static void mb_cmp_7 (void);
+ static void mb_cmp_4 (void);
+ static void mb_cmp_12 (void);
+ static void mb_cmp_10 (void);
+ static void mb_max_6 (void);
+ static void mb_max_4 (void);
+ static void mb_min_6 (void);
+ static void mb_min_4 (void);
+ static void mb_ptr_21__21__2 (void);
+ static void mb_int_40__40__2 (void);
+ static void mb_int_21__21__2 (void);
+ static void mb_value_40__40__2 (void);
+ static void mb_value_21__21__2 (void);
+ static void mb_in_range_2 (void);
+ static void mb_in_range_5 (void);
+ static void mb_abs_6 (void);
+ static void mb_abs_4 (void);
+ static void mb_pack1_2 (void);
+ static void mb_pack2_2 (void);
+ static void mb_pack3_2 (void);
+ static void mb_pack4_2 (void);
+ static void mb_pack5_2 (void);
+ static void mb_unpack2_3 (void);
+ static void mb_unpack3_3 (void);
+ static void mb_unpack4_3 (void);
+ static void mb_unpack5_3 (void);
+ static void mb_file_21__2 (void);
+ static void mb_str_write_21__7 (void);
+ static void mb_str_write_21__9 (void);
+ static void mb_str_write_21__22 (void);
+ static void mb_str_write_21__19 (void);
+ static void mb_str_write_21__29 (void);
+ static void mb_str_write_21__26 (void);
+ static void mb_str_size_3 (void);
+ static void mb_str_buf_write_21__12 (void);
+ static void mb_str_buf_write_21__9 (void);
+ static void mb_str_buf_write_21__19 (void);
+ static void mb_str_buf_write_21__16 (void);
+ static void mb_str_buf_read_21__13 (void);
+ static void mb_str_buf_read_21__10 (void);
+ static void mb_str_buf_length_21__5 (void);
+ static void mb_print_char_21__2 (void);
+ static void mb_build_str_21__10 (void);
+ static void mb_trace_char_21__2 (void);
+ static void mb_int_write_21__2 (void);
+ static void mb_str_buf_int_21__8 (void);
+ static void mb_str_buf_int_21__4 (void);
+ static void mb_str_buf_int_21__11 (void);
+ static void mb_str_buf_int_21__18 (void);
+ static void mb_str_buf_int_21__15 (void);
+ static void mb_str_buf_int_21__34 (void);
+ static void mb_str_buf_int_21__30 (void);
+ static void mb_open_file_21__11 (void);
+ static void mb_open_file_21__8 (void);
+ static void mb_create_file_21__11 (void);
+ static void mb_create_file_21__8 (void);
+ static void mb_close_file_21__9 (void);
+ static void mb_close_file_21__6 (void);
+ static void mb_with_raw_path_10 (void);
+ static void mb_is_directory_3F__2 (void);
+ static void mb_is_directory_3F__6 (void);
+ static void mb_is_directory_3F__16 (void);
+ static void mb_is_directory_3F__13 (void);
+ static void mb_char_40__5 (void);
+ static void mb_char_40__16 (void);
+ static void mb_str_tail_3 (void);
+ static void mb_str_length_7 (void);
+ static void mb_str_length_4 (void);
+ static void mb_str_length_9 (void);
+ static void mb_str_concat_5 (void);
+ static void mb_str_concat_12 (void);
+ static void mb_str_concat_16 (void);
+ static void mb_for_20 (void);
+ static void mb_for_28 (void);
+ static void mb_for_30 (void);
+ static void mb_for_41 (void);
+ static void mb_for_43 (void);
+ static void mb_for_48 (void);
+ static void mb_str_copy_partial_21__2 (void);
+ static void mb_str_copy_partial_21__11 (void);
+ static void mb_str_is_empty_6 (void);
+ static void mb_str_is_empty_3 (void);
+ static void mb_str_buf_dup_21__7 (void);
+ static void mb_char_21__2 (void);
+ static void mb_char_width_3 (void);
+ static void mb_str_buf_reverse_21__8 (void);
+ static void mb_str_buf_reverse_21__5 (void);
+ static void mb_str_buf_reverse_21__12 (void);
+ static void mb_int_show_2 (void);
+ static void mb_str_buf_swap_u8_21__4 (void);
+ static void mb_str_buf_swap_u8_21__8 (void);
+ static void mb_str_for_11 (void);
+ static void mb_str_for_8 (void);
+ static void mb_str_for_15 (void);
+ static void mb_str_transduce_8 (void);
+ static void mb_str_transduce_13 (void);
+ static void mb_str_transduce_10 (void);
+ static void mb_str_transduce_16 (void);
+ static void mb_str_transduce_40 (void);
+ static void mb_str_chars_2 (void);
+ static void mb_str_chars_6 (void);
+ static void mb_str_codepoints_2 (void);
+ static void mb_str_codepoints_6 (void);
+ static void mb_char_codepoint_9 (void);
+ static void mb_char_codepoint_6 (void);
+ static void mb_char_codepoint_17 (void);
+ static void mb_char_codepoint_14 (void);
+ static void mb_char_codepoint_25 (void);
+ static void mb_char_codepoint_22 (void);
+ static void mb_str_bytes_12 (void);
+ static void mb_str_bytes_8 (void);
+ static void mb_str_bytes_15 (void);
+ static void mb_str_bytes_18 (void);
+ static void mb_L4_2B__3 (void);
+ static void mb_L5_2B__3 (void);
+ static void mb_L6_2B__3 (void);
+ static void mb_L7_2B__3 (void);
+ static void mb_L8_2B__3 (void);
+ static void mb_L9_2B__3 (void);
+ static void mb_L10_2B__3 (void);
+ static void mb_L11_2B__3 (void);
+ static void mb_L12_2B__3 (void);
+ static void mb_len_25 (void);
+ static void mb_len_2B__21 (void);
+ static void mb_cons_2B__23 (void);
+ static void mb_cons_2B__25 (void);
+ static void mb_rebalance_2B__3 (void);
+ static void mb_rebalance_2B__20 (void);
+ static void mb_rebalance_2B__12 (void);
+ static void mb_rebalance_2B__22 (void);
+ static void mb_rebalance_2B__35 (void);
+ static void mb_rebalance_2B__28 (void);
+ static void mb_rebalance_2B__31 (void);
+ static void mb_rebalance_2B__15 (void);
+ static void mb_snoc_2B__27 (void);
+ static void mb_snoc_2B__2B__2 (void);
+ static void mb_uncons_19 (void);
+ static void mb_unsnoc_6 (void);
+ static void mb_unsnoc_13 (void);
+ static void mb_unsnoc_20 (void);
+ static void mb_unsnoc_29 (void);
+ static void mb_cat_2B__29 (void);
+ static void mb_cat_2B__55 (void);
+ static void mb_cat_aux_4 (void);
+ static void mb_split_half_left_7 (void);
+ static void mb_split_half_left_15 (void);
+ static void mb_split_half_left_23 (void);
+ static void mb_split_half_right_7 (void);
+ static void mb_split_half_right_15 (void);
+ static void mb_split_half_right_23 (void);
+ static void mb_split_half_right_31 (void);
+ static void mb_split_half_12 (void);
+ static void mb_split_half_20 (void);
+ static void mb_split_half_28 (void);
+ static void mb_split_half_36 (void);
+ static void mb_first_3 (void);
+ static void mb_last_3 (void);
+ static void mb_last_2B__10 (void);
+ static void mb_last_2B__17 (void);
+ static void mb_middle_3 (void);
+ static void mb_reverse_25 (void);
+ static void mb_reverse_2B__21 (void);
+ static void mb_map_21 (void);
+ static void mb_map_26 (void);
+ static void mb_map_35 (void);
+ static void mb_map_37 (void);
+ static void mb_map_43 (void);
+ static void mb_map_45 (void);
+ static void mb_map_51 (void);
+ static void mb_map_53 (void);
+ static void mb_map_63 (void);
+ static void mb_map_65 (void);
+ static void mb_map_67 (void);
+ static void mb_map_73 (void);
+ static void mb_map_75 (void);
+ static void mb_map_2B__17 (void);
+ static void mb_map_2B__22 (void);
+ static void mb_map_2B__31 (void);
+ static void mb_map_2B__33 (void);
+ static void mb_map_2B__39 (void);
+ static void mb_map_2B__41 (void);
+ static void mb_map_2B__47 (void);
+ static void mb_map_2B__49 (void);
+ static void mb_map_2B__59 (void);
+ static void mb_map_2B__61 (void);
+ static void mb_map_2B__63 (void);
+ static void mb_map_2B__69 (void);
+ static void mb_map_2B__71 (void);
+ static void mb_for_2B__16 (void);
+ static void mb_for_2B__24 (void);
+ static void mb_for_2B__26 (void);
+ static void mb_for_2B__37 (void);
+ static void mb_for_2B__39 (void);
+ static void mb_for_2B__44 (void);
+ static void mb_reverse_for_21 (void);
+ static void mb_reverse_for_30 (void);
+ static void mb_reverse_for_35 (void);
+ static void mb_reverse_for_45 (void);
+ static void mb_reverse_for_47 (void);
+ static void mb_reverse_for_52 (void);
+ static void mb_reverse_for_2B__17 (void);
+ static void mb_reverse_for_2B__26 (void);
+ static void mb_reverse_for_2B__31 (void);
+ static void mb_reverse_for_2B__41 (void);
+ static void mb_reverse_for_2B__43 (void);
+ static void mb_reverse_for_2B__48 (void);
+ static void mb_reduce_9 (void);
+ static void mb_reduce_11 (void);
+ static void mb_reduce_2B__26 (void);
+ static void mb_reduce_2B__28 (void);
+ static void mb_reduce_2B__33 (void);
+ static void mb_map_reduce_11 (void);
+ static void mb_map_reduce_15 (void);
+ static void mb_map_reduce_2B__11 (void);
+ static void mb_map_reduce_2B__15 (void);
+ static void mb_filter_17 (void);
+ static void mb_filter_2B__13 (void);
+ static void mb_filter_2B__15 (void);
+ static void mb_filter_2B__20 (void);
+ static void mb_filter_2B__22 (void);
+ static void mb_filter_2B__32 (void);
+ static void mb_filter_2B__46 (void);
+ static void mb_filter_2B__37 (void);
+ static void mb_filter_2B__49 (void);
+ static void mb_filter_2B__39 (void);
+ static void mb_filter_2B__41 (void);
+ static void mb_find_17 (void);
+ static void mb_find_2B__13 (void);
+ static void mb_find_2B__15 (void);
+ static void mb_find_2B__30 (void);
+ static void mb_find_2B__39 (void);
+ static void mb_find_2B__47 (void);
+ static void mb_find_2B__44 (void);
+ static void mb_find_2B__50 (void);
+ static void mb_find_3F__9 (void);
+ static void mb_find_3F__11 (void);
+ static void mb_reverse_find_9 (void);
+ static void mb_reverse_find_3F__9 (void);
+ static void mb_reverse_find_3F__12 (void);
+ static void mb_any_8 (void);
+ static void mb_any_3F__8 (void);
+ static void mb_all_8 (void);
+ static void mb_all_3F__8 (void);
+ static void mb_collect_13 (void);
+ static void mb_collect_11 (void);
+ static void mb_collect_17 (void);
+ static void mb_maybe_filter_19 (void);
+ static void mb_maybe_filter_17 (void);
+ static void mb_char_bytes_11 (void);
+ static void mb_char_bytes_6 (void);
+ static void mb_char_bytes_30 (void);
+ static void mb_char_bytes_16 (void);
+ static void mb_char_bytes_56 (void);
+ static void mb_char_bytes_34 (void);
+ static void mb_char_bytes_63 (void);
+ static void mb_char_bytes_71 (void);
+ static void mb_char_bytes_79 (void);
+ static void mb_char_bytes_41 (void);
+ static void mb_char_bytes_49 (void);
+ static void mb_char_bytes_24 (void);
+ static void mb_char_valid_wobbly_9 (void);
+ static void mb_char_valid_wobbly_6 (void);
+ static void mb_char_valid_wobbly_17 (void);
+ static void mb_char_valid_wobbly_14 (void);
+ static void mb_char_valid_wobbly_25 (void);
+ static void mb_char_valid_wobbly_22 (void);
+ static void mb_char_codepoint_3_8 (void);
+ static void mb_char_codepoint_3_15 (void);
+ static void mb_char_valid_9 (void);
+ static void mb_char_valid_6 (void);
+ static void mb_char_valid_17 (void);
+ static void mb_char_valid_14 (void);
+ static void mb_char_valid_25 (void);
+ static void mb_char_valid_22 (void);
+ static void mb_char_codepoint_4_8 (void);
+ static void mb_char_codepoint_4_15 (void);
+ static void mb_char_codepoint_4_22 (void);
+ static void mb_char_codepoint_2_8 (void);
+ static void mb_char_21__precise_2 (void);
+ static void mb_char_21__precise_18 (void);
+ static void mb_char_21__precise_10 (void);
+ static void mb_char_21__precise_31 (void);
+ static void mb_char_21__precise_23 (void);
+ static void mb_char_21__precise_57 (void);
+ static void mb_char_21__precise_36 (void);
+ static void mb_char_21__precise_60 (void);
+ static void mb_char_21__precise_39 (void);
+ static void mb_char_21__precise_48 (void);
+ static void mb_char_21__precise_26 (void);
+ static void mb_char_21__precise_13 (void);
+ static void mb_char_21__2B__2B__4 (void);
+ static void mb_char_3F__2B__2B__5 (void);
+ static void mb_is_whitespace_3F__7 (void);
+ static void mb_is_whitespace_3F__9 (void);
+ static void mb_is_hexdigit_3F__3 (void);
+ static void mb_is_hexdigit_3F__8 (void);
+ static void mb_is_sign_3F__3 (void);
+ static void mb_is_string_end_3F__7 (void);
+ static void mb_is_string_end_3F__9 (void);
+ static void mb_is_name_char_3F__3 (void);
+ static void mb_is_special_char_3F__9 (void);
+ static void mb_is_special_char_3F__7 (void);
+ static void mb_path_21__2 (void);
+ static void mb_path_separator_7 (void);
+ static void mb_path_separator_5 (void);
+ static void mb_path_join_6 (void);
+ static void mb_path_join_4 (void);
+ static void mb_input_isopen_21__4 (void);
+ static void mb_input_isopen_21__2 (void);
+ static void mb_input_fill_buffer_21__31 (void);
+ static void mb_input_fill_buffer_21__3 (void);
+ static void mb_input_fill_buffer_21__26 (void);
+ static void mb_input_fill_buffer_21__13 (void);
+ static void mb_input_fill_buffer_21__22 (void);
+ static void mb_input_fill_buffer_21__18 (void);
+ static void mb_input_end_21__6 (void);
+ static void mb_input_end_21__3 (void);
+ static void mb_input_peek_8 (void);
+ static void mb_input_peek_3 (void);
+ static void mb_input_move_21__12 (void);
+ static void mb_input_move_21__3 (void);
+ static void mb_input_prepare_for_more_21__31 (void);
+ static void mb_input_prepare_for_more_21__8 (void);
+ static void mb_input_prepare_for_more_21__16 (void);
+ static void mb_input_prepare_for_more_21__13 (void);
+ static void mb_input_prepare_for_more_21__27 (void);
+ static void mb_input_prepare_for_more_21__25 (void);
+ static void mb_input_fill_buffer_tragic_21__43 (void);
+ static void mb_input_fill_buffer_tragic_21__14 (void);
+ static void mb_input_fill_buffer_tragic_21__38 (void);
+ static void mb_input_fill_buffer_tragic_21__26 (void);
+ static void mb_input_fill_buffer_tragic_21__35 (void);
+ static void mb_input_fill_buffer_tragic_21__31 (void);
+ static void mb_lexer_stack_push_21__6 (void);
+ static void mb_lexer_stack_push_21__3 (void);
+ static void mb_lexer_stack_pop_21__6 (void);
+ static void mb_lexer_stack_pop_21__3 (void);
+ static void mb_module_source_path_7 (void);
+ static void mb_module_source_path_3 (void);
+ static void mb_lexer_next_21__8 (void);
+ static void mb_lexer_next_21__5 (void);
+ static void mb_lexer_next_21__14 (void);
+ static void mb_lexer_next_21__11 (void);
+ static void mb_lexer_next_21__20 (void);
+ static void mb_lexer_next_21__17 (void);
+ static void mb_lexer_next_21__25 (void);
+ static void mb_lexer_next_21__23 (void);
+ static void mb_lexer_next_21__31 (void);
+ static void mb_lexer_next_21__28 (void);
+ static void mb_lexer_next_21__38 (void);
+ static void mb_lexer_next_21__34 (void);
+ static void mb_lexer_next_21__44 (void);
+ static void mb_lexer_next_21__41 (void);
+ static void mb_lexer_next_21__50 (void);
+ static void mb_lexer_next_21__47 (void);
+ static void mb_lexer_next_21__56 (void);
+ static void mb_lexer_next_21__53 (void);
+ static void mb_lexer_next_21__62 (void);
+ static void mb_lexer_next_21__59 (void);
+ static void mb_lexer_next_21__68 (void);
+ static void mb_lexer_next_21__65 (void);
+ static void mb_lexer_next_21__74 (void);
+ static void mb_lexer_next_21__71 (void);
+ static void mb_lexer_next_21__80 (void);
+ static void mb_lexer_next_21__77 (void);
+ static void mb_emit_fatal_error_21__2 (void);
+ static void mb_lexer_make_21__5 (void);
+ static void mb_lexer_make_21__10 (void);
+ static void mb_lexer_make_21__14 (void);
+ static void mb_lexer_make_21__19 (void);
+ static void mb_lexer_make_21__23 (void);
+ static void mb_lexer_make_21__28 (void);
+ static void mb_lexer_emit_fatal_error_21__2 (void);
+ static void mb_lexer_emit_name_21__9 (void);
+ static void mb_lexer_emit_name_21__7 (void);
+ static void mb_lexer_emit_name_21__16 (void);
+ static void mb_lexer_emit_name_21__12 (void);
+ static void mb_lexer_emit_name_21__27 (void);
+ static void mb_lexer_emit_name_21__24 (void);
+ static void mb_lexer_emit_name_21__33 (void);
+ static void mb_lexer_emit_name_21__30 (void);
+ static void mb_lexer_skip_comment_21__5 (void);
+ static void mb_lexer_skip_comment_21__2 (void);
+ static void mb_lexer_skip_comment_21__13 (void);
+ static void mb_lexer_skip_comment_21__11 (void);
+ static void mb_lexer_emit_rparen_21__6 (void);
+ static void mb_lexer_emit_rparen_21__3 (void);
+ static void mb_lexer_emit_rparen_21__17 (void);
+ static void mb_lexer_emit_rparen_21__10 (void);
+ static void mb_lexer_emit_rsquare_21__6 (void);
+ static void mb_lexer_emit_rsquare_21__3 (void);
+ static void mb_lexer_emit_rsquare_21__17 (void);
+ static void mb_lexer_emit_rsquare_21__10 (void);
+ static void mb_lexer_emit_rcurly_21__6 (void);
+ static void mb_lexer_emit_rcurly_21__3 (void);
+ static void mb_lexer_emit_rcurly_21__17 (void);
+ static void mb_lexer_emit_rcurly_21__10 (void);
+ static void mb_lexer_emit_string_21__10 (void);
+ static void mb_lexer_emit_string_21__7 (void);
+ static void mb_lexer_emit_string_21__17 (void);
+ static void mb_lexer_emit_string_21__13 (void);
+ static void mb_str_buf_is_doc_start_3F__5 (void);
+ static void mb_str_buf_is_doc_start_3F__11 (void);
+ static void mb_str_buf_is_doc_start_3F__18 (void);
+ static void mb_lexer_skip_doc_21__5 (void);
+ static void mb_lexer_skip_doc_21__2 (void);
+ static void mb_str_buf_is_int_3F__5 (void);
+ static void mb_str_buf_is_int_3F__3 (void);
+ static void mb_str_buf_int_3F__5 (void);
+ static void mb_str_buf_int_3F__3 (void);
+ static void mb_name_new_21__6 (void);
+ static void mb_name_new_21__4 (void);
+ static void mb_name_new_21__20 (void);
+ static void mb_name_new_21__12 (void);
+ static void mb_str_buf_is_arrow_3F__5 (void);
+ static void mb_str_buf_is_dashes_3F__15 (void);
+ static void mb_str_buf_is_dashes_3F__5 (void);
+ static void mb_str_buf_is_equal_3F__10 (void);
+ static void mb_str_buf_is_equal_3F__5 (void);
+ static void mb_str_buf_is_dec_int_3F__10 (void);
+ static void mb_str_buf_is_dec_int_3F__8 (void);
+ static void mb_str_buf_is_dec_int_3F__19 (void);
+ static void mb_str_buf_is_dec_int_3F__14 (void);
+ static void mb_str_buf_is_dec_int_3F__21 (void);
+ static void mb_str_buf_is_dec_int_3F__33 (void);
+ static void mb_str_buf_is_dec_int_3F__30 (void);
+ static void mb_str_buf_is_hex_int_3F__10 (void);
+ static void mb_str_buf_is_hex_int_3F__8 (void);
+ static void mb_str_buf_is_hex_int_3F__53 (void);
+ static void mb_str_buf_is_hex_int_3F__17 (void);
+ static void mb_str_buf_is_hex_int_3F__49 (void);
+ static void mb_str_buf_is_hex_int_3F__23 (void);
+ static void mb_str_buf_is_hex_int_3F__31 (void);
+ static void mb_str_buf_is_hex_int_3F__26 (void);
+ static void mb_str_buf_is_hex_int_3F__33 (void);
+ static void mb_str_buf_is_hex_int_3F__45 (void);
+ static void mb_str_buf_is_hex_int_3F__42 (void);
+ static void mb_is_xX_char_6 (void);
+ static void mb_str_buf_dec_int_3F__22 (void);
+ static void mb_str_buf_dec_int_3F__8 (void);
+ static void mb_str_buf_dec_int_3F__18 (void);
+ static void mb_str_buf_dec_int_3F__12 (void);
+ static void mb_str_buf_dec_int_3F__14 (void);
+ static void mb_str_buf_dec_int_3F__30 (void);
+ static void mb_str_buf_dec_int_3F__26 (void);
+ static void mb_str_buf_dec_int_3F__33 (void);
+ static void mb_str_buf_dec_int_3F__37 (void);
+ static void mb_str_buf_hex_int_3F__22 (void);
+ static void mb_str_buf_hex_int_3F__8 (void);
+ static void mb_str_buf_hex_int_3F__18 (void);
+ static void mb_str_buf_hex_int_3F__12 (void);
+ static void mb_str_buf_hex_int_3F__14 (void);
+ static void mb_str_buf_hex_int_3F__32 (void);
+ static void mb_str_buf_hex_int_3F__28 (void);
+ static void mb_str_buf_hex_int_3F__35 (void);
+ static void mb_str_buf_hex_int_3F__38 (void);
+ static void mb_hexdigit_value_7 (void);
+ static void mb_hexdigit_value_3 (void);
+ static void mb_hexdigit_value_14 (void);
+ static void mb_hexdigit_value_10 (void);
+ static void mb_lexer_push_string_char_21__55 (void);
+ static void mb_lexer_push_string_char_21__3 (void);
+ static void mb_lexer_push_string_char_21__11 (void);
+ static void mb_lexer_push_string_char_21__9 (void);
+ static void mb_lexer_push_string_char_21__19 (void);
+ static void mb_lexer_push_string_char_21__14 (void);
+ static void mb_lexer_push_string_char_21__27 (void);
+ static void mb_lexer_push_string_char_21__22 (void);
+ static void mb_lexer_push_string_char_21__35 (void);
+ static void mb_lexer_push_string_char_21__30 (void);
+ static void mb_lexer_push_string_char_21__40 (void);
+ static void mb_lexer_push_string_char_21__38 (void);
+ static void mb_lexer_push_string_char_21__45 (void);
+ static void mb_lexer_push_string_char_21__43 (void);
+ static void mb_lexer_emit_warning_21__2 (void);
+ static void mb_lexer_comment_end_3F__5 (void);
+ static void mb_lexer_comment_end_3F__3 (void);
+ static void mb_emit_warning_at_21__2 (void);
+ static void mb_lexer_emit_error_21__2 (void);
+ static void mb_emit_error_at_21__2 (void);
+ static void mb_hash_7 (void);
+ static void mb_hash_4 (void);
+ static void mb_hash_11 (void);
+ static void mb_name_keep_going_3F__7 (void);
+ static void mb_name_keep_going_3F__4 (void);
+ static void mb_name_keep_going_3F__9 (void);
+ static void mb_name_cat_21__2 (void);
+ static void mb_name_is_type_hole_17 (void);
+ static void mb_name_is_type_hole_7 (void);
+ static void mb_name_is_type_hole_14 (void);
+ static void mb_name_is_type_hole_11 (void);
+ static void mb_name_is_underscore_10 (void);
+ static void mb_name_is_underscore_7 (void);
+ static void mb_name_could_be_stack_var_10 (void);
+ static void mb_name_could_be_stack_var_7 (void);
+ static void mb_name_could_be_effect_con_12 (void);
+ static void mb_name_could_be_effect_con_7 (void);
+ static void mb_name_mangle_21__13 (void);
+ static void mb_name_mangle_21__4 (void);
+ static void mb_name_mangle_21__8 (void);
+ static void mb_name_mangle_compute_21__3 (void);
+ static void mb_name_mangle_compute_21__8 (void);
+ static void mb_name_mangle_compute_21__6 (void);
+ static void mb_name_mangle_compute_21__13 (void);
+ static void mb_name_mangle_compute_21__11 (void);
+ static void mb_name_mangle_compute_21__18 (void);
+ static void mb_name_mangle_compute_21__16 (void);
+ static void mb_name_mangle_compute_21__25 (void);
+ static void mb_name_mangle_compute_21__21 (void);
+ static void mb_char_hexdigits_8 (void);
+ static void mb_char_hexdigits_4 (void);
+ static void mb_char_hexdigits_first_2 (void);
+ static void mb_char_hexdigits_next_3 (void);
+ static void mb_char_hexdigits_next_12 (void);
+ static void mb_char_hexdigits_next_20 (void);
+ static void mb_char_hexdigits_next_23 (void);
+ static void mb_hexdigit_9 (void);
+ static void mb_hexdigit_5 (void);
+ static void mb_token_prim_3D__3F__2 (void);
+ static void mb_token_prev_22 (void);
+ static void mb_token_prev_20 (void);
+ static void mb_token_next_arg_end_5 (void);
+ static void mb_token_next_arg_end_2 (void);
+ static void mb_token_has_args_3F__8 (void);
+ static void mb_token_has_args_3F__3 (void);
+ static void mb_token_num_args_11 (void);
+ static void mb_token_num_args_3 (void);
+ static void mb_token_num_args_8 (void);
+ static void mb_token_num_args_6 (void);
+ static void mb_token_num_args_34 (void);
+ static void mb_token_num_args_16 (void);
+ static void mb_token_num_args_18 (void);
+ static void mb_token_num_args_25 (void);
+ static void mb_token_num_args_22 (void);
+ static void mb_token_num_args_27 (void);
+ static void mb_token_args_0_7 (void);
+ static void mb_token_args_0_5 (void);
+ static void mb_token_args_1_14 (void);
+ static void mb_token_args_1_5 (void);
+ static void mb_token_args_1_22 (void);
+ static void mb_token_args_1_19 (void);
+ static void mb_token_args_1_10 (void);
+ static void mb_token_args_1_8 (void);
+ static void mb_token_args_2_17 (void);
+ static void mb_token_args_2_5 (void);
+ static void mb_token_args_2_25 (void);
+ static void mb_token_args_2_22 (void);
+ static void mb_token_args_2_10 (void);
+ static void mb_token_args_2_8 (void);
+ static void mb_token_args_3_20 (void);
+ static void mb_token_args_3_5 (void);
+ static void mb_token_args_3_28 (void);
+ static void mb_token_args_3_25 (void);
+ static void mb_token_args_3_10 (void);
+ static void mb_token_args_3_8 (void);
+ static void mb_token_args_27 (void);
+ static void mb_token_args_3 (void);
+ static void mb_token_args_8 (void);
+ static void mb_token_args_6 (void);
+ static void mb_token_args_17 (void);
+ static void mb_token_args_14 (void);
+ static void mb_token_args_21 (void);
+ static void mb_token_is_args_end_3F__6 (void);
+ static void mb_token_is_args_end_3F__4 (void);
+ static void mb_emit_warning_21__2 (void);
+ static void mb_emit_error_21__2 (void);
+ static void mb_sig_is_stack_end_3F__5 (void);
+ static void mb_sig_is_stack_end_3F__3 (void);
+ static void mb_sig_is_stack_end2_3F__5 (void);
+ static void mb_sig_is_stack_end2_3F__3 (void);
+ static void mb_sig_next_stack_end_5 (void);
+ static void mb_sig_next_stack_end_2 (void);
+ static void mb_sig_arity_8 (void);
+ static void mb_sig_arity_3 (void);
+ static void mb_sig_count_types_7 (void);
+ static void mb_sig_count_types_4 (void);
+ static void mb_sig_count_types_15 (void);
+ static void mb_sig_count_types_10 (void);
+ static void mb_sig_count_types_12 (void);
+ static void mb_sig_skip_dashes_6 (void);
+ static void mb_sig_skip_dashes_3 (void);
+ static void mb_module_add_import_21__2 (void);
+ static void mb_set_insert_2 (void);
+ static void mb_module_path_from_name_3 (void);
+ static void mb_module_path_from_name_10 (void);
+ static void mb_module_path_from_name_6 (void);
+ static void mb_module_path_from_name_19 (void);
+ static void mb_module_path_from_name_13 (void);
+ static void mb_bag_replace_5 (void);
+ static void mb_bag_replace_3 (void);
+ static void mb_codegen_flush_21__30 (void);
+ static void mb_codegen_flush_21__5 (void);
+ static void mb_codegen_flush_21__18 (void);
+ static void mb_codegen_flush_21__15 (void);
+ static void mb_codegen_flush_21__25 (void);
+ static void mb_codegen_flush_21__22 (void);
+ static void mb__2E_b_5 (void);
+ static void mb__2E_b_3 (void);
+ static void mb__2E_c_5 (void);
+ static void mb__2E_c_3 (void);
+ static void mb__2E__39 (void);
+ static void mb__2E__11 (void);
+ static void mb__2E__42 (void);
+ static void mb__2E__18 (void);
+ static void mb__2E__14 (void);
+ static void mb__2E__27 (void);
+ static void mb_run_output_c99_21__7 (void);
+ static void mb_run_output_c99_21__5 (void);
+ static void mb_c99_emit_tags_21__2 (void);
+ static void mb_c99_emit_buffers_21__2 (void);
+ static void mb_c99_emit_externals_21__2 (void);
+ static void mb_c99_emit_word_sigs_21__2 (void);
+ static void mb_c99_emit_block_sigs_21__2 (void);
+ static void mb_c99_emit_field_sigs_21__2 (void);
+ static void mb_c99_emit_needs_21__4 (void);
+ static void mb_c99_emit_needs_21__2 (void);
+ static void mb_c99_emit_tag_21__10 (void);
+ static void mb_c99_emit_tag_21__3 (void);
+ static void mb_c99_emit_tag_21__26 (void);
+ static void mb_c99_emit_tag_21__15 (void);
+ static void mb_c99_emit_tag_21__42 (void);
+ static void mb_c99_emit_tag_21__38 (void);
+ static void mb_tag_num_inputs_3F__19 (void);
+ static void mb_tag_num_inputs_3F__3 (void);
+ static void mb_tag_num_inputs_3F__11 (void);
+ static void mb_tag_num_inputs_3F__8 (void);
+ static void mb_tag_num_inputs_3F__14 (void);
+ static void mb_c99_emit_external_21__10 (void);
+ static void mb_c99_emit_external_21__7 (void);
+ static void mb_c99_emit_external_21__18 (void);
+ static void mb_c99_emit_external_21__15 (void);
+ static void mb_c99_emit_external_21__24 (void);
+ static void mb_c99_emit_external_21__48 (void);
+ static void mb_c99_emit_external_21__34 (void);
+ static void mb_c99_emit_external_21__42 (void);
+ static void mb_c99_emit_external_21__39 (void);
+ static void mb_c99_emit_external_21__58 (void);
+ static void mb_c99_emit_external_21__69 (void);
+ static void mb_c99_emit_external_21__66 (void);
+ static void mb_c99_emit_external_21__84 (void);
+ static void mb_c99_emit_external_21__82 (void);
+ static void mb_c99_emit_external_21__89 (void);
+ static void mb_c99_emit_external_21__96 (void);
+ static void mb_c99_emit_external_21__119 (void);
+ static void mb_c99_emit_external_21__100 (void);
+ static void mb_c99_emit_external_21__109 (void);
+ static void mb_c99_emit_external_21__106 (void);
+ static void mb_c99_emit_external_21__130 (void);
+ static void mb_c99_emit_external_21__128 (void);
+ static void mb_c99_emit_arrow_21__4 (void);
+ static void mb_c99_emit_atom_21__26 (void);
+ static void mb_c99_emit_atom_21__51 (void);
+ static void mb_c99_emit_atom_21__85 (void);
+ static void mb_c99_emit_string_21__4 (void);
+ static void mb_need_word_21__5 (void);
+ static void mb_need_word_21__3 (void);
+ static void mb_c99_emit_args_push_21__2 (void);
+ static void mb_fieldword_name_40__3 (void);
+ static void mb_c99_emit_prim_21__36 (void);
+ static void mb_c99_emit_prim_21__60 (void);
+ static void mb_c99_emit_match_21__20 (void);
+ static void mb_c99_emit_match_21__3 (void);
+ static void mb_c99_emit_match_21__25 (void);
+ static void mb_c99_emit_match_21__32 (void);
+ static void mb_c99_emit_match_21__30 (void);
+ static void mb_c99_emit_lambda_21__5 (void);
+ static void mb_c99_emit_lambda_21__17 (void);
+ static void mb_c99_emit_var_21__3 (void);
+ static void mb_c99_emit_var_21__10 (void);
+ static void mb_c99_emit_var_21__7 (void);
+ static void mb_c99_emit_string_char_21__7 (void);
+ static void mb_c99_emit_string_char_21__3 (void);
+ static void mb_c99_emit_string_char_21__14 (void);
+ static void mb_c99_emit_string_char_21__10 (void);
+ static void mb_c99_emit_string_char_21__23 (void);
+ static void mb_c99_emit_string_char_21__21 (void);
+ static void mb_c99_emit_string_char_21__33 (void);
+ static void mb_c99_emit_string_char_21__29 (void);
+ static void mb_c99_emit_string_char_21__43 (void);
+ static void mb_c99_emit_string_char_21__39 (void);
+ static void mb_c99_emit_string_char_21__53 (void);
+ static void mb_c99_emit_string_char_21__49 (void);
+ static void mb_c99_emit_string_char_21__56 (void);
+ static void mb_c99_emit_prim_default_21__2 (void);
+ static void mb_c99_pack_ctx_21__5 (void);
+ static void mb_ctx_physical_vars_3 (void);
+ static void mb_c99_unpack_ctx_21__3 (void);
+ static void mb_c99_decref_ctx_21__3 (void);
+ static void mb_need_block_21__5 (void);
+ static void mb_need_block_21__3 (void);
+ static void mb_need_field_21__5 (void);
+ static void mb_need_field_21__3 (void);
+ static void mb_c99_emit_word_def_21__22 (void);
+ static void mb_c99_emit_word_def_21__3 (void);
+ static void mb_c99_emit_word_def_21__8 (void);
+ static void mb_c99_emit_word_def_21__6 (void);
+ static void mb_c99_emit_block_def_21__28 (void);
+ static void mb_c99_emit_block_def_21__3 (void);
+ static void mb_c99_emit_block_def_21__8 (void);
+ static void mb_c99_emit_block_def_21__6 (void);
+ static void mb_c99_emit_field_def_21__104 (void);
+ static void mb_c99_emit_field_def_21__3 (void);
+ static void mb_c99_emit_field_def_21__8 (void);
+ static void mb_c99_emit_field_def_21__6 (void);
+ static void mb__2E_block_11 (void);
+ static void mb__2E_block_7 (void);
+ static void mb__2E_block_33 (void);
+ static void mb__2E_block_17 (void);
+ static void mb__2E_block_41 (void);
+ static void mb_c99_emit_pattern_21__36 (void);
+ static void mb_c99_emit_pattern_21__22 (void);
+ static void mb_c99_emit_pattern_21__30 (void);
+ static void mb_c99_emit_pattern_21__26 (void);
+ static void mb_c99_emit_block_defs_21__2 (void);
+ static void mb_force_20 (void);
+ static void mb_atom_arg_add_21__2 (void);
+ static void mb_arrow_atom_add_21__2 (void);
+ static void mb_block_force_21__32 (void);
+ static void mb_block_force_21__3 (void);
+ static void mb_block_force_21__10 (void);
+ static void mb_block_force_21__6 (void);
+ static void mb_block_force_21__18 (void);
+ static void mb_block_force_21__23 (void);
+ static void mb_ab_build_21__8 (void);
+ static void mb_elab_atoms_21__5 (void);
+ static void mb_elab_atoms_21__2 (void);
+ static void mb_block_unify_type_21__14 (void);
+ static void mb_block_unify_type_21__4 (void);
+ static void mb_block_unify_type_21__11 (void);
+ static void mb_block_unify_type_21__7 (void);
+ static void mb_block_unify_type_aux_21__5 (void);
+ static void mb_block_unify_type_aux_21__13 (void);
+ static void mb_block_unify_type_aux_21__15 (void);
+ static void mb_block_unify_type_aux_21__22 (void);
+ static void mb_block_unify_type_aux_21__29 (void);
+ static void mb_type_unify_21__36 (void);
+ static void mb_type_unify_21__66 (void);
+ static void mb_type_unify_21__74 (void);
+ static void mb_type_unify_21__86 (void);
+ static void mb_type_unify_21__111 (void);
+ static void mb_type_unify_21__119 (void);
+ static void mb_type_unify_21__127 (void);
+ static void mb_type_unify_21__139 (void);
+ static void mb_type_unify_21__164 (void);
+ static void mb_type_unify_21__172 (void);
+ static void mb_type_unify_21__180 (void);
+ static void mb_type_unify_21__192 (void);
+ static void mb_type_unify_21__217 (void);
+ static void mb_type_unify_21__225 (void);
+ static void mb_type_unify_21__233 (void);
+ static void mb_type_unify_21__245 (void);
+ static void mb_type_unify_21__270 (void);
+ static void mb_type_unify_21__278 (void);
+ static void mb_type_unify_21__286 (void);
+ static void mb_type_unify_21__299 (void);
+ static void mb_type_unify_21__324 (void);
+ static void mb_type_unify_21__332 (void);
+ static void mb_type_unify_21__340 (void);
+ static void mb_type_unify_21__353 (void);
+ static void mb_type_unify_21__378 (void);
+ static void mb_type_unify_21__386 (void);
+ static void mb_type_unify_21__394 (void);
+ static void mb_type_unify_21__407 (void);
+ static void mb_type_unify_21__432 (void);
+ static void mb_type_unify_21__440 (void);
+ static void mb_elab_expand_morphism_21__8 (void);
+ static void mb_elab_expand_morphism_21__21 (void);
+ static void mb_elab_expand_morphism_21__39 (void);
+ static void mb_match_add_case_21__2 (void);
+ static void mb_match_add_case_21__12 (void);
+ static void mb_match_add_case_21__7 (void);
+ static void mb_match_is_exhaustive_3F__5 (void);
+ static void mb_match_is_exhaustive_3F__3 (void);
+ static void mb_match_scrutinee_data_3F__3 (void);
+ static void mb_cases_have_default_case_2 (void);
+ static void mb_cases_cover_case_3 (void);
+ static void mb_case_is_covered_2 (void);
+ static void mb_pattern_is_covered_8 (void);
+ static void mb_pattern_is_covered_5 (void);
+ static void mb_def_type_21__2 (void);
+ static void mb_T1_2 (void);
+ static void mb_T2_2 (void);
+ static void mb_T3_2 (void);
+ static void mb_T4_2 (void);
+ static void mb_T5_2 (void);
+ static void mb_T6_2 (void);
+ static void mb_meta_expand_12 (void);
+ static void mb_meta_expand_3 (void);
+ static void mb_meta_expand_6 (void);
+ static void mb_type_unify_failed_21__2 (void);
+ static void mb_type_unify_failed_21__10 (void);
+ static void mb_type_hole_unify_21__5 (void);
+ static void mb_type_hole_unify_21__3 (void);
+ static void mb_meta_unify_21__6 (void);
+ static void mb_meta_unify_21__3 (void);
+ static void mb_meta_unify_21__13 (void);
+ static void mb_meta_unify_21__11 (void);
+ static void mb_meta_unify_21__21 (void);
+ static void mb_meta_unify_21__17 (void);
+ static void mb_meta_unify_21__24 (void);
+ static void mb_type_var_unify_21__7 (void);
+ static void mb_type_var_unify_21__4 (void);
+ static void mb_type_var_unify_21__9 (void);
+ static void mb_type_prim_unify_21__7 (void);
+ static void mb_type_prim_unify_21__4 (void);
+ static void mb_type_prim_unify_21__9 (void);
+ static void mb_type_data_unify_21__7 (void);
+ static void mb_type_data_unify_21__4 (void);
+ static void mb_type_data_unify_21__9 (void);
+ static void mb_type_table_unify_21__7 (void);
+ static void mb_type_table_unify_21__4 (void);
+ static void mb_type_table_unify_21__9 (void);
+ static void mb_type_unify_pair_21__2 (void);
+ static void mb_type_unify_pair_21__5 (void);
+ static void mb_type_unify_pair_21__12 (void);
+ static void mb_value_unify_21__18 (void);
+ static void mb_value_unify_21__14 (void);
+ static void mb_value_unify_21__55 (void);
+ static void mb_value_unify_21__51 (void);
+ static void mb_value_unify_21__92 (void);
+ static void mb_value_unify_21__88 (void);
+ static void mb_type_has_meta_36 (void);
+ static void mb_type_has_meta_45 (void);
+ static void mb_type_has_meta_42 (void);
+ static void mb_type_has_meta_52 (void);
+ static void mb_type_has_meta_61 (void);
+ static void mb_type_has_meta_58 (void);
+ static void mb_type_has_meta_68 (void);
+ static void mb_type_has_meta_77 (void);
+ static void mb_type_has_meta_74 (void);
+ static void mb_type_trace_stack_dom_21__8 (void);
+ static void mb_type_trace_stack_dom_21__6 (void);
+ static void mb_type_trace_stack_cod_21__8 (void);
+ static void mb_type_trace_stack_cod_21__6 (void);
+ static void mb_type_trace_stack_21__19 (void);
+ static void mb_type_trace_stack_21__17 (void);
+ static void mb_type_semifreshen_sig_5 (void);
+ static void mb_type_semifreshen_sig_3 (void);
+ static void mb_type_sig_needs_fresh_stack_rest_3F__15 (void);
+ static void mb_type_sig_needs_fresh_stack_rest_3F__11 (void);
+ static void mb_type_semifreshen_sig_aux_10 (void);
+ static void mb_type_semifreshen_sig_aux_15 (void);
+ static void mb_type_semifreshen_sig_stack_7 (void);
+ static void mb_type_freshen_sig_5 (void);
+ static void mb_type_freshen_sig_3 (void);
+ static void mb_type_freshen_sig_aux_10 (void);
+ static void mb_type_freshen_sig_aux_15 (void);
+ static void mb_type_freshen_sig_aux_21 (void);
+ static void mb_type_freshen_sig_stack_7 (void);
+ static void mb_type_freshen_sig_stack_12 (void);
+ static void mb_type_var_freshen_7 (void);
+ static void mb_type_var_freshen_4 (void);
+ static void mb_type_var_freshen_12 (void);
+ static void mb_meta_freshen_6 (void);
+ static void mb_meta_freshen_3 (void);
+ static void mb_type_pair_freshen_2 (void);
+ static void mb_type_pair_freshen_8 (void);
+ static void mb_type_max_count_3F__24 (void);
+ static void mb_type_max_count_3F__20 (void);
+ static void mb_data_is_enum_3F__3 (void);
+ static void mb_map_insert_2 (void);
+ static void mb_map_lookup_2 (void);
+ static void mb_subst_match_var_11 (void);
+ static void mb_subst_match_var_3 (void);
+ static void mb_subst_match_var_6 (void);
+ static void mb_data_add_tag_21__8 (void);
+ static void mb_map_keys_3 (void);
+ static void mb_map_values_3 (void);
+ static void mb_order2_6 (void);
+ static void mb_order2_4 (void);
+ static void mb_order3_2 (void);
+ static void mb_order3_10 (void);
+ static void mb_order3_8 (void);
+ static void mb_order3_13 (void);
+ static void mb_Bag__3E_Bag_2B__4 (void);
+ static void mb_bag_split_half_left_4 (void);
+ static void mb_bag_split_half_right_4 (void);
+ static void mb_bag_split_half_4 (void);
+ static void mb_bag_unsnoc_4 (void);
+ static void mb_bag_insert_2B__2B__10 (void);
+ static void mb_bag_insert_2B__2B__4 (void);
+ static void mb_bag_insert_2B__2B__12 (void);
+ static void mb_bag_insert_2B__2B__24 (void);
+ static void mb_bag_insert_2B__2B__20 (void);
+ static void mb_bag_insert_2B__2B__28 (void);
+ static void mb_bag_insert_2B__2B__6 (void);
+ static void mb_bag_has_2B__10 (void);
+ static void mb_bag_has_2B__4 (void);
+ static void mb_bag_has_2B__12 (void);
+ static void mb_bag_has_2B__35 (void);
+ static void mb_bag_has_2B__6 (void);
+ static void mb_bag_cat_unsafe__2B__2 (void);
+ static void mb_bag_cat_unsafe_2B__2 (void);
+ static void mb_bag_cat_unsafe_2 (void);
+ static void mb_bag_lookup_key_2B__18 (void);
+ static void mb_bag_lookup_key_2B__4 (void);
+ static void mb_bag_lookup_key_2B__20 (void);
+ static void mb_bag_lookup_key_2B__34 (void);
+ static void mb_bag_lookup_key_2B__41 (void);
+ static void mb_bag_lookup_key_2B__50 (void);
+ static void mb_bag_lookup_key_2B__6 (void);
+ static void mb_bag_lookup_key_2B__14 (void);
+ static void mb_bag_lookup_key_2B__12 (void);
+ static void mb_bag_replace_key_2B__2B__18 (void);
+ static void mb_bag_replace_key_2B__2B__4 (void);
+ static void mb_bag_replace_key_2B__2B__20 (void);
+ static void mb_bag_replace_key_2B__2B__32 (void);
+ static void mb_bag_replace_key_2B__2B__28 (void);
+ static void mb_bag_replace_key_2B__2B__36 (void);
+ static void mb_bag_replace_key_2B__2B__6 (void);
+ static void mb_bag_replace_key_2B__2B__15 (void);
+ static void mb_bag_replace_key_2B__2B__12 (void);
+ static void mb__3D__3D_key_2 (void);
+ static void mb__3C__3D_key_2 (void);
+ static void mb_delay0_2 (void);
+ static void mb_delay2_3 (void);
+ static void mb_delay3_3 (void);
+ static void mb_delay4_3 (void);
+ static void mb_lazy_map_2 (void);
+ static void mb_lazy_map_4 (void);
+ static void mb_lazy_map2_2 (void);
+ static void mb_lazy_map2_4 (void);
+ static void mb_lazy_map2_6 (void);
+ static void mb_lazy_bind_2 (void);
+ static void mb_lazy_bind_4 (void);
+ static void mb_var_is_physical_3F__3 (void);
+ static void mb_var_is_physical_3F__11 (void);
+ static void mb_var_is_physical_3F__19 (void);
+ static void mb_type_elab_stack_assertion_2 (void);
+ static void mb_elab_type_sig_21__12 (void);
+ static void mb_elab_type_sig_21__4 (void);
+ static void mb_elab_type_sig_21__14 (void);
+ static void mb_elab_type_sig_21__8 (void);
+ static void mb_elab_type_sig_21__21 (void);
+ static void mb_elab_type_sig_21__19 (void);
+ static void mb_elab_type_sig_21__25 (void);
+ static void mb_elab_type_stack_21__9 (void);
+ static void mb_elab_type_stack_21__3 (void);
+ static void mb_elab_type_stack_21__11 (void);
+ static void mb_elab_type_stack_21__6 (void);
+ static void mb_elab_type_stack_rest_21__5 (void);
+ static void mb_elab_type_stack_rest_21__2 (void);
+ static void mb_elab_type_stack_rest_21__8 (void);
+ static void mb_elab_type_stack_rest_21__13 (void);
+ static void mb_elab_type_atom_21__9 (void);
+ static void mb_elab_type_atom_21__3 (void);
+ static void mb_elab_type_atom_21__14 (void);
+ static void mb_elab_type_atom_21__12 (void);
+ static void mb_elab_type_atom_21__19 (void);
+ static void mb_elab_type_atom_21__17 (void);
+ static void mb_elab_type_atom_21__24 (void);
+ static void mb_elab_type_atom_21__22 (void);
+ static void mb_elab_type_atom_21__29 (void);
+ static void mb_elab_type_atom_21__27 (void);
+ static void mb_elab_type_atom_21__34 (void);
+ static void mb_elab_type_atom_21__6 (void);
+ static void mb_elab_type_arg_21__6 (void);
+ static void mb_elab_type_arg_21__4 (void);
+ static void mb_elab_type_con_21__15 (void);
+ static void mb_elab_type_con_21__13 (void);
+ static void mb_elab_type_dont_care_21__2 (void);
+ static void mb_elab_type_dont_care_21__21 (void);
+ static void mb_elab_type_dont_care_21__8 (void);
+ static void mb_elab_type_dont_care_21__16 (void);
+ static void mb_elab_type_dont_care_21__11 (void);
+ static void mb_elab_type_hole_21__2 (void);
+ static void mb_elab_type_hole_21__22 (void);
+ static void mb_elab_type_hole_21__8 (void);
+ static void mb_elab_type_hole_21__16 (void);
+ static void mb_elab_type_hole_21__11 (void);
+ static void mb_elab_type_quote_21__6 (void);
+ static void mb_elab_type_quote_21__4 (void);
+ static void mb_elab_implicit_var_21__2 (void);
+ static void mb_elab_implicit_var_21__7 (void);
+ static void mb_elab_implicit_var_21__20 (void);
+ static void mb_elab_implicit_var_21__30 (void);
+ static void mb_elab_implicit_var_21__32 (void);
+ static void mb_elab_implicit_var_21__39 (void);
+ static void mb_elab_implicit_var_21__46 (void);
+ static void mb_ctx_lookup_3 (void);
+ static void mb_elab_type_unify_21__3 (void);
+ static void mb_ctx_new_21__2 (void);
+ static void mb_elab_type_args_21__2 (void);
+ static void mb_elab_type_args_21__37 (void);
+ static void mb_elab_type_args_21__7 (void);
+ static void mb_elab_type_args_21__9 (void);
+ static void mb_elab_type_args_21__18 (void);
+ static void mb_elab_type_args_21__15 (void);
+ static void mb_elab_type_args_21__22 (void);
+ static void mb_elab_type_args_21__27 (void);
+ static void mb_elab_type_args_21__34 (void);
+ static void mb_elab_simple_type_arg_21__2 (void);
+ static void mb_ab_save_21__9 (void);
+ static void mb_ab_build_word_21__11 (void);
+ static void mb_ab_build_word_21__17 (void);
+ static void mb_ab_build_word_21__30 (void);
+ static void mb_ab_build_word_21__32 (void);
+ static void mb_ab_build_word_21__34 (void);
+ static void mb_ab_unify_type_21__2 (void);
+ static void mb_ab_atom_21__6 (void);
+ static void mb_ab_optimized_snoc_21__11 (void);
+ static void mb_ab_optimized_snoc_21__2 (void);
+ static void mb_ab_optimized_snoc_21__4 (void);
+ static void mb_ab_optimized_snoc_21__8 (void);
+ static void mb_atom_accepts_args_3F__7 (void);
+ static void mb_atoms_turn_last_block_to_arg_26 (void);
+ static void mb_atom_to_run_var_10 (void);
+ static void mb_atom_to_run_var_8 (void);
+ static void mb_ab_op_21__13 (void);
+ static void mb_ab_op_21__19 (void);
+ static void mb_ab_expand_opsig_21__11 (void);
+ static void mb_ab_expand_opsig_21__20 (void);
+ static void mb_ab_expand_opsig_21__27 (void);
+ static void mb_ab_prim_21__8 (void);
+ static void mb_ab_prim_21__4 (void);
+ static void mb_ab_block_at_21__9 (void);
+ static void mb_ab_block_at_21__15 (void);
+ static void mb_ab_block_21__9 (void);
+ static void mb_ab_dip_21__8 (void);
+ static void mb_ab_if_21__2 (void);
+ static void mb_ab_while_21__2 (void);
+ static void mb_ab_lambda_21__20 (void);
+ static void mb_ab_lambda_21__25 (void);
+ static void mb_ab_lambda_21__28 (void);
+ static void mb_ab_lambda_21__50 (void);
+ static void mb_ab_lambda_21__52 (void);
+ static void mb_elab_expand_tensor_21__8 (void);
+ static void mb_elab_expand_tensor_21__21 (void);
+ static void mb_elab_expand_tensor_21__39 (void);
+ static void mb_elab_field_word_type_21__3 (void);
+ static void mb_elab_field_word_type_21__11 (void);
+ static void mb_elab_field_word_type_21__20 (void);
+ static void mb_elab_var_sig_21__7 (void);
+ static void mb_elab_var_sig_21__3 (void);
+ static void mb_elab_tag_ctx_sig_21__9 (void);
+ static void mb_elab_tag_ctx_sig_21__3 (void);
+ static void mb_elab_tag_ctx_sig_21__28 (void);
+ static void mb_elab_tag_ctx_sig_21__45 (void);
+ static void mb_elab_tag_ctx_sig_21__32 (void);
+ static void mb_elab_tag_ctx_sig_21__41 (void);
+ static void mb_elab_tag_ctx_sig_21__39 (void);
+ static void mb_elab_tag_ctx_sig_21__58 (void);
+ static void mb_elab_tag_ctx_sig_21__68 (void);
+ static void mb_elab_tag_ctx_sig_21__6 (void);
+ static void mb_elab_external_ctx_sig_21__9 (void);
+ static void mb_elab_external_ctx_sig_21__3 (void);
+ static void mb_elab_external_ctx_sig_21__12 (void);
+ static void mb_elab_external_ctx_sig_21__18 (void);
+ static void mb_elab_external_ctx_sig_21__23 (void);
+ static void mb_elab_external_ctx_sig_21__6 (void);
+ static void mb_elab_arrow_hom_21__3 (void);
+ static void mb_elab_arrow_fwd_21__2 (void);
+ static void mb_elab_args_21__4 (void);
+ static void mb_elab_lambda_params_21__12 (void);
+ static void mb_elab_lambda_params_21__10 (void);
+ static void mb_elab_lambda_params_21__20 (void);
+ static void mb_elab_lambda_params_21__18 (void);
+ static void mb_elab_lambda_params_21__24 (void);
+ static void mb_elab_lambda_params_21__32 (void);
+ static void mb_elab_lambda_params_21__27 (void);
+ static void mb_elab_lambda_params_21__35 (void);
+ static void mb_elab_lambda_params_21__49 (void);
+ static void mb_elab_lambda_params_21__41 (void);
+ static void mb_elab_lambda_params_21__55 (void);
+ static void mb_elab_lambda_params_21__60 (void);
+ static void mb_elab_lambda_params_21__68 (void);
+ static void mb_elab_lambda_body_21__6 (void);
+ static void mb_elab_lambda_body_21__4 (void);
+ static void mb_elab_lambda_body_21__11 (void);
+ static void mb_elab_lambda_body_21__14 (void);
+ static void mb_elab_lambda_pop_from_mid_21__2 (void);
+ static void mb_elab_lambda_pop_from_mid_21__7 (void);
+ static void mb_token_is_lambda_param_3F__6 (void);
+ static void mb_token_is_lambda_param_3F__3 (void);
+ static void mb_token_is_lambda_param_3F__25 (void);
+ static void mb_token_is_lambda_param_3F__9 (void);
+ static void mb_token_is_lambda_param_3F__13 (void);
+ static void mb_token_is_lambda_param_3F__19 (void);
+ static void mb_expect_token_arrow_5 (void);
+ static void mb_expect_token_arrow_3 (void);
+ static void mb_elab_match_cases_21__15 (void);
+ static void mb_elab_match_cases_21__4 (void);
+ static void mb_elab_match_cases_21__11 (void);
+ static void mb_elab_match_cases_21__8 (void);
+ static void mb_elab_match_exhaustive_21__5 (void);
+ static void mb_elab_match_exhaustive_21__3 (void);
+ static void mb_elab_match_case_21__6 (void);
+ static void mb_elab_match_case_21__15 (void);
+ static void mb_elab_match_case_21__22 (void);
+ static void mb_elab_match_case_21__20 (void);
+ static void mb_elab_case_pattern_21__25 (void);
+ static void mb_elab_case_pattern_21__3 (void);
+ static void mb_elab_case_pattern_21__105 (void);
+ static void mb_elab_case_pattern_21__28 (void);
+ static void mb_elab_case_pattern_21__44 (void);
+ static void mb_elab_case_pattern_21__49 (void);
+ static void mb_elab_case_pattern_21__72 (void);
+ static void mb_elab_case_pattern_21__75 (void);
+ static void mb_elab_case_pattern_21__81 (void);
+ static void mb_elab_case_pattern_21__88 (void);
+ static void mb_elab_case_pattern_21__5 (void);
+ static void mb_elab_case_pattern_21__11 (void);
+ static void mb_elab_case_pattern_21__20 (void);
+ static void mb_elab_case_body_21__2 (void);
+ static void mb_elab_case_body_21__5 (void);
+ static void mb_elab_case_body_21__13 (void);
+ static void mb_elab_case_body_21__23 (void);
+ static void mb_elab_case_body_21__33 (void);
+ static void mb_elab_module_header_21__47 (void);
+ static void mb_elab_module_header_21__4 (void);
+ static void mb_elab_module_header_21__11 (void);
+ static void mb_elab_module_header_21__9 (void);
+ static void mb_elab_module_header_21__22 (void);
+ static void mb_elab_module_header_21__18 (void);
+ static void mb_elab_module_header_21__42 (void);
+ static void mb_elab_module_header_21__40 (void);
+ static void mb_elab_module_decl_21__18 (void);
+ static void mb_elab_module_decl_21__14 (void);
+ static void mb_elab_module_import_21__3 (void);
+ static void mb_elab_module_import_21__18 (void);
+ static void mb_elab_module_import_21__30 (void);
+ static void mb_elab_data_21__3 (void);
+ static void mb_elab_data_21__9 (void);
+ static void mb_elab_data_21__13 (void);
+ static void mb_elab_data_header_21__8 (void);
+ static void mb_elab_data_header_21__6 (void);
+ static void mb_elab_data_header_21__18 (void);
+ static void mb_elab_data_header_21__16 (void);
+ static void mb_elab_data_tag_21__5 (void);
+ static void mb_elab_data_tag_21__3 (void);
+ static void mb_elab_data_tag_21__14 (void);
+ static void mb_elab_data_tag_21__12 (void);
+ static void mb_elab_data_tag_21__32 (void);
+ static void mb_elab_data_tag_21__39 (void);
+ static void mb_elab_data_tag_21__71 (void);
+ static void mb_elab_data_tag_21__51 (void);
+ static void mb_elab_data_tag_21__76 (void);
+ static void mb_elab_data_tag_21__74 (void);
+ static void mb_elab_data_tag_21__53 (void);
+ static void mb_elab_data_tag_21__61 (void);
+ static void mb_elab_data_tag_21__68 (void);
+ static void mb_elab_data_tag_21__65 (void);
+ static void mb_expect_token_comma_5 (void);
+ static void mb_expect_token_comma_3 (void);
+ static void mb_expect_token_rparen_5 (void);
+ static void mb_expect_token_rparen_3 (void);
+ static void mb_elab_def_21__3 (void);
+ static void mb_elab_def_21__12 (void);
+ static void mb_elab_def_21__10 (void);
+ static void mb_elab_def_21__21 (void);
+ static void mb_elab_def_21__19 (void);
+ static void mb_elab_def_21__34 (void);
+ static void mb_elab_def_21__39 (void);
+ static void mb_elab_def_21__44 (void);
+ static void mb_elab_def_21__49 (void);
+ static void mb_elab_def_21__56 (void);
+ static void mb_elab_def_21__66 (void);
+ static void mb_elab_def_21__70 (void);
+ static void mb_elab_def_external_21__3 (void);
+ static void mb_elab_def_external_21__29 (void);
+ static void mb_elab_def_external_21__10 (void);
+ static void mb_elab_def_external_21__24 (void);
+ static void mb_elab_def_external_21__14 (void);
+ static void mb_elab_def_type_21__3 (void);
+ static void mb_elab_def_type_21__26 (void);
+ static void mb_elab_def_type_21__10 (void);
+ static void mb_elab_def_type_21__21 (void);
+ static void mb_elab_def_type_21__14 (void);
+ static void mb_elab_buffer_21__3 (void);
+ static void mb_elab_buffer_21__25 (void);
+ static void mb_elab_buffer_21__10 (void);
+ static void mb_elab_buffer_21__20 (void);
+ static void mb_elab_buffer_21__14 (void);
+ static void mb_elab_table_21__3 (void);
+ static void mb_elab_table_21__13 (void);
+ static void mb_elab_table_21__9 (void);
+ static void mb_table_new_21__32 (void);
+ static void mb_table_new_21__66 (void);
+ static void mb_table_new_21__92 (void);
+ static void mb_table_new_21__134 (void);
+ static void mb_table_new_21__146 (void);
+ static void mb_table_new_21__144 (void);
+ static void mb_table_new_21__217 (void);
+ static void mb_table_new_21__222 (void);
+ static void mb_table_new_21__236 (void);
+ static void mb_table_new_21__226 (void);
+ static void mb_table_new_21__240 (void);
+ static void mb_table_new_21__279 (void);
+ static void mb_elab_target_c99_21__4 (void);
+ static void mb_elab_target_c99_21__9 (void);
+ static void mb_elab_target_c99_21__14 (void);
+ static void mb_elab_field_21__3 (void);
+ static void mb_elab_field_sig_21__5 (void);
+ static void mb_elab_field_sig_21__3 (void);
+ static void mb_name_prim_3D__2 (void);
+ static void mb_def_prim_21__4 (void);
 
  static void mwname_str_40_ (void);
  static void mwname_str_3F_ (void);
@@ -4065,6 +4072,9 @@ static void mwstat (void) {
  static void mwarrow_token_end_40_ (void);
  static void mwarrow_token_end_3F_ (void);
  static void mwarrow_token_end_21_ (void);
+ static void mwarrow_home_40_ (void);
+ static void mwarrow_home_3F_ (void);
+ static void mwarrow_home_21_ (void);
  static void mwarrow_ctx_40_ (void);
  static void mwarrow_ctx_3F_ (void);
  static void mwarrow_ctx_21_ (void);
@@ -4544,7 +4554,7 @@ static void mwstr_buf_swap_u8_21_ (void){
     mwdup2();
     mwswap();
     push_u64(0);
-    push_fnptr(&mb_data_2E_str_140_10);
+    push_fnptr(&mb_str_buf_swap_u8_21__4);
     do_pack_cons();
     mwdip3();
     { value_t d1 = pop_value();
@@ -4586,7 +4596,7 @@ static void mwu8_40_ (void){
     mwprim_2E_u8_2E_get();
 }
 
-static void mb_data_2E_str_140_10 (void) {
+static void mb_str_buf_swap_u8_21__4 (void) {
     do_drop();
     mwstr_buf_u8_40_();
 }
@@ -4808,12 +4818,12 @@ static void mwnum_errors_40_ (void){
 
 static void mwtypecheck_everything_21_ (void){
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_935_14);
+    push_fnptr(&mb_typecheck_everything_21__2);
     do_pack_cons();
     mwName_2E_for();
 }
 
-static void mb_mirth_2E_elab_935_14 (void) {
+static void mb_typecheck_everything_21__2 (void) {
     do_drop();
     mwtypecheck_name_21_();
 }
@@ -4917,13 +4927,13 @@ static void mwelab_tag_ctx_sig_21_ (void){
       push_value(d2); }
     mwdup2();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_438_13);
+    push_fnptr(&mb_elab_tag_ctx_sig_21__68);
     do_pack_cons();
     mwdip2();
     }
 }
 
-static void mb_mirth_2E_elab_438_13 (void) {
+static void mb_elab_tag_ctx_sig_21__68 (void) {
     do_drop();
     mwrotl();
     mwtuck();
@@ -5068,7 +5078,7 @@ static void mwstr_concat (void){
     push_i64(0LL);
     mwswap();
     push_u64(0);
-    push_fnptr(&mb_data_2E_str_28_20);
+    push_fnptr(&mb_str_concat_5);
     do_pack_cons();
     mwfor();
     mwprim_2E_str_2E_alloc();
@@ -5077,7 +5087,7 @@ static void mwstr_concat (void){
     mwprim_2E_str_2E_base();
     mwswap();
     push_u64(0);
-    push_fnptr(&mb_data_2E_str_31_18);
+    push_fnptr(&mb_str_concat_16);
     do_pack_cons();
     mwfor();
     mwnil();
@@ -5091,7 +5101,7 @@ static void mwnil (void){
     mwprim_2E_unsafe_2E_cast();
 }
 
-static void mb_data_2E_str_31_18 (void) {
+static void mb_str_concat_16 (void) {
     do_drop();
     mwswap();
     mwstr_copy_partial_21_();
@@ -5110,7 +5120,7 @@ static void mwstr_copy_partial_21_ (void){
       push_value(d1); }
 }
 
-static void mb_data_2E_str_28_20 (void) {
+static void mb_str_concat_5 (void) {
     do_drop();
     mwstr_size();
     mw_2B_();
@@ -6028,12 +6038,12 @@ static void mwelab_stack_var_21_ (void){
 
 static void mwelab_implicit_var_21_ (void){
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_90_10);
+    push_fnptr(&mb_elab_implicit_var_21__2);
     do_pack_cons();
     mwdip2();
     mwover();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_91_10);
+    push_fnptr(&mb_elab_implicit_var_21__7);
     do_pack_cons();
     mwdip2();
     mwrotl();
@@ -6042,7 +6052,7 @@ static void mwelab_implicit_var_21_ (void){
     do_pack_uncons(); do_drop();
     mwrotr();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_94_23);
+    push_fnptr(&mb_elab_implicit_var_21__20);
     do_pack_cons();
     mwdip2();
     mwelab_type_unify_21_();
@@ -6066,12 +6076,12 @@ static void mwelab_implicit_var_21_ (void){
     }
     mwtoken_next();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_104_10);
+    push_fnptr(&mb_elab_implicit_var_21__46);
     do_pack_cons();
     mwdip2();
 }
 
-static void mb_mirth_2E_elab_104_10 (void) {
+static void mb_elab_implicit_var_21__46 (void) {
     do_drop();
     mwtype_elab_ctx_21_();
 }
@@ -7285,7 +7295,7 @@ static void mwblock_unify_type_aux_21_ (void){
       push_value(d2); }
     mwswap();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_data_2E_arrow_166_19);
+    push_fnptr(&mb_block_unify_type_aux_21__22);
     do_pack_cons();
     mwab_build_21_();
     mwdup2();
@@ -7301,7 +7311,7 @@ static void mwblock_unify_type_aux_21_ (void){
     mwtype_unify_21_();
 }
 
-static void mb_mirth_2E_data_2E_arrow_166_19 (void) {
+static void mb_block_unify_type_aux_21__22 (void) {
     do_drop();
     mwelab_atoms_21_();
 }
@@ -7526,11 +7536,11 @@ static void mwab_atom_21_ (void){
 static void mwab_optimized_snoc_21_ (void){
     while(1) {
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_228_16);
+    push_fnptr(&mb_ab_optimized_snoc_21__4);
     do_pack_cons();
     mwdip_3F_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_228_43);
+    push_fnptr(&mb_ab_optimized_snoc_21__8);
     do_pack_cons();
     mwand();
     if (!pop_u64()) break;
@@ -7732,7 +7742,7 @@ static void mwblock_force_21_ (void){
     mwTMeta();
       push_value(d3); }
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_data_2E_arrow_142_23);
+    push_fnptr(&mb_block_force_21__23);
     do_pack_cons();
     mwab_build_21_();
     mwover();
@@ -7746,7 +7756,7 @@ static void mwblock_force_21_ (void){
     }
 }
 
-static void mb_mirth_2E_data_2E_arrow_142_23 (void) {
+static void mb_block_force_21__23 (void) {
     do_drop();
     mwelab_atoms_21_();
 }
@@ -7803,7 +7813,7 @@ static void mwunsnoc (void){
     }
 }
 
-static void mb_mirth_2E_elab_228_43 (void) {
+static void mb_ab_optimized_snoc_21__8 (void) {
     do_drop();
     mwatom_accepts_args_3F_();
 }
@@ -8022,7 +8032,7 @@ static void mwand (void){
     }
 }
 
-static void mb_mirth_2E_elab_228_16 (void) {
+static void mb_ab_optimized_snoc_21__4 (void) {
     do_drop();
     mwatoms_has_last_block_3F_();
 }
@@ -8056,12 +8066,12 @@ static void mwatoms_has_last_block_3F_ (void){
 static void mwlast (void){
     mwList__3E_List_2B_();
     push_u64(0);
-    push_fnptr(&mb_data_2E_list_198_54);
+    push_fnptr(&mb_last_3);
     do_pack_cons();
     mwmaybe_map();
 }
 
-static void mb_data_2E_list_198_54 (void) {
+static void mb_last_3 (void) {
     do_drop();
     mwlast_2B_();
 }
@@ -9078,12 +9088,12 @@ static void mwBag__3E_Bag_2B_ (void){
     mwunBAG();
     mwList__3E_List_2B_();
     push_u64(0);
-    push_fnptr(&mb_data_2E_bag_26_70);
+    push_fnptr(&mb_Bag__3E_Bag_2B__4);
     do_pack_cons();
     mwmaybe_map();
 }
 
-static void mb_data_2E_bag_26_70 (void) {
+static void mb_Bag__3E_Bag_2B__4 (void) {
     do_drop();
     mwBAG_2B_();
 }
@@ -9645,12 +9655,12 @@ static void mwlambda_body_21_ (void){
 
 static void mwelab_arrow_fwd_21_ (void){
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_486_15);
+    push_fnptr(&mb_elab_arrow_fwd_21__2);
     do_pack_cons();
     mwab_build_21_();
 }
 
-static void mb_mirth_2E_elab_486_15 (void) {
+static void mb_elab_arrow_fwd_21__2 (void) {
     do_drop();
     mwelab_atoms_21_();
 }
@@ -9958,12 +9968,12 @@ static void mwelab_lambda_pop_from_mid_21_ (void){
       push_value(d1); }
     mwelab_expand_tensor_21_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_598_10);
+    push_fnptr(&mb_elab_lambda_pop_from_mid_21__7);
     do_pack_cons();
     mwdip2();
 }
 
-static void mb_mirth_2E_elab_598_10 (void) {
+static void mb_elab_lambda_pop_from_mid_21__7 (void) {
     do_drop();
     mwover();
     mwlambda_mid_21_();
@@ -10291,12 +10301,12 @@ static void mwdata_tags_21_ (void){
 static void mwmatch_scrutinee_data_3F_ (void){
     mwmatch_scrutinee_type_3F_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_data_2E_arrow_235_9);
+    push_fnptr(&mb_match_scrutinee_data_3F__3);
     do_pack_cons();
     mwmaybe_bind();
 }
 
-static void mb_mirth_2E_data_2E_arrow_235_9 (void) {
+static void mb_match_scrutinee_data_3F__3 (void) {
     do_drop();
     mwtype_head();
     switch (get_top_data_tag()) {
@@ -10369,12 +10379,12 @@ static void mwmatch_has_default_case_3F_ (void){
 
 static void mwcases_have_default_case (void){
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_data_2E_arrow_262_9);
+    push_fnptr(&mb_cases_have_default_case_2);
     do_pack_cons();
     mwany();
 }
 
-static void mb_mirth_2E_data_2E_arrow_262_9 (void) {
+static void mb_cases_have_default_case_2 (void) {
     do_drop();
     mwdup();
     mwcase_is_default_case();
@@ -10617,13 +10627,13 @@ static void mwcases_cover_case_3F_ (void){
 static void mwcases_cover_case (void){
     mwswap();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_data_2E_arrow_255_14);
+    push_fnptr(&mb_cases_cover_case_3);
     do_pack_cons();
     mwany();
     mwnip();
 }
 
-static void mb_mirth_2E_data_2E_arrow_255_14 (void) {
+static void mb_cases_cover_case_3 (void) {
     do_drop();
     mwdup2();
     mwcase_is_covered();
@@ -10662,23 +10672,23 @@ static void mwelab_case_body_21_ (void){
     mwarrow_cod_3F_();
       push_value(d1); }
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_725_10);
+    push_fnptr(&mb_elab_case_body_21__23);
     do_pack_cons();
     mwdip2();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_726_10);
+    push_fnptr(&mb_elab_case_body_21__33);
     do_pack_cons();
     mwdip2();
     mwelab_type_unify_21_();
     mwnip();
 }
 
-static void mb_mirth_2E_elab_726_10 (void) {
+static void mb_elab_case_body_21__33 (void) {
     do_drop();
     mwcase_match_3F_();
     mwmatch_cod_40_();
 }
-static void mb_mirth_2E_elab_725_10 (void) {
+static void mb_elab_case_body_21__23 (void) {
     do_drop();
     mwover();
     mwcase_body_21_();
@@ -10782,11 +10792,11 @@ static void mwelab_case_pattern_21_ (void){
     mwPATTERN_TAG();
     mwrotr();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_695_22);
+    push_fnptr(&mb_elab_case_pattern_21__44);
     do_pack_cons();
     mwdip2();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_698_22);
+    push_fnptr(&mb_elab_case_pattern_21__49);
     do_pack_cons();
     mwdip2();
     mwelab_tag_sig_21_();
@@ -10797,7 +10807,7 @@ static void mwelab_case_pattern_21_ (void){
     { value_t d4 = pop_value();
     mwelab_expand_morphism_21_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_703_26);
+    push_fnptr(&mb_elab_case_pattern_21__75);
     do_pack_cons();
     mwdip2();
     mwelab_type_unify_21_();
@@ -10865,16 +10875,16 @@ static void mwcase_subst_21_ (void){
     decref(oldvalue);
 }
 
-static void mb_mirth_2E_elab_703_26 (void) {
+static void mb_elab_case_pattern_21__75 (void) {
     do_drop();
     mwswap();
 }
-static void mb_mirth_2E_elab_698_22 (void) {
+static void mb_elab_case_pattern_21__49 (void) {
     do_drop();
     mwcase_match_3F_();
     mwmatch_dom_40_();
 }
-static void mb_mirth_2E_elab_695_22 (void) {
+static void mb_elab_case_pattern_21__44 (void) {
     do_drop();
     mwover();
     mwcase_pattern_21_();
@@ -11231,12 +11241,12 @@ static void mwelab_args_21_ (void){
     mwab_token_40_();
     mwtoken_args();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_514_38);
+    push_fnptr(&mb_elab_args_21__4);
     do_pack_cons();
     mwreverse_for();
 }
 
-static void mb_mirth_2E_elab_514_38 (void) {
+static void mb_elab_args_21__4 (void) {
     do_drop();
     mwelab_block_at_21_();
 }
@@ -11412,13 +11422,13 @@ static void mwtoken_is_args_end_3F_ (void){
 static void mwctx_lookup (void){
     mwunCTX();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_data_2E_ctx_19_24);
+    push_fnptr(&mb_ctx_lookup_3);
     do_pack_cons();
     mwreverse_find();
     mwnip();
 }
 
-static void mb_mirth_2E_data_2E_ctx_19_24 (void) {
+static void mb_ctx_lookup_3 (void) {
     do_drop();
     mwdup2();
     mwvar_name_40_();
@@ -11522,18 +11532,21 @@ static void mwab_build_21_ (void){
     push_value(var_f_401);
     incref(var_f_401);
     do_pack_cons();
-    push_fnptr(&mb_mirth_2E_elab_188_9);
+    push_fnptr(&mb_ab_build_21__8);
     do_pack_cons();
     mwab_save_21_();
     decref(var_f_401);
     }
 }
 
-static void mb_mirth_2E_elab_188_9 (void) {
+static void mb_ab_build_21__8 (void) {
     do_pack_uncons();
     value_t var_f_401 = pop_value();
     do_drop();
     mwArrow_2E_alloc_21_();
+    mwab_home_40_();
+    mwover();
+    mwarrow_home_21_();
     mwtuck();
     mwdup2();
     mwarrow_token_start_21_();
@@ -11591,6 +11604,44 @@ static void mwarrow_token_start_21_ (void){
     value_t oldvalue = *p;
     *p = newvalue;
     decref(oldvalue);
+}
+
+static value_t* fieldptr_arrow_home (usize i) {
+    static struct value_t * p;
+    static usize n = 0; 
+    if (i >= n) {
+        usize new_n = n+1;
+        while (i >= new_n) new_n *= 2;
+        p = realloc(p, sizeof(struct value_t) * new_n);
+        memset(p+n, 0, sizeof(struct value_t) * (new_n - n));
+        n = new_n;
+    }
+    return p+i;
+}
+
+static void mwarrow_home_40_ (void){
+    usize index = (usize)pop_u64();
+    value_t v = *fieldptr_arrow_home(index);
+    incref(v); push_value(v);
+}
+static void mwarrow_home_3F_ (void){
+    mwdup();
+    usize index = (usize)pop_u64();
+    value_t v = *fieldptr_arrow_home(index);
+    incref(v); push_value(v);
+}
+static void mwarrow_home_21_ (void){
+    usize index = (usize)pop_u64();
+    value_t newvalue = pop_value();
+    value_t* p = fieldptr_arrow_home(index);
+    value_t oldvalue = *p;
+    *p = newvalue;
+    decref(oldvalue);
+}
+
+static void mwab_home_40_ (void){
+    mwAB_HOME();
+    mwvalue_40_();
 }
 
 static void mwArrow_2E_alloc_21_ (void){
@@ -12016,7 +12067,7 @@ static void mwtype_value_unify_21_ (void){
 
 static void mwtype_unify_failed_21_ (void){
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_data_2E_type_158_10);
+    push_fnptr(&mb_type_unify_failed_21__2);
     do_pack_cons();
     mwdip2();
     push_ptr(": error: Failed to unify \0\0\0");
@@ -12430,7 +12481,7 @@ static void mwtype_trace_prim_21_ (void){
     mwstr_trace_21_();
 }
 
-static void mb_mirth_2E_data_2E_type_158_10 (void) {
+static void mb_type_unify_failed_21__2 (void) {
     do_drop();
     mwgamma_token_3F_();
     mwtoken_location();
@@ -12624,19 +12675,19 @@ static void mwtype_expand (void){
     }
 }
 
-static void mb_mirth_2E_elab_94_23 (void) {
+static void mb_elab_implicit_var_21__20 (void) {
     do_drop();
     mwnip();
     mwvar_type_3F_();
 }
-static void mb_mirth_2E_elab_91_10 (void) {
+static void mb_elab_implicit_var_21__7 (void) {
     do_drop();
     mwtoken_name_40_();
     mwdup2();
     mwswap();
     mwctx_lookup();
 }
-static void mb_mirth_2E_elab_90_10 (void) {
+static void mb_elab_implicit_var_21__2 (void) {
     do_drop();
     mwtype_elab_ctx_3F_();
 }
@@ -13498,13 +13549,13 @@ static void mwtype_max_count_3F_ (void){
 static void mwdata_is_enum_3F_ (void){
     mwdata_tags_3F_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_data_2E_type_744_21);
+    push_fnptr(&mb_data_is_enum_3F__3);
     do_pack_cons();
     mwall_3F_();
     mwnip();
 }
 
-static void mb_mirth_2E_data_2E_type_744_21 (void) {
+static void mb_data_is_enum_3F__3 (void) {
     do_drop();
     mwtag_num_inputs_3F_();
     push_i64(0LL);
@@ -13538,7 +13589,7 @@ static void mwall_3F_ (void){
     push_value(var_f_362);
     incref(var_f_362);
     do_pack_cons();
-    push_fnptr(&mb_data_2E_list_389_20);
+    push_fnptr(&mb_all_3F__8);
     do_pack_cons();
     mwfind_3F_();
     mwis_none();
@@ -13550,7 +13601,7 @@ static void mwis_none (void){
     mwis_nil();
 }
 
-static void mb_data_2E_list_389_20 (void) {
+static void mb_all_3F__8 (void) {
     do_pack_uncons();
     value_t var_f_362 = pop_value();
     do_drop();
@@ -13800,13 +13851,13 @@ static void mwelab_external_ctx_sig_21_ (void){
       push_value(d2); }
     mwdup2();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_460_13);
+    push_fnptr(&mb_elab_external_ctx_sig_21__23);
     do_pack_cons();
     mwdip2();
     }
 }
 
-static void mb_mirth_2E_elab_460_13 (void) {
+static void mb_elab_external_ctx_sig_21__23 (void) {
     do_drop();
     mwrotl();
     mwtuck();
@@ -14157,7 +14208,7 @@ static void mwstr_eq (void){
 static void mwmodule_path_from_name (void){
     mwname_str_40_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_data_2E_module_32_9);
+    push_fnptr(&mb_module_path_from_name_3);
     do_pack_cons();
     mwstr_transduce();
     push_ptr(".mth\0\0\0");
@@ -14170,7 +14221,7 @@ static void mwstr_cat (void){
     mwstr_concat();
 }
 
-static void mb_mirth_2E_data_2E_module_32_9 (void) {
+static void mb_module_path_from_name_3 (void) {
     do_drop();
     mwis_dot_3F_();
     if (pop_u64()) {
@@ -14208,14 +14259,14 @@ static void mwstr_transduce (void){
     push_value(var_f_241);
     incref(var_f_241);
     do_pack_cons();
-    push_fnptr(&mb_data_2E_str_175_9);
+    push_fnptr(&mb_str_transduce_8);
     do_pack_cons();
     mwbuild_str_21_();
     decref(var_f_241);
     }
 }
 
-static void mb_data_2E_str_175_9 (void) {
+static void mb_str_transduce_8 (void) {
     do_pack_uncons();
     value_t var_f_241 = pop_value();
     do_drop();
@@ -14252,7 +14303,7 @@ static void mb_data_2E_str_175_9 (void) {
     push_value(var_f_241);
     incref(var_f_241);
     do_pack_cons();
-    push_fnptr(&mb_data_2E_str_181_32);
+    push_fnptr(&mb_str_transduce_40);
     do_pack_cons();
     mwfor();
     break;
@@ -14266,7 +14317,7 @@ static void mb_data_2E_str_175_9 (void) {
     mwdrop();
     decref(var_f_241);
 }
-static void mb_data_2E_str_181_32 (void) {
+static void mb_str_transduce_40 (void) {
     do_pack_uncons();
     value_t var_f_241 = pop_value();
     do_drop();
@@ -15486,7 +15537,7 @@ static void mwstr_buf_hex_int_3F_ (void){
     mwnip();
     if (pop_u64()) {
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_lexer_340_18);
+    push_fnptr(&mb_str_buf_hex_int_3F__14);
     do_pack_cons();
     mwdip2();
     } else {
@@ -15555,7 +15606,7 @@ static void mwis_digit_3F_ (void){
     mwin_range();
 }
 
-static void mb_mirth_2E_lexer_340_18 (void) {
+static void mb_str_buf_hex_int_3F__14 (void) {
     do_drop();
     mwdrop();
     push_i64(-1LL);
@@ -15604,7 +15655,7 @@ static void mwstr_buf_dec_int_3F_ (void){
     mwnip();
     if (pop_u64()) {
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_lexer_320_18);
+    push_fnptr(&mb_str_buf_dec_int_3F__14);
     do_pack_cons();
     mwdip2();
     } else {
@@ -15637,7 +15688,7 @@ static void mwstr_buf_dec_int_3F_ (void){
     mw_2A_();
 }
 
-static void mb_mirth_2E_lexer_320_18 (void) {
+static void mb_str_buf_dec_int_3F__14 (void) {
     do_drop();
     mwdrop();
     push_i64(-1LL);
@@ -15791,34 +15842,34 @@ static void mwstr_buf_is_doc_start_3F_ (void){
     push_i64(3LL);
     mw_3D__3D_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_lexer_240_9);
+    push_fnptr(&mb_str_buf_is_doc_start_3F__5);
     do_pack_cons();
     mwand();
 }
 
-static void mb_mirth_2E_lexer_240_9 (void) {
+static void mb_str_buf_is_doc_start_3F__5 (void) {
     do_drop();
     push_i64(0LL);
     mwstr_buf_char_40_();
     mwis_pipe_3F_();
     mwnip();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_lexer_241_13);
+    push_fnptr(&mb_str_buf_is_doc_start_3F__11);
     do_pack_cons();
     mwand();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_lexer_242_13);
+    push_fnptr(&mb_str_buf_is_doc_start_3F__18);
     do_pack_cons();
     mwand();
 }
-static void mb_mirth_2E_lexer_242_13 (void) {
+static void mb_str_buf_is_doc_start_3F__18 (void) {
     do_drop();
     push_i64(2LL);
     mwstr_buf_char_40_();
     mwis_pipe_3F_();
     mwnip();
 }
-static void mb_mirth_2E_lexer_241_13 (void) {
+static void mb_str_buf_is_doc_start_3F__11 (void) {
     do_drop();
     push_i64(1LL);
     mwstr_buf_char_40_();
@@ -16122,13 +16173,13 @@ static void mwopen_file_21_ (void){
 
 static void mwposix_open_21_ (void){
     push_u64(0);
-    push_fnptr(&mb_prelude_108_43);
+    push_fnptr(&mb_posix_open_21__2);
     do_pack_cons();
     mwdip2();
     mwprim_2E_posix_2E_open();
 }
 
-static void mb_prelude_108_43 (void) {
+static void mb_posix_open_21__2 (void) {
     do_drop();
     mwStr__3E_Ptr();
 }
@@ -16598,47 +16649,47 @@ static void mwinit_prims_21_ (void){
     push_ptr("prim.posix.mmap\0\0\0");
     mwdef_prim_21_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_data_2E_prim_254_7);
+    push_fnptr(&mb_init_prims_21__283);
     do_pack_cons();
     mwPRIM_SYNTAX_IMPORT();
     mwprim_decl_21_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_data_2E_prim_255_7);
+    push_fnptr(&mb_init_prims_21__288);
     do_pack_cons();
     mwPRIM_SYNTAX_DEF();
     mwprim_decl_21_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_data_2E_prim_256_7);
+    push_fnptr(&mb_init_prims_21__293);
     do_pack_cons();
     mwPRIM_SYNTAX_DEF_EXTERNAL();
     mwprim_decl_21_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_data_2E_prim_257_7);
+    push_fnptr(&mb_init_prims_21__298);
     do_pack_cons();
     mwPRIM_SYNTAX_DEF_TYPE();
     mwprim_decl_21_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_data_2E_prim_258_7);
+    push_fnptr(&mb_init_prims_21__303);
     do_pack_cons();
     mwPRIM_SYNTAX_BUFFER();
     mwprim_decl_21_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_data_2E_prim_259_7);
+    push_fnptr(&mb_init_prims_21__308);
     do_pack_cons();
     mwPRIM_SYNTAX_TABLE();
     mwprim_decl_21_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_data_2E_prim_260_7);
+    push_fnptr(&mb_init_prims_21__313);
     do_pack_cons();
     mwPRIM_SYNTAX_FIELD();
     mwprim_decl_21_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_data_2E_prim_261_7);
+    push_fnptr(&mb_init_prims_21__318);
     do_pack_cons();
     mwPRIM_SYNTAX_TARGET_C99();
     mwprim_decl_21_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_data_2E_prim_262_7);
+    push_fnptr(&mb_init_prims_21__323);
     do_pack_cons();
     mwPRIM_SYNTAX_DATA();
     mwprim_decl_21_();
@@ -17567,7 +17618,7 @@ static void mwT3 (void){
     mwT_2A_();
 }
 
-static void mb_mirth_2E_data_2E_prim_262_7 (void) {
+static void mb_init_prims_21__323 (void) {
     do_drop();
     mwelab_data_21_();
 }
@@ -17582,7 +17633,7 @@ static void mwelab_data_21_ (void){
     mwelab_data_header_21_();
       push_value(d2); }
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_800_13);
+    push_fnptr(&mb_elab_data_21__13);
     do_pack_cons();
     mwfor();
     mwdrop();
@@ -17590,7 +17641,7 @@ static void mwelab_data_21_ (void){
     mwtoken_next();
 }
 
-static void mb_mirth_2E_elab_800_13 (void) {
+static void mb_elab_data_21__13 (void) {
     do_drop();
     mwelab_data_tag_21_();
 }
@@ -17811,7 +17862,7 @@ static void mwData_2E_alloc_21_ (void){
     mwprim_2E_unsafe_2E_cast();
 }
 
-static void mb_mirth_2E_data_2E_prim_261_7 (void) {
+static void mb_init_prims_21__318 (void) {
     do_drop();
     mwelab_target_c99_21_();
 }
@@ -18174,12 +18225,12 @@ static void mwname_mangle_21_ (void){
 static void mwname_mangle_compute_21_ (void){
     mwname_str_40_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_data_2E_name_122_9);
+    push_fnptr(&mb_name_mangle_compute_21__3);
     do_pack_cons();
     mwstr_transduce();
 }
 
-static void mb_mirth_2E_data_2E_name_122_9 (void) {
+static void mb_name_mangle_compute_21__3 (void) {
     do_drop();
     mwis_alpha_3F_();
     if (pop_u64()) {
@@ -18503,12 +18554,12 @@ static void mwc99_emit_block_def_21_ (void){
 static void mwc99_decref_ctx_21_ (void){
     mwctx_physical_vars();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_codegen_1355_9);
+    push_fnptr(&mb_c99_decref_ctx_21__3);
     do_pack_cons();
     mwreverse_for();
 }
 
-static void mb_mirth_2E_codegen_1355_9 (void) {
+static void mb_c99_decref_ctx_21__3 (void) {
     do_drop();
     push_ptr("    decref(\0\0\0");
     mw_2E_();
@@ -18534,12 +18585,12 @@ static void mw_2E_n (void){
 
 static void mwint_show (void){
     push_u64(0);
-    push_fnptr(&mb_data_2E_str_135_16);
+    push_fnptr(&mb_int_show_2);
     do_pack_cons();
     mwbuild_str_21_();
 }
 
-static void mb_data_2E_str_135_16 (void) {
+static void mb_int_show_2 (void) {
     do_drop();
     mwstr_buf_int_21_();
 }
@@ -18550,12 +18601,12 @@ static void mwVar_2E_id (void){
 static void mwctx_physical_vars (void){
     mwctx_vars();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_data_2E_ctx_17_21);
+    push_fnptr(&mb_ctx_physical_vars_3);
     do_pack_cons();
     mwfilter();
 }
 
-static void mb_mirth_2E_data_2E_ctx_17_21 (void) {
+static void mb_ctx_physical_vars_3 (void) {
     do_drop();
     mwvar_is_physical_3F_();
 }
@@ -18623,7 +18674,7 @@ static void mwfilter_2B_ (void){
     push_value(var_f_333);
     incref(var_f_333);
     do_pack_cons();
-    push_fnptr(&mb_data_2E_list_332_44);
+    push_fnptr(&mb_filter_2B__20);
     do_pack_cons();
     mwdip_27_();
     mwcat();
@@ -18641,7 +18692,7 @@ static void mwfilter_2B_ (void){
     push_value(var_f_333);
     incref(var_f_333);
     do_pack_cons();
-    push_fnptr(&mb_data_2E_list_335_22);
+    push_fnptr(&mb_filter_2B__39);
     do_pack_cons();
     mwdip_27_();
     mwcons();
@@ -18657,7 +18708,7 @@ static void mwfilter_2B_ (void){
     }
 }
 
-static void mb_data_2E_list_335_22 (void) {
+static void mb_filter_2B__39 (void) {
     do_pack_uncons();
     value_t var_f_333 = pop_value();
     do_drop();
@@ -18695,7 +18746,7 @@ static void mwcat (void){
     }
 }
 
-static void mb_data_2E_list_332_44 (void) {
+static void mb_filter_2B__20 (void) {
     do_pack_uncons();
     value_t var_f_333 = pop_value();
     do_drop();
@@ -18726,7 +18777,7 @@ static void mwc99_emit_arrow_21_ (void){
     mwc99_depth_2B__2B_();
     mwarrow_atoms_40_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_codegen_1208_22);
+    push_fnptr(&mb_c99_emit_arrow_21__4);
     do_pack_cons();
     mwfor();
     mwc99_depth__();
@@ -18748,7 +18799,7 @@ static void mwc99_depth_40_ (void){
     mwint_40_();
 }
 
-static void mb_mirth_2E_codegen_1208_22 (void) {
+static void mb_c99_emit_arrow_21__4 (void) {
     do_drop();
     mwc99_emit_atom_21_();
 }
@@ -18881,12 +18932,12 @@ static void mwc99_pack_ctx_21_ (void){
     mw_3B_();
     mwctx_physical_vars();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_codegen_1341_9);
+    push_fnptr(&mb_c99_pack_ctx_21__5);
     do_pack_cons();
     mwfor();
 }
 
-static void mb_mirth_2E_codegen_1341_9 (void) {
+static void mb_c99_pack_ctx_21__5 (void) {
     do_drop();
     mwc99_emit_var_push_21_();
     push_ptr("    do_pack_cons();\0\0\0");
@@ -18946,21 +18997,21 @@ static void mwc99_emit_lambda_21_ (void){
     mw_3B_();
     mwlambda_params_3F_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_codegen_1433_9);
+    push_fnptr(&mb_c99_emit_lambda_21__5);
     do_pack_cons();
     mwreverse_for();
     mwlambda_body_3F_();
     mwc99_emit_arrow_21_();
     mwlambda_params_40_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_codegen_1437_9);
+    push_fnptr(&mb_c99_emit_lambda_21__17);
     do_pack_cons();
     mwreverse_for();
     push_ptr("    }\0\0\0");
     mw_3B_();
 }
 
-static void mb_mirth_2E_codegen_1437_9 (void) {
+static void mb_c99_emit_lambda_21__17 (void) {
     do_drop();
     push_ptr("    decref(\0\0\0");
     mw_2E_();
@@ -18973,7 +19024,7 @@ static void mwParam__3E_Var (void){
     mwid();
 }
 
-static void mb_mirth_2E_codegen_1433_9 (void) {
+static void mb_c99_emit_lambda_21__5 (void) {
     do_drop();
     push_ptr("    value_t \0\0\0");
     mw_2E_();
@@ -19007,7 +19058,7 @@ static void mwc99_emit_match_21_ (void){
     mw_3B_();
     mwmatch_cases_3F_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_codegen_1451_26);
+    push_fnptr(&mb_c99_emit_match_21__25);
     do_pack_cons();
     mwfor();
     mwmatch_has_default_case_3F_();
@@ -19023,7 +19074,7 @@ static void mwc99_emit_match_21_ (void){
     }
 }
 
-static void mb_mirth_2E_codegen_1451_26 (void) {
+static void mb_c99_emit_match_21__25 (void) {
     do_drop();
     mwc99_emit_case_21_();
 }
@@ -19082,12 +19133,12 @@ static void mwc99_emit_pattern_21_ (void){
 static void mwfirst (void){
     mwList__3E_List_2B_();
     push_u64(0);
-    push_fnptr(&mb_data_2E_list_197_55);
+    push_fnptr(&mb_first_3);
     do_pack_cons();
     mwmaybe_map();
 }
 
-static void mb_data_2E_list_197_55 (void) {
+static void mb_first_3 (void) {
     do_drop();
     mwfirst_2B_();
 }
@@ -19411,12 +19462,12 @@ static void mwword_name_21_ (void){
 
 static void mwc99_emit_args_push_21_ (void){
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_codegen_1322_17);
+    push_fnptr(&mb_c99_emit_args_push_21__2);
     do_pack_cons();
     mwreverse_for();
 }
 
-static void mb_mirth_2E_codegen_1322_17 (void) {
+static void mb_c99_emit_args_push_21__2 (void) {
     do_drop();
     mwc99_emit_arg_push_21_();
 }
@@ -19485,14 +19536,14 @@ static void mwc99_emit_string_21_ (void){
     push_ptr("    push_ptr(\"\0\0\0");
     mw_2E_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_codegen_1251_13);
+    push_fnptr(&mb_c99_emit_string_21__4);
     do_pack_cons();
     mwstr_for();
     push_ptr("\\0\\0\\0\");\0\0\0");
     mw_3B_();
 }
 
-static void mb_mirth_2E_codegen_1251_13 (void) {
+static void mb_c99_emit_string_21__4 (void) {
     do_drop();
     mwc99_emit_string_char_21_();
 }
@@ -19546,7 +19597,7 @@ static void mwc99_emit_string_char_21_ (void){
     } else {
     mwchar_bytes();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_codegen_1270_13);
+    push_fnptr(&mb_c99_emit_string_char_21__56);
     do_pack_cons();
     mwfor();
     }
@@ -19557,7 +19608,7 @@ static void mwc99_emit_string_char_21_ (void){
     }
 }
 
-static void mb_mirth_2E_codegen_1270_13 (void) {
+static void mb_c99_emit_string_char_21__56 (void) {
     do_drop();
     push_ptr("\\x\0\0\0");
     mw_2E_();
@@ -19709,14 +19760,14 @@ static void mwc99_depth_2B__2B_ (void){
 static void mwc99_unpack_ctx_21_ (void){
     mwctx_physical_vars();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_codegen_1347_9);
+    push_fnptr(&mb_c99_unpack_ctx_21__3);
     do_pack_cons();
     mwreverse_for();
     push_ptr("    do_drop();\0\0\0");
     mw_3B_();
 }
 
-static void mb_mirth_2E_codegen_1347_9 (void) {
+static void mb_c99_unpack_ctx_21__3 (void) {
     do_drop();
     push_ptr("    do_pack_uncons();\0\0\0");
     mw_3B_();
@@ -19737,6 +19788,12 @@ static void mw_2E_block (void){
     mwBlock_2E_id();
     mw_2E_n();
     } else {
+    mwover();
+    mwblock_arrow_40_();
+    mwarrow_home_40_();
+    mwis_nil_3F_();
+    if (pop_u64()) {
+    mwdrop();
     mwtoken_module_3F_();
     mwmodule_name_40_();
     mw_2E_name();
@@ -19751,7 +19808,58 @@ static void mw_2E_block (void){
     mwCol__3E_Int();
     mw_2E_n();
     mwdrop();
+    } else {
+    mwword_name_3F_();
+    mw_2E_name();
+    push_ptr("_\0\0\0");
+    mw_2E_();
+    mwword_body_40_();
+    mwToken_2E_id();
+    { value_t d3 = pop_value();
+    mwToken_2E_id();
+      push_value(d3); }
+    mw_();
+    mw_2E_n();
+    mwdrop();
     }
+    }
+}
+
+static void mwToken_2E_id (void){
+    mwprim_2E_unsafe_2E_cast();
+}
+
+static value_t* fieldptr_word_body (usize i) {
+    static struct value_t * p;
+    static usize n = 0; 
+    if (i >= n) {
+        usize new_n = n+1;
+        while (i >= new_n) new_n *= 2;
+        p = realloc(p, sizeof(struct value_t) * new_n);
+        memset(p+n, 0, sizeof(struct value_t) * (new_n - n));
+        n = new_n;
+    }
+    return p+i;
+}
+
+static void mwword_body_40_ (void){
+    usize index = (usize)pop_u64();
+    value_t v = *fieldptr_word_body(index);
+    incref(v); push_value(v);
+}
+static void mwword_body_3F_ (void){
+    mwdup();
+    usize index = (usize)pop_u64();
+    value_t v = *fieldptr_word_body(index);
+    incref(v); push_value(v);
+}
+static void mwword_body_21_ (void){
+    usize index = (usize)pop_u64();
+    value_t newvalue = pop_value();
+    value_t* p = fieldptr_word_body(index);
+    value_t oldvalue = *p;
+    *p = newvalue;
+    decref(oldvalue);
 }
 
 static void mwBlock_2E_id (void){
@@ -19925,13 +20033,13 @@ static void mwc99_emit_main_21_ (void){
 
 static void mwc99_emit_field_sigs_21_ (void){
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_codegen_1500_15);
+    push_fnptr(&mb_c99_emit_field_sigs_21__2);
     do_pack_cons();
     mwField_2E_for();
     mw_2E_lf();
 }
 
-static void mb_mirth_2E_codegen_1500_15 (void) {
+static void mb_c99_emit_field_sigs_21__2 (void) {
     do_drop();
     mwc99_emit_field_sig_21_();
 }
@@ -19995,13 +20103,13 @@ static void mwField_2E_for (void){
 
 static void mwc99_emit_block_sigs_21_ (void){
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_codegen_1492_15);
+    push_fnptr(&mb_c99_emit_block_sigs_21__2);
     do_pack_cons();
     mwBlock_2E_for();
     mw_2E_lf();
 }
 
-static void mb_mirth_2E_codegen_1492_15 (void) {
+static void mb_c99_emit_block_sigs_21__2 (void) {
     do_drop();
     mwc99_emit_block_sig_21_();
 }
@@ -20046,13 +20154,13 @@ static void mwBlock_2E_for (void){
 
 static void mwc99_emit_word_sigs_21_ (void){
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_codegen_1484_14);
+    push_fnptr(&mb_c99_emit_word_sigs_21__2);
     do_pack_cons();
     mwWord_2E_for();
     mw_2E_lf();
 }
 
-static void mb_mirth_2E_codegen_1484_14 (void) {
+static void mb_c99_emit_word_sigs_21__2 (void) {
     do_drop();
     mwc99_emit_word_sig_21_();
 }
@@ -20098,13 +20206,13 @@ static void mwWord_2E_for (void){
 
 static void mwc99_emit_externals_21_ (void){
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_codegen_1157_18);
+    push_fnptr(&mb_c99_emit_externals_21__2);
     do_pack_cons();
     mwExternal_2E_for();
     mw_2E_lf();
 }
 
-static void mb_mirth_2E_codegen_1157_18 (void) {
+static void mb_c99_emit_externals_21__2 (void) {
     do_drop();
     mwc99_emit_external_21_();
 }
@@ -20130,7 +20238,7 @@ static void mwc99_emit_external_21_ (void){
     }
     }
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_codegen_1170_10);
+    push_fnptr(&mb_c99_emit_external_21__24);
     do_pack_cons();
     mwdip2();
     push_ptr(" (\0\0\0");
@@ -20161,7 +20269,7 @@ static void mwc99_emit_external_21_ (void){
     push_ptr("static void mw\0\0\0");
     mw_2E_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_codegen_1182_29);
+    push_fnptr(&mb_c99_emit_external_21__58);
     do_pack_cons();
     mwdip2();
     push_ptr(" (void) {\0\0\0");
@@ -20189,7 +20297,7 @@ static void mwc99_emit_external_21_ (void){
     }
     mw_2E_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_codegen_1188_10);
+    push_fnptr(&mb_c99_emit_external_21__89);
     do_pack_cons();
     mwdip2();
     push_ptr("(\0\0\0");
@@ -20234,17 +20342,17 @@ static void mwc99_emit_external_21_ (void){
     mwdrop3();
 }
 
-static void mb_mirth_2E_codegen_1188_10 (void) {
+static void mb_c99_emit_external_21__89 (void) {
     do_drop();
     mwexternal_name_3F_();
     mw_2E_name();
 }
-static void mb_mirth_2E_codegen_1182_29 (void) {
+static void mb_c99_emit_external_21__58 (void) {
     do_drop();
     mwexternal_name_3F_();
     mw_2E_name();
 }
-static void mb_mirth_2E_codegen_1170_10 (void) {
+static void mb_c99_emit_external_21__24 (void) {
     do_drop();
     mwexternal_name_3F_();
     mw_2E_name();
@@ -20331,13 +20439,13 @@ static void mwExternal_2E_for (void){
 
 static void mwc99_emit_buffers_21_ (void){
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_codegen_209_16);
+    push_fnptr(&mb_c99_emit_buffers_21__2);
     do_pack_cons();
     mwBuffer_2E_for();
     mw_2E_lf();
 }
 
-static void mb_mirth_2E_codegen_209_16 (void) {
+static void mb_c99_emit_buffers_21__2 (void) {
     do_drop();
     mwc99_emit_buffer_21_();
 }
@@ -20424,13 +20532,13 @@ static void mwBuffer_2E_for (void){
 
 static void mwc99_emit_tags_21_ (void){
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_codegen_216_13);
+    push_fnptr(&mb_c99_emit_tags_21__2);
     do_pack_cons();
     mwTag_2E_for();
     mw_2E_lf();
 }
 
-static void mb_mirth_2E_codegen_216_13 (void) {
+static void mb_c99_emit_tags_21__2 (void) {
     do_drop();
     mwc99_emit_tag_21_();
 }
@@ -22395,7 +22503,7 @@ static void mwtoken_args_2 (void){
     }
 }
 
-static void mb_mirth_2E_data_2E_prim_260_7 (void) {
+static void mb_init_prims_21__313 (void) {
     do_drop();
     mwelab_field_21_();
 }
@@ -22503,7 +22611,7 @@ static void mwtoken_args_3 (void){
     }
 }
 
-static void mb_mirth_2E_data_2E_prim_259_7 (void) {
+static void mb_init_prims_21__308 (void) {
     do_drop();
     mwelab_table_21_();
 }
@@ -22556,7 +22664,7 @@ static void mwtable_new_21_ (void){
     mwover();
     mwword_ctx_type_21_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_975_9);
+    push_fnptr(&mb_table_new_21__32);
     do_pack_cons();
     mwab_build_word_21_();
     mwdrop();
@@ -22589,7 +22697,7 @@ static void mwtable_new_21_ (void){
     mwover();
     mwword_ctx_type_21_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_994_9);
+    push_fnptr(&mb_table_new_21__66);
     do_pack_cons();
     mwab_build_word_21_();
     mwdrop();
@@ -22614,7 +22722,7 @@ static void mwtable_new_21_ (void){
     mwover();
     mwword_ctx_type_21_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_1008_9);
+    push_fnptr(&mb_table_new_21__92);
     do_pack_cons();
     mwab_build_word_21_();
     mwdrop();
@@ -22639,7 +22747,7 @@ static void mwtable_new_21_ (void){
     mwover();
     mwword_ctx_type_21_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_1030_9);
+    push_fnptr(&mb_table_new_21__134);
     do_pack_cons();
     mwab_build_word_21_();
     mwdrop();
@@ -22722,7 +22830,7 @@ static void mwtable_new_21_ (void){
     push_value(var_t_559);
     incref(var_t_559);
     do_pack_cons();
-    push_fnptr(&mb_mirth_2E_elab_1064_13);
+    push_fnptr(&mb_table_new_21__217);
     do_pack_cons();
     mwab_build_word_21_();
     mwdrop();
@@ -22753,13 +22861,13 @@ static void mwtable_new_21_ (void){
     mwover();
     mwword_ctx_type_21_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_1097_9);
+    push_fnptr(&mb_table_new_21__279);
     do_pack_cons();
     mwab_build_word_21_();
     mwdrop();
 }
 
-static void mb_mirth_2E_elab_1097_9 (void) {
+static void mb_table_new_21__279 (void) {
     do_drop();
     mwtable_num_buffer_3F_();
     mwab_buffer_21_();
@@ -22785,7 +22893,7 @@ static void mwover3 (void){
     mwswap();
 }
 
-static void mb_mirth_2E_elab_1064_13 (void) {
+static void mb_table_new_21__217 (void) {
     do_pack_uncons();
     value_t var_t_559 = pop_value();
     do_pack_uncons();
@@ -22807,14 +22915,14 @@ static void mb_mirth_2E_elab_1064_13 (void) {
     push_value(var_t_559);
     incref(var_t_559);
     do_pack_cons();
-    push_fnptr(&mb_mirth_2E_elab_1065_17);
+    push_fnptr(&mb_table_new_21__222);
     do_pack_cons();
     mwab_lambda_21_();
     decref(var_t_559);
     decref(var_w_558);
     decref(var_x_557);
 }
-static void mb_mirth_2E_elab_1065_17 (void) {
+static void mb_table_new_21__222 (void) {
     do_pack_uncons();
     value_t var_t_559 = pop_value();
     do_pack_uncons();
@@ -22834,7 +22942,7 @@ static void mb_mirth_2E_elab_1065_17 (void) {
     push_value(var_t_559);
     incref(var_t_559);
     do_pack_cons();
-    push_fnptr(&mb_mirth_2E_elab_1072_21);
+    push_fnptr(&mb_table_new_21__236);
     do_pack_cons();
     push_u64(0);
     push_value(var_x_557);
@@ -22846,7 +22954,7 @@ static void mb_mirth_2E_elab_1065_17 (void) {
     push_value(var_t_559);
     incref(var_t_559);
     do_pack_cons();
-    push_fnptr(&mb_mirth_2E_elab_1067_21);
+    push_fnptr(&mb_table_new_21__226);
     do_pack_cons();
     mwab_while_21_();
     mwPRIM_CORE_DROP();
@@ -22855,7 +22963,7 @@ static void mb_mirth_2E_elab_1065_17 (void) {
     decref(var_w_558);
     decref(var_x_557);
 }
-static void mb_mirth_2E_elab_1067_21 (void) {
+static void mb_table_new_21__226 (void) {
     do_pack_uncons();
     value_t var_t_559 = pop_value();
     do_pack_uncons();
@@ -22877,7 +22985,7 @@ static void mb_mirth_2E_elab_1067_21 (void) {
     decref(var_w_558);
     decref(var_x_557);
 }
-static void mb_mirth_2E_elab_1072_21 (void) {
+static void mb_table_new_21__236 (void) {
     do_pack_uncons();
     value_t var_t_559 = pop_value();
     do_pack_uncons();
@@ -22897,7 +23005,7 @@ static void mb_mirth_2E_elab_1072_21 (void) {
     push_value(var_t_559);
     incref(var_t_559);
     do_pack_cons();
-    push_fnptr(&mb_mirth_2E_elab_1074_25);
+    push_fnptr(&mb_table_new_21__240);
     do_pack_cons();
     mwab_dip_21_();
     push_i64(1LL);
@@ -22908,7 +23016,7 @@ static void mb_mirth_2E_elab_1072_21 (void) {
     decref(var_w_558);
     decref(var_x_557);
 }
-static void mb_mirth_2E_elab_1074_25 (void) {
+static void mb_table_new_21__240 (void) {
     do_pack_uncons();
     value_t var_t_559 = pop_value();
     do_pack_uncons();
@@ -23001,7 +23109,7 @@ static void mwab_lambda_21_ (void){
     push_value(var_f_556);
     incref(var_f_556);
     do_pack_cons();
-    push_fnptr(&mb_mirth_2E_elab_354_13);
+    push_fnptr(&mb_ab_lambda_21__25);
     do_pack_cons();
     mwfor();
       push_value(d2); }
@@ -23017,7 +23125,7 @@ static void mwab_lambda_21_ (void){
     push_value(var_f_556);
     incref(var_f_556);
     do_pack_cons();
-    push_fnptr(&mb_mirth_2E_elab_366_13);
+    push_fnptr(&mb_ab_lambda_21__50);
     do_pack_cons();
     mwab_build_21_();
     mwover();
@@ -23028,7 +23136,7 @@ static void mwab_lambda_21_ (void){
     }
 }
 
-static void mb_mirth_2E_elab_366_13 (void) {
+static void mb_ab_lambda_21__50 (void) {
     do_pack_uncons();
     value_t var_f_556 = pop_value();
     do_drop();
@@ -23042,7 +23150,7 @@ static void mb_mirth_2E_elab_366_13 (void) {
     mwlambda_cod_21_();
     decref(var_f_556);
 }
-static void mb_mirth_2E_elab_354_13 (void) {
+static void mb_ab_lambda_21__25 (void) {
     do_pack_uncons();
     value_t var_f_556 = pop_value();
     do_drop();
@@ -23056,7 +23164,7 @@ static void mb_mirth_2E_elab_354_13 (void) {
     mwdrop2();
     decref(var_f_556);
 }
-static void mb_mirth_2E_elab_1030_9 (void) {
+static void mb_table_new_21__134 (void) {
     do_drop();
     mwPRIM_UNSAFE_CAST();
     mwab_prim_21_();
@@ -23067,20 +23175,20 @@ static void mb_mirth_2E_elab_1030_9 (void) {
     mwPRIM_VALUE_EQ();
     mwab_prim_21_();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_1036_13);
+    push_fnptr(&mb_table_new_21__146);
     do_pack_cons();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_1035_13);
+    push_fnptr(&mb_table_new_21__144);
     do_pack_cons();
     mwab_if_21_();
     mwPRIM_UNSAFE_CAST();
     mwab_prim_21_();
 }
-static void mb_mirth_2E_elab_1035_13 (void) {
+static void mb_table_new_21__144 (void) {
     do_drop();
     mwid();
 }
-static void mb_mirth_2E_elab_1036_13 (void) {
+static void mb_table_new_21__146 (void) {
     do_drop();
     push_i64(1LL);
     mwab_int_21_();
@@ -23096,7 +23204,7 @@ static void mwab_if_21_ (void){
     mwab_prim_21_();
 }
 
-static void mb_mirth_2E_elab_1008_9 (void) {
+static void mb_table_new_21__92 (void) {
     do_drop();
     mwPRIM_UNSAFE_CAST();
     mwab_prim_21_();
@@ -23117,7 +23225,7 @@ static void mb_mirth_2E_elab_1008_9 (void) {
     mwPRIM_UNSAFE_CAST();
     mwab_prim_21_();
 }
-static void mb_mirth_2E_elab_994_9 (void) {
+static void mb_table_new_21__66 (void) {
     do_drop();
     mwPRIM_UNSAFE_CAST();
     mwab_prim_21_();
@@ -23185,7 +23293,7 @@ static void mwBuffer_2E_alloc_21_ (void){
     mwprim_2E_unsafe_2E_cast();
 }
 
-static void mb_mirth_2E_elab_975_9 (void) {
+static void mb_table_new_21__32 (void) {
     do_drop();
     mwTABLE_MAX_SIZE();
     mwab_int_21_();
@@ -23193,6 +23301,8 @@ static void mb_mirth_2E_elab_975_9 (void) {
 static void mwab_build_word_21_ (void){
     {
     value_t var_f_538 = pop_value();
+    mwdup();
+    mwab_home_21_();
     mwdup();
     { value_t d2 = pop_value();
     mwelab_word_ctx_sig_21_();
@@ -23219,6 +23329,8 @@ static void mwab_build_word_21_ (void){
       push_value(d2); }
     mwtuck();
     mwword_arrow_21_();
+    mwnil();
+    mwab_home_21_();
     decref(var_f_538);
     }
 }
@@ -23233,37 +23345,9 @@ static void mwmut (void){
     mwprim_2E_mut_2E_new();
 }
 
-static value_t* fieldptr_word_body (usize i) {
-    static struct value_t * p;
-    static usize n = 0; 
-    if (i >= n) {
-        usize new_n = n+1;
-        while (i >= new_n) new_n *= 2;
-        p = realloc(p, sizeof(struct value_t) * new_n);
-        memset(p+n, 0, sizeof(struct value_t) * (new_n - n));
-        n = new_n;
-    }
-    return p+i;
-}
-
-static void mwword_body_40_ (void){
-    usize index = (usize)pop_u64();
-    value_t v = *fieldptr_word_body(index);
-    incref(v); push_value(v);
-}
-static void mwword_body_3F_ (void){
-    mwdup();
-    usize index = (usize)pop_u64();
-    value_t v = *fieldptr_word_body(index);
-    incref(v); push_value(v);
-}
-static void mwword_body_21_ (void){
-    usize index = (usize)pop_u64();
-    value_t newvalue = pop_value();
-    value_t* p = fieldptr_word_body(index);
-    value_t oldvalue = *p;
-    *p = newvalue;
-    decref(oldvalue);
+static void mwab_home_21_ (void){
+    mwAB_HOME();
+    mwvalue_21_();
 }
 
 static void mwready2 (void){
@@ -23297,7 +23381,7 @@ static void mwTable_2E_alloc_21_ (void){
     mwprim_2E_unsafe_2E_cast();
 }
 
-static void mb_mirth_2E_data_2E_prim_258_7 (void) {
+static void mb_init_prims_21__303 (void) {
     do_drop();
     mwelab_buffer_21_();
 }
@@ -23344,7 +23428,7 @@ static void mwtoken_int_40_ (void){
     }
 }
 
-static void mb_mirth_2E_data_2E_prim_257_7 (void) {
+static void mb_init_prims_21__298 (void) {
     do_drop();
     mwelab_def_type_21_();
 }
@@ -23377,7 +23461,7 @@ static void mwelab_def_type_21_ (void){
     }
 }
 
-static void mb_mirth_2E_data_2E_prim_256_7 (void) {
+static void mb_init_prims_21__293 (void) {
     do_drop();
     mwelab_def_external_21_();
 }
@@ -23424,7 +23508,7 @@ static void mwExternal_2E_alloc_21_ (void){
     mwprim_2E_unsafe_2E_cast();
 }
 
-static void mb_mirth_2E_data_2E_prim_255_7 (void) {
+static void mb_init_prims_21__288 (void) {
     do_drop();
     mwelab_def_21_();
 }
@@ -23471,7 +23555,7 @@ static void mwelab_def_21_ (void){
       push_value(d1); }
     mwdup();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_866_9);
+    push_fnptr(&mb_elab_def_21__49);
     do_pack_cons();
     mwdelay();
     mwdup2();
@@ -23479,30 +23563,34 @@ static void mwelab_def_21_ (void){
     mwword_ctx_type_21_();
     mwover();
     push_u64(0);
-    push_fnptr(&mb_mirth_2E_elab_871_17);
+    push_fnptr(&mb_elab_def_21__66);
     do_pack_cons();
     mwdelay2();
     mwswap();
     mwword_arrow_21_();
 }
 
-static void mb_mirth_2E_elab_871_17 (void) {
+static void mb_elab_def_21__66 (void) {
     do_drop();
+    mwdup();
+    mwab_home_21_();
     { value_t d1 = pop_value();
     mwforce2();
       push_value(d1); }
     mwword_body_40_();
     mwelab_arrow_21_();
+    mwnil();
+    mwab_home_21_();
 }
 static void mwdelay2 (void){
     mwpack3();
     push_u64(0);
-    push_fnptr(&mb_data_2E_lazy_18_17);
+    push_fnptr(&mb_delay2_3);
     do_pack_cons();
     mwdelay();
 }
 
-static void mb_data_2E_lazy_18_17 (void) {
+static void mb_delay2_3 (void) {
     do_drop();
     mwunpack3();
     mwrun();
@@ -23521,7 +23609,7 @@ static void mwpack3 (void){
     mwpack_cons();
 }
 
-static void mb_mirth_2E_elab_866_9 (void) {
+static void mb_elab_def_21__49 (void) {
     do_drop();
     mwtype_elab_default();
     mwswap();
@@ -23572,7 +23660,7 @@ static void mwword_sig_21_ (void){
     decref(oldvalue);
 }
 
-static void mb_mirth_2E_data_2E_prim_254_7 (void) {
+static void mb_init_prims_21__283 (void) {
     do_drop();
     mwelab_module_import_21_();
 }

--- a/src/mirth/codegen.mth
+++ b/src/mirth/codegen.mth
@@ -1531,10 +1531,18 @@ def(.block, Block -- +IO,
     block-arrow? arrow-token-start@
     is-nil? if(
         drop Block.id .n,
-        token-module? module-name@ .name "_" .
-        token-row? Row->Int .n "_" .
-        token-col@ Col->Int .n
-        drop
+        over block-arrow@ arrow-home@ is-nil? if(
+            drop
+            token-module? module-name@ .name "_" .
+            token-row? Row->Int .n "_" .
+            token-col@ Col->Int .n
+            drop,
+
+            word-name? .name "_" .
+            word-body@ Token.id
+            dip(Token.id) - .n
+            drop
+        )
     ))
 
 field(c99-word-emitted, Word, Bool)

--- a/src/mirth/data/arrow.mth
+++ b/src/mirth/data/arrow.mth
@@ -56,6 +56,7 @@ def(Param->Var, Param -- Var, match(PARAM -> id))
 
 field(arrow-token-start, Arrow, Token)
 field(arrow-token-end, Arrow, Token)
+field(arrow-home, Arrow, Word)
 field(arrow-ctx, Arrow, Ctx)
 field(arrow-dom, Arrow, Type)
 field(arrow-cod, Arrow, Type)

--- a/src/mirth/elab.mth
+++ b/src/mirth/elab.mth
@@ -170,6 +170,9 @@ def(elab-simple-type-arg!, Token -- Type,
 ####################
 
 # AB = Arrow Builder = Arrow Elaborator
+buffer(AB_HOME, 16)
+def(ab-home@, Word, AB_HOME value@)
+def(ab-home!, Word --, AB_HOME value!)
 buffer(AB_ARROW, 16)
 def(ab-arrow@, Arrow +AB, AB_ARROW value@)
 def(ab-arrow!, Arrow -- +AB, AB_ARROW value!)
@@ -186,6 +189,7 @@ def(ab-save!, *a [ *a -- *b ] -- *b,
 def(ab-build!, *a Ctx Type Token [ *a -- *b ] -- *b Arrow,
     \([f] -> ab-save!(
         Arrow.alloc!
+        ab-home@ over arrow-home!
         tuck dup2 arrow-token-start! arrow-token-end!
         tuck dup2 arrow-dom! arrow-cod!
         tuck arrow-ctx!
@@ -196,6 +200,7 @@ def(ab-build!, *a Ctx Type Token [ *a -- *b ] -- *b Arrow,
 
 def(ab-build-word!, *a Word [ *a -- *b ] -- *b Word,
     \([f] ->
+        dup ab-home!
         dup dip(elab-word-ctx-sig!)
         word-body? swap
         dip(elab-expand-morphism! swap)
@@ -208,6 +213,7 @@ def(ab-build-word!, *a Word [ *a -- *b ] -- *b Word,
             ready
         )
         tuck word-arrow!
+        nil ab-home!
     ))
 
 def(ab-unify-type!, Type --,
@@ -868,7 +874,11 @@ def(elab-def!, Token -- Token,
         drop dip(type-elab-ctx) pack2
     )
     dup2 swap word-ctx-type!
-    over delay2(dip(force2) word-body@ elab-arrow!) swap word-arrow!)
+    over delay2(
+        dup ab-home!
+        dip(force2) word-body@ elab-arrow!
+        nil ab-home!
+    ) swap word-arrow!)
 
 ||| Elaborate an external declaration `def-external(w, t)`
 def(elab-def-external!, Token -- Token,


### PR DESCRIPTION
Makes generated names for blocks in the codegen depend on the owning word (the "home" of the arrow), instead of depending on the line number.

This should reduce merge conflicts somewhat for bin/mirth0.c somewhat, and improve diffs in general.