### PR TITLE
Add linear resource types to Mirth.

### DIFF
--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -8271,19 +8271,19 @@ static void mw_while_some (void){
     WORD_EXIT(mw_while_some);
 }
 static void mw_Bool_26__26_ (void){
-    WORD_ENTER(mw_Bool_26__26_, "Bool&&", "src/prelude.mth", 43, 32);
-    WORD_ATOM(43, 32, "T");
+    WORD_ENTER(mw_Bool_26__26_, "Bool&&", "src/prelude.mth", 41, 32);
+    WORD_ATOM(41, 32, "T");
     switch (get_top_data_tag()) {
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(43, 37, "id");
+            WORD_ATOM(41, 37, "id");
             mw_prim_id();
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(43, 46, "drop");
+            WORD_ATOM(41, 46, "drop");
             mw_prim_drop();
-            WORD_ATOM(43, 51, "F");
+            WORD_ATOM(41, 51, "F");
             mw_F();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -8291,19 +8291,19 @@ static void mw_Bool_26__26_ (void){
 }    WORD_EXIT(mw_Bool_26__26_);
 }
 static void mw_Bool_7C__7C_ (void){
-    WORD_ENTER(mw_Bool_7C__7C_, "Bool||", "src/prelude.mth", 44, 32);
-    WORD_ATOM(44, 32, "T");
+    WORD_ENTER(mw_Bool_7C__7C_, "Bool||", "src/prelude.mth", 42, 32);
+    WORD_ATOM(42, 32, "T");
     switch (get_top_data_tag()) {
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(44, 37, "drop");
+            WORD_ATOM(42, 37, "drop");
             mw_prim_drop();
-            WORD_ATOM(44, 42, "T");
+            WORD_ATOM(42, 42, "T");
             mw_T();
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(44, 50, "id");
+            WORD_ATOM(42, 50, "id");
             mw_prim_id();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -8311,17 +8311,17 @@ static void mw_Bool_7C__7C_ (void){
 }    WORD_EXIT(mw_Bool_7C__7C_);
 }
 static void mw_Bool_2E_not (void){
-    WORD_ENTER(mw_Bool_2E_not, "Bool.not", "src/prelude.mth", 45, 29);
-    WORD_ATOM(45, 29, "T");
+    WORD_ENTER(mw_Bool_2E_not, "Bool.not", "src/prelude.mth", 43, 29);
+    WORD_ATOM(43, 29, "T");
     switch (get_top_data_tag()) {
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(45, 34, "F");
+            WORD_ATOM(43, 34, "F");
             mw_F();
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(45, 42, "T");
+            WORD_ATOM(43, 42, "T");
             mw_T();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -8329,16 +8329,16 @@ static void mw_Bool_2E_not (void){
 }    WORD_EXIT(mw_Bool_2E_not);
 }
 static void mw_Bool_2E_or (void){
-    WORD_ENTER(mw_Bool_2E_or, "Bool.or", "src/prelude.mth", 46, 54);
-    WORD_ATOM(46, 54, "if");
+    WORD_ENTER(mw_Bool_2E_or, "Bool.or", "src/prelude.mth", 44, 54);
+    WORD_ATOM(44, 54, "if");
     {
         VAL var_p = pop_value();
-        WORD_ATOM(46, 54, "if");
+        WORD_ATOM(44, 54, "if");
         if (pop_u64()) {
-            WORD_ATOM(46, 57, "T");
+            WORD_ATOM(44, 57, "T");
             mw_T();
         } else {
-            WORD_ATOM(46, 60, "p");
+            WORD_ATOM(44, 60, "p");
             incref(var_p);
             run_value(var_p);
         }
@@ -8347,17 +8347,17 @@ static void mw_Bool_2E_or (void){
     WORD_EXIT(mw_Bool_2E_or);
 }
 static void mw_Bool_2E_and (void){
-    WORD_ENTER(mw_Bool_2E_and, "Bool.and", "src/prelude.mth", 47, 54);
-    WORD_ATOM(47, 54, "if");
+    WORD_ENTER(mw_Bool_2E_and, "Bool.and", "src/prelude.mth", 45, 54);
+    WORD_ATOM(45, 54, "if");
     {
         VAL var_p = pop_value();
-        WORD_ATOM(47, 54, "if");
+        WORD_ATOM(45, 54, "if");
         if (pop_u64()) {
-            WORD_ATOM(47, 57, "p");
+            WORD_ATOM(45, 57, "p");
             incref(var_p);
             run_value(var_p);
         } else {
-            WORD_ATOM(47, 60, "F");
+            WORD_ATOM(45, 60, "F");
             mw_F();
         }
         decref(var_p);
@@ -8365,21 +8365,21 @@ static void mw_Bool_2E_and (void){
     WORD_EXIT(mw_Bool_2E_and);
 }
 static void mw_Bool_2E_then (void){
-    WORD_ENTER(mw_Bool_2E_then, "Bool.then", "src/prelude.mth", 53, 5);
-    WORD_ATOM(53, 5, "T");
+    WORD_ENTER(mw_Bool_2E_then, "Bool.then", "src/prelude.mth", 51, 5);
+    WORD_ATOM(51, 5, "T");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(53, 5, "T");
+        WORD_ATOM(51, 5, "T");
         switch (get_top_data_tag()) {
             case 1LL:
                 mw_prim_drop();
-                WORD_ATOM(53, 10, "f");
+                WORD_ATOM(51, 10, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 0LL:
                 mw_prim_drop();
-                WORD_ATOM(54, 10, "id");
+                WORD_ATOM(52, 10, "id");
                 mw_prim_id();
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -8389,20 +8389,20 @@ static void mw_Bool_2E_then (void){
     WORD_EXIT(mw_Bool_2E_then);
 }
 static void mw_Bool_2E_else (void){
-    WORD_ENTER(mw_Bool_2E_else, "Bool.else", "src/prelude.mth", 56, 5);
-    WORD_ATOM(56, 5, "T");
+    WORD_ENTER(mw_Bool_2E_else, "Bool.else", "src/prelude.mth", 54, 5);
+    WORD_ATOM(54, 5, "T");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(56, 5, "T");
+        WORD_ATOM(54, 5, "T");
         switch (get_top_data_tag()) {
             case 1LL:
                 mw_prim_drop();
-                WORD_ATOM(56, 10, "id");
+                WORD_ATOM(54, 10, "id");
                 mw_prim_id();
                 break;
             case 0LL:
                 mw_prim_drop();
-                WORD_ATOM(57, 10, "f");
+                WORD_ATOM(55, 10, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
@@ -8413,72 +8413,72 @@ static void mw_Bool_2E_else (void){
     WORD_EXIT(mw_Bool_2E_else);
 }
 static void mw_Ptr_2E_offset (void){
-    WORD_ENTER(mw_Ptr_2E_offset, "Ptr.offset", "src/prelude.mth", 70, 5);
-    WORD_ATOM(70, 5, "dup");
+    WORD_ENTER(mw_Ptr_2E_offset, "Ptr.offset", "src/prelude.mth", 68, 5);
+    WORD_ATOM(68, 5, "dup");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(70, 5, "dup");
+        WORD_ATOM(68, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(70, 9, "dip");
+        WORD_ATOM(68, 9, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(70, 13, "prim-ptr-add");
+            WORD_ATOM(68, 13, "prim-ptr-add");
             mw_prim_ptr_add();
-            WORD_ATOM(70, 26, "f");
+            WORD_ATOM(68, 26, "f");
             incref(var_f);
             run_value(var_f);
             push_value(d3);
         }
-        WORD_ATOM(70, 29, "drop");
+        WORD_ATOM(68, 29, "drop");
         mw_prim_drop();
         decref(var_f);
     }
     WORD_EXIT(mw_Ptr_2E_offset);
 }
 static void mw_Int_3E_OS (void){
-    WORD_ENTER(mw_Int_3E_OS, "Int>OS", "src/prelude.mth", 102, 5);
-    WORD_ATOM(102, 5, "dup");
+    WORD_ENTER(mw_Int_3E_OS, "Int>OS", "src/prelude.mth", 100, 5);
+    WORD_ATOM(100, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(102, 9, "");
+    WORD_ATOM(100, 9, "");
     push_i64(1LL);
-    WORD_ATOM(102, 11, "=");
+    WORD_ATOM(100, 11, "=");
     mw_prim_int_eq();
-    WORD_ATOM(102, 13, "if");
+    WORD_ATOM(100, 13, "if");
     if (pop_u64()) {
-        WORD_ATOM(103, 9, "drop");
+        WORD_ATOM(101, 9, "drop");
         mw_prim_drop();
-        WORD_ATOM(103, 14, "OS_WINDOWS");
+        WORD_ATOM(101, 14, "OS_WINDOWS");
         mw_OS_5F_WINDOWS();
     } else {
-        WORD_ATOM(104, 5, "dup");
+        WORD_ATOM(102, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(104, 9, "");
+        WORD_ATOM(102, 9, "");
         push_i64(2LL);
-        WORD_ATOM(104, 11, "=");
+        WORD_ATOM(102, 11, "=");
         mw_prim_int_eq();
-        WORD_ATOM(104, 13, "if");
+        WORD_ATOM(102, 13, "if");
         if (pop_u64()) {
-            WORD_ATOM(105, 9, "drop");
+            WORD_ATOM(103, 9, "drop");
             mw_prim_drop();
-            WORD_ATOM(105, 14, "OS_LINUX");
+            WORD_ATOM(103, 14, "OS_LINUX");
             mw_OS_5F_LINUX();
         } else {
-            WORD_ATOM(106, 5, "dup");
+            WORD_ATOM(104, 5, "dup");
             mw_prim_dup();
-            WORD_ATOM(106, 9, "");
+            WORD_ATOM(104, 9, "");
             push_i64(3LL);
-            WORD_ATOM(106, 11, "=");
+            WORD_ATOM(104, 11, "=");
             mw_prim_int_eq();
-            WORD_ATOM(106, 13, "if");
+            WORD_ATOM(104, 13, "if");
             if (pop_u64()) {
-                WORD_ATOM(107, 9, "drop");
+                WORD_ATOM(105, 9, "drop");
                 mw_prim_drop();
-                WORD_ATOM(107, 14, "OS_MACOS");
+                WORD_ATOM(105, 14, "OS_MACOS");
                 mw_OS_5F_MACOS();
             } else {
-                WORD_ATOM(108, 9, "drop");
+                WORD_ATOM(106, 9, "drop");
                 mw_prim_drop();
-                WORD_ATOM(108, 14, "OS_UNKNOWN");
+                WORD_ATOM(106, 14, "OS_UNKNOWN");
                 mw_OS_5F_UNKNOWN();
             }
         }
@@ -8486,183 +8486,183 @@ static void mw_Int_3E_OS (void){
     WORD_EXIT(mw_Int_3E_OS);
 }
 static void mw_RUNNING_5F_OS (void){
-    WORD_ENTER(mw_RUNNING_5F_OS, "RUNNING_OS", "src/prelude.mth", 113, 21);
-    WORD_ATOM(113, 21, "prim-sys-os");
+    WORD_ENTER(mw_RUNNING_5F_OS, "RUNNING_OS", "src/prelude.mth", 111, 21);
+    WORD_ATOM(111, 21, "prim-sys-os");
     mw_prim_sys_os();
-    WORD_ATOM(113, 33, ">OS");
+    WORD_ATOM(111, 33, ">OS");
     mw_Int_3E_OS();
     WORD_EXIT(mw_RUNNING_5F_OS);
 }
 static void mw_posix_open_21_ (void){
-    WORD_ENTER(mw_posix_open_21_, "posix-open!", "src/prelude.mth", 120, 5);
-    WORD_ATOM(120, 5, "rotl");
+    WORD_ENTER(mw_posix_open_21_, "posix-open!", "src/prelude.mth", 118, 5);
+    WORD_ATOM(118, 5, "rotl");
     mw_rotl();
-    WORD_ATOM(120, 10, "dup");
+    WORD_ATOM(118, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(120, 14, "dip");
+    WORD_ATOM(118, 14, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(121, 9, "prim-str-base");
+        WORD_ATOM(119, 9, "prim-str-base");
         mw_prim_str_base();
-        WORD_ATOM(121, 23, "rotr");
+        WORD_ATOM(119, 23, "rotr");
         mw_rotr();
-        WORD_ATOM(122, 9, "prim-posix-open");
+        WORD_ATOM(120, 9, "prim-posix-open");
         mw_prim_posix_open();
         push_value(d2);
     }
-    WORD_ATOM(123, 7, "drop");
+    WORD_ATOM(121, 7, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_posix_open_21_);
 }
 static void mw_rotr (void){
-    WORD_ENTER(mw_rotr, "rotr", "src/prelude.mth", 127, 27);
-    WORD_ATOM(127, 27, "swap");
+    WORD_ENTER(mw_rotr, "rotr", "src/prelude.mth", 125, 27);
+    WORD_ATOM(125, 27, "swap");
     mw_prim_swap();
-    WORD_ATOM(127, 32, "dip");
+    WORD_ATOM(125, 32, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(127, 36, "swap");
+        WORD_ATOM(125, 36, "swap");
         mw_prim_swap();
         push_value(d2);
     }
     WORD_EXIT(mw_rotr);
 }
 static void mw_rotl (void){
-    WORD_ENTER(mw_rotl, "rotl", "src/prelude.mth", 128, 27);
-    WORD_ATOM(128, 27, "dip");
+    WORD_ENTER(mw_rotl, "rotl", "src/prelude.mth", 126, 27);
+    WORD_ATOM(126, 27, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(128, 31, "swap");
+        WORD_ATOM(126, 31, "swap");
         mw_prim_swap();
         push_value(d2);
     }
-    WORD_ATOM(128, 37, "swap");
+    WORD_ATOM(126, 37, "swap");
     mw_prim_swap();
     WORD_EXIT(mw_rotl);
 }
 static void mw_over (void){
-    WORD_ENTER(mw_over, "over", "src/prelude.mth", 130, 25);
-    WORD_ATOM(130, 25, "dip");
+    WORD_ENTER(mw_over, "over", "src/prelude.mth", 131, 25);
+    WORD_ATOM(131, 25, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(130, 29, "dup");
+        WORD_ATOM(131, 29, "dup");
         mw_prim_dup();
         push_value(d2);
     }
-    WORD_ATOM(130, 34, "swap");
+    WORD_ATOM(131, 34, "swap");
     mw_prim_swap();
     WORD_EXIT(mw_over);
 }
 static void mw_over2 (void){
-    WORD_ENTER(mw_over2, "over2", "src/prelude.mth", 131, 34);
-    WORD_ATOM(131, 34, "dip");
+    WORD_ENTER(mw_over2, "over2", "src/prelude.mth", 132, 34);
+    WORD_ATOM(132, 34, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(131, 38, "over");
+        WORD_ATOM(132, 38, "over");
         mw_over();
         push_value(d2);
     }
-    WORD_ATOM(131, 44, "swap");
+    WORD_ATOM(132, 44, "swap");
     mw_prim_swap();
     WORD_EXIT(mw_over2);
 }
 static void mw_over3 (void){
-    WORD_ENTER(mw_over3, "over3", "src/prelude.mth", 132, 40);
-    WORD_ATOM(132, 40, "dip");
+    WORD_ENTER(mw_over3, "over3", "src/prelude.mth", 133, 40);
+    WORD_ATOM(133, 40, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(132, 44, "over2");
+        WORD_ATOM(133, 44, "over2");
         mw_over2();
         push_value(d2);
     }
-    WORD_ATOM(132, 51, "swap");
+    WORD_ATOM(133, 51, "swap");
     mw_prim_swap();
     WORD_EXIT(mw_over3);
 }
 static void mw_tuck (void){
-    WORD_ENTER(mw_tuck, "tuck", "src/prelude.mth", 135, 25);
-    WORD_ATOM(135, 25, "dup");
+    WORD_ENTER(mw_tuck, "tuck", "src/prelude.mth", 136, 25);
+    WORD_ATOM(136, 25, "dup");
     mw_prim_dup();
-    WORD_ATOM(135, 29, "dip");
+    WORD_ATOM(136, 29, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(135, 33, "swap");
+        WORD_ATOM(136, 33, "swap");
         mw_prim_swap();
         push_value(d2);
     }
     WORD_EXIT(mw_tuck);
 }
 static void mw_nip (void){
-    WORD_ENTER(mw_nip, "nip", "src/prelude.mth", 137, 20);
-    WORD_ATOM(137, 20, "dip");
+    WORD_ENTER(mw_nip, "nip", "src/prelude.mth", 138, 20);
+    WORD_ATOM(138, 20, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(137, 24, "drop");
+        WORD_ATOM(138, 24, "drop");
         mw_prim_drop();
         push_value(d2);
     }
     WORD_EXIT(mw_nip);
 }
 static void mw_dup2 (void){
-    WORD_ENTER(mw_dup2, "dup2", "src/prelude.mth", 139, 34);
-    WORD_ATOM(139, 34, "over");
+    WORD_ENTER(mw_dup2, "dup2", "src/prelude.mth", 140, 34);
+    WORD_ATOM(140, 34, "over");
     mw_over();
-    WORD_ATOM(139, 39, "over");
+    WORD_ATOM(140, 39, "over");
     mw_over();
     WORD_EXIT(mw_dup2);
 }
 static void mw_dip_3F_ (void){
-    WORD_ENTER(mw_dip_3F_, "dip?", "src/prelude.mth", 142, 49);
-    WORD_ATOM(142, 49, "dip");
+    WORD_ENTER(mw_dip_3F_, "dip?", "src/prelude.mth", 143, 49);
+    WORD_ATOM(143, 49, "dip");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(142, 49, "dip");
+        WORD_ATOM(143, 49, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(142, 53, "f");
+            WORD_ATOM(143, 53, "f");
             incref(var_f);
             run_value(var_f);
             push_value(d3);
         }
-        WORD_ATOM(142, 56, "swap");
+        WORD_ATOM(143, 56, "swap");
         mw_prim_swap();
         decref(var_f);
     }
     WORD_EXIT(mw_dip_3F_);
 }
 static void mw_dip_27_ (void){
-    WORD_ENTER(mw_dip_27_, "dip'", "src/prelude.mth", 143, 47);
-    WORD_ATOM(143, 47, "swap");
+    WORD_ENTER(mw_dip_27_, "dip'", "src/prelude.mth", 144, 47);
+    WORD_ATOM(144, 47, "swap");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(143, 47, "swap");
+        WORD_ATOM(144, 47, "swap");
         mw_prim_swap();
-        WORD_ATOM(143, 52, "dip");
+        WORD_ATOM(144, 52, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(143, 56, "f");
+            WORD_ATOM(144, 56, "f");
             incref(var_f);
             run_value(var_f);
             push_value(d3);
         }
-        WORD_ATOM(143, 59, "swap");
+        WORD_ATOM(144, 59, "swap");
         mw_prim_swap();
         decref(var_f);
     }
     WORD_EXIT(mw_dip_27_);
 }
 static void mw_dip2 (void){
-    WORD_ENTER(mw_dip2, "dip2", "src/prelude.mth", 146, 5);
-    WORD_ATOM(146, 5, "dip");
+    WORD_ENTER(mw_dip2, "dip2", "src/prelude.mth", 147, 5);
+    WORD_ATOM(147, 5, "dip");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(146, 5, "dip");
+        WORD_ATOM(147, 5, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(146, 9, "dip");
+            WORD_ATOM(147, 9, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(146, 13, "f");
+                WORD_ATOM(147, 13, "f");
                 incref(var_f);
                 run_value(var_f);
                 push_value(d4);
@@ -8674,16 +8674,16 @@ static void mw_dip2 (void){
     WORD_EXIT(mw_dip2);
 }
 static void mw_sip (void){
-    WORD_ENTER(mw_sip, "sip", "src/prelude.mth", 151, 5);
-    WORD_ATOM(151, 5, "dup");
+    WORD_ENTER(mw_sip, "sip", "src/prelude.mth", 157, 5);
+    WORD_ATOM(157, 5, "dup");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(151, 5, "dup");
+        WORD_ATOM(157, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(151, 9, "dip");
+        WORD_ATOM(157, 9, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(151, 13, "f");
+            WORD_ATOM(157, 13, "f");
             incref(var_f);
             run_value(var_f);
             push_value(d3);
@@ -8693,19 +8693,19 @@ static void mw_sip (void){
     WORD_EXIT(mw_sip);
 }
 static void mw_both (void){
-    WORD_ENTER(mw_both, "both", "src/prelude.mth", 155, 35);
-    WORD_ATOM(155, 35, "dip");
+    WORD_ENTER(mw_both, "both", "src/prelude.mth", 161, 35);
+    WORD_ATOM(161, 35, "dip");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(155, 35, "dip");
+        WORD_ATOM(161, 35, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(155, 39, "f");
+            WORD_ATOM(161, 39, "f");
             incref(var_f);
             run_value(var_f);
             push_value(d3);
         }
-        WORD_ATOM(155, 42, "f");
+        WORD_ATOM(161, 42, "f");
         incref(var_f);
         run_value(var_f);
         decref(var_f);
@@ -8713,88 +8713,88 @@ static void mw_both (void){
     WORD_EXIT(mw_both);
 }
 static void mw_drop2 (void){
-    WORD_ENTER(mw_drop2, "drop2", "src/prelude.mth", 158, 20);
-    WORD_ATOM(158, 20, "drop");
+    WORD_ENTER(mw_drop2, "drop2", "src/prelude.mth", 164, 20);
+    WORD_ATOM(164, 20, "drop");
     mw_prim_drop();
-    WORD_ATOM(158, 25, "drop");
+    WORD_ATOM(164, 25, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_drop2);
 }
 static void mw_drop3 (void){
-    WORD_ENTER(mw_drop3, "drop3", "src/prelude.mth", 159, 22);
-    WORD_ATOM(159, 22, "drop");
+    WORD_ENTER(mw_drop3, "drop3", "src/prelude.mth", 165, 22);
+    WORD_ATOM(165, 22, "drop");
     mw_prim_drop();
-    WORD_ATOM(159, 27, "drop");
+    WORD_ATOM(165, 27, "drop");
     mw_prim_drop();
-    WORD_ATOM(159, 32, "drop");
+    WORD_ATOM(165, 32, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_drop3);
 }
 static void mw_rot4r (void){
-    WORD_ENTER(mw_rot4r, "rot4r", "src/prelude.mth", 162, 32);
-    WORD_ATOM(162, 32, "swap");
+    WORD_ENTER(mw_rot4r, "rot4r", "src/prelude.mth", 168, 32);
+    WORD_ATOM(168, 32, "swap");
     mw_prim_swap();
-    WORD_ATOM(162, 37, "dip");
+    WORD_ATOM(168, 37, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(162, 41, "rotr");
+        WORD_ATOM(168, 41, "rotr");
         mw_rotr();
         push_value(d2);
     }
     WORD_EXIT(mw_rot4r);
 }
 static void mw_rot4l (void){
-    WORD_ENTER(mw_rot4l, "rot4l", "src/prelude.mth", 163, 32);
-    WORD_ATOM(163, 32, "dip");
+    WORD_ENTER(mw_rot4l, "rot4l", "src/prelude.mth", 169, 32);
+    WORD_ATOM(169, 32, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(163, 36, "rotl");
+        WORD_ATOM(169, 36, "rotl");
         mw_rotl();
         push_value(d2);
     }
-    WORD_ATOM(163, 42, "swap");
+    WORD_ATOM(169, 42, "swap");
     mw_prim_swap();
     WORD_EXIT(mw_rot4l);
 }
 static void mw_repeat (void){
-    WORD_ENTER(mw_repeat, "repeat", "src/prelude.mth", 166, 5);
-    WORD_ATOM(166, 5, "while");
+    WORD_ENTER(mw_repeat, "repeat", "src/prelude.mth", 175, 5);
+    WORD_ATOM(175, 5, "while");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(166, 5, "while");
+        WORD_ATOM(175, 5, "while");
         while(1) {
-            WORD_ATOM(166, 11, "dup");
+            WORD_ATOM(175, 11, "dup");
             mw_prim_dup();
-            WORD_ATOM(166, 15, "0>");
+            WORD_ATOM(175, 15, "0>");
             mw_0_3E_();
             if (! pop_u64()) break;
-            WORD_ATOM(166, 19, "dip");
+            WORD_ATOM(175, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(166, 23, "f");
+                WORD_ATOM(175, 23, "f");
                 incref(var_f);
                 run_value(var_f);
                 push_value(d4);
             }
-            WORD_ATOM(166, 26, "1-");
+            WORD_ATOM(175, 26, "1-");
             mw_prim_int_pred();
         }
-        WORD_ATOM(166, 30, "drop");
+        WORD_ATOM(175, 30, "drop");
         mw_prim_drop();
         decref(var_f);
     }
     WORD_EXIT(mw_repeat);
 }
 static void mw_count (void){
-    WORD_ENTER(mw_count, "count", "src/prelude.mth", 169, 5);
-    WORD_ATOM(169, 5, "");
+    WORD_ENTER(mw_count, "count", "src/prelude.mth", 178, 5);
+    WORD_ATOM(178, 5, "");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(169, 5, "");
+        WORD_ATOM(178, 5, "");
         push_i64(0LL);
-        WORD_ATOM(169, 7, "swap");
+        WORD_ATOM(178, 7, "swap");
         mw_prim_swap();
-        WORD_ATOM(169, 12, "repeat");
+        WORD_ATOM(178, 12, "repeat");
         push_u64(0);
         incref(var_f);
         push_value(var_f);
@@ -8802,24 +8802,24 @@ static void mw_count (void){
         push_fnptr(&mb_count_2);
         mw_prim_pack_cons();
         mw_repeat();
-        WORD_ATOM(169, 34, "drop");
+        WORD_ATOM(178, 34, "drop");
         mw_prim_drop();
         decref(var_f);
     }
     WORD_EXIT(mw_count);
 }
 static void mw_countdown (void){
-    WORD_ENTER(mw_countdown, "countdown", "src/prelude.mth", 171, 5);
-    WORD_ATOM(171, 5, "dup");
+    WORD_ENTER(mw_countdown, "countdown", "src/prelude.mth", 180, 5);
+    WORD_ATOM(180, 5, "dup");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(171, 5, "dup");
+        WORD_ATOM(180, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(171, 9, "1-");
+        WORD_ATOM(180, 9, "1-");
         mw_prim_int_pred();
-        WORD_ATOM(171, 12, "swap");
+        WORD_ATOM(180, 12, "swap");
         mw_prim_swap();
-        WORD_ATOM(171, 17, "repeat");
+        WORD_ATOM(180, 17, "repeat");
         push_u64(0);
         incref(var_f);
         push_value(var_f);
@@ -8827,41 +8827,41 @@ static void mw_countdown (void){
         push_fnptr(&mb_countdown_2);
         mw_prim_pack_cons();
         mw_repeat();
-        WORD_ATOM(171, 39, "drop");
+        WORD_ATOM(180, 39, "drop");
         mw_prim_drop();
         decref(var_f);
     }
     WORD_EXIT(mw_countdown);
 }
 static void mw_U8_5F_MAX (void){
-    WORD_ENTER(mw_U8_5F_MAX, "U8_MAX", "src/prelude.mth", 176, 18);
-    WORD_ATOM(176, 18, "");
+    WORD_ENTER(mw_U8_5F_MAX, "U8_MAX", "src/prelude.mth", 185, 18);
+    WORD_ATOM(185, 18, "");
     push_i64(255LL);
     WORD_EXIT(mw_U8_5F_MAX);
 }
 static void mw_U8_5F_MIN (void){
-    WORD_ENTER(mw_U8_5F_MIN, "U8_MIN", "src/prelude.mth", 184, 18);
-    WORD_ATOM(184, 18, "");
+    WORD_ENTER(mw_U8_5F_MIN, "U8_MIN", "src/prelude.mth", 193, 18);
+    WORD_ATOM(193, 18, "");
     push_i64(0LL);
     WORD_EXIT(mw_U8_5F_MIN);
 }
 static void mw_Comparison_2E_is_eq (void){
-    WORD_ENTER(mw_Comparison_2E_is_eq, "Comparison.is-eq", "src/prelude.mth", 193, 43);
-    WORD_ATOM(193, 43, "LT");
+    WORD_ENTER(mw_Comparison_2E_is_eq, "Comparison.is-eq", "src/prelude.mth", 202, 43);
+    WORD_ATOM(202, 43, "LT");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(193, 49, "F");
+            WORD_ATOM(202, 49, "F");
             mw_F();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(193, 58, "T");
+            WORD_ATOM(202, 58, "T");
             mw_T();
             break;
         case 2LL:
             mw_prim_drop();
-            WORD_ATOM(193, 67, "F");
+            WORD_ATOM(202, 67, "F");
             mw_F();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -8869,22 +8869,22 @@ static void mw_Comparison_2E_is_eq (void){
 }    WORD_EXIT(mw_Comparison_2E_is_eq);
 }
 static void mw_Comparison_2E_is_ne (void){
-    WORD_ENTER(mw_Comparison_2E_is_ne, "Comparison.is-ne", "src/prelude.mth", 198, 43);
-    WORD_ATOM(198, 43, "LT");
+    WORD_ENTER(mw_Comparison_2E_is_ne, "Comparison.is-ne", "src/prelude.mth", 207, 43);
+    WORD_ATOM(207, 43, "LT");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(198, 49, "T");
+            WORD_ATOM(207, 49, "T");
             mw_T();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(198, 58, "F");
+            WORD_ATOM(207, 58, "F");
             mw_F();
             break;
         case 2LL:
             mw_prim_drop();
-            WORD_ATOM(198, 67, "T");
+            WORD_ATOM(207, 67, "T");
             mw_T();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -8892,165 +8892,165 @@ static void mw_Comparison_2E_is_ne (void){
 }    WORD_EXIT(mw_Comparison_2E_is_ne);
 }
 static void mw_Int_3E_ (void){
-    WORD_ENTER(mw_Int_3E_, "Int>", "src/prelude.mth", 202, 29);
-    WORD_ATOM(202, 29, "swap");
+    WORD_ENTER(mw_Int_3E_, "Int>", "src/prelude.mth", 211, 29);
+    WORD_ATOM(211, 29, "swap");
     mw_prim_swap();
-    WORD_ATOM(202, 34, "<");
+    WORD_ATOM(211, 34, "<");
     mw_prim_int_lt();
     WORD_EXIT(mw_Int_3E_);
 }
 static void mw_Int_3E__3D_ (void){
-    WORD_ENTER(mw_Int_3E__3D_, "Int>=", "src/prelude.mth", 203, 29);
-    WORD_ATOM(203, 29, "<");
+    WORD_ENTER(mw_Int_3E__3D_, "Int>=", "src/prelude.mth", 212, 29);
+    WORD_ATOM(212, 29, "<");
     mw_prim_int_lt();
-    WORD_ATOM(203, 31, "not");
+    WORD_ATOM(212, 31, "not");
     mw_Bool_2E_not();
     WORD_EXIT(mw_Int_3E__3D_);
 }
 static void mw_Int_3C__3D_ (void){
-    WORD_ENTER(mw_Int_3C__3D_, "Int<=", "src/prelude.mth", 204, 29);
-    WORD_ATOM(204, 29, "swap");
+    WORD_ENTER(mw_Int_3C__3D_, "Int<=", "src/prelude.mth", 213, 29);
+    WORD_ATOM(213, 29, "swap");
     mw_prim_swap();
-    WORD_ATOM(204, 34, "<");
+    WORD_ATOM(213, 34, "<");
     mw_prim_int_lt();
-    WORD_ATOM(204, 36, "not");
+    WORD_ATOM(213, 36, "not");
     mw_Bool_2E_not();
     WORD_EXIT(mw_Int_3C__3D_);
 }
 static void mw_Int_2E_cmp (void){
-    WORD_ENTER(mw_Int_2E_cmp, "Int.cmp", "src/prelude.mth", 206, 37);
-    WORD_ATOM(206, 37, "dup2");
+    WORD_ENTER(mw_Int_2E_cmp, "Int.cmp", "src/prelude.mth", 215, 37);
+    WORD_ATOM(215, 37, "dup2");
     mw_dup2();
-    WORD_ATOM(206, 42, "=");
+    WORD_ATOM(215, 42, "=");
     mw_prim_int_eq();
-    WORD_ATOM(206, 44, "if");
+    WORD_ATOM(215, 44, "if");
     if (pop_u64()) {
-        WORD_ATOM(206, 47, "drop2");
+        WORD_ATOM(215, 47, "drop2");
         mw_drop2();
-        WORD_ATOM(206, 53, "EQ");
+        WORD_ATOM(215, 53, "EQ");
         mw_EQ();
     } else {
-        WORD_ATOM(206, 57, "<");
+        WORD_ATOM(215, 57, "<");
         mw_prim_int_lt();
-        WORD_ATOM(206, 59, "if");
+        WORD_ATOM(215, 59, "if");
         if (pop_u64()) {
-            WORD_ATOM(206, 62, "LT");
+            WORD_ATOM(215, 62, "LT");
             mw_LT();
         } else {
-            WORD_ATOM(206, 66, "GT");
+            WORD_ATOM(215, 66, "GT");
             mw_GT();
         }
     }
     WORD_EXIT(mw_Int_2E_cmp);
 }
 static void mw_Int_2E_in_range (void){
-    WORD_ENTER(mw_Int_2E_in_range, "Int.in-range", "src/prelude.mth", 209, 40);
-    WORD_ATOM(209, 40, "dip");
+    WORD_ENTER(mw_Int_2E_in_range, "Int.in-range", "src/prelude.mth", 218, 40);
+    WORD_ATOM(218, 40, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(209, 44, "over");
+        WORD_ATOM(218, 44, "over");
         mw_over();
-        WORD_ATOM(209, 49, "dip");
+        WORD_ATOM(218, 49, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(209, 53, ">=");
+            WORD_ATOM(218, 53, ">=");
             mw_Int_3E__3D_();
             push_value(d3);
         }
         push_value(d2);
     }
-    WORD_ATOM(209, 58, "<=");
+    WORD_ATOM(218, 58, "<=");
     mw_Int_3C__3D_();
-    WORD_ATOM(209, 61, "&&");
+    WORD_ATOM(218, 61, "&&");
     mw_Bool_26__26_();
     WORD_EXIT(mw_Int_2E_in_range);
 }
 static void mw_Str_2E_cmp (void){
-    WORD_ENTER(mw_Str_2E_cmp, "Str.cmp", "src/prelude.mth", 211, 37);
-    WORD_ATOM(211, 37, "prim-str-cmp");
+    WORD_ENTER(mw_Str_2E_cmp, "Str.cmp", "src/prelude.mth", 220, 37);
+    WORD_ATOM(220, 37, "prim-str-cmp");
     mw_prim_str_cmp();
-    WORD_ATOM(211, 50, "");
+    WORD_ATOM(220, 50, "");
     push_i64(0LL);
-    WORD_ATOM(211, 52, ".cmp");
+    WORD_ATOM(220, 52, ".cmp");
     mw_Int_2E_cmp();
     WORD_EXIT(mw_Str_2E_cmp);
 }
 static void mw_Str_3D_ (void){
-    WORD_ENTER(mw_Str_3D_, "Str=", "src/prelude.mth", 212, 29);
-    WORD_ATOM(212, 29, ".cmp");
+    WORD_ENTER(mw_Str_3D_, "Str=", "src/prelude.mth", 221, 29);
+    WORD_ATOM(221, 29, ".cmp");
     mw_Str_2E_cmp();
-    WORD_ATOM(212, 34, ".is-eq");
+    WORD_ATOM(221, 34, ".is-eq");
     mw_Comparison_2E_is_eq();
     WORD_EXIT(mw_Str_3D_);
 }
 static void mw_Str_3C__3E_ (void){
-    WORD_ENTER(mw_Str_3C__3E_, "Str<>", "src/prelude.mth", 217, 29);
-    WORD_ATOM(217, 29, ".cmp");
+    WORD_ENTER(mw_Str_3C__3E_, "Str<>", "src/prelude.mth", 226, 29);
+    WORD_ATOM(226, 29, ".cmp");
     mw_Str_2E_cmp();
-    WORD_ATOM(217, 34, ".is-ne");
+    WORD_ATOM(226, 34, ".is-ne");
     mw_Comparison_2E_is_ne();
     WORD_EXIT(mw_Str_3C__3E_);
 }
 static void mw_prim_int_succ (void){
-    WORD_ENTER(mw_prim_int_succ, "prim-int-succ", "src/prelude.mth", 221, 40);
-    WORD_ATOM(221, 40, "");
+    WORD_ENTER(mw_prim_int_succ, "prim-int-succ", "src/prelude.mth", 230, 40);
+    WORD_ATOM(230, 40, "");
     push_i64(1LL);
-    WORD_ATOM(221, 42, "+");
+    WORD_ATOM(230, 42, "+");
     mw_prim_int_add();
     WORD_EXIT(mw_prim_int_succ);
 }
 static void mw_prim_int_pred (void){
-    WORD_ENTER(mw_prim_int_pred, "prim-int-pred", "src/prelude.mth", 222, 40);
-    WORD_ATOM(222, 40, "");
+    WORD_ENTER(mw_prim_int_pred, "prim-int-pred", "src/prelude.mth", 231, 40);
+    WORD_ATOM(231, 40, "");
     push_i64(1LL);
-    WORD_ATOM(222, 42, "-");
+    WORD_ATOM(231, 42, "-");
     mw_prim_int_sub();
     WORD_EXIT(mw_prim_int_pred);
 }
 static void mw_0_3D_ (void){
-    WORD_ENTER(mw_0_3D_, "0=", "src/prelude.mth", 230, 22);
-    WORD_ATOM(230, 22, "");
+    WORD_ENTER(mw_0_3D_, "0=", "src/prelude.mth", 239, 22);
+    WORD_ATOM(239, 22, "");
     push_i64(0LL);
-    WORD_ATOM(230, 24, "=");
+    WORD_ATOM(239, 24, "=");
     mw_prim_int_eq();
     WORD_EXIT(mw_0_3D_);
 }
 static void mw_0_3C_ (void){
-    WORD_ENTER(mw_0_3C_, "0<", "src/prelude.mth", 231, 22);
-    WORD_ATOM(231, 22, "");
+    WORD_ENTER(mw_0_3C_, "0<", "src/prelude.mth", 240, 22);
+    WORD_ATOM(240, 22, "");
     push_i64(0LL);
-    WORD_ATOM(231, 24, "<");
+    WORD_ATOM(240, 24, "<");
     mw_prim_int_lt();
     WORD_EXIT(mw_0_3C_);
 }
 static void mw_0_3E_ (void){
-    WORD_ENTER(mw_0_3E_, "0>", "src/prelude.mth", 232, 22);
-    WORD_ATOM(232, 22, "");
+    WORD_ENTER(mw_0_3E_, "0>", "src/prelude.mth", 241, 22);
+    WORD_ATOM(241, 22, "");
     push_i64(0LL);
-    WORD_ATOM(232, 24, ">");
+    WORD_ATOM(241, 24, ">");
     mw_Int_3E_();
     WORD_EXIT(mw_0_3E_);
 }
 static void mw_0_3E__3D_ (void){
-    WORD_ENTER(mw_0_3E__3D_, "0>=", "src/prelude.mth", 233, 23);
-    WORD_ATOM(233, 23, "");
+    WORD_ENTER(mw_0_3E__3D_, "0>=", "src/prelude.mth", 242, 23);
+    WORD_ATOM(242, 23, "");
     push_i64(0LL);
-    WORD_ATOM(233, 25, ">=");
+    WORD_ATOM(242, 25, ">=");
     mw_Int_3E__3D_();
     WORD_EXIT(mw_0_3E__3D_);
 }
 static void mw_Ptr_40__40_Ptr (void){
-    WORD_ENTER(mw_Ptr_40__40_Ptr, "Ptr@@Ptr", "src/prelude.mth", 240, 34);
-    WORD_ATOM(240, 34, "dip");
+    WORD_ENTER(mw_Ptr_40__40_Ptr, "Ptr@@Ptr", "src/prelude.mth", 249, 34);
+    WORD_ATOM(249, 34, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(240, 38, "Ptr.sizeof");
+        WORD_ATOM(249, 38, "Ptr.sizeof");
         mw_prim_ptr_size();
-        WORD_ATOM(240, 49, "*");
+        WORD_ATOM(249, 49, "*");
         mw_prim_int_mul();
         push_value(d2);
     }
-    WORD_ATOM(240, 51, ".offset");
+    WORD_ATOM(249, 51, ".offset");
     push_u64(0);
     push_fnptr(&mb_Ptr_40__40_Ptr_2);
     mw_prim_pack_cons();
@@ -9058,34 +9058,7 @@ static void mw_Ptr_40__40_Ptr (void){
     WORD_EXIT(mw_Ptr_40__40_Ptr);
 }
 static void mw_Ptr_40__40_I64 (void){
-    WORD_ENTER(mw_Ptr_40__40_I64, "Ptr@@I64", "src/prelude.mth", 250, 34);
-    WORD_ATOM(250, 34, "dip");
-    {
-        VAL d2 = pop_value();
-        WORD_ATOM(250, 38, "");
-        push_i64(8LL);
-        WORD_ATOM(250, 40, "*");
-        mw_prim_int_mul();
-        push_value(d2);
-    }
-    WORD_ATOM(250, 42, ".offset");
-    push_u64(0);
-    push_fnptr(&mb_Ptr_40__40_I64_2);
-    mw_prim_pack_cons();
-    mw_Ptr_2E_offset();
-    WORD_EXIT(mw_Ptr_40__40_I64);
-}
-static void mw_Ptr_21__21_U8 (void){
-    WORD_ENTER(mw_Ptr_21__21_U8, "Ptr!!U8", "src/prelude.mth", 252, 42);
-    WORD_ATOM(252, 42, ".offset");
-    push_u64(0);
-    push_fnptr(&mb_Ptr_21__21_U8_1);
-    mw_prim_pack_cons();
-    mw_Ptr_2E_offset();
-    WORD_EXIT(mw_Ptr_21__21_U8);
-}
-static void mw_Ptr_21__21_I64 (void){
-    WORD_ENTER(mw_Ptr_21__21_I64, "Ptr!!I64", "src/prelude.mth", 259, 34);
+    WORD_ENTER(mw_Ptr_40__40_I64, "Ptr@@I64", "src/prelude.mth", 259, 34);
     WORD_ATOM(259, 34, "dip");
     {
         VAL d2 = pop_value();
@@ -9097,52 +9070,79 @@ static void mw_Ptr_21__21_I64 (void){
     }
     WORD_ATOM(259, 42, ".offset");
     push_u64(0);
+    push_fnptr(&mb_Ptr_40__40_I64_2);
+    mw_prim_pack_cons();
+    mw_Ptr_2E_offset();
+    WORD_EXIT(mw_Ptr_40__40_I64);
+}
+static void mw_Ptr_21__21_U8 (void){
+    WORD_ENTER(mw_Ptr_21__21_U8, "Ptr!!U8", "src/prelude.mth", 261, 42);
+    WORD_ATOM(261, 42, ".offset");
+    push_u64(0);
+    push_fnptr(&mb_Ptr_21__21_U8_1);
+    mw_prim_pack_cons();
+    mw_Ptr_2E_offset();
+    WORD_EXIT(mw_Ptr_21__21_U8);
+}
+static void mw_Ptr_21__21_I64 (void){
+    WORD_ENTER(mw_Ptr_21__21_I64, "Ptr!!I64", "src/prelude.mth", 268, 34);
+    WORD_ATOM(268, 34, "dip");
+    {
+        VAL d2 = pop_value();
+        WORD_ATOM(268, 38, "");
+        push_i64(8LL);
+        WORD_ATOM(268, 40, "*");
+        mw_prim_int_mul();
+        push_value(d2);
+    }
+    WORD_ATOM(268, 42, ".offset");
+    push_u64(0);
     push_fnptr(&mb_Ptr_21__21_I64_2);
     mw_prim_pack_cons();
     mw_Ptr_2E_offset();
     WORD_EXIT(mw_Ptr_21__21_I64);
 }
 static void mw_U8_3E_Int (void){
-    WORD_ENTER(mw_U8_3E_Int, "U8>Int", "src/prelude.mth", 261, 26);
-    WORD_ATOM(261, 26, "prim-unsafe-cast");
+    WORD_ENTER(mw_U8_3E_Int, "U8>Int", "src/prelude.mth", 270, 26);
+    WORD_ATOM(270, 26, "prim-unsafe-cast");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_U8_3E_Int);
 }
 static void mw_I64_3E_Int (void){
-    WORD_ENTER(mw_I64_3E_Int, "I64>Int", "src/prelude.mth", 271, 26);
-    WORD_ATOM(271, 26, "prim-unsafe-cast");
+    WORD_ENTER(mw_I64_3E_Int, "I64>Int", "src/prelude.mth", 280, 26);
+    WORD_ATOM(280, 26, "prim-unsafe-cast");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_I64_3E_Int);
 }
 static void mw_Int_3E_U8_3F_ (void){
-    WORD_ENTER(mw_Int_3E_U8_3F_, "Int>U8?", "src/prelude.mth", 286, 34);
-    WORD_ATOM(286, 34, "dup");
+    WORD_ENTER(mw_Int_3E_U8_3F_, "Int>U8?", "src/prelude.mth", 295, 34);
+    WORD_ATOM(295, 34, "dup");
     mw_prim_dup();
-    WORD_ATOM(286, 38, "U8_MIN");
+    WORD_ATOM(295, 38, "U8_MIN");
     mw_U8_5F_MIN();
-    WORD_ATOM(286, 46, "U8_MAX");
+    WORD_ATOM(295, 46, "U8_MAX");
     mw_U8_5F_MAX();
-    WORD_ATOM(286, 54, ".in-range");
+    WORD_ATOM(295, 54, ".in-range");
     mw_Int_2E_in_range();
-    WORD_ATOM(286, 64, "if");
+    WORD_ATOM(295, 64, "if");
     if (pop_u64()) {
-        WORD_ATOM(286, 68, ">U8-unsafe");
+        WORD_ATOM(295, 68, ">U8-unsafe");
         mw_Int_3E_U8_unsafe();
-        WORD_ATOM(286, 79, "SOME");
+        WORD_ATOM(295, 79, "SOME");
         mw_SOME();
     } else {
-        WORD_ATOM(286, 85, "drop");
+        WORD_ATOM(295, 85, "drop");
         mw_prim_drop();
-        WORD_ATOM(286, 90, "NONE");
+        WORD_ATOM(295, 90, "NONE");
         mw_NONE();
     }
     WORD_EXIT(mw_Int_3E_U8_3F_);
 }
 static void mw_Int_3E_U8 (void){
-    WORD_ENTER(mw_Int_3E_U8, "Int>U8", "src/prelude.mth", 290, 26);
-    WORD_ATOM(290, 26, "Int>U8?");
+    WORD_ENTER(mw_Int_3E_U8, "Int>U8", "src/prelude.mth", 299, 26);
+    WORD_ATOM(299, 26, "Int>U8?");
     mw_Int_3E_U8_3F_();
-    WORD_ATOM(290, 35, "unwrap-or");
+    WORD_ATOM(299, 35, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_Int_3E_U8_1);
     mw_prim_pack_cons();
@@ -9150,99 +9150,99 @@ static void mw_Int_3E_U8 (void){
     WORD_EXIT(mw_Int_3E_U8);
 }
 static void mw_Int_3E_I64 (void){
-    WORD_ENTER(mw_Int_3E_I64, "Int>I64", "src/prelude.mth", 302, 26);
-    WORD_ATOM(302, 26, ">I64-unsafe");
+    WORD_ENTER(mw_Int_3E_I64, "Int>I64", "src/prelude.mth", 311, 26);
+    WORD_ATOM(311, 26, ">I64-unsafe");
     mw_Int_3E_I64_unsafe();
     WORD_EXIT(mw_Int_3E_I64);
 }
 static void mw_pack1 (void){
-    WORD_ENTER(mw_pack1, "pack1", "src/prelude.mth", 314, 22);
-    WORD_ATOM(314, 22, "dip");
+    WORD_ENTER(mw_pack1, "pack1", "src/prelude.mth", 323, 22);
+    WORD_ATOM(323, 22, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(314, 26, "pack0");
+        WORD_ATOM(323, 26, "pack0");
         mw_prim_pack_nil();
         push_value(d2);
     }
-    WORD_ATOM(314, 33, "prim-pack-cons");
+    WORD_ATOM(323, 33, "prim-pack-cons");
     mw_prim_pack_cons();
     WORD_EXIT(mw_pack1);
 }
 static void mw_pack2 (void){
-    WORD_ENTER(mw_pack2, "pack2", "src/prelude.mth", 315, 26);
-    WORD_ATOM(315, 26, "dip");
+    WORD_ENTER(mw_pack2, "pack2", "src/prelude.mth", 324, 26);
+    WORD_ATOM(324, 26, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(315, 30, "pack1");
+        WORD_ATOM(324, 30, "pack1");
         mw_pack1();
         push_value(d2);
     }
-    WORD_ATOM(315, 37, "prim-pack-cons");
+    WORD_ATOM(324, 37, "prim-pack-cons");
     mw_prim_pack_cons();
     WORD_EXIT(mw_pack2);
 }
 static void mw_unpack1 (void){
-    WORD_ENTER(mw_unpack1, "unpack1", "src/prelude.mth", 321, 24);
-    WORD_ATOM(321, 24, "prim-pack-uncons");
+    WORD_ENTER(mw_unpack1, "unpack1", "src/prelude.mth", 330, 24);
+    WORD_ATOM(330, 24, "prim-pack-uncons");
     mw_prim_pack_uncons();
-    WORD_ATOM(321, 41, "nip");
+    WORD_ATOM(330, 41, "nip");
     mw_nip();
     WORD_EXIT(mw_unpack1);
 }
 static void mw_unpack2 (void){
-    WORD_ENTER(mw_unpack2, "unpack2", "src/prelude.mth", 322, 28);
-    WORD_ATOM(322, 28, "prim-pack-uncons");
+    WORD_ENTER(mw_unpack2, "unpack2", "src/prelude.mth", 331, 28);
+    WORD_ATOM(331, 28, "prim-pack-uncons");
     mw_prim_pack_uncons();
-    WORD_ATOM(322, 45, "dip");
+    WORD_ATOM(331, 45, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(322, 49, "unpack1");
+        WORD_ATOM(331, 49, "unpack1");
         mw_unpack1();
         push_value(d2);
     }
     WORD_EXIT(mw_unpack2);
 }
 static void mw_modify (void){
-    WORD_ENTER(mw_modify, "modify", "src/prelude.mth", 330, 48);
-    WORD_ATOM(330, 48, "dup");
+    WORD_ENTER(mw_modify, "modify", "src/prelude.mth", 339, 48);
+    WORD_ATOM(339, 48, "dup");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(330, 48, "dup");
+        WORD_ATOM(339, 48, "dup");
         mw_prim_dup();
-        WORD_ATOM(330, 52, "dip");
+        WORD_ATOM(339, 52, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(330, 56, "@");
+            WORD_ATOM(339, 56, "@");
             mw_prim_mut_get();
-            WORD_ATOM(330, 58, "f");
+            WORD_ATOM(339, 58, "f");
             incref(var_f);
             run_value(var_f);
             push_value(d3);
         }
-        WORD_ATOM(330, 61, "!");
+        WORD_ATOM(339, 61, "!");
         mw_prim_mut_set();
         decref(var_f);
     }
     WORD_EXIT(mw_modify);
 }
 static void mw_expect_21_ (void){
-    WORD_ENTER(mw_expect_21_, "expect!", "src/prelude.mth", 334, 5);
-    WORD_ATOM(334, 5, "f");
+    WORD_ENTER(mw_expect_21_, "expect!", "src/prelude.mth", 343, 5);
+    WORD_ATOM(343, 5, "f");
     {
         VAL var_g = pop_value();
         VAL var_f = pop_value();
-        WORD_ATOM(334, 5, "f");
+        WORD_ATOM(343, 5, "f");
         incref(var_f);
         run_value(var_f);
-        WORD_ATOM(334, 7, "if");
+        WORD_ATOM(343, 7, "if");
         if (pop_u64()) {
-            WORD_ATOM(334, 10, "id");
+            WORD_ATOM(343, 10, "id");
             mw_prim_id();
         } else {
-            WORD_ATOM(334, 14, "g");
+            WORD_ATOM(343, 14, "g");
             incref(var_g);
             run_value(var_g);
-            WORD_ATOM(334, 16, "panic!");
+            WORD_ATOM(343, 16, "panic!");
             mw_prim_panic();
         }
         decref(var_g);
@@ -9251,12 +9251,12 @@ static void mw_expect_21_ (void){
     WORD_EXIT(mw_expect_21_);
 }
 static void mw_assert_21_ (void){
-    WORD_ENTER(mw_assert_21_, "assert!", "src/prelude.mth", 336, 5);
-    WORD_ATOM(336, 5, "expect!");
+    WORD_ENTER(mw_assert_21_, "assert!", "src/prelude.mth", 345, 5);
+    WORD_ATOM(345, 5, "expect!");
     {
         VAL var_g = pop_value();
         VAL var_f = pop_value();
-        WORD_ATOM(336, 5, "expect!");
+        WORD_ATOM(345, 5, "expect!");
         incref(var_f);
         push_value(var_f);
         push_u64(0);
@@ -27554,22 +27554,22 @@ static void mw_StackType_2E_trace_base_21_ (void){
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(727, 19, "trace!");
-            mw_MetaVar_2E_trace_21_();
-            WORD_ATOM(727, 26, "");
+            WORD_ATOM(727, 19, "");
             {
                 static bool vready = false;
                 static VAL v;
                 if (! vready) {
-                    v = mkstr(" .", 2);
+                    v = mkstr("*", 1);
                     vready = true;
                 }
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(727, 31, "trace!");
+            WORD_ATOM(727, 23, "trace!");
             mw_Str_2E_trace_21_();
-            WORD_ATOM(727, 38, "T");
+            WORD_ATOM(727, 30, "trace!");
+            mw_MetaVar_2E_trace_21_();
+            WORD_ATOM(727, 37, "T");
             mw_T();
             break;
         case 3LL:
@@ -27618,12 +27618,12 @@ static void mw_StackType_2E_trace_21_ (void){
         mw_List_2E_for();
         push_value(d2);
     }
-    WORD_ATOM(736, 5, "reverse-for");
+    WORD_ATOM(736, 5, "for");
     push_u64(0);
     push_fnptr(&mb_StackType_2E_trace_21__5);
     mw_prim_pack_cons();
-    mw_List_2E_reverse_for();
-    WORD_ATOM(736, 49, "drop");
+    mw_List_2E_for();
+    WORD_ATOM(736, 41, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_StackType_2E_trace_21_);
 }
@@ -34573,83 +34573,83 @@ static void mb_main_2 (void) {
 }
 
 static void mb_count_2 (void) {
-    WORD_ENTER(mb_count_2, "count block", "src/prelude.mth", 169, 19);
+    WORD_ENTER(mb_count_2, "count block", "src/prelude.mth", 178, 19);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(169, 19, "dup");
+    WORD_ATOM(178, 19, "dup");
     mw_prim_dup();
-    WORD_ATOM(169, 23, "dip");
+    WORD_ATOM(178, 23, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(169, 27, "f");
+        WORD_ATOM(178, 27, "f");
         incref(var_f);
         run_value(var_f);
         push_value(d2);
     }
-    WORD_ATOM(169, 30, "1+");
+    WORD_ATOM(178, 30, "1+");
     mw_prim_int_succ();
     decref(var_f);
     WORD_EXIT(mb_count_2);
 }
 
 static void mb_countdown_2 (void) {
-    WORD_ENTER(mb_countdown_2, "countdown block", "src/prelude.mth", 171, 24);
+    WORD_ENTER(mb_countdown_2, "countdown block", "src/prelude.mth", 180, 24);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(171, 24, "dup");
+    WORD_ATOM(180, 24, "dup");
     mw_prim_dup();
-    WORD_ATOM(171, 28, "dip");
+    WORD_ATOM(180, 28, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(171, 32, "f");
+        WORD_ATOM(180, 32, "f");
         incref(var_f);
         run_value(var_f);
         push_value(d2);
     }
-    WORD_ATOM(171, 35, "1-");
+    WORD_ATOM(180, 35, "1-");
     mw_prim_int_pred();
     decref(var_f);
     WORD_EXIT(mb_countdown_2);
 }
 
 static void mb_Ptr_40__40_Ptr_2 (void) {
-    WORD_ENTER(mb_Ptr_40__40_Ptr_2, "Ptr@@Ptr block", "src/prelude.mth", 240, 59);
+    WORD_ENTER(mb_Ptr_40__40_Ptr_2, "Ptr@@Ptr block", "src/prelude.mth", 249, 59);
     mw_prim_drop();
-    WORD_ATOM(240, 59, "@Ptr");
+    WORD_ATOM(249, 59, "@Ptr");
     mw_prim_ptr_get();
     WORD_EXIT(mb_Ptr_40__40_Ptr_2);
 }
 
 static void mb_Ptr_40__40_I64_2 (void) {
-    WORD_ENTER(mb_Ptr_40__40_I64_2, "Ptr@@I64 block", "src/prelude.mth", 250, 50);
+    WORD_ENTER(mb_Ptr_40__40_I64_2, "Ptr@@I64 block", "src/prelude.mth", 259, 50);
     mw_prim_drop();
-    WORD_ATOM(250, 50, "@I64");
+    WORD_ATOM(259, 50, "@I64");
     mw_prim_i64_get();
     WORD_EXIT(mb_Ptr_40__40_I64_2);
 }
 
 static void mb_Ptr_21__21_U8_1 (void) {
-    WORD_ENTER(mb_Ptr_21__21_U8_1, "Ptr!!U8 block", "src/prelude.mth", 252, 50);
+    WORD_ENTER(mb_Ptr_21__21_U8_1, "Ptr!!U8 block", "src/prelude.mth", 261, 50);
     mw_prim_drop();
-    WORD_ATOM(252, 50, "!U8");
+    WORD_ATOM(261, 50, "!U8");
     mw_prim_u8_set();
     WORD_EXIT(mb_Ptr_21__21_U8_1);
 }
 
 static void mb_Ptr_21__21_I64_2 (void) {
-    WORD_ENTER(mb_Ptr_21__21_I64_2, "Ptr!!I64 block", "src/prelude.mth", 259, 50);
+    WORD_ENTER(mb_Ptr_21__21_I64_2, "Ptr!!I64 block", "src/prelude.mth", 268, 50);
     mw_prim_drop();
-    WORD_ATOM(259, 50, "!I64");
+    WORD_ATOM(268, 50, "!I64");
     mw_prim_i64_set();
     WORD_EXIT(mb_Ptr_21__21_I64_2);
 }
 
 static void mb_Int_3E_U8_1 (void) {
-    WORD_ENTER(mb_Int_3E_U8_1, "Int>U8 block", "src/prelude.mth", 290, 46);
+    WORD_ENTER(mb_Int_3E_U8_1, "Int>U8 block", "src/prelude.mth", 299, 46);
     mw_prim_drop();
-    WORD_ATOM(290, 46, "");
+    WORD_ATOM(299, 46, "");
     {
         static bool vready = false;
         static VAL v;
@@ -34660,22 +34660,22 @@ static void mb_Int_3E_U8_1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(290, 65, "panic!");
+    WORD_ATOM(299, 65, "panic!");
     mw_prim_panic();
     WORD_EXIT(mb_Int_3E_U8_1);
 }
 
 static void mb_assert_21__3 (void) {
-    WORD_ENTER(mb_assert_21__3, "assert! block", "src/prelude.mth", 336, 15);
+    WORD_ENTER(mb_assert_21__3, "assert! block", "src/prelude.mth", 345, 15);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_pack_uncons();
     VAL var_g = pop_value();
     mw_prim_drop();
-    WORD_ATOM(336, 15, "g");
+    WORD_ATOM(345, 15, "g");
     incref(var_g);
     run_value(var_g);
-    WORD_ATOM(336, 17, "");
+    WORD_ATOM(345, 17, "");
     {
         static bool vready = false;
         static VAL v;
@@ -34686,9 +34686,9 @@ static void mb_assert_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(336, 38, "swap");
+    WORD_ATOM(345, 38, "swap");
     mw_prim_swap();
-    WORD_ATOM(336, 43, "prim-str-cat");
+    WORD_ATOM(345, 43, "prim-str-cat");
     mw_prim_str_cat();
     decref(var_f);
     decref(var_g);
@@ -36829,26 +36829,26 @@ static void mb_StackType_2E_trace_21__4 (void) {
 }
 
 static void mb_StackType_2E_trace_21__5 (void) {
-    WORD_ENTER(mb_StackType_2E_trace_21__5, "StackType.trace! block", "src/mirth/data/type.mth", 736, 17);
+    WORD_ENTER(mb_StackType_2E_trace_21__5, "StackType.trace! block", "src/mirth/data/type.mth", 736, 9);
     mw_prim_drop();
-    WORD_ATOM(736, 17, "swap");
+    WORD_ATOM(736, 9, "swap");
     mw_prim_swap();
-    WORD_ATOM(736, 22, "then");
+    WORD_ATOM(736, 14, "then");
     push_u64(0);
     push_fnptr(&mb_StackType_2E_trace_21__6);
     mw_prim_pack_cons();
     mw_Bool_2E_then();
-    WORD_ATOM(736, 39, "trace!");
+    WORD_ATOM(736, 31, "trace!");
     mw_Resource_2E_trace_21_();
-    WORD_ATOM(736, 46, "T");
+    WORD_ATOM(736, 38, "T");
     mw_T();
     WORD_EXIT(mb_StackType_2E_trace_21__5);
 }
 
 static void mb_StackType_2E_trace_21__6 (void) {
-    WORD_ENTER(mb_StackType_2E_trace_21__6, "StackType.trace! block", "src/mirth/data/type.mth", 736, 27);
+    WORD_ENTER(mb_StackType_2E_trace_21__6, "StackType.trace! block", "src/mirth/data/type.mth", 736, 19);
     mw_prim_drop();
-    WORD_ATOM(736, 27, "");
+    WORD_ATOM(736, 19, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36859,7 +36859,7 @@ static void mb_StackType_2E_trace_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(736, 31, "trace!");
+    WORD_ATOM(736, 23, "trace!");
     mw_Str_2E_trace_21_();
     WORD_EXIT(mb_StackType_2E_trace_21__6);
 }

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -370,6 +370,10 @@ static USIZE get_top_data_tag(void) {
     return get_data_tag(top_value());
 }
 
+static USIZE get_top_resource_data_tag(void) {
+    return get_data_tag(top_resource());
+}
+
 static int value_cmp_(VAL v1, VAL v2) {
     while (IS_CONS(v1) || IS_CONS(v2)) {
         VAL v1car, v1cdr; value_uncons(v1, &v1car, &v1cdr);
@@ -3406,6 +3410,7 @@ static void mw_Data_3D_ (void);
 static void mw_Data_2E_num_tags (void);
 static void mw_Data_2E_add_tag_21_ (void);
 static void mw_Data_2E_is_transparent_3F_ (void);
+static void mw_Data_2E_is_resource_3F_ (void);
 static void mw_Tag_2E_num_inputs_from_sig (void);
 static void mw_Tag_2E_is_transparent_3F_ (void);
 static void mw_Tag_3D_ (void);
@@ -4477,11 +4482,13 @@ static void mb_c99_prim_21__20 (void);
 static void mb_c99_prim_21__21 (void);
 static void mb_c99_prim_21__22 (void);
 static void mb_c99_match_21__3 (void);
-static void mb_c99_match_21__4 (void);
 static void mb_c99_match_21__5 (void);
-static void mb_c99_match_21__6 (void);
 static void mb_c99_match_21__7 (void);
 static void mb_c99_match_21__8 (void);
+static void mb_c99_match_21__9 (void);
+static void mb_c99_match_21__10 (void);
+static void mb_c99_match_21__11 (void);
+static void mb_c99_match_21__12 (void);
 static void mb_c99_lambda_21__1 (void);
 static void mb_c99_lambda_21__2 (void);
 static void mb_c99_lambda_21__3 (void);
@@ -11777,6 +11784,14 @@ static void mw_Data_2E_is_transparent_3F_ (void){
     
 }    WORD_EXIT(mw_Data_2E_is_transparent_3F_);
 }
+static void mw_Data_2E_is_resource_3F_ (void){
+    WORD_ENTER(mw_Data_2E_is_resource_3F_, "Data.is-resource?", "src/mirth/data/data.mth", 126, 5);
+    WORD_ATOM(126, 5, "name");
+    mw_Data_2E_name();
+    WORD_ATOM(126, 10, "could-be-resource-con");
+    mw_Name_2E_could_be_resource_con();
+    WORD_EXIT(mw_Data_2E_is_resource_3F_);
+}
 static void mw_Tag_2E_num_inputs_from_sig (void){
     WORD_ENTER(mw_Tag_2E_num_inputs_from_sig, "Tag.num-inputs-from-sig", "src/mirth/data/data.mth", 133, 5);
     WORD_ATOM(133, 5, "sig?");
@@ -15684,6 +15699,10 @@ static uint8_t b[] = {                47,42,32,77,73,82,84,72,32,72,69,65,68,69,
                 32,32,32,32,114,101,116,117,114,110,32,103,101,116,95,100,97,116,97,95,116,97,103,40,116,111,112,95,118,97,108,117,101,40,41,41,59,10,
                 125,10,
                 10,
+                115,116,97,116,105,99,32,85,83,73,90,69,32,103,101,116,95,116,111,112,95,114,101,115,111,117,114,99,101,95,100,97,116,97,95,116,97,103,40,118,111,105,100,41,32,123,10,
+                32,32,32,32,114,101,116,117,114,110,32,103,101,116,95,100,97,116,97,95,116,97,103,40,116,111,112,95,114,101,115,111,117,114,99,101,40,41,41,59,10,
+                125,10,
+                10,
                 115,116,97,116,105,99,32,105,110,116,32,118,97,108,117,101,95,99,109,112,95,40,86,65,76,32,118,49,44,32,86,65,76,32,118,50,41,32,123,10,
                 32,32,32,32,119,104,105,108,101,32,40,73,83,95,67,79,78,83,40,118,49,41,32,124,124,32,73,83,95,67,79,78,83,40,118,50,41,41,32,123,10,
                 32,32,32,32,32,32,32,32,86,65,76,32,118,49,99,97,114,44,32,118,49,99,100,114,59,32,118,97,108,117,101,95,117,110,99,111,110,115,40,118,49,44,32,38,118,49,99,97,114,44,32,38,118,49,99,100,114,41,59,10,
@@ -16527,7 +16546,7 @@ static uint8_t b[] = {                47,42,32,77,73,82,84,72,32,72,69,65,68,69,
                 47,42,32,71,69,78,69,82,65,84,69,68,32,67,57,57,32,42,47,10,
                 
             };
-            v = mkstr((char*)b, 32087);
+            v = mkstr((char*)b, 32178);
             vready = true;
         }
         push_value(v);
@@ -18025,35 +18044,55 @@ static void mw_c99_match_21_ (void){
         WORD_ATOM(490, 33, "c99-arrow!");
         mw_c99_arrow_21_();
     } else {
-        WORD_ATOM(492, 9, "c99-line");
+        WORD_ATOM(492, 9, "dup");
+        mw_prim_dup();
+        WORD_ATOM(492, 13, "scrutinee-data?");
+        mw_Match_2E_scrutinee_data_3F_();
+        WORD_ATOM(493, 9, "unwrap-or");
         push_u64(0);
         push_fnptr(&mb_c99_match_21__3);
         mw_prim_pack_cons();
-        mw_c99_line();
-        WORD_ATOM(493, 9, "c99-nest");
-        push_u64(0);
-        push_fnptr(&mb_c99_match_21__4);
-        mw_prim_pack_cons();
-        mw_c99_nest();
-        WORD_ATOM(499, 9, "c99-line");
+        mw_Maybe_2E_unwrap_or();
+        WORD_ATOM(494, 9, "is-resource?");
+        mw_Data_2E_is_resource_3F_();
+        WORD_ATOM(494, 22, "if");
+        if (pop_u64()) {
+            WORD_ATOM(495, 13, "c99-line");
+            push_u64(0);
+            push_fnptr(&mb_c99_match_21__5);
+            mw_prim_pack_cons();
+            mw_c99_line();
+        } else {
+            WORD_ATOM(496, 13, "c99-line");
+            push_u64(0);
+            push_fnptr(&mb_c99_match_21__7);
+            mw_prim_pack_cons();
+            mw_c99_line();
+        }
+        WORD_ATOM(498, 9, "c99-nest");
         push_u64(0);
         push_fnptr(&mb_c99_match_21__8);
         mw_prim_pack_cons();
+        mw_c99_nest();
+        WORD_ATOM(504, 9, "c99-line");
+        push_u64(0);
+        push_fnptr(&mb_c99_match_21__12);
+        mw_prim_pack_cons();
         mw_c99_line();
-        WORD_ATOM(499, 22, ".");
+        WORD_ATOM(504, 22, ".");
         mw__2E_();
     }
     WORD_EXIT(mw_c99_match_21_);
 }
 static void mw_c99_case_21_ (void){
-    WORD_ENTER(mw_c99_case_21_, "c99-case!", "src/mirth/codegen.mth", 503, 5);
-    WORD_ATOM(503, 5, "dup");
+    WORD_ENTER(mw_c99_case_21_, "c99-case!", "src/mirth/codegen.mth", 508, 5);
+    WORD_ATOM(508, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(503, 9, "pattern");
+    WORD_ATOM(508, 9, "pattern");
     mw_Case_2E_pattern();
-    WORD_ATOM(503, 17, "c99-pattern!");
+    WORD_ATOM(508, 17, "c99-pattern!");
     mw_c99_pattern_21_();
-    WORD_ATOM(504, 5, "c99-nest");
+    WORD_ATOM(509, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_case_21__1);
     mw_prim_pack_cons();
@@ -18061,12 +18100,12 @@ static void mw_c99_case_21_ (void){
     WORD_EXIT(mw_c99_case_21_);
 }
 static void mw_c99_pattern_21_ (void){
-    WORD_ENTER(mw_c99_pattern_21_, "c99-pattern!", "src/mirth/codegen.mth", 510, 5);
-    WORD_ATOM(510, 5, "PATTERN_UNDERSCORE");
+    WORD_ENTER(mw_c99_pattern_21_, "c99-pattern!", "src/mirth/codegen.mth", 515, 5);
+    WORD_ATOM(515, 5, "PATTERN_UNDERSCORE");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(511, 9, "c99-line");
+            WORD_ATOM(516, 9, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_pattern_21__2);
             mw_prim_pack_cons();
@@ -18074,12 +18113,12 @@ static void mw_c99_pattern_21_ (void){
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(514, 9, "c99-line");
+            WORD_ATOM(519, 9, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_pattern_21__4);
             mw_prim_pack_cons();
             mw_c99_line();
-            WORD_ATOM(515, 9, "c99-nest");
+            WORD_ATOM(520, 9, "c99-nest");
             push_u64(0);
             push_fnptr(&mb_c99_pattern_21__5);
             mw_prim_pack_cons();
@@ -18090,19 +18129,19 @@ static void mw_c99_pattern_21_ (void){
 }    WORD_EXIT(mw_c99_pattern_21_);
 }
 static void mw_c99_word_sigs_21_ (void){
-    WORD_ENTER(mw_c99_word_sigs_21_, "c99-word-sigs!", "src/mirth/codegen.mth", 524, 25);
-    WORD_ATOM(524, 25, "for-needed-words");
+    WORD_ENTER(mw_c99_word_sigs_21_, "c99-word-sigs!", "src/mirth/codegen.mth", 529, 25);
+    WORD_ATOM(529, 25, "for-needed-words");
     push_u64(0);
     push_fnptr(&mb_c99_word_sigs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_words();
-    WORD_ATOM(524, 57, ".lf");
+    WORD_ATOM(529, 57, ".lf");
     mw__2E_lf();
     WORD_EXIT(mw_c99_word_sigs_21_);
 }
 static void mw_c99_word_sig_21_ (void){
-    WORD_ENTER(mw_c99_word_sig_21_, "c99-word-sig!", "src/mirth/codegen.mth", 526, 5);
-    WORD_ATOM(526, 5, "c99-line");
+    WORD_ENTER(mw_c99_word_sig_21_, "c99-word-sig!", "src/mirth/codegen.mth", 531, 5);
+    WORD_ATOM(531, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_sig_21__1);
     mw_prim_pack_cons();
@@ -18110,19 +18149,19 @@ static void mw_c99_word_sig_21_ (void){
     WORD_EXIT(mw_c99_word_sig_21_);
 }
 static void mw_c99_block_sigs_21_ (void){
-    WORD_ENTER(mw_c99_block_sigs_21_, "c99-block-sigs!", "src/mirth/codegen.mth", 528, 26);
-    WORD_ATOM(528, 26, "for-needed-blocks");
+    WORD_ENTER(mw_c99_block_sigs_21_, "c99-block-sigs!", "src/mirth/codegen.mth", 533, 26);
+    WORD_ATOM(533, 26, "for-needed-blocks");
     push_u64(0);
     push_fnptr(&mb_c99_block_sigs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_blocks();
-    WORD_ATOM(528, 60, ".lf");
+    WORD_ATOM(533, 60, ".lf");
     mw__2E_lf();
     WORD_EXIT(mw_c99_block_sigs_21_);
 }
 static void mw_c99_block_sig_21_ (void){
-    WORD_ENTER(mw_c99_block_sig_21_, "c99-block-sig!", "src/mirth/codegen.mth", 530, 5);
-    WORD_ATOM(530, 5, "c99-line");
+    WORD_ENTER(mw_c99_block_sig_21_, "c99-block-sig!", "src/mirth/codegen.mth", 535, 5);
+    WORD_ATOM(535, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_sig_21__1);
     mw_prim_pack_cons();
@@ -18130,19 +18169,19 @@ static void mw_c99_block_sig_21_ (void){
     WORD_EXIT(mw_c99_block_sig_21_);
 }
 static void mw_c99_field_sigs_21_ (void){
-    WORD_ENTER(mw_c99_field_sigs_21_, "c99-field-sigs!", "src/mirth/codegen.mth", 532, 26);
-    WORD_ATOM(532, 26, "Field.for");
+    WORD_ENTER(mw_c99_field_sigs_21_, "c99-field-sigs!", "src/mirth/codegen.mth", 537, 26);
+    WORD_ATOM(537, 26, "Field.for");
     push_u64(0);
     push_fnptr(&mb_c99_field_sigs_21__1);
     mw_prim_pack_cons();
     mw_Field_2E_for();
-    WORD_ATOM(532, 52, ".lf");
+    WORD_ATOM(537, 52, ".lf");
     mw__2E_lf();
     WORD_EXIT(mw_c99_field_sigs_21_);
 }
 static void mw_c99_field_sig_21_ (void){
-    WORD_ENTER(mw_c99_field_sig_21_, "c99-field-sig!", "src/mirth/codegen.mth", 534, 5);
-    WORD_ATOM(534, 5, "c99-line");
+    WORD_ENTER(mw_c99_field_sig_21_, "c99-field-sig!", "src/mirth/codegen.mth", 539, 5);
+    WORD_ATOM(539, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_field_sig_21__1);
     mw_prim_pack_cons();
@@ -18150,19 +18189,19 @@ static void mw_c99_field_sig_21_ (void){
     WORD_EXIT(mw_c99_field_sig_21_);
 }
 static void mw_c99_block_enter_21_ (void){
-    WORD_ENTER(mw_c99_block_enter_21_, "c99-block-enter!", "src/mirth/codegen.mth", 537, 5);
-    WORD_ATOM(537, 5, "c99-line");
+    WORD_ENTER(mw_c99_block_enter_21_, "c99-block-enter!", "src/mirth/codegen.mth", 542, 5);
+    WORD_ATOM(542, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_enter_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(546, 5, "drop");
+    WORD_ATOM(551, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_block_enter_21_);
 }
 static void mw_c99_block_exit_21_ (void){
-    WORD_ENTER(mw_c99_block_exit_21_, "c99-block-exit!", "src/mirth/codegen.mth", 549, 5);
-    WORD_ATOM(549, 5, "c99-line");
+    WORD_ENTER(mw_c99_block_exit_21_, "c99-block-exit!", "src/mirth/codegen.mth", 554, 5);
+    WORD_ATOM(554, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_exit_21__1);
     mw_prim_pack_cons();
@@ -18170,40 +18209,40 @@ static void mw_c99_block_exit_21_ (void){
     WORD_EXIT(mw_c99_block_exit_21_);
 }
 static void mw_c99_block_defs_21_ (void){
-    WORD_ENTER(mw_c99_block_defs_21_, "c99-block-defs!", "src/mirth/codegen.mth", 551, 26);
-    WORD_ATOM(551, 26, "for-needed-blocks");
+    WORD_ENTER(mw_c99_block_defs_21_, "c99-block-defs!", "src/mirth/codegen.mth", 556, 26);
+    WORD_ATOM(556, 26, "for-needed-blocks");
     push_u64(0);
     push_fnptr(&mb_c99_block_defs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_blocks();
-    WORD_ATOM(551, 60, ".lf");
+    WORD_ATOM(556, 60, ".lf");
     mw__2E_lf();
     WORD_EXIT(mw_c99_block_defs_21_);
 }
 static void mw_c99_block_def_21_ (void){
-    WORD_ENTER(mw_c99_block_def_21_, "c99-block-def!", "src/mirth/codegen.mth", 553, 5);
-    WORD_ATOM(553, 5, "c99-line");
+    WORD_ENTER(mw_c99_block_def_21_, "c99-block-def!", "src/mirth/codegen.mth", 558, 5);
+    WORD_ATOM(558, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_def_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(554, 5, "c99-nest");
+    WORD_ATOM(559, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_block_def_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(562, 5, "c99-line");
+    WORD_ATOM(567, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_def_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(562, 21, ".lf");
+    WORD_ATOM(567, 21, ".lf");
     mw__2E_lf();
     WORD_EXIT(mw_c99_block_def_21_);
 }
 static void mw__2E_block (void){
-    WORD_ENTER(mw__2E_block, ".block", "src/mirth/codegen.mth", 565, 5);
-    WORD_ATOM(565, 5, "");
+    WORD_ENTER(mw__2E_block, ".block", "src/mirth/codegen.mth", 570, 5);
+    WORD_ATOM(570, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18214,34 +18253,34 @@ static void mw__2E_block (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(565, 11, ".");
+    WORD_ATOM(570, 11, ".");
     mw__2E_();
-    WORD_ATOM(566, 5, "dup");
+    WORD_ATOM(571, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(566, 9, "arrow");
+    WORD_ATOM(571, 9, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(566, 15, "dup");
+    WORD_ATOM(571, 15, "dup");
     mw_prim_dup();
-    WORD_ATOM(566, 19, "home");
+    WORD_ATOM(571, 19, "home");
     mw_Arrow_2E_home();
-    WORD_ATOM(566, 24, "match");
+    WORD_ATOM(571, 24, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(567, 17, "drop");
+            WORD_ATOM(572, 17, "drop");
             mw_prim_drop();
-            WORD_ATOM(567, 22, "Block.id");
+            WORD_ATOM(572, 22, "Block.id");
             mw_Block_2E_id();
-            WORD_ATOM(567, 31, ".n");
+            WORD_ATOM(572, 31, ".n");
             mw__2E_n();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(569, 13, "name");
+            WORD_ATOM(574, 13, "name");
             mw_Word_2E_name();
-            WORD_ATOM(569, 18, ".name");
+            WORD_ATOM(574, 18, ".name");
             mw__2E_name();
-            WORD_ATOM(569, 24, "");
+            WORD_ATOM(574, 24, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -18252,13 +18291,13 @@ static void mw__2E_block (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(569, 28, ".");
+            WORD_ATOM(574, 28, ".");
             mw__2E_();
-            WORD_ATOM(570, 13, "homeidx");
+            WORD_ATOM(575, 13, "homeidx");
             mw_Arrow_2E_homeidx();
-            WORD_ATOM(570, 21, ".n");
+            WORD_ATOM(575, 21, ".n");
             mw__2E_n();
-            WORD_ATOM(570, 24, "drop");
+            WORD_ATOM(575, 24, "drop");
             mw_prim_drop();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -18266,73 +18305,73 @@ static void mw__2E_block (void){
 }    WORD_EXIT(mw__2E_block);
 }
 static void mw_c99_word_enter_21_ (void){
-    WORD_ENTER(mw_c99_word_enter_21_, "c99-word-enter!", "src/mirth/codegen.mth", 574, 5);
-    WORD_ATOM(574, 5, "c99-line");
+    WORD_ENTER(mw_c99_word_enter_21_, "c99-word-enter!", "src/mirth/codegen.mth", 579, 5);
+    WORD_ATOM(579, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_enter_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(580, 5, "drop");
+    WORD_ATOM(585, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_word_enter_21_);
 }
 static void mw_c99_word_exit_21_ (void){
-    WORD_ENTER(mw_c99_word_exit_21_, "c99-word-exit!", "src/mirth/codegen.mth", 583, 5);
-    WORD_ATOM(583, 5, "c99-line");
+    WORD_ENTER(mw_c99_word_exit_21_, "c99-word-exit!", "src/mirth/codegen.mth", 588, 5);
+    WORD_ATOM(588, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_exit_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(585, 5, "drop");
+    WORD_ATOM(590, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_word_exit_21_);
 }
 static void mw_c99_word_defs_21_ (void){
-    WORD_ENTER(mw_c99_word_defs_21_, "c99-word-defs!", "src/mirth/codegen.mth", 587, 25);
-    WORD_ATOM(587, 25, "for-needed-words");
+    WORD_ENTER(mw_c99_word_defs_21_, "c99-word-defs!", "src/mirth/codegen.mth", 592, 25);
+    WORD_ATOM(592, 25, "for-needed-words");
     push_u64(0);
     push_fnptr(&mb_c99_word_defs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_words();
-    WORD_ATOM(587, 57, ".lf");
+    WORD_ATOM(592, 57, ".lf");
     mw__2E_lf();
     WORD_EXIT(mw_c99_word_defs_21_);
 }
 static void mw_c99_word_def_21_ (void){
-    WORD_ENTER(mw_c99_word_def_21_, "c99-word-def!", "src/mirth/codegen.mth", 589, 5);
-    WORD_ATOM(589, 5, "c99-line");
+    WORD_ENTER(mw_c99_word_def_21_, "c99-word-def!", "src/mirth/codegen.mth", 594, 5);
+    WORD_ATOM(594, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_def_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(590, 5, "c99-nest");
+    WORD_ATOM(595, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_word_def_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(595, 5, "c99-line");
+    WORD_ATOM(600, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_def_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(596, 5, "drop");
+    WORD_ATOM(601, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_word_def_21_);
 }
 static void mw_c99_field_defs_21_ (void){
-    WORD_ENTER(mw_c99_field_defs_21_, "c99-field-defs!", "src/mirth/codegen.mth", 598, 26);
-    WORD_ATOM(598, 26, "Field.for");
+    WORD_ENTER(mw_c99_field_defs_21_, "c99-field-defs!", "src/mirth/codegen.mth", 603, 26);
+    WORD_ATOM(603, 26, "Field.for");
     push_u64(0);
     push_fnptr(&mb_c99_field_defs_21__1);
     mw_prim_pack_cons();
     mw_Field_2E_for();
-    WORD_ATOM(598, 52, ".lf");
+    WORD_ATOM(603, 52, ".lf");
     mw__2E_lf();
     WORD_EXIT(mw_c99_field_defs_21_);
 }
 static void mw_c99_field_def_21_ (void){
-    WORD_ENTER(mw_c99_field_def_21_, "c99-field-def!", "src/mirth/codegen.mth", 600, 5);
-    WORD_ATOM(600, 5, "");
+    WORD_ENTER(mw_c99_field_def_21_, "c99-field-def!", "src/mirth/codegen.mth", 605, 5);
+    WORD_ATOM(605, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18343,15 +18382,15 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(600, 29, ".");
+    WORD_ATOM(605, 29, ".");
     mw__2E_();
-    WORD_ATOM(600, 31, "dup");
+    WORD_ATOM(605, 31, "dup");
     mw_prim_dup();
-    WORD_ATOM(600, 35, "name");
+    WORD_ATOM(605, 35, "name");
     mw_Field_2E_name();
-    WORD_ATOM(600, 40, ".name");
+    WORD_ATOM(605, 40, ".name");
     mw__2E_name();
-    WORD_ATOM(600, 46, "");
+    WORD_ATOM(605, 46, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18362,9 +18401,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(600, 62, ";");
+    WORD_ATOM(605, 62, ";");
     mw__3B_();
-    WORD_ATOM(601, 5, "");
+    WORD_ATOM(606, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18375,9 +18414,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(601, 37, ";");
+    WORD_ATOM(606, 37, ";");
     mw__3B_();
-    WORD_ATOM(602, 5, "");
+    WORD_ATOM(607, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18388,13 +18427,13 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(602, 23, ".");
+    WORD_ATOM(607, 23, ".");
     mw__2E_();
-    WORD_ATOM(602, 25, "TABLE_MAX_SIZE");
+    WORD_ATOM(607, 25, "TABLE_MAX_SIZE");
     mw_TABLE_5F_MAX_5F_SIZE();
-    WORD_ATOM(602, 40, ".n");
+    WORD_ATOM(607, 40, ".n");
     mw__2E_n();
-    WORD_ATOM(602, 43, "");
+    WORD_ATOM(607, 43, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18405,9 +18444,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(602, 47, ";");
+    WORD_ATOM(607, 47, ";");
     mw__3B_();
-    WORD_ATOM(603, 5, "");
+    WORD_ATOM(608, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18418,9 +18457,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(603, 50, ";");
+    WORD_ATOM(608, 50, ";");
     mw__3B_();
-    WORD_ATOM(604, 5, "");
+    WORD_ATOM(609, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18431,9 +18470,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(604, 70, ";");
+    WORD_ATOM(609, 70, ";");
     mw__3B_();
-    WORD_ATOM(605, 5, "");
+    WORD_ATOM(610, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18444,9 +18483,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(605, 23, ";");
+    WORD_ATOM(610, 23, ";");
     mw__3B_();
-    WORD_ATOM(606, 5, "");
+    WORD_ATOM(611, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18457,15 +18496,15 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(606, 9, ";;");
+    WORD_ATOM(611, 9, ";;");
     mw__3B__3B_();
-    WORD_ATOM(609, 5, "dup");
+    WORD_ATOM(614, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(609, 9, "name");
+    WORD_ATOM(614, 9, "name");
     mw_Field_2E_name();
-    WORD_ATOM(609, 14, ".w");
+    WORD_ATOM(614, 14, ".w");
     mw__2E_w();
-    WORD_ATOM(609, 17, "");
+    WORD_ATOM(614, 17, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18476,9 +18515,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(609, 21, ";");
+    WORD_ATOM(614, 21, ";");
     mw__3B_();
-    WORD_ATOM(610, 5, "");
+    WORD_ATOM(615, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18489,9 +18528,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(610, 45, ";");
+    WORD_ATOM(615, 45, ";");
     mw__3B_();
-    WORD_ATOM(611, 5, "");
+    WORD_ATOM(616, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18502,15 +18541,15 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(611, 30, ".");
+    WORD_ATOM(616, 30, ".");
     mw__2E_();
-    WORD_ATOM(611, 32, "dup");
+    WORD_ATOM(616, 32, "dup");
     mw_prim_dup();
-    WORD_ATOM(611, 36, "name");
+    WORD_ATOM(616, 36, "name");
     mw_Field_2E_name();
-    WORD_ATOM(611, 41, ".name");
+    WORD_ATOM(616, 41, ".name");
     mw__2E_name();
-    WORD_ATOM(611, 47, "");
+    WORD_ATOM(616, 47, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18521,9 +18560,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(611, 58, ";");
+    WORD_ATOM(616, 58, ";");
     mw__3B_();
-    WORD_ATOM(612, 5, "");
+    WORD_ATOM(617, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18534,9 +18573,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(612, 24, ";");
+    WORD_ATOM(617, 24, ";");
     mw__3B_();
-    WORD_ATOM(613, 5, "");
+    WORD_ATOM(618, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18547,25 +18586,25 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(613, 9, ";;");
+    WORD_ATOM(618, 9, ";;");
     mw__3B__3B_();
-    WORD_ATOM(615, 5, "drop");
+    WORD_ATOM(620, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_field_def_21_);
 }
 static void mw_c99_main_21_ (void){
-    WORD_ENTER(mw_c99_main_21_, "c99-main!", "src/mirth/codegen.mth", 618, 5);
-    WORD_ATOM(618, 5, "c99-line");
+    WORD_ENTER(mw_c99_main_21_, "c99-main!", "src/mirth/codegen.mth", 623, 5);
+    WORD_ATOM(623, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(619, 5, "c99-nest");
+    WORD_ATOM(624, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(632, 5, "c99-line");
+    WORD_ATOM(637, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__8);
     mw_prim_pack_cons();
@@ -39854,33 +39893,33 @@ static void mb_c99_externals_21__1 (void) {
 }
 
 static void mb_c99_word_sigs_21__1 (void) {
-    WORD_ENTER(mb_c99_word_sigs_21__1, "c99-word-sigs! block", "src/mirth/codegen.mth", 524, 42);
+    WORD_ENTER(mb_c99_word_sigs_21__1, "c99-word-sigs! block", "src/mirth/codegen.mth", 529, 42);
     mw_prim_drop();
-    WORD_ATOM(524, 42, "c99-word-sig!");
+    WORD_ATOM(529, 42, "c99-word-sig!");
     mw_c99_word_sig_21_();
     WORD_EXIT(mb_c99_word_sigs_21__1);
 }
 
 static void mb_c99_block_sigs_21__1 (void) {
-    WORD_ENTER(mb_c99_block_sigs_21__1, "c99-block-sigs! block", "src/mirth/codegen.mth", 528, 44);
+    WORD_ENTER(mb_c99_block_sigs_21__1, "c99-block-sigs! block", "src/mirth/codegen.mth", 533, 44);
     mw_prim_drop();
-    WORD_ATOM(528, 44, "c99-block-sig!");
+    WORD_ATOM(533, 44, "c99-block-sig!");
     mw_c99_block_sig_21_();
     WORD_EXIT(mb_c99_block_sigs_21__1);
 }
 
 static void mb_c99_field_sigs_21__1 (void) {
-    WORD_ENTER(mb_c99_field_sigs_21__1, "c99-field-sigs! block", "src/mirth/codegen.mth", 532, 36);
+    WORD_ENTER(mb_c99_field_sigs_21__1, "c99-field-sigs! block", "src/mirth/codegen.mth", 537, 36);
     mw_prim_drop();
-    WORD_ATOM(532, 36, "c99-field-sig!");
+    WORD_ATOM(537, 36, "c99-field-sig!");
     mw_c99_field_sig_21_();
     WORD_EXIT(mb_c99_field_sigs_21__1);
 }
 
 static void mb_c99_main_21__1 (void) {
-    WORD_ENTER(mb_c99_main_21__1, "c99-main! block", "src/mirth/codegen.mth", 618, 14);
+    WORD_ENTER(mb_c99_main_21__1, "c99-main! block", "src/mirth/codegen.mth", 623, 14);
     mw_prim_drop();
-    WORD_ATOM(618, 14, "");
+    WORD_ATOM(623, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -39891,37 +39930,37 @@ static void mb_c99_main_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(618, 51, ".");
+    WORD_ATOM(623, 51, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_main_21__1);
 }
 
 static void mb_c99_main_21__2 (void) {
-    WORD_ENTER(mb_c99_main_21__2, "c99-main! block", "src/mirth/codegen.mth", 620, 9);
+    WORD_ENTER(mb_c99_main_21__2, "c99-main! block", "src/mirth/codegen.mth", 625, 9);
     mw_prim_drop();
-    WORD_ATOM(620, 9, "c99-line");
+    WORD_ATOM(625, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(621, 9, "c99-line");
+    WORD_ATOM(626, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__4);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(622, 9, "c99-line");
+    WORD_ATOM(627, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__5);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(628, 9, "c99-arrow!");
+    WORD_ATOM(633, 9, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(629, 9, "c99-line");
+    WORD_ATOM(634, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__6);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(630, 9, "c99-line");
+    WORD_ATOM(635, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__7);
     mw_prim_pack_cons();
@@ -39930,9 +39969,9 @@ static void mb_c99_main_21__2 (void) {
 }
 
 static void mb_c99_main_21__3 (void) {
-    WORD_ENTER(mb_c99_main_21__3, "c99-main! block", "src/mirth/codegen.mth", 620, 18);
+    WORD_ENTER(mb_c99_main_21__3, "c99-main! block", "src/mirth/codegen.mth", 625, 18);
     mw_prim_drop();
-    WORD_ATOM(620, 18, "");
+    WORD_ATOM(625, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -39943,15 +39982,15 @@ static void mb_c99_main_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(620, 40, ".");
+    WORD_ATOM(625, 40, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_main_21__3);
 }
 
 static void mb_c99_main_21__4 (void) {
-    WORD_ENTER(mb_c99_main_21__4, "c99-main! block", "src/mirth/codegen.mth", 621, 18);
+    WORD_ENTER(mb_c99_main_21__4, "c99-main! block", "src/mirth/codegen.mth", 626, 18);
     mw_prim_drop();
-    WORD_ATOM(621, 18, "");
+    WORD_ATOM(626, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -39962,15 +40001,15 @@ static void mb_c99_main_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(621, 40, ".");
+    WORD_ATOM(626, 40, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_main_21__4);
 }
 
 static void mb_c99_main_21__5 (void) {
-    WORD_ENTER(mb_c99_main_21__5, "c99-main! block", "src/mirth/codegen.mth", 622, 18);
+    WORD_ENTER(mb_c99_main_21__5, "c99-main! block", "src/mirth/codegen.mth", 627, 18);
     mw_prim_drop();
-    WORD_ATOM(622, 18, "");
+    WORD_ATOM(627, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -39981,9 +40020,9 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(622, 32, ".");
+    WORD_ATOM(627, 32, ".");
     mw__2E_();
-    WORD_ATOM(623, 13, "");
+    WORD_ATOM(628, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -39994,9 +40033,9 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(623, 34, ".");
+    WORD_ATOM(628, 34, ".");
     mw__2E_();
-    WORD_ATOM(624, 13, "");
+    WORD_ATOM(629, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40007,21 +40046,21 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(624, 28, ".");
+    WORD_ATOM(629, 28, ".");
     mw__2E_();
-    WORD_ATOM(625, 13, "dup");
+    WORD_ATOM(630, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(625, 17, "token-start");
+    WORD_ATOM(630, 17, "token-start");
     mw_Arrow_2E_token_start();
-    WORD_ATOM(625, 29, ".module");
+    WORD_ATOM(630, 29, ".module");
     mw_Token_2E_module();
-    WORD_ATOM(625, 37, "source-path");
+    WORD_ATOM(630, 37, "source-path");
     mw_Module_2E_source_path();
-    WORD_ATOM(625, 49, ">Str");
+    WORD_ATOM(630, 49, ">Str");
     mw_Path_3E_Str();
-    WORD_ATOM(625, 54, ".str");
+    WORD_ATOM(630, 54, ".str");
     mw__2E_str();
-    WORD_ATOM(625, 59, "");
+    WORD_ATOM(630, 59, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40032,19 +40071,19 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(625, 64, ".");
+    WORD_ATOM(630, 64, ".");
     mw__2E_();
-    WORD_ATOM(626, 13, "dup");
+    WORD_ATOM(631, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(626, 17, "token-start");
+    WORD_ATOM(631, 17, "token-start");
     mw_Arrow_2E_token_start();
-    WORD_ATOM(626, 29, "row");
+    WORD_ATOM(631, 29, "row");
     mw_Token_2E_row();
-    WORD_ATOM(626, 33, ">Int");
+    WORD_ATOM(631, 33, ">Int");
     mw_Row_3E_Int();
-    WORD_ATOM(626, 38, ".n");
+    WORD_ATOM(631, 38, ".n");
     mw__2E_n();
-    WORD_ATOM(626, 41, "");
+    WORD_ATOM(631, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40055,19 +40094,19 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(626, 46, ".");
+    WORD_ATOM(631, 46, ".");
     mw__2E_();
-    WORD_ATOM(627, 13, "dup");
+    WORD_ATOM(632, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(627, 17, "token-start");
+    WORD_ATOM(632, 17, "token-start");
     mw_Arrow_2E_token_start();
-    WORD_ATOM(627, 29, "col");
+    WORD_ATOM(632, 29, "col");
     mw_Token_2E_col();
-    WORD_ATOM(627, 33, ">Int");
+    WORD_ATOM(632, 33, ">Int");
     mw_Col_3E_Int();
-    WORD_ATOM(627, 38, ".n");
+    WORD_ATOM(632, 38, ".n");
     mw__2E_n();
-    WORD_ATOM(627, 41, "");
+    WORD_ATOM(632, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40078,15 +40117,15 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(627, 46, ".");
+    WORD_ATOM(632, 46, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_main_21__5);
 }
 
 static void mb_c99_main_21__6 (void) {
-    WORD_ENTER(mb_c99_main_21__6, "c99-main! block", "src/mirth/codegen.mth", 629, 18);
+    WORD_ENTER(mb_c99_main_21__6, "c99-main! block", "src/mirth/codegen.mth", 634, 18);
     mw_prim_drop();
-    WORD_ATOM(629, 18, "");
+    WORD_ATOM(634, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40097,15 +40136,15 @@ static void mb_c99_main_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(629, 49, ".");
+    WORD_ATOM(634, 49, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_main_21__6);
 }
 
 static void mb_c99_main_21__7 (void) {
-    WORD_ENTER(mb_c99_main_21__7, "c99-main! block", "src/mirth/codegen.mth", 630, 18);
+    WORD_ENTER(mb_c99_main_21__7, "c99-main! block", "src/mirth/codegen.mth", 635, 18);
     mw_prim_drop();
-    WORD_ATOM(630, 18, "");
+    WORD_ATOM(635, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40116,15 +40155,15 @@ static void mb_c99_main_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(630, 30, ".");
+    WORD_ATOM(635, 30, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_main_21__7);
 }
 
 static void mb_c99_main_21__8 (void) {
-    WORD_ENTER(mb_c99_main_21__8, "c99-main! block", "src/mirth/codegen.mth", 632, 14);
+    WORD_ENTER(mb_c99_main_21__8, "c99-main! block", "src/mirth/codegen.mth", 637, 14);
     mw_prim_drop();
-    WORD_ATOM(632, 14, "");
+    WORD_ATOM(637, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40135,31 +40174,31 @@ static void mb_c99_main_21__8 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(632, 18, ".");
+    WORD_ATOM(637, 18, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_main_21__8);
 }
 
 static void mb_c99_field_defs_21__1 (void) {
-    WORD_ENTER(mb_c99_field_defs_21__1, "c99-field-defs! block", "src/mirth/codegen.mth", 598, 36);
+    WORD_ENTER(mb_c99_field_defs_21__1, "c99-field-defs! block", "src/mirth/codegen.mth", 603, 36);
     mw_prim_drop();
-    WORD_ATOM(598, 36, "c99-field-def!");
+    WORD_ATOM(603, 36, "c99-field-def!");
     mw_c99_field_def_21_();
     WORD_EXIT(mb_c99_field_defs_21__1);
 }
 
 static void mb_c99_word_defs_21__1 (void) {
-    WORD_ENTER(mb_c99_word_defs_21__1, "c99-word-defs! block", "src/mirth/codegen.mth", 587, 42);
+    WORD_ENTER(mb_c99_word_defs_21__1, "c99-word-defs! block", "src/mirth/codegen.mth", 592, 42);
     mw_prim_drop();
-    WORD_ATOM(587, 42, "c99-word-def!");
+    WORD_ATOM(592, 42, "c99-word-def!");
     mw_c99_word_def_21_();
     WORD_EXIT(mb_c99_word_defs_21__1);
 }
 
 static void mb_c99_block_defs_21__1 (void) {
-    WORD_ENTER(mb_c99_block_defs_21__1, "c99-block-defs! block", "src/mirth/codegen.mth", 551, 44);
+    WORD_ENTER(mb_c99_block_defs_21__1, "c99-block-defs! block", "src/mirth/codegen.mth", 556, 44);
     mw_prim_drop();
-    WORD_ATOM(551, 44, "c99-block-def!");
+    WORD_ATOM(556, 44, "c99-block-def!");
     mw_c99_block_def_21_();
     WORD_EXIT(mb_c99_block_defs_21__1);
 }
@@ -41288,9 +41327,49 @@ static void mb_c99_prim_21__22 (void) {
 }
 
 static void mb_c99_match_21__3 (void) {
-    WORD_ENTER(mb_c99_match_21__3, "c99-match! block", "src/mirth/codegen.mth", 492, 18);
+    WORD_ENTER(mb_c99_match_21__3, "c99-match! block", "src/mirth/codegen.mth", 493, 19);
     mw_prim_drop();
-    WORD_ATOM(492, 18, "");
+    WORD_ATOM(493, 19, "token");
+    mw_Match_2E_token();
+    WORD_ATOM(493, 25, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("non-uniform match, not supported at present", 43);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(493, 71, "emit-fatal-error!");
+    mw_emit_fatal_error_21_();
+    WORD_EXIT(mb_c99_match_21__3);
+}
+
+static void mb_c99_match_21__5 (void) {
+    WORD_ENTER(mb_c99_match_21__5, "c99-match! block", "src/mirth/codegen.mth", 495, 22);
+    mw_prim_drop();
+    WORD_ATOM(495, 22, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("switch (get_top_resource_data_tag()) {", 38);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(495, 63, ".");
+    mw__2E_();
+    WORD_EXIT(mb_c99_match_21__5);
+}
+
+static void mb_c99_match_21__7 (void) {
+    WORD_ENTER(mb_c99_match_21__7, "c99-match! block", "src/mirth/codegen.mth", 496, 22);
+    mw_prim_drop();
+    WORD_ATOM(496, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41301,56 +41380,56 @@ static void mb_c99_match_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(492, 50, ".");
+    WORD_ATOM(496, 54, ".");
     mw__2E_();
-    WORD_EXIT(mb_c99_match_21__3);
+    WORD_EXIT(mb_c99_match_21__7);
 }
 
-static void mb_c99_match_21__4 (void) {
-    WORD_ENTER(mb_c99_match_21__4, "c99-match! block", "src/mirth/codegen.mth", 494, 13);
+static void mb_c99_match_21__8 (void) {
+    WORD_ENTER(mb_c99_match_21__8, "c99-match! block", "src/mirth/codegen.mth", 499, 13);
     mw_prim_drop();
-    WORD_ATOM(494, 13, "dup");
+    WORD_ATOM(499, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(494, 17, "cases");
+    WORD_ATOM(499, 17, "cases");
     mw_Match_2E_cases();
-    WORD_ATOM(494, 23, "for");
+    WORD_ATOM(499, 23, "for");
     push_u64(0);
-    push_fnptr(&mb_c99_match_21__5);
+    push_fnptr(&mb_c99_match_21__9);
     mw_prim_pack_cons();
     mw_List_2E_for();
-    WORD_ATOM(495, 13, "has-default-case?");
+    WORD_ATOM(500, 13, "has-default-case?");
     mw_Match_2E_has_default_case_3F_();
-    WORD_ATOM(495, 31, "else");
+    WORD_ATOM(500, 31, "else");
     push_u64(0);
-    push_fnptr(&mb_c99_match_21__6);
+    push_fnptr(&mb_c99_match_21__10);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_EXIT(mb_c99_match_21__4);
+    WORD_EXIT(mb_c99_match_21__8);
 }
 
-static void mb_c99_match_21__5 (void) {
-    WORD_ENTER(mb_c99_match_21__5, "c99-match! block", "src/mirth/codegen.mth", 494, 27);
+static void mb_c99_match_21__9 (void) {
+    WORD_ENTER(mb_c99_match_21__9, "c99-match! block", "src/mirth/codegen.mth", 499, 27);
     mw_prim_drop();
-    WORD_ATOM(494, 27, "c99-case!");
+    WORD_ATOM(499, 27, "c99-case!");
     mw_c99_case_21_();
-    WORD_EXIT(mb_c99_match_21__5);
+    WORD_EXIT(mb_c99_match_21__9);
 }
 
-static void mb_c99_match_21__6 (void) {
-    WORD_ENTER(mb_c99_match_21__6, "c99-match! block", "src/mirth/codegen.mth", 496, 17);
+static void mb_c99_match_21__10 (void) {
+    WORD_ENTER(mb_c99_match_21__10, "c99-match! block", "src/mirth/codegen.mth", 501, 17);
     mw_prim_drop();
-    WORD_ATOM(496, 17, "c99-line");
+    WORD_ATOM(501, 17, "c99-line");
     push_u64(0);
-    push_fnptr(&mb_c99_match_21__7);
+    push_fnptr(&mb_c99_match_21__11);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_EXIT(mb_c99_match_21__6);
+    WORD_EXIT(mb_c99_match_21__10);
 }
 
-static void mb_c99_match_21__7 (void) {
-    WORD_ENTER(mb_c99_match_21__7, "c99-match! block", "src/mirth/codegen.mth", 496, 26);
+static void mb_c99_match_21__11 (void) {
+    WORD_ENTER(mb_c99_match_21__11, "c99-match! block", "src/mirth/codegen.mth", 501, 26);
     mw_prim_drop();
-    WORD_ATOM(496, 26, "");
+    WORD_ATOM(501, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41361,15 +41440,15 @@ static void mb_c99_match_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(496, 118, ".");
+    WORD_ATOM(501, 118, ".");
     mw__2E_();
-    WORD_EXIT(mb_c99_match_21__7);
+    WORD_EXIT(mb_c99_match_21__11);
 }
 
-static void mb_c99_match_21__8 (void) {
-    WORD_ENTER(mb_c99_match_21__8, "c99-match! block", "src/mirth/codegen.mth", 499, 18);
+static void mb_c99_match_21__12 (void) {
+    WORD_ENTER(mb_c99_match_21__12, "c99-match! block", "src/mirth/codegen.mth", 504, 18);
     mw_prim_drop();
-    WORD_ATOM(499, 18, "");
+    WORD_ATOM(504, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41380,7 +41459,7 @@ static void mb_c99_match_21__8 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_EXIT(mb_c99_match_21__8);
+    WORD_EXIT(mb_c99_match_21__12);
 }
 
 static void mb_c99_lambda_21__1 (void) {
@@ -41921,13 +42000,13 @@ static void mb_c99_var_run_21__2 (void) {
 }
 
 static void mb_c99_case_21__1 (void) {
-    WORD_ENTER(mb_c99_case_21__1, "c99-case! block", "src/mirth/codegen.mth", 505, 9);
+    WORD_ENTER(mb_c99_case_21__1, "c99-case! block", "src/mirth/codegen.mth", 510, 9);
     mw_prim_drop();
-    WORD_ATOM(505, 9, "body");
+    WORD_ATOM(510, 9, "body");
     mw_Case_2E_body();
-    WORD_ATOM(505, 14, "c99-arrow!");
+    WORD_ATOM(510, 14, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(506, 9, "c99-line");
+    WORD_ATOM(511, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_case_21__2);
     mw_prim_pack_cons();
@@ -41936,9 +42015,9 @@ static void mb_c99_case_21__1 (void) {
 }
 
 static void mb_c99_case_21__2 (void) {
-    WORD_ENTER(mb_c99_case_21__2, "c99-case! block", "src/mirth/codegen.mth", 506, 18);
+    WORD_ENTER(mb_c99_case_21__2, "c99-case! block", "src/mirth/codegen.mth", 511, 18);
     mw_prim_drop();
-    WORD_ATOM(506, 18, "");
+    WORD_ATOM(511, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41949,15 +42028,15 @@ static void mb_c99_case_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(506, 27, ".");
+    WORD_ATOM(511, 27, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_case_21__2);
 }
 
 static void mb_c99_pattern_21__2 (void) {
-    WORD_ENTER(mb_c99_pattern_21__2, "c99-pattern! block", "src/mirth/codegen.mth", 511, 18);
+    WORD_ENTER(mb_c99_pattern_21__2, "c99-pattern! block", "src/mirth/codegen.mth", 516, 18);
     mw_prim_drop();
-    WORD_ATOM(511, 18, "");
+    WORD_ATOM(516, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41968,15 +42047,15 @@ static void mb_c99_pattern_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(511, 29, ".");
+    WORD_ATOM(516, 29, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_pattern_21__2);
 }
 
 static void mb_c99_pattern_21__4 (void) {
-    WORD_ENTER(mb_c99_pattern_21__4, "c99-pattern! block", "src/mirth/codegen.mth", 514, 18);
+    WORD_ENTER(mb_c99_pattern_21__4, "c99-pattern! block", "src/mirth/codegen.mth", 519, 18);
     mw_prim_drop();
-    WORD_ATOM(514, 18, "");
+    WORD_ATOM(519, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41987,15 +42066,15 @@ static void mb_c99_pattern_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(514, 26, ".");
+    WORD_ATOM(519, 26, ".");
     mw__2E_();
-    WORD_ATOM(514, 28, "dup");
+    WORD_ATOM(519, 28, "dup");
     mw_prim_dup();
-    WORD_ATOM(514, 32, "value");
+    WORD_ATOM(519, 32, "value");
     mw_Tag_2E_value();
-    WORD_ATOM(514, 38, ".n");
+    WORD_ATOM(519, 38, ".n");
     mw__2E_n();
-    WORD_ATOM(514, 41, "");
+    WORD_ATOM(519, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42006,38 +42085,38 @@ static void mb_c99_pattern_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(514, 47, ".");
+    WORD_ATOM(519, 47, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_pattern_21__4);
 }
 
 static void mb_c99_pattern_21__5 (void) {
-    WORD_ENTER(mb_c99_pattern_21__5, "c99-pattern! block", "src/mirth/codegen.mth", 516, 13);
+    WORD_ENTER(mb_c99_pattern_21__5, "c99-pattern! block", "src/mirth/codegen.mth", 521, 13);
     mw_prim_drop();
-    WORD_ATOM(516, 13, "num-inputs");
+    WORD_ATOM(521, 13, "num-inputs");
     mw_Tag_2E_num_inputs();
-    WORD_ATOM(516, 24, "dup");
+    WORD_ATOM(521, 24, "dup");
     mw_prim_dup();
-    WORD_ATOM(516, 28, "0>");
+    WORD_ATOM(521, 28, "0>");
     mw_0_3E_();
-    WORD_ATOM(516, 31, "if");
+    WORD_ATOM(521, 31, "if");
     if (pop_u64()) {
-        WORD_ATOM(517, 17, "c99-line");
+        WORD_ATOM(522, 17, "c99-line");
         push_u64(0);
         push_fnptr(&mb_c99_pattern_21__7);
         mw_prim_pack_cons();
         mw_c99_line();
-        WORD_ATOM(518, 17, "1-");
+        WORD_ATOM(523, 17, "1-");
         mw_prim_int_pred();
-        WORD_ATOM(518, 20, "repeat");
+        WORD_ATOM(523, 20, "repeat");
         push_u64(0);
         push_fnptr(&mb_c99_pattern_21__8);
         mw_prim_pack_cons();
         mw_repeat();
     } else {
-        WORD_ATOM(519, 17, "drop");
+        WORD_ATOM(524, 17, "drop");
         mw_prim_drop();
-        WORD_ATOM(519, 22, "c99-line");
+        WORD_ATOM(524, 22, "c99-line");
         push_u64(0);
         push_fnptr(&mb_c99_pattern_21__11);
         mw_prim_pack_cons();
@@ -42047,9 +42126,9 @@ static void mb_c99_pattern_21__5 (void) {
 }
 
 static void mb_c99_pattern_21__7 (void) {
-    WORD_ENTER(mb_c99_pattern_21__7, "c99-pattern! block", "src/mirth/codegen.mth", 517, 26);
+    WORD_ENTER(mb_c99_pattern_21__7, "c99-pattern! block", "src/mirth/codegen.mth", 522, 26);
     mw_prim_drop();
-    WORD_ATOM(517, 26, "");
+    WORD_ATOM(522, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42060,15 +42139,15 @@ static void mb_c99_pattern_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(517, 67, ".");
+    WORD_ATOM(522, 67, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_pattern_21__7);
 }
 
 static void mb_c99_pattern_21__8 (void) {
-    WORD_ENTER(mb_c99_pattern_21__8, "c99-pattern! block", "src/mirth/codegen.mth", 518, 27);
+    WORD_ENTER(mb_c99_pattern_21__8, "c99-pattern! block", "src/mirth/codegen.mth", 523, 27);
     mw_prim_drop();
-    WORD_ATOM(518, 27, "c99-line");
+    WORD_ATOM(523, 27, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_pattern_21__9);
     mw_prim_pack_cons();
@@ -42077,9 +42156,9 @@ static void mb_c99_pattern_21__8 (void) {
 }
 
 static void mb_c99_pattern_21__9 (void) {
-    WORD_ENTER(mb_c99_pattern_21__9, "c99-pattern! block", "src/mirth/codegen.mth", 518, 36);
+    WORD_ENTER(mb_c99_pattern_21__9, "c99-pattern! block", "src/mirth/codegen.mth", 523, 36);
     mw_prim_drop();
-    WORD_ATOM(518, 36, "");
+    WORD_ATOM(523, 36, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42090,15 +42169,15 @@ static void mb_c99_pattern_21__9 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(518, 77, ".");
+    WORD_ATOM(523, 77, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_pattern_21__9);
 }
 
 static void mb_c99_pattern_21__11 (void) {
-    WORD_ENTER(mb_c99_pattern_21__11, "c99-pattern! block", "src/mirth/codegen.mth", 519, 31);
+    WORD_ENTER(mb_c99_pattern_21__11, "c99-pattern! block", "src/mirth/codegen.mth", 524, 31);
     mw_prim_drop();
-    WORD_ATOM(519, 31, "");
+    WORD_ATOM(524, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42109,15 +42188,15 @@ static void mb_c99_pattern_21__11 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(519, 49, ".");
+    WORD_ATOM(524, 49, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_pattern_21__11);
 }
 
 static void mb_c99_word_sig_21__1 (void) {
-    WORD_ENTER(mb_c99_word_sig_21__1, "c99-word-sig! block", "src/mirth/codegen.mth", 526, 14);
+    WORD_ENTER(mb_c99_word_sig_21__1, "c99-word-sig! block", "src/mirth/codegen.mth", 531, 14);
     mw_prim_drop();
-    WORD_ATOM(526, 14, "");
+    WORD_ATOM(531, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42128,13 +42207,13 @@ static void mb_c99_word_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(526, 32, ".");
+    WORD_ATOM(531, 32, ".");
     mw__2E_();
-    WORD_ATOM(526, 34, "name");
+    WORD_ATOM(531, 34, "name");
     mw_Word_2E_name();
-    WORD_ATOM(526, 39, ".name");
+    WORD_ATOM(531, 39, ".name");
     mw__2E_name();
-    WORD_ATOM(526, 45, "");
+    WORD_ATOM(531, 45, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42145,15 +42224,15 @@ static void mb_c99_word_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(526, 56, ".");
+    WORD_ATOM(531, 56, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_word_sig_21__1);
 }
 
 static void mb_c99_block_sig_21__1 (void) {
-    WORD_ENTER(mb_c99_block_sig_21__1, "c99-block-sig! block", "src/mirth/codegen.mth", 530, 14);
+    WORD_ENTER(mb_c99_block_sig_21__1, "c99-block-sig! block", "src/mirth/codegen.mth", 535, 14);
     mw_prim_drop();
-    WORD_ATOM(530, 14, "");
+    WORD_ATOM(535, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42164,11 +42243,11 @@ static void mb_c99_block_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(530, 29, ".");
+    WORD_ATOM(535, 29, ".");
     mw__2E_();
-    WORD_ATOM(530, 31, ".block");
+    WORD_ATOM(535, 31, ".block");
     mw__2E_block();
-    WORD_ATOM(530, 38, "");
+    WORD_ATOM(535, 38, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42179,15 +42258,15 @@ static void mb_c99_block_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(530, 49, ".");
+    WORD_ATOM(535, 49, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_block_sig_21__1);
 }
 
 static void mb_c99_field_sig_21__1 (void) {
-    WORD_ENTER(mb_c99_field_sig_21__1, "c99-field-sig! block", "src/mirth/codegen.mth", 534, 14);
+    WORD_ENTER(mb_c99_field_sig_21__1, "c99-field-sig! block", "src/mirth/codegen.mth", 539, 14);
     mw_prim_drop();
-    WORD_ATOM(534, 14, "");
+    WORD_ATOM(539, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42198,13 +42277,13 @@ static void mb_c99_field_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(534, 32, ".");
+    WORD_ATOM(539, 32, ".");
     mw__2E_();
-    WORD_ATOM(534, 34, "name");
+    WORD_ATOM(539, 34, "name");
     mw_Field_2E_name();
-    WORD_ATOM(534, 39, ".name");
+    WORD_ATOM(539, 39, ".name");
     mw__2E_name();
-    WORD_ATOM(534, 45, "");
+    WORD_ATOM(539, 45, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42215,15 +42294,15 @@ static void mb_c99_field_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(534, 56, ".");
+    WORD_ATOM(539, 56, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_field_sig_21__1);
 }
 
 static void mb_c99_block_enter_21__1 (void) {
-    WORD_ENTER(mb_c99_block_enter_21__1, "c99-block-enter! block", "src/mirth/codegen.mth", 537, 14);
+    WORD_ENTER(mb_c99_block_enter_21__1, "c99-block-enter! block", "src/mirth/codegen.mth", 542, 14);
     mw_prim_drop();
-    WORD_ATOM(537, 14, "");
+    WORD_ATOM(542, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42234,13 +42313,13 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(537, 28, ".");
+    WORD_ATOM(542, 28, ".");
     mw__2E_();
-    WORD_ATOM(538, 9, "dup");
+    WORD_ATOM(543, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(538, 13, ".block");
+    WORD_ATOM(543, 13, ".block");
     mw__2E_block();
-    WORD_ATOM(538, 20, "");
+    WORD_ATOM(543, 20, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42251,19 +42330,19 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(538, 25, ".");
+    WORD_ATOM(543, 25, ".");
     mw__2E_();
-    WORD_ATOM(539, 9, "dup");
+    WORD_ATOM(544, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(539, 13, "arrow");
+    WORD_ATOM(544, 13, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(539, 19, "home");
+    WORD_ATOM(544, 19, "home");
     mw_Arrow_2E_home();
-    WORD_ATOM(539, 24, "match");
+    WORD_ATOM(544, 24, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(540, 21, "");
+            WORD_ATOM(545, 21, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -42277,11 +42356,11 @@ static void mb_c99_block_enter_21__1 (void) {
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(541, 21, "name");
+            WORD_ATOM(546, 21, "name");
             mw_Word_2E_name();
-            WORD_ATOM(541, 26, ">Str");
+            WORD_ATOM(546, 26, ">Str");
             mw_Name_3E_Str();
-            WORD_ATOM(541, 31, "");
+            WORD_ATOM(546, 31, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -42292,14 +42371,14 @@ static void mb_c99_block_enter_21__1 (void) {
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(541, 40, "cat");
+            WORD_ATOM(546, 40, "cat");
             mw_prim_str_cat();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
     
-}    WORD_ATOM(542, 11, ".str");
+}    WORD_ATOM(547, 11, ".str");
     mw__2E_str();
-    WORD_ATOM(542, 16, "");
+    WORD_ATOM(547, 16, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42310,21 +42389,21 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(542, 21, ".");
+    WORD_ATOM(547, 21, ".");
     mw__2E_();
-    WORD_ATOM(543, 9, "dup");
+    WORD_ATOM(548, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(543, 13, "token");
+    WORD_ATOM(548, 13, "token");
     mw_Block_2E_token();
-    WORD_ATOM(543, 19, ".module");
+    WORD_ATOM(548, 19, ".module");
     mw_Token_2E_module();
-    WORD_ATOM(543, 27, "source-path");
+    WORD_ATOM(548, 27, "source-path");
     mw_Module_2E_source_path();
-    WORD_ATOM(543, 39, ">Str");
+    WORD_ATOM(548, 39, ">Str");
     mw_Path_3E_Str();
-    WORD_ATOM(543, 44, ".str");
+    WORD_ATOM(548, 44, ".str");
     mw__2E_str();
-    WORD_ATOM(543, 49, "");
+    WORD_ATOM(548, 49, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42335,19 +42414,19 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(543, 54, ".");
+    WORD_ATOM(548, 54, ".");
     mw__2E_();
-    WORD_ATOM(544, 9, "dup");
+    WORD_ATOM(549, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(544, 13, "token");
+    WORD_ATOM(549, 13, "token");
     mw_Block_2E_token();
-    WORD_ATOM(544, 19, "row");
+    WORD_ATOM(549, 19, "row");
     mw_Token_2E_row();
-    WORD_ATOM(544, 23, ">Int");
+    WORD_ATOM(549, 23, ">Int");
     mw_Row_3E_Int();
-    WORD_ATOM(544, 28, ".n");
+    WORD_ATOM(549, 28, ".n");
     mw__2E_n();
-    WORD_ATOM(544, 31, "");
+    WORD_ATOM(549, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42358,19 +42437,19 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(544, 36, ".");
+    WORD_ATOM(549, 36, ".");
     mw__2E_();
-    WORD_ATOM(545, 9, "dup");
+    WORD_ATOM(550, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(545, 13, "token");
+    WORD_ATOM(550, 13, "token");
     mw_Block_2E_token();
-    WORD_ATOM(545, 19, "col");
+    WORD_ATOM(550, 19, "col");
     mw_Token_2E_col();
-    WORD_ATOM(545, 23, ">Int");
+    WORD_ATOM(550, 23, ">Int");
     mw_Col_3E_Int();
-    WORD_ATOM(545, 28, ".n");
+    WORD_ATOM(550, 28, ".n");
     mw__2E_n();
-    WORD_ATOM(545, 31, "");
+    WORD_ATOM(550, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42381,15 +42460,15 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(545, 36, ".");
+    WORD_ATOM(550, 36, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_block_enter_21__1);
 }
 
 static void mb_c99_block_exit_21__1 (void) {
-    WORD_ENTER(mb_c99_block_exit_21__1, "c99-block-exit! block", "src/mirth/codegen.mth", 549, 14);
+    WORD_ENTER(mb_c99_block_exit_21__1, "c99-block-exit! block", "src/mirth/codegen.mth", 554, 14);
     mw_prim_drop();
-    WORD_ATOM(549, 14, "");
+    WORD_ATOM(554, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42400,11 +42479,11 @@ static void mb_c99_block_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(549, 27, ".");
+    WORD_ATOM(554, 27, ".");
     mw__2E_();
-    WORD_ATOM(549, 29, ".block");
+    WORD_ATOM(554, 29, ".block");
     mw__2E_block();
-    WORD_ATOM(549, 36, "");
+    WORD_ATOM(554, 36, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42415,15 +42494,15 @@ static void mb_c99_block_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(549, 41, ".");
+    WORD_ATOM(554, 41, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_block_exit_21__1);
 }
 
 static void mb_c99_block_def_21__1 (void) {
-    WORD_ENTER(mb_c99_block_def_21__1, "c99-block-def! block", "src/mirth/codegen.mth", 553, 14);
+    WORD_ENTER(mb_c99_block_def_21__1, "c99-block-def! block", "src/mirth/codegen.mth", 558, 14);
     mw_prim_drop();
-    WORD_ATOM(553, 14, "");
+    WORD_ATOM(558, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42434,13 +42513,13 @@ static void mb_c99_block_def_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(553, 29, ".");
+    WORD_ATOM(558, 29, ".");
     mw__2E_();
-    WORD_ATOM(553, 31, "dup");
+    WORD_ATOM(558, 31, "dup");
     mw_prim_dup();
-    WORD_ATOM(553, 35, ".block");
+    WORD_ATOM(558, 35, ".block");
     mw__2E_block();
-    WORD_ATOM(553, 42, "");
+    WORD_ATOM(558, 42, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42451,45 +42530,45 @@ static void mb_c99_block_def_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(553, 54, ".");
+    WORD_ATOM(558, 54, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_block_def_21__1);
 }
 
 static void mb_c99_block_def_21__2 (void) {
-    WORD_ENTER(mb_c99_block_def_21__2, "c99-block-def! block", "src/mirth/codegen.mth", 555, 9);
+    WORD_ENTER(mb_c99_block_def_21__2, "c99-block-def! block", "src/mirth/codegen.mth", 560, 9);
     mw_prim_drop();
-    WORD_ATOM(555, 9, "dup");
+    WORD_ATOM(560, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(555, 13, "c99-block-enter!");
+    WORD_ATOM(560, 13, "c99-block-enter!");
     mw_c99_block_enter_21_();
-    WORD_ATOM(556, 9, "dup");
+    WORD_ATOM(561, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(556, 13, "arrow");
+    WORD_ATOM(561, 13, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(557, 9, "dup");
+    WORD_ATOM(562, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(557, 13, "ctx");
+    WORD_ATOM(562, 13, "ctx");
     mw_Arrow_2E_ctx();
-    WORD_ATOM(557, 17, "c99-unpack-ctx!");
+    WORD_ATOM(562, 17, "c99-unpack-ctx!");
     mw_c99_unpack_ctx_21_();
-    WORD_ATOM(558, 9, "dup");
+    WORD_ATOM(563, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(558, 13, "c99-arrow!");
+    WORD_ATOM(563, 13, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(559, 9, "ctx");
+    WORD_ATOM(564, 9, "ctx");
     mw_Arrow_2E_ctx();
-    WORD_ATOM(559, 13, "c99-decref-ctx!");
+    WORD_ATOM(564, 13, "c99-decref-ctx!");
     mw_c99_decref_ctx_21_();
-    WORD_ATOM(560, 9, "c99-block-exit!");
+    WORD_ATOM(565, 9, "c99-block-exit!");
     mw_c99_block_exit_21_();
     WORD_EXIT(mb_c99_block_def_21__2);
 }
 
 static void mb_c99_block_def_21__3 (void) {
-    WORD_ENTER(mb_c99_block_def_21__3, "c99-block-def! block", "src/mirth/codegen.mth", 562, 14);
+    WORD_ENTER(mb_c99_block_def_21__3, "c99-block-def! block", "src/mirth/codegen.mth", 567, 14);
     mw_prim_drop();
-    WORD_ATOM(562, 14, "");
+    WORD_ATOM(567, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42500,15 +42579,15 @@ static void mb_c99_block_def_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(562, 18, ".");
+    WORD_ATOM(567, 18, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_block_def_21__3);
 }
 
 static void mb_c99_word_enter_21__1 (void) {
-    WORD_ENTER(mb_c99_word_enter_21__1, "c99-word-enter! block", "src/mirth/codegen.mth", 574, 14);
+    WORD_ENTER(mb_c99_word_enter_21__1, "c99-word-enter! block", "src/mirth/codegen.mth", 579, 14);
     mw_prim_drop();
-    WORD_ATOM(574, 14, "");
+    WORD_ATOM(579, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42519,9 +42598,9 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(574, 28, ".");
+    WORD_ATOM(579, 28, ".");
     mw__2E_();
-    WORD_ATOM(575, 9, "");
+    WORD_ATOM(580, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42532,15 +42611,15 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(575, 15, ".");
+    WORD_ATOM(580, 15, ".");
     mw__2E_();
-    WORD_ATOM(575, 17, "dup");
+    WORD_ATOM(580, 17, "dup");
     mw_prim_dup();
-    WORD_ATOM(575, 21, "name");
+    WORD_ATOM(580, 21, "name");
     mw_Word_2E_name();
-    WORD_ATOM(575, 26, ".name");
+    WORD_ATOM(580, 26, ".name");
     mw__2E_name();
-    WORD_ATOM(575, 32, "");
+    WORD_ATOM(580, 32, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42551,17 +42630,17 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(575, 37, ".");
+    WORD_ATOM(580, 37, ".");
     mw__2E_();
-    WORD_ATOM(576, 9, "dup");
+    WORD_ATOM(581, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(576, 13, "name");
+    WORD_ATOM(581, 13, "name");
     mw_Word_2E_name();
-    WORD_ATOM(576, 18, ">Str");
+    WORD_ATOM(581, 18, ">Str");
     mw_Name_3E_Str();
-    WORD_ATOM(576, 23, ".str");
+    WORD_ATOM(581, 23, ".str");
     mw__2E_str();
-    WORD_ATOM(576, 28, "");
+    WORD_ATOM(581, 28, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42572,21 +42651,21 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(576, 33, ".");
+    WORD_ATOM(581, 33, ".");
     mw__2E_();
-    WORD_ATOM(577, 9, "dup");
+    WORD_ATOM(582, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(577, 13, "body");
+    WORD_ATOM(582, 13, "body");
     mw_Word_2E_body();
-    WORD_ATOM(577, 18, ".module");
+    WORD_ATOM(582, 18, ".module");
     mw_Token_2E_module();
-    WORD_ATOM(577, 26, "source-path");
+    WORD_ATOM(582, 26, "source-path");
     mw_Module_2E_source_path();
-    WORD_ATOM(577, 38, ">Str");
+    WORD_ATOM(582, 38, ">Str");
     mw_Path_3E_Str();
-    WORD_ATOM(577, 43, ".str");
+    WORD_ATOM(582, 43, ".str");
     mw__2E_str();
-    WORD_ATOM(577, 48, "");
+    WORD_ATOM(582, 48, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42597,19 +42676,19 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(577, 53, ".");
+    WORD_ATOM(582, 53, ".");
     mw__2E_();
-    WORD_ATOM(578, 9, "dup");
+    WORD_ATOM(583, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(578, 13, "body");
+    WORD_ATOM(583, 13, "body");
     mw_Word_2E_body();
-    WORD_ATOM(578, 18, "row");
+    WORD_ATOM(583, 18, "row");
     mw_Token_2E_row();
-    WORD_ATOM(578, 22, ">Int");
+    WORD_ATOM(583, 22, ">Int");
     mw_Row_3E_Int();
-    WORD_ATOM(578, 27, ".n");
+    WORD_ATOM(583, 27, ".n");
     mw__2E_n();
-    WORD_ATOM(578, 30, "");
+    WORD_ATOM(583, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42620,19 +42699,19 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(578, 35, ".");
+    WORD_ATOM(583, 35, ".");
     mw__2E_();
-    WORD_ATOM(579, 9, "dup");
+    WORD_ATOM(584, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(579, 13, "body");
+    WORD_ATOM(584, 13, "body");
     mw_Word_2E_body();
-    WORD_ATOM(579, 18, "col");
+    WORD_ATOM(584, 18, "col");
     mw_Token_2E_col();
-    WORD_ATOM(579, 22, ">Int");
+    WORD_ATOM(584, 22, ">Int");
     mw_Col_3E_Int();
-    WORD_ATOM(579, 27, ".n");
+    WORD_ATOM(584, 27, ".n");
     mw__2E_n();
-    WORD_ATOM(579, 30, "");
+    WORD_ATOM(584, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42643,15 +42722,15 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(579, 35, ".");
+    WORD_ATOM(584, 35, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_word_enter_21__1);
 }
 
 static void mb_c99_word_exit_21__1 (void) {
-    WORD_ENTER(mb_c99_word_exit_21__1, "c99-word-exit! block", "src/mirth/codegen.mth", 583, 14);
+    WORD_ENTER(mb_c99_word_exit_21__1, "c99-word-exit! block", "src/mirth/codegen.mth", 588, 14);
     mw_prim_drop();
-    WORD_ATOM(583, 14, "");
+    WORD_ATOM(588, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42662,9 +42741,9 @@ static void mb_c99_word_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(583, 27, ".");
+    WORD_ATOM(588, 27, ".");
     mw__2E_();
-    WORD_ATOM(584, 9, "");
+    WORD_ATOM(589, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42675,15 +42754,15 @@ static void mb_c99_word_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(584, 15, ".");
+    WORD_ATOM(589, 15, ".");
     mw__2E_();
-    WORD_ATOM(584, 17, "dup");
+    WORD_ATOM(589, 17, "dup");
     mw_prim_dup();
-    WORD_ATOM(584, 21, "name");
+    WORD_ATOM(589, 21, "name");
     mw_Word_2E_name();
-    WORD_ATOM(584, 26, ".name");
+    WORD_ATOM(589, 26, ".name");
     mw__2E_name();
-    WORD_ATOM(584, 32, "");
+    WORD_ATOM(589, 32, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42694,21 +42773,21 @@ static void mb_c99_word_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(584, 37, ".");
+    WORD_ATOM(589, 37, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_word_exit_21__1);
 }
 
 static void mb_c99_word_def_21__1 (void) {
-    WORD_ENTER(mb_c99_word_def_21__1, "c99-word-def! block", "src/mirth/codegen.mth", 589, 14);
+    WORD_ENTER(mb_c99_word_def_21__1, "c99-word-def! block", "src/mirth/codegen.mth", 594, 14);
     mw_prim_drop();
-    WORD_ATOM(589, 14, "dup");
+    WORD_ATOM(594, 14, "dup");
     mw_prim_dup();
-    WORD_ATOM(589, 18, "name");
+    WORD_ATOM(594, 18, "name");
     mw_Word_2E_name();
-    WORD_ATOM(589, 23, ".w");
+    WORD_ATOM(594, 23, ".w");
     mw__2E_w();
-    WORD_ATOM(589, 26, "");
+    WORD_ATOM(594, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42719,35 +42798,35 @@ static void mb_c99_word_def_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(589, 30, ".");
+    WORD_ATOM(594, 30, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_word_def_21__1);
 }
 
 static void mb_c99_word_def_21__2 (void) {
-    WORD_ENTER(mb_c99_word_def_21__2, "c99-word-def! block", "src/mirth/codegen.mth", 591, 9);
+    WORD_ENTER(mb_c99_word_def_21__2, "c99-word-def! block", "src/mirth/codegen.mth", 596, 9);
     mw_prim_drop();
-    WORD_ATOM(591, 9, "dup");
+    WORD_ATOM(596, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(591, 13, "c99-word-enter!");
+    WORD_ATOM(596, 13, "c99-word-enter!");
     mw_c99_word_enter_21_();
-    WORD_ATOM(592, 9, "dup");
+    WORD_ATOM(597, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(592, 13, "arrow");
+    WORD_ATOM(597, 13, "arrow");
     mw_Word_2E_arrow();
-    WORD_ATOM(592, 19, "c99-arrow!");
+    WORD_ATOM(597, 19, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(593, 9, "dup");
+    WORD_ATOM(598, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(593, 13, "c99-word-exit!");
+    WORD_ATOM(598, 13, "c99-word-exit!");
     mw_c99_word_exit_21_();
     WORD_EXIT(mb_c99_word_def_21__2);
 }
 
 static void mb_c99_word_def_21__3 (void) {
-    WORD_ENTER(mb_c99_word_def_21__3, "c99-word-def! block", "src/mirth/codegen.mth", 595, 14);
+    WORD_ENTER(mb_c99_word_def_21__3, "c99-word-def! block", "src/mirth/codegen.mth", 600, 14);
     mw_prim_drop();
-    WORD_ATOM(595, 14, "");
+    WORD_ATOM(600, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42758,7 +42837,7 @@ static void mb_c99_word_def_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(595, 18, ".");
+    WORD_ATOM(600, 18, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_word_def_21__3);
 }

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -1200,7 +1200,6 @@ static void mw_F (void) {
 }
 static void mp_F (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_T (void) {
@@ -1210,7 +1209,6 @@ static void mw_T (void) {
 }
 static void mp_T (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Int_3E_U64_unsafe (void) {
@@ -1252,7 +1250,6 @@ static void mw_L0 (void) {
 }
 static void mp_L0 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_L1 (void) {
@@ -1396,7 +1393,6 @@ static void mw_NONE (void) {
 }
 static void mp_NONE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_SOME (void) {
@@ -1423,7 +1419,6 @@ static void mw_OS_5F_UNKNOWN (void) {
 }
 static void mp_OS_5F_UNKNOWN (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_OS_5F_WINDOWS (void) {
@@ -1433,7 +1428,6 @@ static void mw_OS_5F_WINDOWS (void) {
 }
 static void mp_OS_5F_WINDOWS (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_OS_5F_LINUX (void) {
@@ -1443,7 +1437,6 @@ static void mw_OS_5F_LINUX (void) {
 }
 static void mp_OS_5F_LINUX (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_OS_5F_MACOS (void) {
@@ -1453,7 +1446,6 @@ static void mw_OS_5F_MACOS (void) {
 }
 static void mp_OS_5F_MACOS (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_LT (void) {
@@ -1463,7 +1455,6 @@ static void mw_LT (void) {
 }
 static void mp_LT (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_EQ (void) {
@@ -1473,7 +1464,6 @@ static void mw_EQ (void) {
 }
 static void mp_EQ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_GT (void) {
@@ -1483,7 +1473,6 @@ static void mw_GT (void) {
 }
 static void mp_GT (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BNUL (void) {
@@ -1493,7 +1482,6 @@ static void mw_BNUL (void) {
 }
 static void mp_BNUL (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BSOH (void) {
@@ -1503,7 +1491,6 @@ static void mw_BSOH (void) {
 }
 static void mp_BSOH (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BSTX (void) {
@@ -1513,7 +1500,6 @@ static void mw_BSTX (void) {
 }
 static void mp_BSTX (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BETX (void) {
@@ -1523,7 +1509,6 @@ static void mw_BETX (void) {
 }
 static void mp_BETX (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BEOT (void) {
@@ -1533,7 +1518,6 @@ static void mw_BEOT (void) {
 }
 static void mp_BEOT (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BENQ (void) {
@@ -1543,7 +1527,6 @@ static void mw_BENQ (void) {
 }
 static void mp_BENQ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BACK (void) {
@@ -1553,7 +1536,6 @@ static void mw_BACK (void) {
 }
 static void mp_BACK (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BBEL (void) {
@@ -1563,7 +1545,6 @@ static void mw_BBEL (void) {
 }
 static void mp_BBEL (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BBS (void) {
@@ -1573,7 +1554,6 @@ static void mw_BBS (void) {
 }
 static void mp_BBS (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BHT (void) {
@@ -1583,7 +1563,6 @@ static void mw_BHT (void) {
 }
 static void mp_BHT (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BLF (void) {
@@ -1593,7 +1572,6 @@ static void mw_BLF (void) {
 }
 static void mp_BLF (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BVT (void) {
@@ -1603,7 +1581,6 @@ static void mw_BVT (void) {
 }
 static void mp_BVT (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BFF (void) {
@@ -1613,7 +1590,6 @@ static void mw_BFF (void) {
 }
 static void mp_BFF (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BCR (void) {
@@ -1623,7 +1599,6 @@ static void mw_BCR (void) {
 }
 static void mp_BCR (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BSO (void) {
@@ -1633,7 +1608,6 @@ static void mw_BSO (void) {
 }
 static void mp_BSO (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BSI (void) {
@@ -1643,7 +1617,6 @@ static void mw_BSI (void) {
 }
 static void mp_BSI (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BDLE (void) {
@@ -1653,7 +1626,6 @@ static void mw_BDLE (void) {
 }
 static void mp_BDLE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BDC1 (void) {
@@ -1663,7 +1635,6 @@ static void mw_BDC1 (void) {
 }
 static void mp_BDC1 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BDC2 (void) {
@@ -1673,7 +1644,6 @@ static void mw_BDC2 (void) {
 }
 static void mp_BDC2 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BDC3 (void) {
@@ -1683,7 +1653,6 @@ static void mw_BDC3 (void) {
 }
 static void mp_BDC3 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BDC4 (void) {
@@ -1693,7 +1662,6 @@ static void mw_BDC4 (void) {
 }
 static void mp_BDC4 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BNAK (void) {
@@ -1703,7 +1671,6 @@ static void mw_BNAK (void) {
 }
 static void mp_BNAK (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BSYN (void) {
@@ -1713,7 +1680,6 @@ static void mw_BSYN (void) {
 }
 static void mp_BSYN (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BETB (void) {
@@ -1723,7 +1689,6 @@ static void mw_BETB (void) {
 }
 static void mp_BETB (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BCAN (void) {
@@ -1733,7 +1698,6 @@ static void mw_BCAN (void) {
 }
 static void mp_BCAN (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BEM (void) {
@@ -1743,7 +1707,6 @@ static void mw_BEM (void) {
 }
 static void mp_BEM (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BSUB (void) {
@@ -1753,7 +1716,6 @@ static void mw_BSUB (void) {
 }
 static void mp_BSUB (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BESC (void) {
@@ -1763,7 +1725,6 @@ static void mw_BESC (void) {
 }
 static void mp_BESC (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BFS (void) {
@@ -1773,7 +1734,6 @@ static void mw_BFS (void) {
 }
 static void mp_BFS (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BGS (void) {
@@ -1783,7 +1743,6 @@ static void mw_BGS (void) {
 }
 static void mp_BGS (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BRS (void) {
@@ -1793,7 +1752,6 @@ static void mw_BRS (void) {
 }
 static void mp_BRS (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BUS (void) {
@@ -1803,7 +1761,6 @@ static void mw_BUS (void) {
 }
 static void mp_BUS (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BSPACE (void) {
@@ -1813,7 +1770,6 @@ static void mw_BSPACE (void) {
 }
 static void mp_BSPACE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27__21__27_ (void) {
@@ -1823,7 +1779,6 @@ static void mw_B_27__21__27_ (void) {
 }
 static void mp_B_27__21__27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BQUOTE (void) {
@@ -1833,7 +1788,6 @@ static void mw_BQUOTE (void) {
 }
 static void mp_BQUOTE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BHASH (void) {
@@ -1843,7 +1797,6 @@ static void mw_BHASH (void) {
 }
 static void mp_BHASH (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27__24__27_ (void) {
@@ -1853,7 +1806,6 @@ static void mw_B_27__24__27_ (void) {
 }
 static void mp_B_27__24__27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27__25__27_ (void) {
@@ -1863,7 +1815,6 @@ static void mw_B_27__25__27_ (void) {
 }
 static void mp_B_27__25__27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27__26__27_ (void) {
@@ -1873,7 +1824,6 @@ static void mw_B_27__26__27_ (void) {
 }
 static void mp_B_27__26__27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BTICK (void) {
@@ -1883,7 +1833,6 @@ static void mw_BTICK (void) {
 }
 static void mp_BTICK (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BLPAREN (void) {
@@ -1893,7 +1842,6 @@ static void mw_BLPAREN (void) {
 }
 static void mp_BLPAREN (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BRPAREN (void) {
@@ -1903,7 +1851,6 @@ static void mw_BRPAREN (void) {
 }
 static void mp_BRPAREN (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27__2A__27_ (void) {
@@ -1913,7 +1860,6 @@ static void mw_B_27__2A__27_ (void) {
 }
 static void mp_B_27__2A__27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27__2B__27_ (void) {
@@ -1923,7 +1869,6 @@ static void mw_B_27__2B__27_ (void) {
 }
 static void mp_B_27__2B__27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BCOMMA (void) {
@@ -1933,7 +1878,6 @@ static void mw_BCOMMA (void) {
 }
 static void mp_BCOMMA (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27___27_ (void) {
@@ -1943,7 +1887,6 @@ static void mw_B_27___27_ (void) {
 }
 static void mp_B_27___27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27__2E__27_ (void) {
@@ -1953,7 +1896,6 @@ static void mw_B_27__2E__27_ (void) {
 }
 static void mp_B_27__2E__27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27__2F__27_ (void) {
@@ -1963,7 +1905,6 @@ static void mw_B_27__2F__27_ (void) {
 }
 static void mp_B_27__2F__27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_0_27_ (void) {
@@ -1973,7 +1914,6 @@ static void mw_B_27_0_27_ (void) {
 }
 static void mp_B_27_0_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_1_27_ (void) {
@@ -1983,7 +1923,6 @@ static void mw_B_27_1_27_ (void) {
 }
 static void mp_B_27_1_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_2_27_ (void) {
@@ -1993,7 +1932,6 @@ static void mw_B_27_2_27_ (void) {
 }
 static void mp_B_27_2_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_3_27_ (void) {
@@ -2003,7 +1941,6 @@ static void mw_B_27_3_27_ (void) {
 }
 static void mp_B_27_3_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_4_27_ (void) {
@@ -2013,7 +1950,6 @@ static void mw_B_27_4_27_ (void) {
 }
 static void mp_B_27_4_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_5_27_ (void) {
@@ -2023,7 +1959,6 @@ static void mw_B_27_5_27_ (void) {
 }
 static void mp_B_27_5_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_6_27_ (void) {
@@ -2033,7 +1968,6 @@ static void mw_B_27_6_27_ (void) {
 }
 static void mp_B_27_6_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_7_27_ (void) {
@@ -2043,7 +1977,6 @@ static void mw_B_27_7_27_ (void) {
 }
 static void mp_B_27_7_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_8_27_ (void) {
@@ -2053,7 +1986,6 @@ static void mw_B_27_8_27_ (void) {
 }
 static void mp_B_27_8_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_9_27_ (void) {
@@ -2063,7 +1995,6 @@ static void mw_B_27_9_27_ (void) {
 }
 static void mp_B_27_9_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BCOLON (void) {
@@ -2073,7 +2004,6 @@ static void mw_BCOLON (void) {
 }
 static void mp_BCOLON (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27__3B__27_ (void) {
@@ -2083,7 +2013,6 @@ static void mw_B_27__3B__27_ (void) {
 }
 static void mp_B_27__3B__27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27__3C__27_ (void) {
@@ -2093,7 +2022,6 @@ static void mw_B_27__3C__27_ (void) {
 }
 static void mp_B_27__3C__27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27__3D__27_ (void) {
@@ -2103,7 +2031,6 @@ static void mw_B_27__3D__27_ (void) {
 }
 static void mp_B_27__3D__27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27__3E__27_ (void) {
@@ -2113,7 +2040,6 @@ static void mw_B_27__3E__27_ (void) {
 }
 static void mp_B_27__3E__27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27__3F__27_ (void) {
@@ -2123,7 +2049,6 @@ static void mw_B_27__3F__27_ (void) {
 }
 static void mp_B_27__3F__27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27__40__27_ (void) {
@@ -2133,7 +2058,6 @@ static void mw_B_27__40__27_ (void) {
 }
 static void mp_B_27__40__27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_A_27_ (void) {
@@ -2143,7 +2067,6 @@ static void mw_B_27_A_27_ (void) {
 }
 static void mp_B_27_A_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_B_27_ (void) {
@@ -2153,7 +2076,6 @@ static void mw_B_27_B_27_ (void) {
 }
 static void mp_B_27_B_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_C_27_ (void) {
@@ -2163,7 +2085,6 @@ static void mw_B_27_C_27_ (void) {
 }
 static void mp_B_27_C_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_D_27_ (void) {
@@ -2173,7 +2094,6 @@ static void mw_B_27_D_27_ (void) {
 }
 static void mp_B_27_D_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_E_27_ (void) {
@@ -2183,7 +2103,6 @@ static void mw_B_27_E_27_ (void) {
 }
 static void mp_B_27_E_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_F_27_ (void) {
@@ -2193,7 +2112,6 @@ static void mw_B_27_F_27_ (void) {
 }
 static void mp_B_27_F_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_G_27_ (void) {
@@ -2203,7 +2121,6 @@ static void mw_B_27_G_27_ (void) {
 }
 static void mp_B_27_G_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_H_27_ (void) {
@@ -2213,7 +2130,6 @@ static void mw_B_27_H_27_ (void) {
 }
 static void mp_B_27_H_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_I_27_ (void) {
@@ -2223,7 +2139,6 @@ static void mw_B_27_I_27_ (void) {
 }
 static void mp_B_27_I_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_J_27_ (void) {
@@ -2233,7 +2148,6 @@ static void mw_B_27_J_27_ (void) {
 }
 static void mp_B_27_J_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_K_27_ (void) {
@@ -2243,7 +2157,6 @@ static void mw_B_27_K_27_ (void) {
 }
 static void mp_B_27_K_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_L_27_ (void) {
@@ -2253,7 +2166,6 @@ static void mw_B_27_L_27_ (void) {
 }
 static void mp_B_27_L_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_M_27_ (void) {
@@ -2263,7 +2175,6 @@ static void mw_B_27_M_27_ (void) {
 }
 static void mp_B_27_M_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_N_27_ (void) {
@@ -2273,7 +2184,6 @@ static void mw_B_27_N_27_ (void) {
 }
 static void mp_B_27_N_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_O_27_ (void) {
@@ -2283,7 +2193,6 @@ static void mw_B_27_O_27_ (void) {
 }
 static void mp_B_27_O_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_P_27_ (void) {
@@ -2293,7 +2202,6 @@ static void mw_B_27_P_27_ (void) {
 }
 static void mp_B_27_P_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_Q_27_ (void) {
@@ -2303,7 +2211,6 @@ static void mw_B_27_Q_27_ (void) {
 }
 static void mp_B_27_Q_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_R_27_ (void) {
@@ -2313,7 +2220,6 @@ static void mw_B_27_R_27_ (void) {
 }
 static void mp_B_27_R_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_S_27_ (void) {
@@ -2323,7 +2229,6 @@ static void mw_B_27_S_27_ (void) {
 }
 static void mp_B_27_S_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_T_27_ (void) {
@@ -2333,7 +2238,6 @@ static void mw_B_27_T_27_ (void) {
 }
 static void mp_B_27_T_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_U_27_ (void) {
@@ -2343,7 +2247,6 @@ static void mw_B_27_U_27_ (void) {
 }
 static void mp_B_27_U_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_V_27_ (void) {
@@ -2353,7 +2256,6 @@ static void mw_B_27_V_27_ (void) {
 }
 static void mp_B_27_V_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_W_27_ (void) {
@@ -2363,7 +2265,6 @@ static void mw_B_27_W_27_ (void) {
 }
 static void mp_B_27_W_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_X_27_ (void) {
@@ -2373,7 +2274,6 @@ static void mw_B_27_X_27_ (void) {
 }
 static void mp_B_27_X_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_Y_27_ (void) {
@@ -2383,7 +2283,6 @@ static void mw_B_27_Y_27_ (void) {
 }
 static void mp_B_27_Y_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_Z_27_ (void) {
@@ -2393,7 +2292,6 @@ static void mw_B_27_Z_27_ (void) {
 }
 static void mp_B_27_Z_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BLSQUARE (void) {
@@ -2403,7 +2301,6 @@ static void mw_BLSQUARE (void) {
 }
 static void mp_BLSQUARE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27__5C__27_ (void) {
@@ -2413,7 +2310,6 @@ static void mw_B_27__5C__27_ (void) {
 }
 static void mp_B_27__5C__27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BRSQUARE (void) {
@@ -2423,7 +2319,6 @@ static void mw_BRSQUARE (void) {
 }
 static void mp_BRSQUARE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27__5E__27_ (void) {
@@ -2433,7 +2328,6 @@ static void mw_B_27__5E__27_ (void) {
 }
 static void mp_B_27__5E__27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27__5F__27_ (void) {
@@ -2443,7 +2337,6 @@ static void mw_B_27__5F__27_ (void) {
 }
 static void mp_B_27__5F__27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27__60__27_ (void) {
@@ -2453,7 +2346,6 @@ static void mw_B_27__60__27_ (void) {
 }
 static void mp_B_27__60__27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_a_27_ (void) {
@@ -2463,7 +2355,6 @@ static void mw_B_27_a_27_ (void) {
 }
 static void mp_B_27_a_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_b_27_ (void) {
@@ -2473,7 +2364,6 @@ static void mw_B_27_b_27_ (void) {
 }
 static void mp_B_27_b_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_c_27_ (void) {
@@ -2483,7 +2373,6 @@ static void mw_B_27_c_27_ (void) {
 }
 static void mp_B_27_c_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_d_27_ (void) {
@@ -2493,7 +2382,6 @@ static void mw_B_27_d_27_ (void) {
 }
 static void mp_B_27_d_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_e_27_ (void) {
@@ -2503,7 +2391,6 @@ static void mw_B_27_e_27_ (void) {
 }
 static void mp_B_27_e_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_f_27_ (void) {
@@ -2513,7 +2400,6 @@ static void mw_B_27_f_27_ (void) {
 }
 static void mp_B_27_f_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_g_27_ (void) {
@@ -2523,7 +2409,6 @@ static void mw_B_27_g_27_ (void) {
 }
 static void mp_B_27_g_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_h_27_ (void) {
@@ -2533,7 +2418,6 @@ static void mw_B_27_h_27_ (void) {
 }
 static void mp_B_27_h_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_i_27_ (void) {
@@ -2543,7 +2427,6 @@ static void mw_B_27_i_27_ (void) {
 }
 static void mp_B_27_i_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_j_27_ (void) {
@@ -2553,7 +2436,6 @@ static void mw_B_27_j_27_ (void) {
 }
 static void mp_B_27_j_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_k_27_ (void) {
@@ -2563,7 +2445,6 @@ static void mw_B_27_k_27_ (void) {
 }
 static void mp_B_27_k_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_l_27_ (void) {
@@ -2573,7 +2454,6 @@ static void mw_B_27_l_27_ (void) {
 }
 static void mp_B_27_l_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_m_27_ (void) {
@@ -2583,7 +2463,6 @@ static void mw_B_27_m_27_ (void) {
 }
 static void mp_B_27_m_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_n_27_ (void) {
@@ -2593,7 +2472,6 @@ static void mw_B_27_n_27_ (void) {
 }
 static void mp_B_27_n_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_o_27_ (void) {
@@ -2603,7 +2481,6 @@ static void mw_B_27_o_27_ (void) {
 }
 static void mp_B_27_o_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_p_27_ (void) {
@@ -2613,7 +2490,6 @@ static void mw_B_27_p_27_ (void) {
 }
 static void mp_B_27_p_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_q_27_ (void) {
@@ -2623,7 +2499,6 @@ static void mw_B_27_q_27_ (void) {
 }
 static void mp_B_27_q_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_r_27_ (void) {
@@ -2633,7 +2508,6 @@ static void mw_B_27_r_27_ (void) {
 }
 static void mp_B_27_r_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_s_27_ (void) {
@@ -2643,7 +2517,6 @@ static void mw_B_27_s_27_ (void) {
 }
 static void mp_B_27_s_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_t_27_ (void) {
@@ -2653,7 +2526,6 @@ static void mw_B_27_t_27_ (void) {
 }
 static void mp_B_27_t_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_u_27_ (void) {
@@ -2663,7 +2535,6 @@ static void mw_B_27_u_27_ (void) {
 }
 static void mp_B_27_u_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_v_27_ (void) {
@@ -2673,7 +2544,6 @@ static void mw_B_27_v_27_ (void) {
 }
 static void mp_B_27_v_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_w_27_ (void) {
@@ -2683,7 +2553,6 @@ static void mw_B_27_w_27_ (void) {
 }
 static void mp_B_27_w_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_x_27_ (void) {
@@ -2693,7 +2562,6 @@ static void mw_B_27_x_27_ (void) {
 }
 static void mp_B_27_x_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_y_27_ (void) {
@@ -2703,7 +2571,6 @@ static void mw_B_27_y_27_ (void) {
 }
 static void mp_B_27_y_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27_z_27_ (void) {
@@ -2713,7 +2580,6 @@ static void mw_B_27_z_27_ (void) {
 }
 static void mp_B_27_z_27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BLCURLY (void) {
@@ -2723,7 +2589,6 @@ static void mw_BLCURLY (void) {
 }
 static void mp_BLCURLY (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27__7C__27_ (void) {
@@ -2733,7 +2598,6 @@ static void mw_B_27__7C__27_ (void) {
 }
 static void mp_B_27__7C__27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BRCURLY (void) {
@@ -2743,7 +2607,6 @@ static void mw_BRCURLY (void) {
 }
 static void mp_BRCURLY (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_B_27__7E__27_ (void) {
@@ -2753,7 +2616,6 @@ static void mw_B_27__7E__27_ (void) {
 }
 static void mp_B_27__7E__27_ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BDEL (void) {
@@ -2763,7 +2625,6 @@ static void mw_BDEL (void) {
 }
 static void mp_BDEL (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx80 (void) {
@@ -2773,7 +2634,6 @@ static void mw_Bx80 (void) {
 }
 static void mp_Bx80 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx81 (void) {
@@ -2783,7 +2643,6 @@ static void mw_Bx81 (void) {
 }
 static void mp_Bx81 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx82 (void) {
@@ -2793,7 +2652,6 @@ static void mw_Bx82 (void) {
 }
 static void mp_Bx82 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx83 (void) {
@@ -2803,7 +2661,6 @@ static void mw_Bx83 (void) {
 }
 static void mp_Bx83 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx84 (void) {
@@ -2813,7 +2670,6 @@ static void mw_Bx84 (void) {
 }
 static void mp_Bx84 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx85 (void) {
@@ -2823,7 +2679,6 @@ static void mw_Bx85 (void) {
 }
 static void mp_Bx85 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx86 (void) {
@@ -2833,7 +2688,6 @@ static void mw_Bx86 (void) {
 }
 static void mp_Bx86 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx87 (void) {
@@ -2843,7 +2697,6 @@ static void mw_Bx87 (void) {
 }
 static void mp_Bx87 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx88 (void) {
@@ -2853,7 +2706,6 @@ static void mw_Bx88 (void) {
 }
 static void mp_Bx88 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx89 (void) {
@@ -2863,7 +2715,6 @@ static void mw_Bx89 (void) {
 }
 static void mp_Bx89 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx8A (void) {
@@ -2873,7 +2724,6 @@ static void mw_Bx8A (void) {
 }
 static void mp_Bx8A (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx8B (void) {
@@ -2883,7 +2733,6 @@ static void mw_Bx8B (void) {
 }
 static void mp_Bx8B (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx8C (void) {
@@ -2893,7 +2742,6 @@ static void mw_Bx8C (void) {
 }
 static void mp_Bx8C (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx8D (void) {
@@ -2903,7 +2751,6 @@ static void mw_Bx8D (void) {
 }
 static void mp_Bx8D (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx8E (void) {
@@ -2913,7 +2760,6 @@ static void mw_Bx8E (void) {
 }
 static void mp_Bx8E (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx8F (void) {
@@ -2923,7 +2769,6 @@ static void mw_Bx8F (void) {
 }
 static void mp_Bx8F (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx90 (void) {
@@ -2933,7 +2778,6 @@ static void mw_Bx90 (void) {
 }
 static void mp_Bx90 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx91 (void) {
@@ -2943,7 +2787,6 @@ static void mw_Bx91 (void) {
 }
 static void mp_Bx91 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx92 (void) {
@@ -2953,7 +2796,6 @@ static void mw_Bx92 (void) {
 }
 static void mp_Bx92 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx93 (void) {
@@ -2963,7 +2805,6 @@ static void mw_Bx93 (void) {
 }
 static void mp_Bx93 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx94 (void) {
@@ -2973,7 +2814,6 @@ static void mw_Bx94 (void) {
 }
 static void mp_Bx94 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx95 (void) {
@@ -2983,7 +2823,6 @@ static void mw_Bx95 (void) {
 }
 static void mp_Bx95 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx96 (void) {
@@ -2993,7 +2832,6 @@ static void mw_Bx96 (void) {
 }
 static void mp_Bx96 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx97 (void) {
@@ -3003,7 +2841,6 @@ static void mw_Bx97 (void) {
 }
 static void mp_Bx97 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx98 (void) {
@@ -3013,7 +2850,6 @@ static void mw_Bx98 (void) {
 }
 static void mp_Bx98 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx99 (void) {
@@ -3023,7 +2859,6 @@ static void mw_Bx99 (void) {
 }
 static void mp_Bx99 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx9A (void) {
@@ -3033,7 +2868,6 @@ static void mw_Bx9A (void) {
 }
 static void mp_Bx9A (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx9B (void) {
@@ -3043,7 +2877,6 @@ static void mw_Bx9B (void) {
 }
 static void mp_Bx9B (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx9C (void) {
@@ -3053,7 +2886,6 @@ static void mw_Bx9C (void) {
 }
 static void mp_Bx9C (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx9D (void) {
@@ -3063,7 +2895,6 @@ static void mw_Bx9D (void) {
 }
 static void mp_Bx9D (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx9E (void) {
@@ -3073,7 +2904,6 @@ static void mw_Bx9E (void) {
 }
 static void mp_Bx9E (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Bx9F (void) {
@@ -3083,7 +2913,6 @@ static void mw_Bx9F (void) {
 }
 static void mp_Bx9F (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxA0 (void) {
@@ -3093,7 +2922,6 @@ static void mw_BxA0 (void) {
 }
 static void mp_BxA0 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxA1 (void) {
@@ -3103,7 +2931,6 @@ static void mw_BxA1 (void) {
 }
 static void mp_BxA1 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxA2 (void) {
@@ -3113,7 +2940,6 @@ static void mw_BxA2 (void) {
 }
 static void mp_BxA2 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxA3 (void) {
@@ -3123,7 +2949,6 @@ static void mw_BxA3 (void) {
 }
 static void mp_BxA3 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxA4 (void) {
@@ -3133,7 +2958,6 @@ static void mw_BxA4 (void) {
 }
 static void mp_BxA4 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxA5 (void) {
@@ -3143,7 +2967,6 @@ static void mw_BxA5 (void) {
 }
 static void mp_BxA5 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxA6 (void) {
@@ -3153,7 +2976,6 @@ static void mw_BxA6 (void) {
 }
 static void mp_BxA6 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxA7 (void) {
@@ -3163,7 +2985,6 @@ static void mw_BxA7 (void) {
 }
 static void mp_BxA7 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxA8 (void) {
@@ -3173,7 +2994,6 @@ static void mw_BxA8 (void) {
 }
 static void mp_BxA8 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxA9 (void) {
@@ -3183,7 +3003,6 @@ static void mw_BxA9 (void) {
 }
 static void mp_BxA9 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxAA (void) {
@@ -3193,7 +3012,6 @@ static void mw_BxAA (void) {
 }
 static void mp_BxAA (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxAB (void) {
@@ -3203,7 +3021,6 @@ static void mw_BxAB (void) {
 }
 static void mp_BxAB (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxAC (void) {
@@ -3213,7 +3030,6 @@ static void mw_BxAC (void) {
 }
 static void mp_BxAC (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxAD (void) {
@@ -3223,7 +3039,6 @@ static void mw_BxAD (void) {
 }
 static void mp_BxAD (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxAE (void) {
@@ -3233,7 +3048,6 @@ static void mw_BxAE (void) {
 }
 static void mp_BxAE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxAF (void) {
@@ -3243,7 +3057,6 @@ static void mw_BxAF (void) {
 }
 static void mp_BxAF (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxB0 (void) {
@@ -3253,7 +3066,6 @@ static void mw_BxB0 (void) {
 }
 static void mp_BxB0 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxB1 (void) {
@@ -3263,7 +3075,6 @@ static void mw_BxB1 (void) {
 }
 static void mp_BxB1 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxB2 (void) {
@@ -3273,7 +3084,6 @@ static void mw_BxB2 (void) {
 }
 static void mp_BxB2 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxB3 (void) {
@@ -3283,7 +3093,6 @@ static void mw_BxB3 (void) {
 }
 static void mp_BxB3 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxB4 (void) {
@@ -3293,7 +3102,6 @@ static void mw_BxB4 (void) {
 }
 static void mp_BxB4 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxB5 (void) {
@@ -3303,7 +3111,6 @@ static void mw_BxB5 (void) {
 }
 static void mp_BxB5 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxB6 (void) {
@@ -3313,7 +3120,6 @@ static void mw_BxB6 (void) {
 }
 static void mp_BxB6 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxB7 (void) {
@@ -3323,7 +3129,6 @@ static void mw_BxB7 (void) {
 }
 static void mp_BxB7 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxB8 (void) {
@@ -3333,7 +3138,6 @@ static void mw_BxB8 (void) {
 }
 static void mp_BxB8 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxB9 (void) {
@@ -3343,7 +3147,6 @@ static void mw_BxB9 (void) {
 }
 static void mp_BxB9 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxBA (void) {
@@ -3353,7 +3156,6 @@ static void mw_BxBA (void) {
 }
 static void mp_BxBA (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxBB (void) {
@@ -3363,7 +3165,6 @@ static void mw_BxBB (void) {
 }
 static void mp_BxBB (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxBC (void) {
@@ -3373,7 +3174,6 @@ static void mw_BxBC (void) {
 }
 static void mp_BxBC (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxBD (void) {
@@ -3383,7 +3183,6 @@ static void mw_BxBD (void) {
 }
 static void mp_BxBD (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxBE (void) {
@@ -3393,7 +3192,6 @@ static void mw_BxBE (void) {
 }
 static void mp_BxBE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxBF (void) {
@@ -3403,7 +3201,6 @@ static void mw_BxBF (void) {
 }
 static void mp_BxBF (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxC0 (void) {
@@ -3413,7 +3210,6 @@ static void mw_BxC0 (void) {
 }
 static void mp_BxC0 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxC1 (void) {
@@ -3423,7 +3219,6 @@ static void mw_BxC1 (void) {
 }
 static void mp_BxC1 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxC2 (void) {
@@ -3433,7 +3228,6 @@ static void mw_BxC2 (void) {
 }
 static void mp_BxC2 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxC3 (void) {
@@ -3443,7 +3237,6 @@ static void mw_BxC3 (void) {
 }
 static void mp_BxC3 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxC4 (void) {
@@ -3453,7 +3246,6 @@ static void mw_BxC4 (void) {
 }
 static void mp_BxC4 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxC5 (void) {
@@ -3463,7 +3255,6 @@ static void mw_BxC5 (void) {
 }
 static void mp_BxC5 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxC6 (void) {
@@ -3473,7 +3264,6 @@ static void mw_BxC6 (void) {
 }
 static void mp_BxC6 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxC7 (void) {
@@ -3483,7 +3273,6 @@ static void mw_BxC7 (void) {
 }
 static void mp_BxC7 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxC8 (void) {
@@ -3493,7 +3282,6 @@ static void mw_BxC8 (void) {
 }
 static void mp_BxC8 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxC9 (void) {
@@ -3503,7 +3291,6 @@ static void mw_BxC9 (void) {
 }
 static void mp_BxC9 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxCA (void) {
@@ -3513,7 +3300,6 @@ static void mw_BxCA (void) {
 }
 static void mp_BxCA (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxCB (void) {
@@ -3523,7 +3309,6 @@ static void mw_BxCB (void) {
 }
 static void mp_BxCB (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxCC (void) {
@@ -3533,7 +3318,6 @@ static void mw_BxCC (void) {
 }
 static void mp_BxCC (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxCD (void) {
@@ -3543,7 +3327,6 @@ static void mw_BxCD (void) {
 }
 static void mp_BxCD (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxCE (void) {
@@ -3553,7 +3336,6 @@ static void mw_BxCE (void) {
 }
 static void mp_BxCE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxCF (void) {
@@ -3563,7 +3345,6 @@ static void mw_BxCF (void) {
 }
 static void mp_BxCF (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxD0 (void) {
@@ -3573,7 +3354,6 @@ static void mw_BxD0 (void) {
 }
 static void mp_BxD0 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxD1 (void) {
@@ -3583,7 +3363,6 @@ static void mw_BxD1 (void) {
 }
 static void mp_BxD1 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxD2 (void) {
@@ -3593,7 +3372,6 @@ static void mw_BxD2 (void) {
 }
 static void mp_BxD2 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxD3 (void) {
@@ -3603,7 +3381,6 @@ static void mw_BxD3 (void) {
 }
 static void mp_BxD3 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxD4 (void) {
@@ -3613,7 +3390,6 @@ static void mw_BxD4 (void) {
 }
 static void mp_BxD4 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxD5 (void) {
@@ -3623,7 +3399,6 @@ static void mw_BxD5 (void) {
 }
 static void mp_BxD5 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxD6 (void) {
@@ -3633,7 +3408,6 @@ static void mw_BxD6 (void) {
 }
 static void mp_BxD6 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxD7 (void) {
@@ -3643,7 +3417,6 @@ static void mw_BxD7 (void) {
 }
 static void mp_BxD7 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxD8 (void) {
@@ -3653,7 +3426,6 @@ static void mw_BxD8 (void) {
 }
 static void mp_BxD8 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxD9 (void) {
@@ -3663,7 +3435,6 @@ static void mw_BxD9 (void) {
 }
 static void mp_BxD9 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxDA (void) {
@@ -3673,7 +3444,6 @@ static void mw_BxDA (void) {
 }
 static void mp_BxDA (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxDB (void) {
@@ -3683,7 +3453,6 @@ static void mw_BxDB (void) {
 }
 static void mp_BxDB (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxDC (void) {
@@ -3693,7 +3462,6 @@ static void mw_BxDC (void) {
 }
 static void mp_BxDC (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxDD (void) {
@@ -3703,7 +3471,6 @@ static void mw_BxDD (void) {
 }
 static void mp_BxDD (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxDE (void) {
@@ -3713,7 +3480,6 @@ static void mw_BxDE (void) {
 }
 static void mp_BxDE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxDF (void) {
@@ -3723,7 +3489,6 @@ static void mw_BxDF (void) {
 }
 static void mp_BxDF (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxE0 (void) {
@@ -3733,7 +3498,6 @@ static void mw_BxE0 (void) {
 }
 static void mp_BxE0 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxE1 (void) {
@@ -3743,7 +3507,6 @@ static void mw_BxE1 (void) {
 }
 static void mp_BxE1 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxE2 (void) {
@@ -3753,7 +3516,6 @@ static void mw_BxE2 (void) {
 }
 static void mp_BxE2 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxE3 (void) {
@@ -3763,7 +3525,6 @@ static void mw_BxE3 (void) {
 }
 static void mp_BxE3 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxE4 (void) {
@@ -3773,7 +3534,6 @@ static void mw_BxE4 (void) {
 }
 static void mp_BxE4 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxE5 (void) {
@@ -3783,7 +3543,6 @@ static void mw_BxE5 (void) {
 }
 static void mp_BxE5 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxE6 (void) {
@@ -3793,7 +3552,6 @@ static void mw_BxE6 (void) {
 }
 static void mp_BxE6 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxE7 (void) {
@@ -3803,7 +3561,6 @@ static void mw_BxE7 (void) {
 }
 static void mp_BxE7 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxE8 (void) {
@@ -3813,7 +3570,6 @@ static void mw_BxE8 (void) {
 }
 static void mp_BxE8 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxE9 (void) {
@@ -3823,7 +3579,6 @@ static void mw_BxE9 (void) {
 }
 static void mp_BxE9 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxEA (void) {
@@ -3833,7 +3588,6 @@ static void mw_BxEA (void) {
 }
 static void mp_BxEA (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxEB (void) {
@@ -3843,7 +3597,6 @@ static void mw_BxEB (void) {
 }
 static void mp_BxEB (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxEC (void) {
@@ -3853,7 +3606,6 @@ static void mw_BxEC (void) {
 }
 static void mp_BxEC (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxED (void) {
@@ -3863,7 +3615,6 @@ static void mw_BxED (void) {
 }
 static void mp_BxED (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxEE (void) {
@@ -3873,7 +3624,6 @@ static void mw_BxEE (void) {
 }
 static void mp_BxEE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxEF (void) {
@@ -3883,7 +3633,6 @@ static void mw_BxEF (void) {
 }
 static void mp_BxEF (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxF0 (void) {
@@ -3893,7 +3642,6 @@ static void mw_BxF0 (void) {
 }
 static void mp_BxF0 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxF1 (void) {
@@ -3903,7 +3651,6 @@ static void mw_BxF1 (void) {
 }
 static void mp_BxF1 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxF2 (void) {
@@ -3913,7 +3660,6 @@ static void mw_BxF2 (void) {
 }
 static void mp_BxF2 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxF3 (void) {
@@ -3923,7 +3669,6 @@ static void mw_BxF3 (void) {
 }
 static void mp_BxF3 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxF4 (void) {
@@ -3933,7 +3678,6 @@ static void mw_BxF4 (void) {
 }
 static void mp_BxF4 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxF5 (void) {
@@ -3943,7 +3687,6 @@ static void mw_BxF5 (void) {
 }
 static void mp_BxF5 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxF6 (void) {
@@ -3953,7 +3696,6 @@ static void mw_BxF6 (void) {
 }
 static void mp_BxF6 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxF7 (void) {
@@ -3963,7 +3705,6 @@ static void mw_BxF7 (void) {
 }
 static void mp_BxF7 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxF8 (void) {
@@ -3973,7 +3714,6 @@ static void mw_BxF8 (void) {
 }
 static void mp_BxF8 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxF9 (void) {
@@ -3983,7 +3723,6 @@ static void mw_BxF9 (void) {
 }
 static void mp_BxF9 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxFA (void) {
@@ -3993,7 +3732,6 @@ static void mw_BxFA (void) {
 }
 static void mp_BxFA (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxFB (void) {
@@ -4003,7 +3741,6 @@ static void mw_BxFB (void) {
 }
 static void mp_BxFB (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxFC (void) {
@@ -4013,7 +3750,6 @@ static void mw_BxFC (void) {
 }
 static void mp_BxFC (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxFD (void) {
@@ -4023,7 +3759,6 @@ static void mw_BxFD (void) {
 }
 static void mp_BxFD (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxFE (void) {
@@ -4033,7 +3768,6 @@ static void mw_BxFE (void) {
 }
 static void mp_BxFE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_BxFF (void) {
@@ -4043,7 +3777,6 @@ static void mw_BxFF (void) {
 }
 static void mp_BxFF (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_Str_3E_Path (void) {
@@ -4090,7 +3823,6 @@ static void mw_LAZY_5F_WAIT (void) {
 }
 static void mp_LAZY_5F_WAIT (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_CTX (void) {
@@ -4104,7 +3836,6 @@ static void mw_PATTERN_5F_UNDERSCORE (void) {
 }
 static void mp_PATTERN_5F_UNDERSCORE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PATTERN_5F_TAG (void) {
@@ -4153,7 +3884,6 @@ static void mw_STACK_5F_NIL (void) {
 }
 static void mp_STACK_5F_NIL (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_STACK_5F_CONS (void) {
@@ -4240,7 +3970,6 @@ static void mw_OPSIG_5F_ID (void) {
 }
 static void mp_OPSIG_5F_ID (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_OPSIG_5F_PUSH (void) {
@@ -4280,7 +4009,6 @@ static void mw_OP_5F_NONE (void) {
 }
 static void mp_OP_5F_NONE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_OP_5F_PRIM (void) {
@@ -4476,7 +4204,6 @@ static void mw_TYPE_5F_ERROR (void) {
 }
 static void mp_TYPE_5F_ERROR (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_TYPE_5F_DONT_5F_CARE (void) {
@@ -4486,7 +4213,6 @@ static void mw_TYPE_5F_DONT_5F_CARE (void) {
 }
 static void mp_TYPE_5F_DONT_5F_CARE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_TPrim (void) {
@@ -4681,7 +4407,6 @@ static void mw_PRIM_5F_TYPE_5F_TYPE (void) {
 }
 static void mp_PRIM_5F_TYPE_5F_TYPE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_TYPE_5F_STACK (void) {
@@ -4691,7 +4416,6 @@ static void mw_PRIM_5F_TYPE_5F_STACK (void) {
 }
 static void mp_PRIM_5F_TYPE_5F_STACK (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_TYPE_5F_RESOURCE (void) {
@@ -4701,7 +4425,6 @@ static void mw_PRIM_5F_TYPE_5F_RESOURCE (void) {
 }
 static void mp_PRIM_5F_TYPE_5F_RESOURCE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_TYPE_5F_INT (void) {
@@ -4711,7 +4434,6 @@ static void mw_PRIM_5F_TYPE_5F_INT (void) {
 }
 static void mp_PRIM_5F_TYPE_5F_INT (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_TYPE_5F_PTR (void) {
@@ -4721,7 +4443,6 @@ static void mw_PRIM_5F_TYPE_5F_PTR (void) {
 }
 static void mp_PRIM_5F_TYPE_5F_PTR (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_TYPE_5F_STR (void) {
@@ -4731,7 +4452,6 @@ static void mw_PRIM_5F_TYPE_5F_STR (void) {
 }
 static void mp_PRIM_5F_TYPE_5F_STR (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_TYPE_5F__2B_PLATFORM (void) {
@@ -4741,7 +4461,6 @@ static void mw_PRIM_5F_TYPE_5F__2B_PLATFORM (void) {
 }
 static void mp_PRIM_5F_TYPE_5F__2B_PLATFORM (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_GAMMA (void) {
@@ -4759,7 +4478,6 @@ static void mw_STACK_5F_TYPE_5F_ERROR (void) {
 }
 static void mp_STACK_5F_TYPE_5F_ERROR (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_STACK_5F_TYPE_5F_DONT_5F_CARE (void) {
@@ -4769,7 +4487,6 @@ static void mw_STACK_5F_TYPE_5F_DONT_5F_CARE (void) {
 }
 static void mp_STACK_5F_TYPE_5F_DONT_5F_CARE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_STACK_5F_TYPE_5F_UNIT (void) {
@@ -4779,7 +4496,6 @@ static void mw_STACK_5F_TYPE_5F_UNIT (void) {
 }
 static void mp_STACK_5F_TYPE_5F_UNIT (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_STVar (void) {
@@ -4863,7 +4579,6 @@ static void mw_SUBST_5F_NIL (void) {
 }
 static void mp_SUBST_5F_NIL (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_SUBST_5F_CON (void) {
@@ -4892,7 +4607,6 @@ static void mw_PRIM_5F_CORE_5F_ID (void) {
 }
 static void mp_PRIM_5F_CORE_5F_ID (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_DUP (void) {
@@ -4902,7 +4616,6 @@ static void mw_PRIM_5F_CORE_5F_DUP (void) {
 }
 static void mp_PRIM_5F_CORE_5F_DUP (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_DROP (void) {
@@ -4912,7 +4625,6 @@ static void mw_PRIM_5F_CORE_5F_DROP (void) {
 }
 static void mp_PRIM_5F_CORE_5F_DROP (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_SWAP (void) {
@@ -4922,7 +4634,6 @@ static void mw_PRIM_5F_CORE_5F_SWAP (void) {
 }
 static void mp_PRIM_5F_CORE_5F_SWAP (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_DIP (void) {
@@ -4932,7 +4643,6 @@ static void mw_PRIM_5F_CORE_5F_DIP (void) {
 }
 static void mp_PRIM_5F_CORE_5F_DIP (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_IF (void) {
@@ -4942,7 +4652,6 @@ static void mw_PRIM_5F_CORE_5F_IF (void) {
 }
 static void mp_PRIM_5F_CORE_5F_IF (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_WHILE (void) {
@@ -4952,7 +4661,6 @@ static void mw_PRIM_5F_CORE_5F_WHILE (void) {
 }
 static void mp_PRIM_5F_CORE_5F_WHILE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_DEBUG (void) {
@@ -4962,7 +4670,6 @@ static void mw_PRIM_5F_CORE_5F_DEBUG (void) {
 }
 static void mp_PRIM_5F_CORE_5F_DEBUG (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_PANIC (void) {
@@ -4972,7 +4679,6 @@ static void mw_PRIM_5F_CORE_5F_PANIC (void) {
 }
 static void mp_PRIM_5F_CORE_5F_PANIC (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_RUN (void) {
@@ -4982,7 +4688,6 @@ static void mw_PRIM_5F_CORE_5F_RUN (void) {
 }
 static void mp_PRIM_5F_CORE_5F_RUN (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_MATCH (void) {
@@ -4992,7 +4697,6 @@ static void mw_PRIM_5F_CORE_5F_MATCH (void) {
 }
 static void mp_PRIM_5F_CORE_5F_MATCH (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_LAMBDA (void) {
@@ -5002,7 +4706,6 @@ static void mw_PRIM_5F_CORE_5F_LAMBDA (void) {
 }
 static void mp_PRIM_5F_CORE_5F_LAMBDA (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_RSWAP (void) {
@@ -5012,7 +4715,6 @@ static void mw_PRIM_5F_CORE_5F_RSWAP (void) {
 }
 static void mp_PRIM_5F_CORE_5F_RSWAP (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_RDIP (void) {
@@ -5022,7 +4724,6 @@ static void mw_PRIM_5F_CORE_5F_RDIP (void) {
 }
 static void mp_PRIM_5F_CORE_5F_RDIP (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_UNSAFE_5F_CAST (void) {
@@ -5032,7 +4733,6 @@ static void mw_PRIM_5F_UNSAFE_5F_CAST (void) {
 }
 static void mp_PRIM_5F_UNSAFE_5F_CAST (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_INT_5F_EQ (void) {
@@ -5042,7 +4742,6 @@ static void mw_PRIM_5F_INT_5F_EQ (void) {
 }
 static void mp_PRIM_5F_INT_5F_EQ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_INT_5F_LT (void) {
@@ -5052,7 +4751,6 @@ static void mw_PRIM_5F_INT_5F_LT (void) {
 }
 static void mp_PRIM_5F_INT_5F_LT (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_INT_5F_ADD (void) {
@@ -5062,7 +4760,6 @@ static void mw_PRIM_5F_INT_5F_ADD (void) {
 }
 static void mp_PRIM_5F_INT_5F_ADD (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_INT_5F_SUB (void) {
@@ -5072,7 +4769,6 @@ static void mw_PRIM_5F_INT_5F_SUB (void) {
 }
 static void mp_PRIM_5F_INT_5F_SUB (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_INT_5F_MUL (void) {
@@ -5082,7 +4778,6 @@ static void mw_PRIM_5F_INT_5F_MUL (void) {
 }
 static void mp_PRIM_5F_INT_5F_MUL (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_INT_5F_DIV (void) {
@@ -5092,7 +4787,6 @@ static void mw_PRIM_5F_INT_5F_DIV (void) {
 }
 static void mp_PRIM_5F_INT_5F_DIV (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_INT_5F_MOD (void) {
@@ -5102,7 +4796,6 @@ static void mw_PRIM_5F_INT_5F_MOD (void) {
 }
 static void mp_PRIM_5F_INT_5F_MOD (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_INT_5F_AND (void) {
@@ -5112,7 +4805,6 @@ static void mw_PRIM_5F_INT_5F_AND (void) {
 }
 static void mp_PRIM_5F_INT_5F_AND (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_INT_5F_OR (void) {
@@ -5122,7 +4814,6 @@ static void mw_PRIM_5F_INT_5F_OR (void) {
 }
 static void mp_PRIM_5F_INT_5F_OR (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_INT_5F_XOR (void) {
@@ -5132,7 +4823,6 @@ static void mw_PRIM_5F_INT_5F_XOR (void) {
 }
 static void mp_PRIM_5F_INT_5F_XOR (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_INT_5F_SHL (void) {
@@ -5142,7 +4832,6 @@ static void mw_PRIM_5F_INT_5F_SHL (void) {
 }
 static void mp_PRIM_5F_INT_5F_SHL (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_INT_5F_SHR (void) {
@@ -5152,7 +4841,6 @@ static void mw_PRIM_5F_INT_5F_SHR (void) {
 }
 static void mp_PRIM_5F_INT_5F_SHR (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_INT_5F_TO_5F_STR (void) {
@@ -5162,7 +4850,6 @@ static void mw_PRIM_5F_INT_5F_TO_5F_STR (void) {
 }
 static void mp_PRIM_5F_INT_5F_TO_5F_STR (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_PACK_5F_NIL (void) {
@@ -5172,7 +4859,6 @@ static void mw_PRIM_5F_PACK_5F_NIL (void) {
 }
 static void mp_PRIM_5F_PACK_5F_NIL (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_PACK_5F_CONS (void) {
@@ -5182,7 +4868,6 @@ static void mw_PRIM_5F_PACK_5F_CONS (void) {
 }
 static void mp_PRIM_5F_PACK_5F_CONS (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_PACK_5F_UNCONS (void) {
@@ -5192,7 +4877,6 @@ static void mw_PRIM_5F_PACK_5F_UNCONS (void) {
 }
 static void mp_PRIM_5F_PACK_5F_UNCONS (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_MUT_5F_NEW (void) {
@@ -5202,7 +4886,6 @@ static void mw_PRIM_5F_MUT_5F_NEW (void) {
 }
 static void mp_PRIM_5F_MUT_5F_NEW (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_MUT_5F_GET (void) {
@@ -5212,7 +4895,6 @@ static void mw_PRIM_5F_MUT_5F_GET (void) {
 }
 static void mp_PRIM_5F_MUT_5F_GET (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_MUT_5F_SET (void) {
@@ -5222,7 +4904,6 @@ static void mw_PRIM_5F_MUT_5F_SET (void) {
 }
 static void mp_PRIM_5F_MUT_5F_SET (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_MUT_5F_IS_5F_SET (void) {
@@ -5232,7 +4913,6 @@ static void mw_PRIM_5F_MUT_5F_IS_5F_SET (void) {
 }
 static void mp_PRIM_5F_MUT_5F_IS_5F_SET (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_PTR_5F_NIL (void) {
@@ -5242,7 +4922,6 @@ static void mw_PRIM_5F_PTR_5F_NIL (void) {
 }
 static void mp_PRIM_5F_PTR_5F_NIL (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_PTR_5F_ADD (void) {
@@ -5252,7 +4931,6 @@ static void mw_PRIM_5F_PTR_5F_ADD (void) {
 }
 static void mp_PRIM_5F_PTR_5F_ADD (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_PTR_5F_SIZE (void) {
@@ -5262,7 +4940,6 @@ static void mw_PRIM_5F_PTR_5F_SIZE (void) {
 }
 static void mp_PRIM_5F_PTR_5F_SIZE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_PTR_5F_GET (void) {
@@ -5272,7 +4949,6 @@ static void mw_PRIM_5F_PTR_5F_GET (void) {
 }
 static void mp_PRIM_5F_PTR_5F_GET (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_PTR_5F_SET (void) {
@@ -5282,7 +4958,6 @@ static void mw_PRIM_5F_PTR_5F_SET (void) {
 }
 static void mp_PRIM_5F_PTR_5F_SET (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_PTR_5F_ALLOC (void) {
@@ -5292,7 +4967,6 @@ static void mw_PRIM_5F_PTR_5F_ALLOC (void) {
 }
 static void mp_PRIM_5F_PTR_5F_ALLOC (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_PTR_5F_REALLOC (void) {
@@ -5302,7 +4976,6 @@ static void mw_PRIM_5F_PTR_5F_REALLOC (void) {
 }
 static void mp_PRIM_5F_PTR_5F_REALLOC (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_PTR_5F_COPY (void) {
@@ -5312,7 +4985,6 @@ static void mw_PRIM_5F_PTR_5F_COPY (void) {
 }
 static void mp_PRIM_5F_PTR_5F_COPY (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_PTR_5F_FILL (void) {
@@ -5322,7 +4994,6 @@ static void mw_PRIM_5F_PTR_5F_FILL (void) {
 }
 static void mp_PRIM_5F_PTR_5F_FILL (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_PTR_5F_RAW (void) {
@@ -5332,7 +5003,6 @@ static void mw_PRIM_5F_PTR_5F_RAW (void) {
 }
 static void mp_PRIM_5F_PTR_5F_RAW (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_STR_5F_CMP (void) {
@@ -5342,7 +5012,6 @@ static void mw_PRIM_5F_STR_5F_CMP (void) {
 }
 static void mp_PRIM_5F_STR_5F_CMP (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_STR_5F_ALLOC (void) {
@@ -5352,7 +5021,6 @@ static void mw_PRIM_5F_STR_5F_ALLOC (void) {
 }
 static void mp_PRIM_5F_STR_5F_ALLOC (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_STR_5F_COPY (void) {
@@ -5362,7 +5030,6 @@ static void mw_PRIM_5F_STR_5F_COPY (void) {
 }
 static void mp_PRIM_5F_STR_5F_COPY (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_STR_5F_NUM_5F_BYTES (void) {
@@ -5372,7 +5039,6 @@ static void mw_PRIM_5F_STR_5F_NUM_5F_BYTES (void) {
 }
 static void mp_PRIM_5F_STR_5F_NUM_5F_BYTES (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_STR_5F_BASE (void) {
@@ -5382,7 +5048,6 @@ static void mw_PRIM_5F_STR_5F_BASE (void) {
 }
 static void mp_PRIM_5F_STR_5F_BASE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_STR_5F_CAT (void) {
@@ -5392,7 +5057,6 @@ static void mw_PRIM_5F_STR_5F_CAT (void) {
 }
 static void mp_PRIM_5F_STR_5F_CAT (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_U8_5F_GET (void) {
@@ -5402,7 +5066,6 @@ static void mw_PRIM_5F_U8_5F_GET (void) {
 }
 static void mp_PRIM_5F_U8_5F_GET (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_U8_5F_SET (void) {
@@ -5412,7 +5075,6 @@ static void mw_PRIM_5F_U8_5F_SET (void) {
 }
 static void mp_PRIM_5F_U8_5F_SET (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_U16_5F_GET (void) {
@@ -5422,7 +5084,6 @@ static void mw_PRIM_5F_U16_5F_GET (void) {
 }
 static void mp_PRIM_5F_U16_5F_GET (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_U16_5F_SET (void) {
@@ -5432,7 +5093,6 @@ static void mw_PRIM_5F_U16_5F_SET (void) {
 }
 static void mp_PRIM_5F_U16_5F_SET (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_U32_5F_GET (void) {
@@ -5442,7 +5102,6 @@ static void mw_PRIM_5F_U32_5F_GET (void) {
 }
 static void mp_PRIM_5F_U32_5F_GET (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_U32_5F_SET (void) {
@@ -5452,7 +5111,6 @@ static void mw_PRIM_5F_U32_5F_SET (void) {
 }
 static void mp_PRIM_5F_U32_5F_SET (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_U64_5F_GET (void) {
@@ -5462,7 +5120,6 @@ static void mw_PRIM_5F_U64_5F_GET (void) {
 }
 static void mp_PRIM_5F_U64_5F_GET (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_U64_5F_SET (void) {
@@ -5472,7 +5129,6 @@ static void mw_PRIM_5F_U64_5F_SET (void) {
 }
 static void mp_PRIM_5F_U64_5F_SET (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_I8_5F_GET (void) {
@@ -5482,7 +5138,6 @@ static void mw_PRIM_5F_I8_5F_GET (void) {
 }
 static void mp_PRIM_5F_I8_5F_GET (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_I8_5F_SET (void) {
@@ -5492,7 +5147,6 @@ static void mw_PRIM_5F_I8_5F_SET (void) {
 }
 static void mp_PRIM_5F_I8_5F_SET (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_I16_5F_GET (void) {
@@ -5502,7 +5156,6 @@ static void mw_PRIM_5F_I16_5F_GET (void) {
 }
 static void mp_PRIM_5F_I16_5F_GET (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_I16_5F_SET (void) {
@@ -5512,7 +5165,6 @@ static void mw_PRIM_5F_I16_5F_SET (void) {
 }
 static void mp_PRIM_5F_I16_5F_SET (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_I32_5F_GET (void) {
@@ -5522,7 +5174,6 @@ static void mw_PRIM_5F_I32_5F_GET (void) {
 }
 static void mp_PRIM_5F_I32_5F_GET (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_I32_5F_SET (void) {
@@ -5532,7 +5183,6 @@ static void mw_PRIM_5F_I32_5F_SET (void) {
 }
 static void mp_PRIM_5F_I32_5F_SET (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_I64_5F_GET (void) {
@@ -5542,7 +5192,6 @@ static void mw_PRIM_5F_I64_5F_GET (void) {
 }
 static void mp_PRIM_5F_I64_5F_GET (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_I64_5F_SET (void) {
@@ -5552,7 +5201,6 @@ static void mw_PRIM_5F_I64_5F_SET (void) {
 }
 static void mp_PRIM_5F_I64_5F_SET (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_SYS_5F_OS (void) {
@@ -5562,7 +5210,6 @@ static void mw_PRIM_5F_SYS_5F_OS (void) {
 }
 static void mp_PRIM_5F_SYS_5F_OS (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_SYS_5F_ARGC (void) {
@@ -5572,7 +5219,6 @@ static void mw_PRIM_5F_SYS_5F_ARGC (void) {
 }
 static void mp_PRIM_5F_SYS_5F_ARGC (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_SYS_5F_ARGV (void) {
@@ -5582,7 +5228,6 @@ static void mw_PRIM_5F_SYS_5F_ARGV (void) {
 }
 static void mp_PRIM_5F_SYS_5F_ARGV (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_POSIX_5F_READ (void) {
@@ -5592,7 +5237,6 @@ static void mw_PRIM_5F_POSIX_5F_READ (void) {
 }
 static void mp_PRIM_5F_POSIX_5F_READ (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_POSIX_5F_WRITE (void) {
@@ -5602,7 +5246,6 @@ static void mw_PRIM_5F_POSIX_5F_WRITE (void) {
 }
 static void mp_PRIM_5F_POSIX_5F_WRITE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_POSIX_5F_OPEN (void) {
@@ -5612,7 +5255,6 @@ static void mw_PRIM_5F_POSIX_5F_OPEN (void) {
 }
 static void mp_PRIM_5F_POSIX_5F_OPEN (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_POSIX_5F_CLOSE (void) {
@@ -5622,7 +5264,6 @@ static void mw_PRIM_5F_POSIX_5F_CLOSE (void) {
 }
 static void mp_PRIM_5F_POSIX_5F_CLOSE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_POSIX_5F_EXIT (void) {
@@ -5632,7 +5273,6 @@ static void mw_PRIM_5F_POSIX_5F_EXIT (void) {
 }
 static void mp_PRIM_5F_POSIX_5F_EXIT (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_POSIX_5F_MMAP (void) {
@@ -5642,7 +5282,6 @@ static void mw_PRIM_5F_POSIX_5F_MMAP (void) {
 }
 static void mp_PRIM_5F_POSIX_5F_MMAP (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_MODULE (void) {
@@ -5652,7 +5291,6 @@ static void mw_PRIM_5F_SYNTAX_5F_MODULE (void) {
 }
 static void mp_PRIM_5F_SYNTAX_5F_MODULE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_IMPORT (void) {
@@ -5662,7 +5300,6 @@ static void mw_PRIM_5F_SYNTAX_5F_IMPORT (void) {
 }
 static void mp_PRIM_5F_SYNTAX_5F_IMPORT (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_ALIAS (void) {
@@ -5672,7 +5309,6 @@ static void mw_PRIM_5F_SYNTAX_5F_ALIAS (void) {
 }
 static void mp_PRIM_5F_SYNTAX_5F_ALIAS (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_DEF (void) {
@@ -5682,7 +5318,6 @@ static void mw_PRIM_5F_SYNTAX_5F_DEF (void) {
 }
 static void mp_PRIM_5F_SYNTAX_5F_DEF (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_DEF_5F_MISSING (void) {
@@ -5692,7 +5327,6 @@ static void mw_PRIM_5F_SYNTAX_5F_DEF_5F_MISSING (void) {
 }
 static void mp_PRIM_5F_SYNTAX_5F_DEF_5F_MISSING (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_DEF_5F_TYPE (void) {
@@ -5702,7 +5336,6 @@ static void mw_PRIM_5F_SYNTAX_5F_DEF_5F_TYPE (void) {
 }
 static void mp_PRIM_5F_SYNTAX_5F_DEF_5F_TYPE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_BUFFER (void) {
@@ -5712,7 +5345,6 @@ static void mw_PRIM_5F_SYNTAX_5F_BUFFER (void) {
 }
 static void mp_PRIM_5F_SYNTAX_5F_BUFFER (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_VARIABLE (void) {
@@ -5722,7 +5354,6 @@ static void mw_PRIM_5F_SYNTAX_5F_VARIABLE (void) {
 }
 static void mp_PRIM_5F_SYNTAX_5F_VARIABLE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_DEF_5F_EXTERNAL (void) {
@@ -5732,7 +5363,6 @@ static void mw_PRIM_5F_SYNTAX_5F_DEF_5F_EXTERNAL (void) {
 }
 static void mp_PRIM_5F_SYNTAX_5F_DEF_5F_EXTERNAL (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_TARGET_5F_C99 (void) {
@@ -5742,7 +5372,6 @@ static void mw_PRIM_5F_SYNTAX_5F_TARGET_5F_C99 (void) {
 }
 static void mp_PRIM_5F_SYNTAX_5F_TARGET_5F_C99 (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_EMBED_5F_STR (void) {
@@ -5752,7 +5381,6 @@ static void mw_PRIM_5F_SYNTAX_5F_EMBED_5F_STR (void) {
 }
 static void mp_PRIM_5F_SYNTAX_5F_EMBED_5F_STR (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_TABLE (void) {
@@ -5762,7 +5390,6 @@ static void mw_PRIM_5F_SYNTAX_5F_TABLE (void) {
 }
 static void mp_PRIM_5F_SYNTAX_5F_TABLE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_FIELD (void) {
@@ -5772,7 +5399,6 @@ static void mw_PRIM_5F_SYNTAX_5F_FIELD (void) {
 }
 static void mp_PRIM_5F_SYNTAX_5F_FIELD (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_DATA (void) {
@@ -5782,7 +5408,6 @@ static void mw_PRIM_5F_SYNTAX_5F_DATA (void) {
 }
 static void mp_PRIM_5F_SYNTAX_5F_DATA (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_DASHES (void) {
@@ -5792,7 +5417,6 @@ static void mw_PRIM_5F_SYNTAX_5F_DASHES (void) {
 }
 static void mp_PRIM_5F_SYNTAX_5F_DASHES (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_ARROW (void) {
@@ -5802,7 +5426,6 @@ static void mw_PRIM_5F_SYNTAX_5F_ARROW (void) {
 }
 static void mp_PRIM_5F_SYNTAX_5F_ARROW (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_TOKEN_5F_NONE (void) {
@@ -5812,7 +5435,6 @@ static void mw_TOKEN_5F_NONE (void) {
 }
 static void mp_TOKEN_5F_NONE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_TOKEN_5F_COMMA (void) {
@@ -5822,7 +5444,6 @@ static void mw_TOKEN_5F_COMMA (void) {
 }
 static void mp_TOKEN_5F_COMMA (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_TOKEN_5F_LPAREN_5F_OPEN (void) {
@@ -5832,7 +5453,6 @@ static void mw_TOKEN_5F_LPAREN_5F_OPEN (void) {
 }
 static void mp_TOKEN_5F_LPAREN_5F_OPEN (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_TOKEN_5F_LPAREN (void) {
@@ -5868,7 +5488,6 @@ static void mw_TOKEN_5F_LSQUARE_5F_OPEN (void) {
 }
 static void mp_TOKEN_5F_LSQUARE_5F_OPEN (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_TOKEN_5F_LSQUARE (void) {
@@ -5904,7 +5523,6 @@ static void mw_TOKEN_5F_LCURLY_5F_OPEN (void) {
 }
 static void mp_TOKEN_5F_LCURLY_5F_OPEN (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_TOKEN_5F_LCURLY (void) {
@@ -5979,7 +5597,6 @@ static void mw_DEF_5F_NONE (void) {
 }
 static void mp_DEF_5F_NONE (void) {
     VAL car = pop_value();
-    VAL cdr;
     decref(car);
 }
 static void mw_DEF_5F_ALIAS (void) {
@@ -7725,6 +7342,7 @@ static void mb_c99_tag_21__3 (void);
 static void mb_c99_tag_21__4 (void);
 static void mb_c99_tag_21__11 (void);
 static void mb_c99_tag_21__12 (void);
+static void mb_c99_tag_21__13 (void);
 static void mb_c99_external_21__5 (void);
 static void mb_c99_external_21__7 (void);
 static void mb_c99_external_21__9 (void);
@@ -20199,22 +19817,24 @@ static void mw_c99_tag_21_ (void) {
         mw_Str_2B_C99_2E_put();
         WORD_ATOM(234, 15, "line");
         mw__2B_C99_2E_line();
-        WORD_ATOM(235, 9, "");
-        {
-            static bool vready = false;
-            static VAL v;
-            if (! vready) {
-                v = mkstr("    VAL cdr;", 12);
-                vready = true;
-            }
-            push_value(v);
-            incref(v);
-        }
-        WORD_ATOM(235, 24, "put");
-        mw_Str_2B_C99_2E_put();
-        WORD_ATOM(235, 28, "line");
-        mw__2B_C99_2E_line();
-        WORD_ATOM(236, 9, "");
+        WORD_ATOM(235, 9, "dup");
+        mw_prim_dup();
+        WORD_ATOM(235, 13, "num-resource-inputs");
+        mw_Tag_2E_num_resource_inputs();
+        WORD_ATOM(235, 33, "over");
+        mw_over();
+        WORD_ATOM(235, 38, "num-type-inputs");
+        mw_Tag_2E_num_type_inputs();
+        WORD_ATOM(235, 54, "+");
+        mw_prim_int_add();
+        WORD_ATOM(235, 56, "0>");
+        mw_0_3E_();
+        WORD_ATOM(235, 59, "then");
+        push_u64(0);
+        push_fnptr(&mb_c99_tag_21__11);
+        mw_prim_pack_cons();
+        mw_Bool_2E_then();
+        WORD_ATOM(238, 9, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20225,27 +19845,27 @@ static void mw_c99_tag_21_ (void) {
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(237, 9, "over");
+        WORD_ATOM(239, 9, "over");
         mw_over();
-        WORD_ATOM(237, 14, "num-resource-inputs");
+        WORD_ATOM(239, 14, "num-resource-inputs");
         mw_Tag_2E_num_resource_inputs();
-        WORD_ATOM(237, 34, "repeat");
-        push_u64(0);
-        push_fnptr(&mb_c99_tag_21__11);
-        mw_prim_pack_cons();
-        mw_repeat();
-        WORD_ATOM(242, 9, "over");
-        mw_over();
-        WORD_ATOM(242, 14, "num-type-inputs");
-        mw_Tag_2E_num_type_inputs();
-        WORD_ATOM(242, 30, "repeat");
+        WORD_ATOM(239, 34, "repeat");
         push_u64(0);
         push_fnptr(&mb_c99_tag_21__12);
         mw_prim_pack_cons();
         mw_repeat();
-        WORD_ATOM(247, 9, "put");
+        WORD_ATOM(244, 9, "over");
+        mw_over();
+        WORD_ATOM(244, 14, "num-type-inputs");
+        mw_Tag_2E_num_type_inputs();
+        WORD_ATOM(244, 30, "repeat");
+        push_u64(0);
+        push_fnptr(&mb_c99_tag_21__13);
+        mw_prim_pack_cons();
+        mw_repeat();
+        WORD_ATOM(249, 9, "put");
         mw_Str_2B_C99_2E_put();
-        WORD_ATOM(247, 13, "");
+        WORD_ATOM(249, 13, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20256,12 +19876,12 @@ static void mw_c99_tag_21_ (void) {
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(247, 21, "put");
+        WORD_ATOM(249, 21, "put");
         mw_Str_2B_C99_2E_put();
-        WORD_ATOM(247, 25, "line");
+        WORD_ATOM(249, 25, "line");
         mw__2B_C99_2E_line();
     }
-    WORD_ATOM(249, 5, "");
+    WORD_ATOM(251, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20272,42 +19892,42 @@ static void mw_c99_tag_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(249, 9, "put");
+    WORD_ATOM(251, 9, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(249, 13, "line");
+    WORD_ATOM(251, 13, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(251, 5, "drop");
+    WORD_ATOM(253, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_tag_21_);
 }
 static void mw_c99_externals_21_ (void) {
-    WORD_ENTER(mw_c99_externals_21_, "c99-externals!", "src/mirth/codegen.mth", 254, 5);
-    WORD_ATOM(254, 5, "External.for");
+    WORD_ENTER(mw_c99_externals_21_, "c99-externals!", "src/mirth/codegen.mth", 256, 5);
+    WORD_ATOM(256, 5, "External.for");
     push_u64(0);
     push_fnptr(&mb_c99_externals_21__1);
     mw_prim_pack_cons();
     mw_External_2E_for();
-    WORD_ATOM(254, 33, "line");
+    WORD_ATOM(256, 33, "line");
     mw__2B_C99_2E_line();
     WORD_EXIT(mw_c99_externals_21_);
 }
 static void mw_c99_external_21_ (void) {
-    WORD_ENTER(mw_c99_external_21_, "c99-external!", "src/mirth/codegen.mth", 257, 5);
-    WORD_ATOM(257, 5, "dup");
+    WORD_ENTER(mw_c99_external_21_, "c99-external!", "src/mirth/codegen.mth", 259, 5);
+    WORD_ATOM(259, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(257, 9, "sig");
+    WORD_ATOM(259, 9, "sig");
     mw_External_2E_sig();
-    WORD_ATOM(257, 13, "sig-arity");
+    WORD_ATOM(259, 13, "sig-arity");
     mw_Token_2E_sig_arity();
-    WORD_ATOM(258, 5, "dup");
+    WORD_ATOM(260, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(258, 9, "");
+    WORD_ATOM(260, 9, "");
     push_i64(2LL);
-    WORD_ATOM(258, 11, ">=");
+    WORD_ATOM(260, 11, ">=");
     mw_Int_3E__3D_();
-    WORD_ATOM(258, 14, "if");
+    WORD_ATOM(260, 14, "if");
     if (pop_u64()) {
-        WORD_ATOM(259, 9, "");
+        WORD_ATOM(261, 9, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20318,18 +19938,18 @@ static void mw_c99_external_21_ (void) {
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(259, 62, "panic!");
+        WORD_ATOM(261, 62, "panic!");
         mw_prim_panic();
     } else {
-        WORD_ATOM(261, 9, "dup");
+        WORD_ATOM(263, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(261, 13, "");
+        WORD_ATOM(263, 13, "");
         push_i64(1LL);
-        WORD_ATOM(261, 15, ">=");
+        WORD_ATOM(263, 15, ">=");
         mw_Int_3E__3D_();
-        WORD_ATOM(261, 18, "if");
+        WORD_ATOM(263, 18, "if");
         if (pop_u64()) {
-            WORD_ATOM(262, 13, "");
+            WORD_ATOM(264, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20341,7 +19961,7 @@ static void mw_c99_external_21_ (void) {
                 incref(v);
             }
         } else {
-            WORD_ATOM(263, 13, "");
+            WORD_ATOM(265, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20353,15 +19973,15 @@ static void mw_c99_external_21_ (void) {
                 incref(v);
             }
         }
-        WORD_ATOM(264, 11, "put");
+        WORD_ATOM(266, 11, "put");
         mw_Str_2B_C99_2E_put();
     }
-    WORD_ATOM(267, 5, "dip2");
+    WORD_ATOM(269, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_c99_external_21__5);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(269, 5, "");
+    WORD_ATOM(271, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20372,17 +19992,17 @@ static void mw_c99_external_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(269, 10, "put");
+    WORD_ATOM(271, 10, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(270, 5, "over");
+    WORD_ATOM(272, 5, "over");
     mw_over();
-    WORD_ATOM(270, 10, "dup");
+    WORD_ATOM(272, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(270, 14, "0>");
+    WORD_ATOM(272, 14, "0>");
     mw_0_3E_();
-    WORD_ATOM(270, 17, "if");
+    WORD_ATOM(272, 17, "if");
     if (pop_u64()) {
-        WORD_ATOM(270, 20, "");
+        WORD_ATOM(272, 20, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20393,19 +20013,19 @@ static void mw_c99_external_21_ (void) {
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(270, 30, "put");
+        WORD_ATOM(272, 30, "put");
         mw_Str_2B_C99_2E_put();
-        WORD_ATOM(270, 34, "1-");
+        WORD_ATOM(272, 34, "1-");
         mw_prim_int_pred();
-        WORD_ATOM(270, 37, "repeat");
+        WORD_ATOM(272, 37, "repeat");
         push_u64(0);
         push_fnptr(&mb_c99_external_21__7);
         mw_prim_pack_cons();
         mw_repeat();
     } else {
-        WORD_ATOM(270, 62, "drop");
+        WORD_ATOM(272, 62, "drop");
         mw_prim_drop();
-        WORD_ATOM(270, 67, "");
+        WORD_ATOM(272, 67, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20416,10 +20036,10 @@ static void mw_c99_external_21_ (void) {
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(270, 74, "put");
+        WORD_ATOM(272, 74, "put");
         mw_Str_2B_C99_2E_put();
     }
-    WORD_ATOM(271, 5, "");
+    WORD_ATOM(273, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20430,16 +20050,16 @@ static void mw_c99_external_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(271, 10, "put");
+    WORD_ATOM(273, 10, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(271, 14, "line");
+    WORD_ATOM(273, 14, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(273, 5, "dip2");
+    WORD_ATOM(275, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_c99_external_21__9);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(273, 28, "");
+    WORD_ATOM(275, 28, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20450,24 +20070,24 @@ static void mw_c99_external_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(273, 33, "put");
+    WORD_ATOM(275, 33, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(273, 37, "line");
+    WORD_ATOM(275, 37, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(274, 5, "over");
+    WORD_ATOM(276, 5, "over");
     mw_over();
-    WORD_ATOM(274, 10, "countdown");
+    WORD_ATOM(276, 10, "countdown");
     push_u64(0);
     push_fnptr(&mb_c99_external_21__10);
     mw_prim_pack_cons();
     mw_countdown();
-    WORD_ATOM(275, 5, "dup");
+    WORD_ATOM(277, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(275, 9, "0>");
+    WORD_ATOM(277, 9, "0>");
     mw_0_3E_();
-    WORD_ATOM(275, 12, "if");
+    WORD_ATOM(277, 12, "if");
     if (pop_u64()) {
-        WORD_ATOM(275, 15, "");
+        WORD_ATOM(277, 15, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20479,7 +20099,7 @@ static void mw_c99_external_21_ (void) {
             incref(v);
         }
     } else {
-        WORD_ATOM(275, 32, "");
+        WORD_ATOM(277, 32, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20491,14 +20111,14 @@ static void mw_c99_external_21_ (void) {
             incref(v);
         }
     }
-    WORD_ATOM(275, 40, "put");
+    WORD_ATOM(277, 40, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(276, 5, "dip2");
+    WORD_ATOM(278, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_c99_external_21__13);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(277, 5, "");
+    WORD_ATOM(279, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20509,29 +20129,29 @@ static void mw_c99_external_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(277, 9, "put");
+    WORD_ATOM(279, 9, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(278, 5, "dip");
+    WORD_ATOM(280, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(278, 9, "dup");
+        WORD_ATOM(280, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(278, 13, "0>");
+        WORD_ATOM(280, 13, "0>");
         mw_0_3E_();
-        WORD_ATOM(278, 16, "if");
+        WORD_ATOM(280, 16, "if");
         if (pop_u64()) {
-            WORD_ATOM(279, 9, "dup");
+            WORD_ATOM(281, 9, "dup");
             mw_prim_dup();
-            WORD_ATOM(279, 13, "1-");
+            WORD_ATOM(281, 13, "1-");
             mw_prim_int_pred();
-            WORD_ATOM(279, 16, "dup");
+            WORD_ATOM(281, 16, "dup");
             mw_prim_dup();
-            WORD_ATOM(279, 20, "count");
+            WORD_ATOM(281, 20, "count");
             push_u64(0);
             push_fnptr(&mb_c99_external_21__16);
             mw_prim_pack_cons();
             mw_count();
-            WORD_ATOM(279, 48, "");
+            WORD_ATOM(281, 48, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20542,17 +20162,17 @@ static void mw_c99_external_21_ (void) {
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(279, 52, "put");
+            WORD_ATOM(281, 52, "put");
             mw_Str_2B_C99_2E_put();
-            WORD_ATOM(279, 56, "put");
+            WORD_ATOM(281, 56, "put");
             mw_Int_2B_C99_2E_put();
         } else {
-            WORD_ATOM(280, 9, "id");
+            WORD_ATOM(282, 9, "id");
             mw_prim_id();
         }
         push_value(d2);
     }
-    WORD_ATOM(282, 5, "");
+    WORD_ATOM(284, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20563,15 +20183,15 @@ static void mw_c99_external_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(282, 9, "put");
+    WORD_ATOM(284, 9, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(283, 5, "dup");
+    WORD_ATOM(285, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(283, 9, "0>");
+    WORD_ATOM(285, 9, "0>");
     mw_0_3E_();
-    WORD_ATOM(283, 12, "if");
+    WORD_ATOM(285, 12, "if");
     if (pop_u64()) {
-        WORD_ATOM(283, 15, "");
+        WORD_ATOM(285, 15, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20583,7 +20203,7 @@ static void mw_c99_external_21_ (void) {
             incref(v);
         }
     } else {
-        WORD_ATOM(283, 21, "");
+        WORD_ATOM(285, 21, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20595,11 +20215,11 @@ static void mw_c99_external_21_ (void) {
             incref(v);
         }
     }
-    WORD_ATOM(283, 26, "put");
+    WORD_ATOM(285, 26, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(283, 30, "line");
+    WORD_ATOM(285, 30, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(284, 5, "");
+    WORD_ATOM(286, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20610,43 +20230,43 @@ static void mw_c99_external_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(284, 9, "put");
+    WORD_ATOM(286, 9, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(284, 13, "line");
+    WORD_ATOM(286, 13, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(285, 5, "drop3");
+    WORD_ATOM(287, 5, "drop3");
     mw_drop3();
     WORD_EXIT(mw_c99_external_21_);
 }
 static void mw_c99_nest (void) {
-    WORD_ENTER(mw_c99_nest, "c99-nest", "src/mirth/codegen.mth", 288, 5);
-    WORD_ATOM(288, 5, "depth@");
+    WORD_ENTER(mw_c99_nest, "c99-nest", "src/mirth/codegen.mth", 290, 5);
+    WORD_ATOM(290, 5, "depth@");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(288, 5, "depth@");
-        mw__2B_C99_2E_depth_40_();
-        WORD_ATOM(288, 12, "1+");
-        mw_prim_int_succ();
-        WORD_ATOM(288, 15, "depth!");
-        mw__2B_C99_2E_depth_21_();
-        WORD_ATOM(289, 5, "f");
-        incref(var_f);
-        run_value(var_f);
         WORD_ATOM(290, 5, "depth@");
         mw__2B_C99_2E_depth_40_();
-        WORD_ATOM(290, 12, "1-");
-        mw_prim_int_pred();
+        WORD_ATOM(290, 12, "1+");
+        mw_prim_int_succ();
         WORD_ATOM(290, 15, "depth!");
+        mw__2B_C99_2E_depth_21_();
+        WORD_ATOM(291, 5, "f");
+        incref(var_f);
+        run_value(var_f);
+        WORD_ATOM(292, 5, "depth@");
+        mw__2B_C99_2E_depth_40_();
+        WORD_ATOM(292, 12, "1-");
+        mw_prim_int_pred();
+        WORD_ATOM(292, 15, "depth!");
         mw__2B_C99_2E_depth_21_();
         decref(var_f);
     }
     WORD_EXIT(mw_c99_nest);
 }
 static void mw_c99_indent (void) {
-    WORD_ENTER(mw_c99_indent, "c99-indent", "src/mirth/codegen.mth", 292, 31);
-    WORD_ATOM(292, 31, "depth@");
+    WORD_ENTER(mw_c99_indent, "c99-indent", "src/mirth/codegen.mth", 294, 31);
+    WORD_ATOM(294, 31, "depth@");
     mw__2B_C99_2E_depth_40_();
-    WORD_ATOM(292, 38, "repeat");
+    WORD_ATOM(294, 38, "repeat");
     push_u64(0);
     push_fnptr(&mb_c99_indent_1);
     mw_prim_pack_cons();
@@ -20654,31 +20274,31 @@ static void mw_c99_indent (void) {
     WORD_EXIT(mw_c99_indent);
 }
 static void mw_c99_line (void) {
-    WORD_ENTER(mw_c99_line, "c99-line", "src/mirth/codegen.mth", 293, 59);
-    WORD_ATOM(293, 59, "c99-indent");
+    WORD_ENTER(mw_c99_line, "c99-line", "src/mirth/codegen.mth", 295, 59);
+    WORD_ATOM(295, 59, "c99-indent");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(293, 59, "c99-indent");
+        WORD_ATOM(295, 59, "c99-indent");
         mw_c99_indent();
-        WORD_ATOM(293, 70, "f");
+        WORD_ATOM(295, 70, "f");
         incref(var_f);
         run_value(var_f);
-        WORD_ATOM(293, 72, "line");
+        WORD_ATOM(295, 72, "line");
         mw__2B_C99_2E_line();
         decref(var_f);
     }
     WORD_EXIT(mw_c99_line);
 }
 static void mw_c99_call_21_ (void) {
-    WORD_ENTER(mw_c99_call_21_, "c99-call!", "src/mirth/codegen.mth", 296, 5);
-    WORD_ATOM(296, 5, "dip");
+    WORD_ENTER(mw_c99_call_21_, "c99-call!", "src/mirth/codegen.mth", 298, 5);
+    WORD_ATOM(298, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(296, 9, "c99-args-push!");
+        WORD_ATOM(298, 9, "c99-args-push!");
         mw_c99_args_push_21_();
         push_value(d2);
     }
-    WORD_ATOM(297, 5, "c99-line");
+    WORD_ATOM(299, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_call_21__2);
     mw_prim_pack_cons();
@@ -20686,10 +20306,10 @@ static void mw_c99_call_21_ (void) {
     WORD_EXIT(mw_c99_call_21_);
 }
 static void mw_c99_arrow_21_ (void) {
-    WORD_ENTER(mw_c99_arrow_21_, "c99-arrow!", "src/mirth/codegen.mth", 299, 37);
-    WORD_ATOM(299, 37, "atoms");
+    WORD_ENTER(mw_c99_arrow_21_, "c99-arrow!", "src/mirth/codegen.mth", 301, 37);
+    WORD_ATOM(301, 37, "atoms");
     mw_Arrow_2E_atoms();
-    WORD_ATOM(299, 43, "for");
+    WORD_ATOM(301, 43, "for");
     push_u64(0);
     push_fnptr(&mb_c99_arrow_21__1);
     mw_prim_pack_cons();
@@ -20697,126 +20317,126 @@ static void mw_c99_arrow_21_ (void) {
     WORD_EXIT(mw_c99_arrow_21_);
 }
 static void mw_c99_atom_21_ (void) {
-    WORD_ENTER(mw_c99_atom_21_, "c99-atom!", "src/mirth/codegen.mth", 301, 5);
-    WORD_ATOM(301, 5, "c99-line");
+    WORD_ENTER(mw_c99_atom_21_, "c99-atom!", "src/mirth/codegen.mth", 303, 5);
+    WORD_ATOM(303, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_atom_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(306, 5, "sip");
+    WORD_ATOM(308, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_c99_atom_21__4);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(306, 15, "op");
+    WORD_ATOM(308, 15, "op");
     mw_Atom_2E_op();
-    WORD_ATOM(307, 5, "c99-args-op!");
+    WORD_ATOM(309, 5, "c99-args-op!");
     mw_c99_args_op_21_();
     WORD_EXIT(mw_c99_atom_21_);
 }
 static void mw_c99_args_op_21_ (void) {
-    WORD_ENTER(mw_c99_args_op_21_, "c99-args-op!", "src/mirth/codegen.mth", 310, 5);
-    WORD_ATOM(310, 5, "OP_NONE");
+    WORD_ENTER(mw_c99_args_op_21_, "c99-args-op!", "src/mirth/codegen.mth", 312, 5);
+    WORD_ATOM(312, 5, "OP_NONE");
     switch (get_top_data_tag()) {
         case 0LL:
             mp_OP_5F_NONE();
-            WORD_ATOM(310, 20, "drop");
+            WORD_ATOM(312, 20, "drop");
             mw_prim_drop();
             break;
         case 8LL:
             mp_OP_5F_INT();
-            WORD_ATOM(311, 20, "nip");
+            WORD_ATOM(313, 20, "nip");
             mw_nip();
-            WORD_ATOM(311, 24, "c99-int!");
+            WORD_ATOM(313, 24, "c99-int!");
             mw_c99_int_21_();
             break;
         case 9LL:
             mp_OP_5F_STR();
-            WORD_ATOM(312, 20, "nip");
+            WORD_ATOM(314, 20, "nip");
             mw_nip();
-            WORD_ATOM(312, 24, "c99-str!");
+            WORD_ATOM(314, 24, "c99-str!");
             mw_c99_str_21_();
             break;
         case 6LL:
             mp_OP_5F_CONSTANT();
-            WORD_ATOM(313, 20, "nip");
+            WORD_ATOM(315, 20, "nip");
             mw_nip();
-            WORD_ATOM(313, 24, "c99-constant!");
+            WORD_ATOM(315, 24, "c99-constant!");
             mw_c99_constant_21_();
             break;
         case 2LL:
             mp_OP_5F_WORD();
-            WORD_ATOM(314, 20, "name");
+            WORD_ATOM(316, 20, "name");
             mw_Word_2E_name();
-            WORD_ATOM(314, 25, "c99-call!");
+            WORD_ATOM(316, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 3LL:
             mp_OP_5F_EXTERNAL();
-            WORD_ATOM(315, 20, "name");
+            WORD_ATOM(317, 20, "name");
             mw_External_2E_name();
-            WORD_ATOM(315, 25, "c99-call!");
+            WORD_ATOM(317, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 4LL:
             mp_OP_5F_BUFFER();
-            WORD_ATOM(316, 20, "name");
+            WORD_ATOM(318, 20, "name");
             mw_Buffer_2E_name();
-            WORD_ATOM(316, 25, "c99-call!");
+            WORD_ATOM(318, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 5LL:
             mp_OP_5F_VARIABLE();
-            WORD_ATOM(317, 20, "name");
+            WORD_ATOM(319, 20, "name");
             mw_Variable_2E_name();
-            WORD_ATOM(317, 25, "c99-call!");
+            WORD_ATOM(319, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 7LL:
             mp_OP_5F_FIELD();
-            WORD_ATOM(318, 20, "name");
+            WORD_ATOM(320, 20, "name");
             mw_Field_2E_name();
-            WORD_ATOM(318, 25, "c99-call!");
+            WORD_ATOM(320, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 10LL:
             mp_OP_5F_TAG();
-            WORD_ATOM(319, 20, "name");
+            WORD_ATOM(321, 20, "name");
             mw_Tag_2E_name();
-            WORD_ATOM(319, 25, "c99-call!");
+            WORD_ATOM(321, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 1LL:
             mp_OP_5F_PRIM();
-            WORD_ATOM(320, 20, "c99-prim!");
+            WORD_ATOM(322, 20, "c99-prim!");
             mw_c99_prim_21_();
             break;
         case 11LL:
             mp_OP_5F_MATCH();
-            WORD_ATOM(321, 20, "nip");
+            WORD_ATOM(323, 20, "nip");
             mw_nip();
-            WORD_ATOM(321, 24, "c99-match!");
+            WORD_ATOM(323, 24, "c99-match!");
             mw_c99_match_21_();
             break;
         case 12LL:
             mp_OP_5F_LAMBDA();
-            WORD_ATOM(322, 20, "nip");
+            WORD_ATOM(324, 20, "nip");
             mw_nip();
-            WORD_ATOM(322, 24, "c99-lambda!");
+            WORD_ATOM(324, 24, "c99-lambda!");
             mw_c99_lambda_21_();
             break;
         case 13LL:
             mp_OP_5F_VAR();
-            WORD_ATOM(323, 20, "nip");
+            WORD_ATOM(325, 20, "nip");
             mw_nip();
-            WORD_ATOM(323, 24, "c99-var!");
+            WORD_ATOM(325, 24, "c99-var!");
             mw_c99_var_21_();
             break;
         case 14LL:
             mp_OP_5F_BLOCK();
-            WORD_ATOM(324, 20, "nip");
+            WORD_ATOM(326, 20, "nip");
             mw_nip();
-            WORD_ATOM(324, 24, "c99-block-push!");
+            WORD_ATOM(326, 24, "c99-block-push!");
             mw_c99_block_push_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -20824,8 +20444,8 @@ static void mw_c99_args_op_21_ (void) {
     WORD_EXIT(mw_c99_args_op_21_);
 }
 static void mw_c99_int_21_ (void) {
-    WORD_ENTER(mw_c99_int_21_, "c99-int!", "src/mirth/codegen.mth", 327, 5);
-    WORD_ATOM(327, 5, "c99-line");
+    WORD_ENTER(mw_c99_int_21_, "c99-int!", "src/mirth/codegen.mth", 329, 5);
+    WORD_ATOM(329, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_int_21__1);
     mw_prim_pack_cons();
@@ -20833,29 +20453,29 @@ static void mw_c99_int_21_ (void) {
     WORD_EXIT(mw_c99_int_21_);
 }
 static void mw_c99_str_21_ (void) {
-    WORD_ENTER(mw_c99_str_21_, "c99-str!", "src/mirth/codegen.mth", 330, 5);
-    WORD_ATOM(330, 5, "c99-line");
+    WORD_ENTER(mw_c99_str_21_, "c99-str!", "src/mirth/codegen.mth", 332, 5);
+    WORD_ATOM(332, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(331, 5, "c99-nest");
+    WORD_ATOM(333, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(354, 5, "c99-line");
+    WORD_ATOM(356, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__20);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(355, 5, "drop");
+    WORD_ATOM(357, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_str_21_);
 }
 static void mw__2B_C99_2E_put_cstr (void) {
-    WORD_ENTER(mw__2B_C99_2E_put_cstr, "+C99.put-cstr", "src/mirth/codegen.mth", 358, 5);
-    WORD_ATOM(358, 5, "");
+    WORD_ENTER(mw__2B_C99_2E_put_cstr, "+C99.put-cstr", "src/mirth/codegen.mth", 360, 5);
+    WORD_ATOM(360, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20866,14 +20486,14 @@ static void mw__2B_C99_2E_put_cstr (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(358, 10, "put");
+    WORD_ATOM(360, 10, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(358, 14, "str-bytes-for");
+    WORD_ATOM(360, 14, "str-bytes-for");
     push_u64(0);
     push_fnptr(&mb__2B_C99_2E_put_cstr_1);
     mw_prim_pack_cons();
     mw_str_bytes_for();
-    WORD_ATOM(358, 46, "");
+    WORD_ATOM(360, 46, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20884,17 +20504,17 @@ static void mw__2B_C99_2E_put_cstr (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(358, 51, "put");
+    WORD_ATOM(360, 51, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mw__2B_C99_2E_put_cstr);
 }
 static void mw_c99_string_byte_21_ (void) {
-    WORD_ENTER(mw_c99_string_byte_21_, "c99-string-byte!", "src/mirth/codegen.mth", 361, 5);
-    WORD_ATOM(361, 5, "B'\\'");
+    WORD_ENTER(mw_c99_string_byte_21_, "c99-string-byte!", "src/mirth/codegen.mth", 363, 5);
+    WORD_ATOM(363, 5, "B'\\'");
     switch (get_top_data_tag()) {
         case 92LL:
             mp_B_27__5C__27_();
-            WORD_ATOM(361, 13, "");
+            WORD_ATOM(363, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20905,12 +20525,12 @@ static void mw_c99_string_byte_21_ (void) {
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(361, 20, "put");
+            WORD_ATOM(363, 20, "put");
             mw_Str_2B_C99_2E_put();
             break;
         case 34LL:
             mp_BQUOTE();
-            WORD_ATOM(362, 15, "");
+            WORD_ATOM(364, 15, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20921,12 +20541,12 @@ static void mw_c99_string_byte_21_ (void) {
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(362, 22, "put");
+            WORD_ATOM(364, 22, "put");
             mw_Str_2B_C99_2E_put();
             break;
         case 9LL:
             mp_BHT();
-            WORD_ATOM(363, 12, "");
+            WORD_ATOM(365, 12, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20937,12 +20557,12 @@ static void mw_c99_string_byte_21_ (void) {
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(363, 18, "put");
+            WORD_ATOM(365, 18, "put");
             mw_Str_2B_C99_2E_put();
             break;
         case 10LL:
             mp_BLF();
-            WORD_ATOM(364, 12, "");
+            WORD_ATOM(366, 12, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20953,12 +20573,12 @@ static void mw_c99_string_byte_21_ (void) {
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(364, 18, "put");
+            WORD_ATOM(366, 18, "put");
             mw_Str_2B_C99_2E_put();
             break;
         case 13LL:
             mp_BCR();
-            WORD_ATOM(365, 12, "");
+            WORD_ATOM(367, 12, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20969,24 +20589,24 @@ static void mw_c99_string_byte_21_ (void) {
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(365, 18, "put");
+            WORD_ATOM(367, 18, "put");
             mw_Str_2B_C99_2E_put();
             break;
         default:
-            WORD_ATOM(367, 9, "dup");
+            WORD_ATOM(369, 9, "dup");
             mw_prim_dup();
-            WORD_ATOM(367, 13, "BSPACE");
+            WORD_ATOM(369, 13, "BSPACE");
             mw_BSPACE();
-            WORD_ATOM(367, 20, "B'~'");
+            WORD_ATOM(369, 20, "B'~'");
             mw_B_27__7E__27_();
-            WORD_ATOM(367, 25, "in-range");
+            WORD_ATOM(369, 25, "in-range");
             mw_Byte_2E_in_range();
-            WORD_ATOM(367, 34, "if");
+            WORD_ATOM(369, 34, "if");
             if (pop_u64()) {
-                WORD_ATOM(368, 13, "put");
+                WORD_ATOM(370, 13, "put");
                 mw_Byte_2B_C99_2E_put();
             } else {
-                WORD_ATOM(369, 13, "");
+                WORD_ATOM(371, 13, "");
                 {
                     static bool vready = false;
                     static VAL v;
@@ -20997,18 +20617,18 @@ static void mw_c99_string_byte_21_ (void) {
                     push_value(v);
                     incref(v);
                 }
-                WORD_ATOM(369, 19, "put");
+                WORD_ATOM(371, 19, "put");
                 mw_Str_2B_C99_2E_put();
-                WORD_ATOM(369, 23, "to-hexdigits");
+                WORD_ATOM(371, 23, "to-hexdigits");
                 mw_Byte_2E_to_hexdigits();
-                WORD_ATOM(369, 36, "dip");
+                WORD_ATOM(371, 36, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(369, 40, "put");
+                    WORD_ATOM(371, 40, "put");
                     mw_Byte_2B_C99_2E_put();
                     push_value(d5);
                 }
-                WORD_ATOM(369, 45, "put");
+                WORD_ATOM(371, 45, "put");
                 mw_Byte_2B_C99_2E_put();
             }
             break;
@@ -21016,30 +20636,30 @@ static void mw_c99_string_byte_21_ (void) {
     WORD_EXIT(mw_c99_string_byte_21_);
 }
 static void mw_c99_constant_21_ (void) {
-    WORD_ENTER(mw_c99_constant_21_, "c99-constant!", "src/mirth/codegen.mth", 374, 5);
-    WORD_ATOM(374, 5, "value");
+    WORD_ENTER(mw_c99_constant_21_, "c99-constant!", "src/mirth/codegen.mth", 376, 5);
+    WORD_ATOM(376, 5, "value");
     mw_Constant_2E_value();
-    WORD_ATOM(374, 11, "c99-value!");
+    WORD_ATOM(376, 11, "c99-value!");
     mw_c99_value_21_();
     WORD_EXIT(mw_c99_constant_21_);
 }
 static void mw_c99_value_21_ (void) {
-    WORD_ENTER(mw_c99_value_21_, "c99-value!", "src/mirth/codegen.mth", 377, 5);
-    WORD_ATOM(377, 5, "VALUE_INT");
+    WORD_ENTER(mw_c99_value_21_, "c99-value!", "src/mirth/codegen.mth", 379, 5);
+    WORD_ATOM(379, 5, "VALUE_INT");
     switch (get_top_data_tag()) {
         case 0LL:
             mp_VALUE_5F_INT();
-            WORD_ATOM(377, 18, "c99-int!");
+            WORD_ATOM(379, 18, "c99-int!");
             mw_c99_int_21_();
             break;
         case 1LL:
             mp_VALUE_5F_STR();
-            WORD_ATOM(378, 18, "c99-str!");
+            WORD_ATOM(380, 18, "c99-str!");
             mw_c99_str_21_();
             break;
         case 2LL:
             mp_VALUE_5F_BLOCK();
-            WORD_ATOM(379, 20, "c99-block-push!");
+            WORD_ATOM(381, 20, "c99-block-push!");
             mw_c99_block_push_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -21047,157 +20667,157 @@ static void mw_c99_value_21_ (void) {
     WORD_EXIT(mw_c99_value_21_);
 }
 static void mw_c99_prim_21_ (void) {
-    WORD_ENTER(mw_c99_prim_21_, "c99-prim!", "src/mirth/codegen.mth", 382, 5);
-    WORD_ATOM(382, 5, "PRIM_CORE_DIP");
+    WORD_ENTER(mw_c99_prim_21_, "c99-prim!", "src/mirth/codegen.mth", 384, 5);
+    WORD_ATOM(384, 5, "PRIM_CORE_DIP");
     switch (get_top_data_tag()) {
         case 4LL:
             mp_PRIM_5F_CORE_5F_DIP();
-            WORD_ATOM(383, 9, "match");
+            WORD_ATOM(385, 9, "match");
             switch (get_top_data_tag()) {
                 case 1LL:
                     mp_L1();
-                    WORD_ATOM(385, 17, "c99-line");
+                    WORD_ATOM(387, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__3);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(386, 17, "c99-nest");
+                    WORD_ATOM(388, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__4);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(391, 17, "c99-line");
+                    WORD_ATOM(393, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__7);
                     mw_prim_pack_cons();
                     mw_c99_line();
                     break;
                 default:
-                    WORD_ATOM(393, 17, "PRIM_CORE_DIP");
+                    WORD_ATOM(395, 17, "PRIM_CORE_DIP");
                     mw_PRIM_5F_CORE_5F_DIP();
-                    WORD_ATOM(393, 31, "c99-prim-default!");
+                    WORD_ATOM(395, 31, "c99-prim-default!");
                     mw_c99_prim_default_21_();
                     break;
             }
             break;
         case 13LL:
             mp_PRIM_5F_CORE_5F_RDIP();
-            WORD_ATOM(397, 9, "match");
+            WORD_ATOM(399, 9, "match");
             switch (get_top_data_tag()) {
                 case 1LL:
                     mp_L1();
-                    WORD_ATOM(399, 17, "c99-line");
+                    WORD_ATOM(401, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__11);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(400, 17, "c99-nest");
+                    WORD_ATOM(402, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__12);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(405, 17, "c99-line");
+                    WORD_ATOM(407, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__15);
                     mw_prim_pack_cons();
                     mw_c99_line();
                     break;
                 default:
-                    WORD_ATOM(407, 17, "PRIM_CORE_RDIP");
+                    WORD_ATOM(409, 17, "PRIM_CORE_RDIP");
                     mw_PRIM_5F_CORE_5F_RDIP();
-                    WORD_ATOM(407, 32, "c99-prim-default!");
+                    WORD_ATOM(409, 32, "c99-prim-default!");
                     mw_c99_prim_default_21_();
                     break;
             }
             break;
         case 5LL:
             mp_PRIM_5F_CORE_5F_IF();
-            WORD_ATOM(411, 9, "match");
+            WORD_ATOM(413, 9, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
                     mp_L2();
-                    WORD_ATOM(413, 17, "c99-line");
+                    WORD_ATOM(415, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__19);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(414, 17, "c99-nest");
+                    WORD_ATOM(416, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__20);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(415, 17, "c99-line");
+                    WORD_ATOM(417, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__21);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(416, 17, "c99-nest");
+                    WORD_ATOM(418, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__22);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(417, 17, "c99-line");
+                    WORD_ATOM(419, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__23);
                     mw_prim_pack_cons();
                     mw_c99_line();
                     break;
                 default:
-                    WORD_ATOM(419, 17, "PRIM_CORE_IF");
+                    WORD_ATOM(421, 17, "PRIM_CORE_IF");
                     mw_PRIM_5F_CORE_5F_IF();
-                    WORD_ATOM(419, 30, "c99-prim-default!");
+                    WORD_ATOM(421, 30, "c99-prim-default!");
                     mw_c99_prim_default_21_();
                     break;
             }
             break;
         case 6LL:
             mp_PRIM_5F_CORE_5F_WHILE();
-            WORD_ATOM(423, 9, "match");
+            WORD_ATOM(425, 9, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
                     mp_L2();
-                    WORD_ATOM(425, 17, "c99-line");
+                    WORD_ATOM(427, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__27);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(426, 17, "c99-nest");
+                    WORD_ATOM(428, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__28);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(431, 17, "c99-line");
+                    WORD_ATOM(433, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__30);
                     mw_prim_pack_cons();
                     mw_c99_line();
                     break;
                 default:
-                    WORD_ATOM(434, 17, "PRIM_CORE_WHILE");
+                    WORD_ATOM(436, 17, "PRIM_CORE_WHILE");
                     mw_PRIM_5F_CORE_5F_WHILE();
-                    WORD_ATOM(434, 33, "c99-prim-default!");
+                    WORD_ATOM(436, 33, "c99-prim-default!");
                     mw_c99_prim_default_21_();
                     break;
             }
             break;
         default:
-            WORD_ATOM(437, 10, "c99-prim-default!");
+            WORD_ATOM(439, 10, "c99-prim-default!");
             mw_c99_prim_default_21_();
             break;
     }
     WORD_EXIT(mw_c99_prim_21_);
 }
 static void mw_c99_prim_default_21_ (void) {
-    WORD_ENTER(mw_c99_prim_default_21_, "c99-prim-default!", "src/mirth/codegen.mth", 440, 5);
-    WORD_ATOM(440, 5, "name");
+    WORD_ENTER(mw_c99_prim_default_21_, "c99-prim-default!", "src/mirth/codegen.mth", 442, 5);
+    WORD_ATOM(442, 5, "name");
     mw_Prim_2E_name();
-    WORD_ATOM(440, 10, "c99-call!");
+    WORD_ATOM(442, 10, "c99-call!");
     mw_c99_call_21_();
     WORD_EXIT(mw_c99_prim_default_21_);
 }
 static void mw_c99_args_push_21_ (void) {
-    WORD_ENTER(mw_c99_args_push_21_, "c99-args-push!", "src/mirth/codegen.mth", 443, 5);
-    WORD_ATOM(443, 5, "for");
+    WORD_ENTER(mw_c99_args_push_21_, "c99-args-push!", "src/mirth/codegen.mth", 445, 5);
+    WORD_ATOM(445, 5, "for");
     push_u64(0);
     push_fnptr(&mb_c99_args_push_21__1);
     mw_prim_pack_cons();
@@ -21205,30 +20825,30 @@ static void mw_c99_args_push_21_ (void) {
     WORD_EXIT(mw_c99_args_push_21_);
 }
 static void mw_c99_arg_push_21_ (void) {
-    WORD_ENTER(mw_c99_arg_push_21_, "c99-arg-push!", "src/mirth/codegen.mth", 446, 5);
-    WORD_ATOM(446, 5, "ARG_BLOCK");
-    WORD_ATOM(446, 18, "c99-block-push!");
+    WORD_ENTER(mw_c99_arg_push_21_, "c99-arg-push!", "src/mirth/codegen.mth", 448, 5);
+    WORD_ATOM(448, 5, "ARG_BLOCK");
+    WORD_ATOM(448, 18, "c99-block-push!");
     mw_c99_block_push_21_();
     WORD_EXIT(mw_c99_arg_push_21_);
 }
 static void mw_c99_arg_run_21_ (void) {
-    WORD_ENTER(mw_c99_arg_run_21_, "c99-arg-run!", "src/mirth/codegen.mth", 449, 5);
-    WORD_ATOM(449, 5, "ARG_BLOCK");
-    WORD_ATOM(449, 18, "c99-block-run!");
+    WORD_ENTER(mw_c99_arg_run_21_, "c99-arg-run!", "src/mirth/codegen.mth", 451, 5);
+    WORD_ATOM(451, 5, "ARG_BLOCK");
+    WORD_ATOM(451, 18, "c99-block-run!");
     mw_c99_block_run_21_();
     WORD_EXIT(mw_c99_arg_run_21_);
 }
 static void mw_c99_block_run_21_ (void) {
-    WORD_ENTER(mw_c99_block_run_21_, "c99-block-run!", "src/mirth/codegen.mth", 452, 5);
-    WORD_ATOM(452, 5, "arrow");
+    WORD_ENTER(mw_c99_block_run_21_, "c99-block-run!", "src/mirth/codegen.mth", 454, 5);
+    WORD_ATOM(454, 5, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(452, 11, "c99-arrow!");
+    WORD_ATOM(454, 11, "c99-arrow!");
     mw_c99_arrow_21_();
     WORD_EXIT(mw_c99_block_run_21_);
 }
 static void mw_Var_2B_C99_2E_put (void) {
-    WORD_ENTER(mw_Var_2B_C99_2E_put, "Var+C99.put", "src/mirth/codegen.mth", 454, 36);
-    WORD_ATOM(454, 36, "");
+    WORD_ENTER(mw_Var_2B_C99_2E_put, "Var+C99.put", "src/mirth/codegen.mth", 456, 36);
+    WORD_ATOM(456, 36, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21239,32 +20859,32 @@ static void mw_Var_2B_C99_2E_put (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(454, 43, "put");
+    WORD_ATOM(456, 43, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(454, 47, "name");
+    WORD_ATOM(456, 47, "name");
     mw_Var_2E_name();
-    WORD_ATOM(454, 52, "put");
+    WORD_ATOM(456, 52, "put");
     mw_Name_2B_C99_2E_put();
     WORD_EXIT(mw_Var_2B_C99_2E_put);
 }
 static void mw_Param_2B_C99_2E_put (void) {
-    WORD_ENTER(mw_Param_2B_C99_2E_put, "Param+C99.put", "src/mirth/codegen.mth", 455, 40);
-    WORD_ATOM(455, 40, ">Var");
+    WORD_ENTER(mw_Param_2B_C99_2E_put, "Param+C99.put", "src/mirth/codegen.mth", 457, 40);
+    WORD_ATOM(457, 40, ">Var");
     mw_Param_3E_Var();
-    WORD_ATOM(455, 45, "put");
+    WORD_ATOM(457, 45, "put");
     mw_Var_2B_C99_2E_put();
     WORD_EXIT(mw_Param_2B_C99_2E_put);
 }
 static void mw_c99_pack_ctx_21_ (void) {
-    WORD_ENTER(mw_c99_pack_ctx_21_, "c99-pack-ctx!", "src/mirth/codegen.mth", 458, 5);
-    WORD_ATOM(458, 5, "c99-line");
+    WORD_ENTER(mw_c99_pack_ctx_21_, "c99-pack-ctx!", "src/mirth/codegen.mth", 460, 5);
+    WORD_ATOM(460, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_pack_ctx_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(459, 5, "physical-vars");
+    WORD_ATOM(461, 5, "physical-vars");
     mw_Ctx_2E_physical_vars();
-    WORD_ATOM(459, 19, "for");
+    WORD_ATOM(461, 19, "for");
     push_u64(0);
     push_fnptr(&mb_c99_pack_ctx_21__2);
     mw_prim_pack_cons();
@@ -21272,15 +20892,15 @@ static void mw_c99_pack_ctx_21_ (void) {
     WORD_EXIT(mw_c99_pack_ctx_21_);
 }
 static void mw_c99_unpack_ctx_21_ (void) {
-    WORD_ENTER(mw_c99_unpack_ctx_21_, "c99-unpack-ctx!", "src/mirth/codegen.mth", 465, 5);
-    WORD_ATOM(465, 5, "physical-vars");
+    WORD_ENTER(mw_c99_unpack_ctx_21_, "c99-unpack-ctx!", "src/mirth/codegen.mth", 467, 5);
+    WORD_ATOM(467, 5, "physical-vars");
     mw_Ctx_2E_physical_vars();
-    WORD_ATOM(465, 19, "reverse-for");
+    WORD_ATOM(467, 19, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_c99_unpack_ctx_21__1);
     mw_prim_pack_cons();
     mw_List_2E_reverse_for();
-    WORD_ATOM(469, 5, "c99-line");
+    WORD_ATOM(471, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_unpack_ctx_21__4);
     mw_prim_pack_cons();
@@ -21288,10 +20908,10 @@ static void mw_c99_unpack_ctx_21_ (void) {
     WORD_EXIT(mw_c99_unpack_ctx_21_);
 }
 static void mw_c99_decref_ctx_21_ (void) {
-    WORD_ENTER(mw_c99_decref_ctx_21_, "c99-decref-ctx!", "src/mirth/codegen.mth", 472, 5);
-    WORD_ATOM(472, 5, "physical-vars");
+    WORD_ENTER(mw_c99_decref_ctx_21_, "c99-decref-ctx!", "src/mirth/codegen.mth", 474, 5);
+    WORD_ATOM(474, 5, "physical-vars");
     mw_Ctx_2E_physical_vars();
-    WORD_ATOM(472, 19, "reverse-for");
+    WORD_ATOM(474, 19, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_c99_decref_ctx_21__1);
     mw_prim_pack_cons();
@@ -21299,34 +20919,34 @@ static void mw_c99_decref_ctx_21_ (void) {
     WORD_EXIT(mw_c99_decref_ctx_21_);
 }
 static void mw_c99_block_push_21_ (void) {
-    WORD_ENTER(mw_c99_block_push_21_, "c99-block-push!", "src/mirth/codegen.mth", 477, 5);
-    WORD_ATOM(477, 5, "dup");
+    WORD_ENTER(mw_c99_block_push_21_, "c99-block-push!", "src/mirth/codegen.mth", 479, 5);
+    WORD_ATOM(479, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(477, 9, "block-to-run-var");
+    WORD_ATOM(479, 9, "block-to-run-var");
     mw_block_to_run_var();
-    WORD_ATOM(477, 26, "match");
+    WORD_ATOM(479, 26, "match");
     switch (get_top_data_tag()) {
         case 1LL:
             mp_SOME();
-            WORD_ATOM(478, 17, "nip");
+            WORD_ATOM(480, 17, "nip");
             mw_nip();
-            WORD_ATOM(478, 21, "c99-var-push!");
+            WORD_ATOM(480, 21, "c99-var-push!");
             mw_c99_var_push_21_();
             break;
         case 0LL:
             mp_NONE();
-            WORD_ATOM(480, 13, "dup");
+            WORD_ATOM(482, 13, "dup");
             mw_prim_dup();
-            WORD_ATOM(480, 17, "ctx");
+            WORD_ATOM(482, 17, "ctx");
             mw_Block_2E_ctx();
-            WORD_ATOM(480, 21, "c99-pack-ctx!");
+            WORD_ATOM(482, 21, "c99-pack-ctx!");
             mw_c99_pack_ctx_21_();
-            WORD_ATOM(481, 13, "c99-line");
+            WORD_ATOM(483, 13, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_block_push_21__3);
             mw_prim_pack_cons();
             mw_c99_line();
-            WORD_ATOM(482, 13, "c99-line");
+            WORD_ATOM(484, 13, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_block_push_21__4);
             mw_prim_pack_cons();
@@ -21337,66 +20957,66 @@ static void mw_c99_block_push_21_ (void) {
     WORD_EXIT(mw_c99_block_push_21_);
 }
 static void mw_c99_var_21_ (void) {
-    WORD_ENTER(mw_c99_var_21_, "c99-var!", "src/mirth/codegen.mth", 486, 5);
-    WORD_ATOM(486, 5, "dup");
+    WORD_ENTER(mw_c99_var_21_, "c99-var!", "src/mirth/codegen.mth", 488, 5);
+    WORD_ATOM(488, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(486, 9, "auto-run?");
+    WORD_ATOM(488, 9, "auto-run?");
     mw_Var_2E_auto_run_3F_();
-    WORD_ATOM(486, 19, "if");
+    WORD_ATOM(488, 19, "if");
     if (pop_u64()) {
-        WORD_ATOM(486, 22, "c99-var-run!");
+        WORD_ATOM(488, 22, "c99-var-run!");
         mw_c99_var_run_21_();
     } else {
-        WORD_ATOM(486, 36, "c99-var-push!");
+        WORD_ATOM(488, 36, "c99-var-push!");
         mw_c99_var_push_21_();
     }
     WORD_EXIT(mw_c99_var_21_);
 }
 static void mw_c99_var_run_21_ (void) {
-    WORD_ENTER(mw_c99_var_run_21_, "c99-var-run!", "src/mirth/codegen.mth", 489, 5);
-    WORD_ATOM(489, 5, "c99-line");
+    WORD_ENTER(mw_c99_var_run_21_, "c99-var-run!", "src/mirth/codegen.mth", 491, 5);
+    WORD_ATOM(491, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_var_run_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(490, 5, "c99-line");
+    WORD_ATOM(492, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_var_run_21__2);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(491, 5, "drop");
+    WORD_ATOM(493, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_var_run_21_);
 }
 static void mw_c99_var_push_21_ (void) {
-    WORD_ENTER(mw_c99_var_push_21_, "c99-var-push!", "src/mirth/codegen.mth", 494, 5);
-    WORD_ATOM(494, 5, "c99-line");
+    WORD_ENTER(mw_c99_var_push_21_, "c99-var-push!", "src/mirth/codegen.mth", 496, 5);
+    WORD_ATOM(496, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_var_push_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(495, 5, "c99-line");
+    WORD_ATOM(497, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_var_push_21__2);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(496, 5, "drop");
+    WORD_ATOM(498, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_var_push_21_);
 }
 static void mw_c99_lambda_21_ (void) {
-    WORD_ENTER(mw_c99_lambda_21_, "c99-lambda!", "src/mirth/codegen.mth", 499, 5);
-    WORD_ATOM(499, 5, "c99-line");
+    WORD_ENTER(mw_c99_lambda_21_, "c99-lambda!", "src/mirth/codegen.mth", 501, 5);
+    WORD_ATOM(501, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(500, 5, "c99-nest");
+    WORD_ATOM(502, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(509, 5, "c99-line");
+    WORD_ATOM(511, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__7);
     mw_prim_pack_cons();
@@ -21404,55 +21024,55 @@ static void mw_c99_lambda_21_ (void) {
     WORD_EXIT(mw_c99_lambda_21_);
 }
 static void mw_c99_match_21_ (void) {
-    WORD_ENTER(mw_c99_match_21_, "c99-match!", "src/mirth/codegen.mth", 512, 5);
-    WORD_ATOM(512, 5, "dup");
+    WORD_ENTER(mw_c99_match_21_, "c99-match!", "src/mirth/codegen.mth", 514, 5);
+    WORD_ATOM(514, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(512, 9, "is-transparent?");
+    WORD_ATOM(514, 9, "is-transparent?");
     mw_Match_2E_is_transparent_3F_();
-    WORD_ATOM(512, 25, "if");
+    WORD_ATOM(514, 25, "if");
     if (pop_u64()) {
-        WORD_ATOM(513, 9, "cases");
+        WORD_ATOM(515, 9, "cases");
         mw_Match_2E_cases();
-        WORD_ATOM(513, 15, "first");
+        WORD_ATOM(515, 15, "first");
         mw_List_2E_first();
-        WORD_ATOM(513, 21, "unwrap");
+        WORD_ATOM(515, 21, "unwrap");
         mw_Maybe_2E_unwrap();
-        WORD_ATOM(513, 28, "body");
+        WORD_ATOM(515, 28, "body");
         mw_Case_2E_body();
-        WORD_ATOM(513, 33, "c99-arrow!");
+        WORD_ATOM(515, 33, "c99-arrow!");
         mw_c99_arrow_21_();
     } else {
-        WORD_ATOM(515, 9, "dup");
+        WORD_ATOM(517, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(515, 13, "scrutinee-data?");
+        WORD_ATOM(517, 13, "scrutinee-data?");
         mw_Match_2E_scrutinee_data_3F_();
-        WORD_ATOM(516, 9, "unwrap-or");
+        WORD_ATOM(518, 9, "unwrap-or");
         push_u64(0);
         push_fnptr(&mb_c99_match_21__3);
         mw_prim_pack_cons();
         mw_Maybe_2E_unwrap_or();
-        WORD_ATOM(517, 9, "is-resource?");
+        WORD_ATOM(519, 9, "is-resource?");
         mw_Data_2E_is_resource_3F_();
-        WORD_ATOM(517, 22, "if");
+        WORD_ATOM(519, 22, "if");
         if (pop_u64()) {
-            WORD_ATOM(518, 13, "c99-line");
+            WORD_ATOM(520, 13, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_match_21__5);
             mw_prim_pack_cons();
             mw_c99_line();
         } else {
-            WORD_ATOM(519, 13, "c99-line");
+            WORD_ATOM(521, 13, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_match_21__7);
             mw_prim_pack_cons();
             mw_c99_line();
         }
-        WORD_ATOM(521, 9, "c99-nest");
+        WORD_ATOM(523, 9, "c99-nest");
         push_u64(0);
         push_fnptr(&mb_c99_match_21__8);
         mw_prim_pack_cons();
         mw_c99_nest();
-        WORD_ATOM(527, 9, "c99-line");
+        WORD_ATOM(529, 9, "c99-line");
         push_u64(0);
         push_fnptr(&mb_c99_match_21__12);
         mw_prim_pack_cons();
@@ -21461,14 +21081,14 @@ static void mw_c99_match_21_ (void) {
     WORD_EXIT(mw_c99_match_21_);
 }
 static void mw_c99_case_21_ (void) {
-    WORD_ENTER(mw_c99_case_21_, "c99-case!", "src/mirth/codegen.mth", 531, 5);
-    WORD_ATOM(531, 5, "dup");
+    WORD_ENTER(mw_c99_case_21_, "c99-case!", "src/mirth/codegen.mth", 533, 5);
+    WORD_ATOM(533, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(531, 9, "pattern");
+    WORD_ATOM(533, 9, "pattern");
     mw_Case_2E_pattern();
-    WORD_ATOM(531, 17, "c99-pattern!");
+    WORD_ATOM(533, 17, "c99-pattern!");
     mw_c99_pattern_21_();
-    WORD_ATOM(532, 5, "c99-nest");
+    WORD_ATOM(534, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_case_21__1);
     mw_prim_pack_cons();
@@ -21476,12 +21096,12 @@ static void mw_c99_case_21_ (void) {
     WORD_EXIT(mw_c99_case_21_);
 }
 static void mw_c99_pattern_21_ (void) {
-    WORD_ENTER(mw_c99_pattern_21_, "c99-pattern!", "src/mirth/codegen.mth", 538, 5);
-    WORD_ATOM(538, 5, "PATTERN_UNDERSCORE");
+    WORD_ENTER(mw_c99_pattern_21_, "c99-pattern!", "src/mirth/codegen.mth", 540, 5);
+    WORD_ATOM(540, 5, "PATTERN_UNDERSCORE");
     switch (get_top_data_tag()) {
         case 0LL:
             mp_PATTERN_5F_UNDERSCORE();
-            WORD_ATOM(539, 9, "c99-line");
+            WORD_ATOM(541, 9, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_pattern_21__2);
             mw_prim_pack_cons();
@@ -21489,12 +21109,12 @@ static void mw_c99_pattern_21_ (void) {
             break;
         case 1LL:
             mp_PATTERN_5F_TAG();
-            WORD_ATOM(542, 9, "c99-line");
+            WORD_ATOM(544, 9, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_pattern_21__4);
             mw_prim_pack_cons();
             mw_c99_line();
-            WORD_ATOM(543, 9, "c99-nest");
+            WORD_ATOM(545, 9, "c99-nest");
             push_u64(0);
             push_fnptr(&mb_c99_pattern_21__5);
             mw_prim_pack_cons();
@@ -21505,19 +21125,19 @@ static void mw_c99_pattern_21_ (void) {
     WORD_EXIT(mw_c99_pattern_21_);
 }
 static void mw_c99_word_sigs_21_ (void) {
-    WORD_ENTER(mw_c99_word_sigs_21_, "c99-word-sigs!", "src/mirth/codegen.mth", 548, 35);
-    WORD_ATOM(548, 35, "for-needed-words");
+    WORD_ENTER(mw_c99_word_sigs_21_, "c99-word-sigs!", "src/mirth/codegen.mth", 550, 35);
+    WORD_ATOM(550, 35, "for-needed-words");
     push_u64(0);
     push_fnptr(&mb_c99_word_sigs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_words();
-    WORD_ATOM(548, 67, "line");
+    WORD_ATOM(550, 67, "line");
     mw__2B_C99_2E_line();
     WORD_EXIT(mw_c99_word_sigs_21_);
 }
 static void mw_c99_word_sig_21_ (void) {
-    WORD_ENTER(mw_c99_word_sig_21_, "c99-word-sig!", "src/mirth/codegen.mth", 550, 5);
-    WORD_ATOM(550, 5, "c99-line");
+    WORD_ENTER(mw_c99_word_sig_21_, "c99-word-sig!", "src/mirth/codegen.mth", 552, 5);
+    WORD_ATOM(552, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_sig_21__1);
     mw_prim_pack_cons();
@@ -21525,19 +21145,19 @@ static void mw_c99_word_sig_21_ (void) {
     WORD_EXIT(mw_c99_word_sig_21_);
 }
 static void mw_c99_block_sigs_21_ (void) {
-    WORD_ENTER(mw_c99_block_sigs_21_, "c99-block-sigs!", "src/mirth/codegen.mth", 552, 36);
-    WORD_ATOM(552, 36, "for-needed-blocks");
+    WORD_ENTER(mw_c99_block_sigs_21_, "c99-block-sigs!", "src/mirth/codegen.mth", 554, 36);
+    WORD_ATOM(554, 36, "for-needed-blocks");
     push_u64(0);
     push_fnptr(&mb_c99_block_sigs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_blocks();
-    WORD_ATOM(552, 70, "line");
+    WORD_ATOM(554, 70, "line");
     mw__2B_C99_2E_line();
     WORD_EXIT(mw_c99_block_sigs_21_);
 }
 static void mw_c99_block_sig_21_ (void) {
-    WORD_ENTER(mw_c99_block_sig_21_, "c99-block-sig!", "src/mirth/codegen.mth", 554, 5);
-    WORD_ATOM(554, 5, "c99-line");
+    WORD_ENTER(mw_c99_block_sig_21_, "c99-block-sig!", "src/mirth/codegen.mth", 556, 5);
+    WORD_ATOM(556, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_sig_21__1);
     mw_prim_pack_cons();
@@ -21545,19 +21165,19 @@ static void mw_c99_block_sig_21_ (void) {
     WORD_EXIT(mw_c99_block_sig_21_);
 }
 static void mw_c99_field_sigs_21_ (void) {
-    WORD_ENTER(mw_c99_field_sigs_21_, "c99-field-sigs!", "src/mirth/codegen.mth", 556, 36);
-    WORD_ATOM(556, 36, "Field.for");
+    WORD_ENTER(mw_c99_field_sigs_21_, "c99-field-sigs!", "src/mirth/codegen.mth", 558, 36);
+    WORD_ATOM(558, 36, "Field.for");
     push_u64(0);
     push_fnptr(&mb_c99_field_sigs_21__1);
     mw_prim_pack_cons();
     mw_Field_2E_for();
-    WORD_ATOM(556, 62, "line");
+    WORD_ATOM(558, 62, "line");
     mw__2B_C99_2E_line();
     WORD_EXIT(mw_c99_field_sigs_21_);
 }
 static void mw_c99_field_sig_21_ (void) {
-    WORD_ENTER(mw_c99_field_sig_21_, "c99-field-sig!", "src/mirth/codegen.mth", 558, 5);
-    WORD_ATOM(558, 5, "c99-line");
+    WORD_ENTER(mw_c99_field_sig_21_, "c99-field-sig!", "src/mirth/codegen.mth", 560, 5);
+    WORD_ATOM(560, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_field_sig_21__1);
     mw_prim_pack_cons();
@@ -21565,19 +21185,19 @@ static void mw_c99_field_sig_21_ (void) {
     WORD_EXIT(mw_c99_field_sig_21_);
 }
 static void mw_c99_block_enter_21_ (void) {
-    WORD_ENTER(mw_c99_block_enter_21_, "c99-block-enter!", "src/mirth/codegen.mth", 561, 5);
-    WORD_ATOM(561, 5, "c99-line");
+    WORD_ENTER(mw_c99_block_enter_21_, "c99-block-enter!", "src/mirth/codegen.mth", 563, 5);
+    WORD_ATOM(563, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_enter_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(570, 5, "drop");
+    WORD_ATOM(572, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_block_enter_21_);
 }
 static void mw_c99_block_exit_21_ (void) {
-    WORD_ENTER(mw_c99_block_exit_21_, "c99-block-exit!", "src/mirth/codegen.mth", 573, 5);
-    WORD_ATOM(573, 5, "c99-line");
+    WORD_ENTER(mw_c99_block_exit_21_, "c99-block-exit!", "src/mirth/codegen.mth", 575, 5);
+    WORD_ATOM(575, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_exit_21__1);
     mw_prim_pack_cons();
@@ -21585,40 +21205,40 @@ static void mw_c99_block_exit_21_ (void) {
     WORD_EXIT(mw_c99_block_exit_21_);
 }
 static void mw_c99_block_defs_21_ (void) {
-    WORD_ENTER(mw_c99_block_defs_21_, "c99-block-defs!", "src/mirth/codegen.mth", 575, 36);
-    WORD_ATOM(575, 36, "for-needed-blocks");
+    WORD_ENTER(mw_c99_block_defs_21_, "c99-block-defs!", "src/mirth/codegen.mth", 577, 36);
+    WORD_ATOM(577, 36, "for-needed-blocks");
     push_u64(0);
     push_fnptr(&mb_c99_block_defs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_blocks();
-    WORD_ATOM(575, 70, "line");
+    WORD_ATOM(577, 70, "line");
     mw__2B_C99_2E_line();
     WORD_EXIT(mw_c99_block_defs_21_);
 }
 static void mw_c99_block_def_21_ (void) {
-    WORD_ENTER(mw_c99_block_def_21_, "c99-block-def!", "src/mirth/codegen.mth", 577, 5);
-    WORD_ATOM(577, 5, "c99-line");
+    WORD_ENTER(mw_c99_block_def_21_, "c99-block-def!", "src/mirth/codegen.mth", 579, 5);
+    WORD_ATOM(579, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_def_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(578, 5, "c99-nest");
+    WORD_ATOM(580, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_block_def_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(586, 5, "c99-line");
+    WORD_ATOM(588, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_def_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(586, 23, "line");
+    WORD_ATOM(588, 23, "line");
     mw__2B_C99_2E_line();
     WORD_EXIT(mw_c99_block_def_21_);
 }
 static void mw_Block_2B_C99_2E_put (void) {
-    WORD_ENTER(mw_Block_2B_C99_2E_put, "Block+C99.put", "src/mirth/codegen.mth", 589, 5);
-    WORD_ATOM(589, 5, "");
+    WORD_ENTER(mw_Block_2B_C99_2E_put, "Block+C99.put", "src/mirth/codegen.mth", 591, 5);
+    WORD_ATOM(591, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21629,34 +21249,34 @@ static void mw_Block_2B_C99_2E_put (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(589, 11, "put");
+    WORD_ATOM(591, 11, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(590, 5, "dup");
+    WORD_ATOM(592, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(590, 9, "arrow");
+    WORD_ATOM(592, 9, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(590, 15, "dup");
+    WORD_ATOM(592, 15, "dup");
     mw_prim_dup();
-    WORD_ATOM(590, 19, "home");
+    WORD_ATOM(592, 19, "home");
     mw_Arrow_2E_home();
-    WORD_ATOM(590, 24, "match");
+    WORD_ATOM(592, 24, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mp_NONE();
-            WORD_ATOM(591, 17, "drop");
+            WORD_ATOM(593, 17, "drop");
             mw_prim_drop();
-            WORD_ATOM(591, 22, "Block.id");
+            WORD_ATOM(593, 22, "Block.id");
             mw_Block_2E_id();
-            WORD_ATOM(591, 31, "put");
+            WORD_ATOM(593, 31, "put");
             mw_Int_2B_C99_2E_put();
             break;
         case 1LL:
             mp_SOME();
-            WORD_ATOM(593, 13, "name");
+            WORD_ATOM(595, 13, "name");
             mw_Word_2E_name();
-            WORD_ATOM(593, 18, "put");
+            WORD_ATOM(595, 18, "put");
             mw_Name_2B_C99_2E_put();
-            WORD_ATOM(593, 22, "");
+            WORD_ATOM(595, 22, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -21667,13 +21287,13 @@ static void mw_Block_2B_C99_2E_put (void) {
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(593, 26, "put");
+            WORD_ATOM(595, 26, "put");
             mw_Str_2B_C99_2E_put();
-            WORD_ATOM(594, 13, "homeidx");
+            WORD_ATOM(596, 13, "homeidx");
             mw_Arrow_2E_homeidx();
-            WORD_ATOM(594, 21, "put");
+            WORD_ATOM(596, 21, "put");
             mw_Int_2B_C99_2E_put();
-            WORD_ATOM(594, 25, "drop");
+            WORD_ATOM(596, 25, "drop");
             mw_prim_drop();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -21681,73 +21301,73 @@ static void mw_Block_2B_C99_2E_put (void) {
     WORD_EXIT(mw_Block_2B_C99_2E_put);
 }
 static void mw_c99_word_enter_21_ (void) {
-    WORD_ENTER(mw_c99_word_enter_21_, "c99-word-enter!", "src/mirth/codegen.mth", 598, 5);
-    WORD_ATOM(598, 5, "c99-line");
+    WORD_ENTER(mw_c99_word_enter_21_, "c99-word-enter!", "src/mirth/codegen.mth", 600, 5);
+    WORD_ATOM(600, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_enter_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(604, 5, "drop");
+    WORD_ATOM(606, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_word_enter_21_);
 }
 static void mw_c99_word_exit_21_ (void) {
-    WORD_ENTER(mw_c99_word_exit_21_, "c99-word-exit!", "src/mirth/codegen.mth", 607, 5);
-    WORD_ATOM(607, 5, "c99-line");
+    WORD_ENTER(mw_c99_word_exit_21_, "c99-word-exit!", "src/mirth/codegen.mth", 609, 5);
+    WORD_ATOM(609, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_exit_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(609, 5, "drop");
+    WORD_ATOM(611, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_word_exit_21_);
 }
 static void mw_c99_word_defs_21_ (void) {
-    WORD_ENTER(mw_c99_word_defs_21_, "c99-word-defs!", "src/mirth/codegen.mth", 611, 35);
-    WORD_ATOM(611, 35, "for-needed-words");
+    WORD_ENTER(mw_c99_word_defs_21_, "c99-word-defs!", "src/mirth/codegen.mth", 613, 35);
+    WORD_ATOM(613, 35, "for-needed-words");
     push_u64(0);
     push_fnptr(&mb_c99_word_defs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_words();
-    WORD_ATOM(611, 67, "line");
+    WORD_ATOM(613, 67, "line");
     mw__2B_C99_2E_line();
     WORD_EXIT(mw_c99_word_defs_21_);
 }
 static void mw_c99_word_def_21_ (void) {
-    WORD_ENTER(mw_c99_word_def_21_, "c99-word-def!", "src/mirth/codegen.mth", 613, 5);
-    WORD_ATOM(613, 5, "c99-line");
+    WORD_ENTER(mw_c99_word_def_21_, "c99-word-def!", "src/mirth/codegen.mth", 615, 5);
+    WORD_ATOM(615, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_def_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(614, 5, "c99-nest");
+    WORD_ATOM(616, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_word_def_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(619, 5, "c99-line");
+    WORD_ATOM(621, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_def_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(620, 5, "drop");
+    WORD_ATOM(622, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_word_def_21_);
 }
 static void mw_c99_field_defs_21_ (void) {
-    WORD_ENTER(mw_c99_field_defs_21_, "c99-field-defs!", "src/mirth/codegen.mth", 622, 36);
-    WORD_ATOM(622, 36, "Field.for");
+    WORD_ENTER(mw_c99_field_defs_21_, "c99-field-defs!", "src/mirth/codegen.mth", 624, 36);
+    WORD_ATOM(624, 36, "Field.for");
     push_u64(0);
     push_fnptr(&mb_c99_field_defs_21__1);
     mw_prim_pack_cons();
     mw_Field_2E_for();
-    WORD_ATOM(622, 62, "line");
+    WORD_ATOM(624, 62, "line");
     mw__2B_C99_2E_line();
     WORD_EXIT(mw_c99_field_defs_21_);
 }
 static void mw_c99_field_def_21_ (void) {
-    WORD_ENTER(mw_c99_field_def_21_, "c99-field-def!", "src/mirth/codegen.mth", 624, 5);
-    WORD_ATOM(624, 5, "");
+    WORD_ENTER(mw_c99_field_def_21_, "c99-field-def!", "src/mirth/codegen.mth", 626, 5);
+    WORD_ATOM(626, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21758,15 +21378,15 @@ static void mw_c99_field_def_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(624, 29, "put");
+    WORD_ATOM(626, 29, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(624, 33, "dup");
+    WORD_ATOM(626, 33, "dup");
     mw_prim_dup();
-    WORD_ATOM(624, 37, "name");
+    WORD_ATOM(626, 37, "name");
     mw_Field_2E_name();
-    WORD_ATOM(624, 42, "put");
+    WORD_ATOM(626, 42, "put");
     mw_Name_2B_C99_2E_put();
-    WORD_ATOM(624, 46, "");
+    WORD_ATOM(626, 46, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21777,11 +21397,11 @@ static void mw_c99_field_def_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(624, 62, "put");
+    WORD_ATOM(626, 62, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(624, 66, "line");
+    WORD_ATOM(626, 66, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(625, 5, "");
+    WORD_ATOM(627, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21792,11 +21412,11 @@ static void mw_c99_field_def_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(625, 38, "put");
+    WORD_ATOM(627, 38, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(625, 42, "line");
+    WORD_ATOM(627, 42, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(626, 5, "");
+    WORD_ATOM(628, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21807,13 +21427,13 @@ static void mw_c99_field_def_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(626, 23, "put");
+    WORD_ATOM(628, 23, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(626, 27, "TABLE_MAX_SIZE");
+    WORD_ATOM(628, 27, "TABLE_MAX_SIZE");
     mw_TABLE_5F_MAX_5F_SIZE();
-    WORD_ATOM(626, 42, "put");
+    WORD_ATOM(628, 42, "put");
     mw_Int_2B_C99_2E_put();
-    WORD_ATOM(626, 46, "");
+    WORD_ATOM(628, 46, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21824,11 +21444,11 @@ static void mw_c99_field_def_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(626, 50, "put");
+    WORD_ATOM(628, 50, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(626, 54, "line");
+    WORD_ATOM(628, 54, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(627, 5, "");
+    WORD_ATOM(629, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21839,11 +21459,11 @@ static void mw_c99_field_def_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(627, 50, "put");
+    WORD_ATOM(629, 50, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(627, 54, "line");
+    WORD_ATOM(629, 54, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(628, 5, "");
+    WORD_ATOM(630, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21854,11 +21474,11 @@ static void mw_c99_field_def_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(628, 70, "put");
+    WORD_ATOM(630, 70, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(628, 74, "line");
+    WORD_ATOM(630, 74, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(629, 5, "");
+    WORD_ATOM(631, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21869,11 +21489,11 @@ static void mw_c99_field_def_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(629, 23, "put");
+    WORD_ATOM(631, 23, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(629, 27, "line");
+    WORD_ATOM(631, 27, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(630, 5, "");
+    WORD_ATOM(632, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21884,21 +21504,21 @@ static void mw_c99_field_def_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(630, 9, "put");
+    WORD_ATOM(632, 9, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(630, 13, "line");
+    WORD_ATOM(632, 13, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(630, 18, "line");
+    WORD_ATOM(632, 18, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(634, 5, "dup");
+    WORD_ATOM(636, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(634, 9, "name");
+    WORD_ATOM(636, 9, "name");
     mw_Field_2E_name();
-    WORD_ATOM(634, 14, "sig");
+    WORD_ATOM(636, 14, "sig");
     mw_Name_2B_C99_2E_sig();
-    WORD_ATOM(634, 18, "put");
+    WORD_ATOM(636, 18, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(634, 22, "");
+    WORD_ATOM(636, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21909,9 +21529,9 @@ static void mw_c99_field_def_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(634, 26, "put");
+    WORD_ATOM(636, 26, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(635, 5, "");
+    WORD_ATOM(637, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21922,11 +21542,11 @@ static void mw_c99_field_def_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(635, 45, "put");
+    WORD_ATOM(637, 45, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(635, 49, "line");
+    WORD_ATOM(637, 49, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(636, 5, "");
+    WORD_ATOM(638, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21937,15 +21557,15 @@ static void mw_c99_field_def_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(636, 30, "put");
+    WORD_ATOM(638, 30, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(636, 34, "dup");
+    WORD_ATOM(638, 34, "dup");
     mw_prim_dup();
-    WORD_ATOM(636, 38, "name");
+    WORD_ATOM(638, 38, "name");
     mw_Field_2E_name();
-    WORD_ATOM(636, 43, "put");
+    WORD_ATOM(638, 43, "put");
     mw_Name_2B_C99_2E_put();
-    WORD_ATOM(636, 47, "");
+    WORD_ATOM(638, 47, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21956,11 +21576,11 @@ static void mw_c99_field_def_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(636, 58, "put");
+    WORD_ATOM(638, 58, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(636, 62, "line");
+    WORD_ATOM(638, 62, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(637, 5, "");
+    WORD_ATOM(639, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21971,11 +21591,11 @@ static void mw_c99_field_def_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(637, 24, "put");
+    WORD_ATOM(639, 24, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(637, 28, "line");
+    WORD_ATOM(639, 28, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(638, 5, "");
+    WORD_ATOM(640, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21986,29 +21606,29 @@ static void mw_c99_field_def_21_ (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(638, 9, "put");
+    WORD_ATOM(640, 9, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(638, 13, "line");
+    WORD_ATOM(640, 13, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(638, 18, "line");
+    WORD_ATOM(640, 18, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(639, 5, "drop");
+    WORD_ATOM(641, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_field_def_21_);
 }
 static void mw_c99_main_21_ (void) {
-    WORD_ENTER(mw_c99_main_21_, "c99-main!", "src/mirth/codegen.mth", 642, 5);
-    WORD_ATOM(642, 5, "c99-line");
+    WORD_ENTER(mw_c99_main_21_, "c99-main!", "src/mirth/codegen.mth", 644, 5);
+    WORD_ATOM(644, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(643, 5, "c99-nest");
+    WORD_ATOM(645, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(656, 5, "c99-line");
+    WORD_ATOM(658, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__8);
     mw_prim_pack_cons();
@@ -43707,41 +43327,41 @@ static void mb_c99_variables_21__1 (void) {
 }
 
 static void mb_c99_externals_21__1 (void) {
-    WORD_ENTER(mb_c99_externals_21__1, "c99-externals! block", "src/mirth/codegen.mth", 254, 18);
+    WORD_ENTER(mb_c99_externals_21__1, "c99-externals! block", "src/mirth/codegen.mth", 256, 18);
     mw_prim_drop();
-    WORD_ATOM(254, 18, "c99-external!");
+    WORD_ATOM(256, 18, "c99-external!");
     mw_c99_external_21_();
     WORD_EXIT(mb_c99_externals_21__1);
 }
 
 static void mb_c99_word_sigs_21__1 (void) {
-    WORD_ENTER(mb_c99_word_sigs_21__1, "c99-word-sigs! block", "src/mirth/codegen.mth", 548, 52);
+    WORD_ENTER(mb_c99_word_sigs_21__1, "c99-word-sigs! block", "src/mirth/codegen.mth", 550, 52);
     mw_prim_drop();
-    WORD_ATOM(548, 52, "c99-word-sig!");
+    WORD_ATOM(550, 52, "c99-word-sig!");
     mw_c99_word_sig_21_();
     WORD_EXIT(mb_c99_word_sigs_21__1);
 }
 
 static void mb_c99_block_sigs_21__1 (void) {
-    WORD_ENTER(mb_c99_block_sigs_21__1, "c99-block-sigs! block", "src/mirth/codegen.mth", 552, 54);
+    WORD_ENTER(mb_c99_block_sigs_21__1, "c99-block-sigs! block", "src/mirth/codegen.mth", 554, 54);
     mw_prim_drop();
-    WORD_ATOM(552, 54, "c99-block-sig!");
+    WORD_ATOM(554, 54, "c99-block-sig!");
     mw_c99_block_sig_21_();
     WORD_EXIT(mb_c99_block_sigs_21__1);
 }
 
 static void mb_c99_field_sigs_21__1 (void) {
-    WORD_ENTER(mb_c99_field_sigs_21__1, "c99-field-sigs! block", "src/mirth/codegen.mth", 556, 46);
+    WORD_ENTER(mb_c99_field_sigs_21__1, "c99-field-sigs! block", "src/mirth/codegen.mth", 558, 46);
     mw_prim_drop();
-    WORD_ATOM(556, 46, "c99-field-sig!");
+    WORD_ATOM(558, 46, "c99-field-sig!");
     mw_c99_field_sig_21_();
     WORD_EXIT(mb_c99_field_sigs_21__1);
 }
 
 static void mb_c99_main_21__1 (void) {
-    WORD_ENTER(mb_c99_main_21__1, "c99-main! block", "src/mirth/codegen.mth", 642, 14);
+    WORD_ENTER(mb_c99_main_21__1, "c99-main! block", "src/mirth/codegen.mth", 644, 14);
     mw_prim_drop();
-    WORD_ATOM(642, 14, "");
+    WORD_ATOM(644, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43752,37 +43372,37 @@ static void mb_c99_main_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(642, 51, "put");
+    WORD_ATOM(644, 51, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_main_21__1);
 }
 
 static void mb_c99_main_21__2 (void) {
-    WORD_ENTER(mb_c99_main_21__2, "c99-main! block", "src/mirth/codegen.mth", 644, 9);
+    WORD_ENTER(mb_c99_main_21__2, "c99-main! block", "src/mirth/codegen.mth", 646, 9);
     mw_prim_drop();
-    WORD_ATOM(644, 9, "c99-line");
+    WORD_ATOM(646, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(645, 9, "c99-line");
+    WORD_ATOM(647, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__4);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(646, 9, "c99-line");
+    WORD_ATOM(648, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__5);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(652, 9, "c99-arrow!");
+    WORD_ATOM(654, 9, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(653, 9, "c99-line");
+    WORD_ATOM(655, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__6);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(654, 9, "c99-line");
+    WORD_ATOM(656, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__7);
     mw_prim_pack_cons();
@@ -43791,9 +43411,9 @@ static void mb_c99_main_21__2 (void) {
 }
 
 static void mb_c99_main_21__3 (void) {
-    WORD_ENTER(mb_c99_main_21__3, "c99-main! block", "src/mirth/codegen.mth", 644, 18);
+    WORD_ENTER(mb_c99_main_21__3, "c99-main! block", "src/mirth/codegen.mth", 646, 18);
     mw_prim_drop();
-    WORD_ATOM(644, 18, "");
+    WORD_ATOM(646, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43804,15 +43424,15 @@ static void mb_c99_main_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(644, 40, "put");
+    WORD_ATOM(646, 40, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_main_21__3);
 }
 
 static void mb_c99_main_21__4 (void) {
-    WORD_ENTER(mb_c99_main_21__4, "c99-main! block", "src/mirth/codegen.mth", 645, 18);
+    WORD_ENTER(mb_c99_main_21__4, "c99-main! block", "src/mirth/codegen.mth", 647, 18);
     mw_prim_drop();
-    WORD_ATOM(645, 18, "");
+    WORD_ATOM(647, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43823,15 +43443,15 @@ static void mb_c99_main_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(645, 40, "put");
+    WORD_ATOM(647, 40, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_main_21__4);
 }
 
 static void mb_c99_main_21__5 (void) {
-    WORD_ENTER(mb_c99_main_21__5, "c99-main! block", "src/mirth/codegen.mth", 646, 18);
+    WORD_ENTER(mb_c99_main_21__5, "c99-main! block", "src/mirth/codegen.mth", 648, 18);
     mw_prim_drop();
-    WORD_ATOM(646, 18, "");
+    WORD_ATOM(648, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43842,9 +43462,9 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(646, 32, "put");
+    WORD_ATOM(648, 32, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(647, 13, "");
+    WORD_ATOM(649, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43855,9 +43475,9 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(647, 34, "put");
+    WORD_ATOM(649, 34, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(648, 13, "");
+    WORD_ATOM(650, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43868,67 +43488,67 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(648, 28, "put");
-    mw_Str_2B_C99_2E_put();
-    WORD_ATOM(649, 13, "dup");
-    mw_prim_dup();
-    WORD_ATOM(649, 17, "token-start");
-    mw_Arrow_2E_token_start();
-    WORD_ATOM(649, 29, ".module");
-    mw_Token_2E_module();
-    WORD_ATOM(649, 37, "source-path");
-    mw_Module_2E_source_path();
-    WORD_ATOM(649, 49, ">Str");
-    mw_Path_3E_Str();
-    WORD_ATOM(649, 54, "put-cstr");
-    mw__2B_C99_2E_put_cstr();
-    WORD_ATOM(649, 63, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr(", ", 2);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(649, 68, "put");
-    mw_Str_2B_C99_2E_put();
-    WORD_ATOM(650, 13, "dup");
-    mw_prim_dup();
-    WORD_ATOM(650, 17, "token-start");
-    mw_Arrow_2E_token_start();
-    WORD_ATOM(650, 29, "row");
-    mw_Token_2E_row();
-    WORD_ATOM(650, 33, ">Int");
-    mw_Row_3E_Int();
-    WORD_ATOM(650, 38, "put");
-    mw_Int_2B_C99_2E_put();
-    WORD_ATOM(650, 42, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr(", ", 2);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(650, 47, "put");
+    WORD_ATOM(650, 28, "put");
     mw_Str_2B_C99_2E_put();
     WORD_ATOM(651, 13, "dup");
     mw_prim_dup();
     WORD_ATOM(651, 17, "token-start");
     mw_Arrow_2E_token_start();
-    WORD_ATOM(651, 29, "col");
-    mw_Token_2E_col();
-    WORD_ATOM(651, 33, ">Int");
-    mw_Col_3E_Int();
-    WORD_ATOM(651, 38, "put");
+    WORD_ATOM(651, 29, ".module");
+    mw_Token_2E_module();
+    WORD_ATOM(651, 37, "source-path");
+    mw_Module_2E_source_path();
+    WORD_ATOM(651, 49, ">Str");
+    mw_Path_3E_Str();
+    WORD_ATOM(651, 54, "put-cstr");
+    mw__2B_C99_2E_put_cstr();
+    WORD_ATOM(651, 63, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr(", ", 2);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(651, 68, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(652, 13, "dup");
+    mw_prim_dup();
+    WORD_ATOM(652, 17, "token-start");
+    mw_Arrow_2E_token_start();
+    WORD_ATOM(652, 29, "row");
+    mw_Token_2E_row();
+    WORD_ATOM(652, 33, ">Int");
+    mw_Row_3E_Int();
+    WORD_ATOM(652, 38, "put");
     mw_Int_2B_C99_2E_put();
-    WORD_ATOM(651, 42, "");
+    WORD_ATOM(652, 42, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr(", ", 2);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(652, 47, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(653, 13, "dup");
+    mw_prim_dup();
+    WORD_ATOM(653, 17, "token-start");
+    mw_Arrow_2E_token_start();
+    WORD_ATOM(653, 29, "col");
+    mw_Token_2E_col();
+    WORD_ATOM(653, 33, ">Int");
+    mw_Col_3E_Int();
+    WORD_ATOM(653, 38, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(653, 42, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43939,15 +43559,15 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(651, 47, "put");
+    WORD_ATOM(653, 47, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_main_21__5);
 }
 
 static void mb_c99_main_21__6 (void) {
-    WORD_ENTER(mb_c99_main_21__6, "c99-main! block", "src/mirth/codegen.mth", 653, 18);
+    WORD_ENTER(mb_c99_main_21__6, "c99-main! block", "src/mirth/codegen.mth", 655, 18);
     mw_prim_drop();
-    WORD_ATOM(653, 18, "");
+    WORD_ATOM(655, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43958,15 +43578,15 @@ static void mb_c99_main_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(653, 49, "put");
+    WORD_ATOM(655, 49, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_main_21__6);
 }
 
 static void mb_c99_main_21__7 (void) {
-    WORD_ENTER(mb_c99_main_21__7, "c99-main! block", "src/mirth/codegen.mth", 654, 18);
+    WORD_ENTER(mb_c99_main_21__7, "c99-main! block", "src/mirth/codegen.mth", 656, 18);
     mw_prim_drop();
-    WORD_ATOM(654, 18, "");
+    WORD_ATOM(656, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43977,15 +43597,15 @@ static void mb_c99_main_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(654, 30, "put");
+    WORD_ATOM(656, 30, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_main_21__7);
 }
 
 static void mb_c99_main_21__8 (void) {
-    WORD_ENTER(mb_c99_main_21__8, "c99-main! block", "src/mirth/codegen.mth", 656, 14);
+    WORD_ENTER(mb_c99_main_21__8, "c99-main! block", "src/mirth/codegen.mth", 658, 14);
     mw_prim_drop();
-    WORD_ATOM(656, 14, "");
+    WORD_ATOM(658, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43996,31 +43616,31 @@ static void mb_c99_main_21__8 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(656, 18, "put");
+    WORD_ATOM(658, 18, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_main_21__8);
 }
 
 static void mb_c99_field_defs_21__1 (void) {
-    WORD_ENTER(mb_c99_field_defs_21__1, "c99-field-defs! block", "src/mirth/codegen.mth", 622, 46);
+    WORD_ENTER(mb_c99_field_defs_21__1, "c99-field-defs! block", "src/mirth/codegen.mth", 624, 46);
     mw_prim_drop();
-    WORD_ATOM(622, 46, "c99-field-def!");
+    WORD_ATOM(624, 46, "c99-field-def!");
     mw_c99_field_def_21_();
     WORD_EXIT(mb_c99_field_defs_21__1);
 }
 
 static void mb_c99_word_defs_21__1 (void) {
-    WORD_ENTER(mb_c99_word_defs_21__1, "c99-word-defs! block", "src/mirth/codegen.mth", 611, 52);
+    WORD_ENTER(mb_c99_word_defs_21__1, "c99-word-defs! block", "src/mirth/codegen.mth", 613, 52);
     mw_prim_drop();
-    WORD_ATOM(611, 52, "c99-word-def!");
+    WORD_ATOM(613, 52, "c99-word-def!");
     mw_c99_word_def_21_();
     WORD_EXIT(mb_c99_word_defs_21__1);
 }
 
 static void mb_c99_block_defs_21__1 (void) {
-    WORD_ENTER(mb_c99_block_defs_21__1, "c99-block-defs! block", "src/mirth/codegen.mth", 575, 54);
+    WORD_ENTER(mb_c99_block_defs_21__1, "c99-block-defs! block", "src/mirth/codegen.mth", 577, 54);
     mw_prim_drop();
-    WORD_ATOM(575, 54, "c99-block-def!");
+    WORD_ATOM(577, 54, "c99-block-def!");
     mw_c99_block_def_21_();
     WORD_EXIT(mb_c99_block_defs_21__1);
 }
@@ -44094,9 +43714,30 @@ static void mb_c99_tag_21__4 (void) {
 }
 
 static void mb_c99_tag_21__11 (void) {
-    WORD_ENTER(mb_c99_tag_21__11, "c99-tag! block", "src/mirth/codegen.mth", 238, 13);
+    WORD_ENTER(mb_c99_tag_21__11, "c99-tag! block", "src/mirth/codegen.mth", 236, 13);
     mw_prim_drop();
-    WORD_ATOM(238, 13, "");
+    WORD_ATOM(236, 13, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("    VAL cdr;", 12);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(236, 28, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(236, 32, "line");
+    mw__2B_C99_2E_line();
+    WORD_EXIT(mb_c99_tag_21__11);
+}
+
+static void mb_c99_tag_21__12 (void) {
+    WORD_ENTER(mb_c99_tag_21__12, "c99-tag! block", "src/mirth/codegen.mth", 240, 13);
+    mw_prim_drop();
+    WORD_ATOM(240, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44107,13 +43748,13 @@ static void mb_c99_tag_21__11 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(238, 52, "put");
+    WORD_ATOM(240, 52, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(238, 56, "line");
+    WORD_ATOM(240, 56, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(239, 13, "put");
+    WORD_ATOM(241, 13, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(239, 17, "");
+    WORD_ATOM(241, 17, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44124,11 +43765,11 @@ static void mb_c99_tag_21__11 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(239, 25, "put");
+    WORD_ATOM(241, 25, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(239, 29, "line");
+    WORD_ATOM(241, 29, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(240, 13, "");
+    WORD_ATOM(242, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44139,13 +43780,13 @@ static void mb_c99_tag_21__11 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_EXIT(mb_c99_tag_21__11);
+    WORD_EXIT(mb_c99_tag_21__12);
 }
 
-static void mb_c99_tag_21__12 (void) {
-    WORD_ENTER(mb_c99_tag_21__12, "c99-tag! block", "src/mirth/codegen.mth", 243, 13);
+static void mb_c99_tag_21__13 (void) {
+    WORD_ENTER(mb_c99_tag_21__13, "c99-tag! block", "src/mirth/codegen.mth", 245, 13);
     mw_prim_drop();
-    WORD_ATOM(243, 13, "");
+    WORD_ATOM(245, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44156,13 +43797,13 @@ static void mb_c99_tag_21__12 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(243, 52, "put");
+    WORD_ATOM(245, 52, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(243, 56, "line");
+    WORD_ATOM(245, 56, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(244, 13, "put");
+    WORD_ATOM(246, 13, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(244, 17, "");
+    WORD_ATOM(246, 17, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44173,11 +43814,11 @@ static void mb_c99_tag_21__12 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(244, 25, "put");
+    WORD_ATOM(246, 25, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(244, 29, "line");
+    WORD_ATOM(246, 29, "line");
     mw__2B_C99_2E_line();
-    WORD_ATOM(245, 13, "");
+    WORD_ATOM(247, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44188,27 +43829,27 @@ static void mb_c99_tag_21__12 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_EXIT(mb_c99_tag_21__12);
+    WORD_EXIT(mb_c99_tag_21__13);
 }
 
 static void mb_c99_external_21__5 (void) {
-    WORD_ENTER(mb_c99_external_21__5, "c99-external! block", "src/mirth/codegen.mth", 267, 10);
+    WORD_ENTER(mb_c99_external_21__5, "c99-external! block", "src/mirth/codegen.mth", 269, 10);
     mw_prim_drop();
-    WORD_ATOM(267, 10, "dup");
+    WORD_ATOM(269, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(267, 14, "name");
+    WORD_ATOM(269, 14, "name");
     mw_External_2E_name();
-    WORD_ATOM(267, 19, ">Str");
+    WORD_ATOM(269, 19, ">Str");
     mw_Name_3E_Str();
-    WORD_ATOM(267, 24, "put");
+    WORD_ATOM(269, 24, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_external_21__5);
 }
 
 static void mb_c99_external_21__7 (void) {
-    WORD_ENTER(mb_c99_external_21__7, "c99-external! block", "src/mirth/codegen.mth", 270, 44);
+    WORD_ENTER(mb_c99_external_21__7, "c99-external! block", "src/mirth/codegen.mth", 272, 44);
     mw_prim_drop();
-    WORD_ATOM(270, 44, "");
+    WORD_ATOM(272, 44, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44219,29 +43860,29 @@ static void mb_c99_external_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(270, 56, "put");
+    WORD_ATOM(272, 56, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_external_21__7);
 }
 
 static void mb_c99_external_21__9 (void) {
-    WORD_ENTER(mb_c99_external_21__9, "c99-external! block", "src/mirth/codegen.mth", 273, 10);
+    WORD_ENTER(mb_c99_external_21__9, "c99-external! block", "src/mirth/codegen.mth", 275, 10);
     mw_prim_drop();
-    WORD_ATOM(273, 10, "dup");
+    WORD_ATOM(275, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(273, 14, "name");
+    WORD_ATOM(275, 14, "name");
     mw_External_2E_name();
-    WORD_ATOM(273, 19, "sig");
+    WORD_ATOM(275, 19, "sig");
     mw_Name_2B_C99_2E_sig();
-    WORD_ATOM(273, 23, "put");
+    WORD_ATOM(275, 23, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_external_21__9);
 }
 
 static void mb_c99_external_21__10 (void) {
-    WORD_ENTER(mb_c99_external_21__10, "c99-external! block", "src/mirth/codegen.mth", 274, 20);
+    WORD_ENTER(mb_c99_external_21__10, "c99-external! block", "src/mirth/codegen.mth", 276, 20);
     mw_prim_drop();
-    WORD_ATOM(274, 20, "");
+    WORD_ATOM(276, 20, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44252,11 +43893,11 @@ static void mb_c99_external_21__10 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(274, 36, "put");
+    WORD_ATOM(276, 36, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(274, 40, "put");
+    WORD_ATOM(276, 40, "put");
     mw_Int_2B_C99_2E_put();
-    WORD_ATOM(274, 44, "");
+    WORD_ATOM(276, 44, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44267,31 +43908,31 @@ static void mb_c99_external_21__10 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(274, 60, "put");
+    WORD_ATOM(276, 60, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(274, 64, "line");
+    WORD_ATOM(276, 64, "line");
     mw__2B_C99_2E_line();
     WORD_EXIT(mb_c99_external_21__10);
 }
 
 static void mb_c99_external_21__13 (void) {
-    WORD_ENTER(mb_c99_external_21__13, "c99-external! block", "src/mirth/codegen.mth", 276, 10);
+    WORD_ENTER(mb_c99_external_21__13, "c99-external! block", "src/mirth/codegen.mth", 278, 10);
     mw_prim_drop();
-    WORD_ATOM(276, 10, "dup");
+    WORD_ATOM(278, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(276, 14, "name");
+    WORD_ATOM(278, 14, "name");
     mw_External_2E_name();
-    WORD_ATOM(276, 19, ">Str");
+    WORD_ATOM(278, 19, ">Str");
     mw_Name_3E_Str();
-    WORD_ATOM(276, 24, "put");
+    WORD_ATOM(278, 24, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_external_21__13);
 }
 
 static void mb_c99_external_21__16 (void) {
-    WORD_ENTER(mb_c99_external_21__16, "c99-external! block", "src/mirth/codegen.mth", 279, 26);
+    WORD_ENTER(mb_c99_external_21__16, "c99-external! block", "src/mirth/codegen.mth", 281, 26);
     mw_prim_drop();
-    WORD_ATOM(279, 26, "");
+    WORD_ATOM(281, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44302,11 +43943,11 @@ static void mb_c99_external_21__16 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(279, 30, "put");
+    WORD_ATOM(281, 30, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(279, 34, "put");
+    WORD_ATOM(281, 34, "put");
     mw_Int_2B_C99_2E_put();
-    WORD_ATOM(279, 38, "");
+    WORD_ATOM(281, 38, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44317,15 +43958,15 @@ static void mb_c99_external_21__16 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(279, 43, "put");
+    WORD_ATOM(281, 43, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_external_21__16);
 }
 
 static void mb_c99_indent_1 (void) {
-    WORD_ENTER(mb_c99_indent_1, "c99-indent block", "src/mirth/codegen.mth", 292, 45);
+    WORD_ENTER(mb_c99_indent_1, "c99-indent block", "src/mirth/codegen.mth", 294, 45);
     mw_prim_drop();
-    WORD_ATOM(292, 45, "");
+    WORD_ATOM(294, 45, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44336,15 +43977,15 @@ static void mb_c99_indent_1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(292, 52, "put");
+    WORD_ATOM(294, 52, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_indent_1);
 }
 
 static void mb_c99_call_21__2 (void) {
-    WORD_ENTER(mb_c99_call_21__2, "c99-call! block", "src/mirth/codegen.mth", 297, 14);
+    WORD_ENTER(mb_c99_call_21__2, "c99-call! block", "src/mirth/codegen.mth", 299, 14);
     mw_prim_drop();
-    WORD_ATOM(297, 14, "");
+    WORD_ATOM(299, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44355,11 +43996,11 @@ static void mb_c99_call_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(297, 20, "put");
+    WORD_ATOM(299, 20, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(297, 24, "put");
+    WORD_ATOM(299, 24, "put");
     mw_Name_2B_C99_2E_put();
-    WORD_ATOM(297, 28, "");
+    WORD_ATOM(299, 28, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44370,31 +44011,31 @@ static void mb_c99_call_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(297, 34, "put");
+    WORD_ATOM(299, 34, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_call_21__2);
 }
 
 static void mb_c99_args_push_21__1 (void) {
-    WORD_ENTER(mb_c99_args_push_21__1, "c99-args-push! block", "src/mirth/codegen.mth", 443, 9);
+    WORD_ENTER(mb_c99_args_push_21__1, "c99-args-push! block", "src/mirth/codegen.mth", 445, 9);
     mw_prim_drop();
-    WORD_ATOM(443, 9, "c99-arg-push!");
+    WORD_ATOM(445, 9, "c99-arg-push!");
     mw_c99_arg_push_21_();
     WORD_EXIT(mb_c99_args_push_21__1);
 }
 
 static void mb_c99_arrow_21__1 (void) {
-    WORD_ENTER(mb_c99_arrow_21__1, "c99-arrow! block", "src/mirth/codegen.mth", 299, 47);
+    WORD_ENTER(mb_c99_arrow_21__1, "c99-arrow! block", "src/mirth/codegen.mth", 301, 47);
     mw_prim_drop();
-    WORD_ATOM(299, 47, "c99-atom!");
+    WORD_ATOM(301, 47, "c99-atom!");
     mw_c99_atom_21_();
     WORD_EXIT(mb_c99_arrow_21__1);
 }
 
 static void mb_c99_atom_21__1 (void) {
-    WORD_ENTER(mb_c99_atom_21__1, "c99-atom! block", "src/mirth/codegen.mth", 301, 14);
+    WORD_ENTER(mb_c99_atom_21__1, "c99-atom! block", "src/mirth/codegen.mth", 303, 14);
     mw_prim_drop();
-    WORD_ATOM(301, 14, "");
+    WORD_ATOM(303, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44405,61 +44046,61 @@ static void mb_c99_atom_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(301, 27, "put");
-    mw_Str_2B_C99_2E_put();
-    WORD_ATOM(302, 9, "dup");
-    mw_prim_dup();
-    WORD_ATOM(302, 13, "token");
-    mw_Atom_2E_token();
-    WORD_ATOM(302, 19, "row");
-    mw_Token_2E_row();
-    WORD_ATOM(302, 23, ">Int");
-    mw_Row_3E_Int();
-    WORD_ATOM(302, 28, "put");
-    mw_Int_2B_C99_2E_put();
-    WORD_ATOM(302, 32, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr(", ", 2);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(302, 37, "put");
-    mw_Str_2B_C99_2E_put();
-    WORD_ATOM(303, 9, "dup");
-    mw_prim_dup();
-    WORD_ATOM(303, 13, "token");
-    mw_Atom_2E_token();
-    WORD_ATOM(303, 19, "col");
-    mw_Token_2E_col();
-    WORD_ATOM(303, 23, ">Int");
-    mw_Col_3E_Int();
-    WORD_ATOM(303, 28, "put");
-    mw_Int_2B_C99_2E_put();
-    WORD_ATOM(303, 32, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr(", ", 2);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(303, 37, "put");
+    WORD_ATOM(303, 27, "put");
     mw_Str_2B_C99_2E_put();
     WORD_ATOM(304, 9, "dup");
     mw_prim_dup();
     WORD_ATOM(304, 13, "token");
     mw_Atom_2E_token();
-    WORD_ATOM(304, 19, "name?");
+    WORD_ATOM(304, 19, "row");
+    mw_Token_2E_row();
+    WORD_ATOM(304, 23, ">Int");
+    mw_Row_3E_Int();
+    WORD_ATOM(304, 28, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(304, 32, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr(", ", 2);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(304, 37, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(305, 9, "dup");
+    mw_prim_dup();
+    WORD_ATOM(305, 13, "token");
+    mw_Atom_2E_token();
+    WORD_ATOM(305, 19, "col");
+    mw_Token_2E_col();
+    WORD_ATOM(305, 23, ">Int");
+    mw_Col_3E_Int();
+    WORD_ATOM(305, 28, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(305, 32, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr(", ", 2);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(305, 37, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(306, 9, "dup");
+    mw_prim_dup();
+    WORD_ATOM(306, 13, "token");
+    mw_Atom_2E_token();
+    WORD_ATOM(306, 19, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(304, 25, "if-some");
+    WORD_ATOM(306, 25, "if-some");
     push_u64(0);
     push_fnptr(&mb_c99_atom_21__2);
     mw_prim_pack_cons();
@@ -44467,9 +44108,9 @@ static void mb_c99_atom_21__1 (void) {
     push_fnptr(&mb_c99_atom_21__3);
     mw_prim_pack_cons();
     mw_Maybe_2E_if_some();
-    WORD_ATOM(304, 43, "put-cstr");
+    WORD_ATOM(306, 43, "put-cstr");
     mw__2B_C99_2E_put_cstr();
-    WORD_ATOM(305, 9, "");
+    WORD_ATOM(307, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44480,23 +44121,23 @@ static void mb_c99_atom_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(305, 14, "put");
+    WORD_ATOM(307, 14, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_atom_21__1);
 }
 
 static void mb_c99_atom_21__2 (void) {
-    WORD_ENTER(mb_c99_atom_21__2, "c99-atom! block", "src/mirth/codegen.mth", 304, 33);
+    WORD_ENTER(mb_c99_atom_21__2, "c99-atom! block", "src/mirth/codegen.mth", 306, 33);
     mw_prim_drop();
-    WORD_ATOM(304, 33, ">Str");
+    WORD_ATOM(306, 33, ">Str");
     mw_Name_3E_Str();
     WORD_EXIT(mb_c99_atom_21__2);
 }
 
 static void mb_c99_atom_21__3 (void) {
-    WORD_ENTER(mb_c99_atom_21__3, "c99-atom! block", "src/mirth/codegen.mth", 304, 39);
+    WORD_ENTER(mb_c99_atom_21__3, "c99-atom! block", "src/mirth/codegen.mth", 306, 39);
     mw_prim_drop();
-    WORD_ATOM(304, 39, "");
+    WORD_ATOM(306, 39, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44511,17 +44152,17 @@ static void mb_c99_atom_21__3 (void) {
 }
 
 static void mb_c99_atom_21__4 (void) {
-    WORD_ENTER(mb_c99_atom_21__4, "c99-atom! block", "src/mirth/codegen.mth", 306, 9);
+    WORD_ENTER(mb_c99_atom_21__4, "c99-atom! block", "src/mirth/codegen.mth", 308, 9);
     mw_prim_drop();
-    WORD_ATOM(306, 9, "args");
+    WORD_ATOM(308, 9, "args");
     mw_Atom_2E_args();
     WORD_EXIT(mb_c99_atom_21__4);
 }
 
 static void mb_c99_int_21__1 (void) {
-    WORD_ENTER(mb_c99_int_21__1, "c99-int! block", "src/mirth/codegen.mth", 327, 14);
+    WORD_ENTER(mb_c99_int_21__1, "c99-int! block", "src/mirth/codegen.mth", 329, 14);
     mw_prim_drop();
-    WORD_ATOM(327, 14, "");
+    WORD_ATOM(329, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44532,11 +44173,11 @@ static void mb_c99_int_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(327, 26, "put");
+    WORD_ATOM(329, 26, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(327, 30, "put");
+    WORD_ATOM(329, 30, "put");
     mw_Int_2B_C99_2E_put();
-    WORD_ATOM(327, 34, "");
+    WORD_ATOM(329, 34, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44547,15 +44188,15 @@ static void mb_c99_int_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(327, 41, "put");
+    WORD_ATOM(329, 41, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_int_21__1);
 }
 
 static void mb_c99_str_21__1 (void) {
-    WORD_ENTER(mb_c99_str_21__1, "c99-str! block", "src/mirth/codegen.mth", 330, 14);
+    WORD_ENTER(mb_c99_str_21__1, "c99-str! block", "src/mirth/codegen.mth", 332, 14);
     mw_prim_drop();
-    WORD_ATOM(330, 14, "");
+    WORD_ATOM(332, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44566,45 +44207,45 @@ static void mb_c99_str_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(330, 18, "put");
+    WORD_ATOM(332, 18, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__1);
 }
 
 static void mb_c99_str_21__2 (void) {
-    WORD_ENTER(mb_c99_str_21__2, "c99-str! block", "src/mirth/codegen.mth", 332, 9);
+    WORD_ENTER(mb_c99_str_21__2, "c99-str! block", "src/mirth/codegen.mth", 334, 9);
     mw_prim_drop();
-    WORD_ATOM(332, 9, "c99-line");
+    WORD_ATOM(334, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(333, 9, "c99-line");
+    WORD_ATOM(335, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__4);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(334, 9, "c99-line");
+    WORD_ATOM(336, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__5);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(335, 9, "c99-nest");
+    WORD_ATOM(337, 9, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__6);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(350, 9, "c99-line");
+    WORD_ATOM(352, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__17);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(351, 9, "c99-line");
+    WORD_ATOM(353, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__18);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(352, 9, "c99-line");
+    WORD_ATOM(354, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__19);
     mw_prim_pack_cons();
@@ -44613,9 +44254,9 @@ static void mb_c99_str_21__2 (void) {
 }
 
 static void mb_c99_str_21__3 (void) {
-    WORD_ENTER(mb_c99_str_21__3, "c99-str! block", "src/mirth/codegen.mth", 332, 18);
+    WORD_ENTER(mb_c99_str_21__3, "c99-str! block", "src/mirth/codegen.mth", 334, 18);
     mw_prim_drop();
-    WORD_ATOM(332, 18, "");
+    WORD_ATOM(334, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44626,15 +44267,15 @@ static void mb_c99_str_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(332, 48, "put");
+    WORD_ATOM(334, 48, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__3);
 }
 
 static void mb_c99_str_21__4 (void) {
-    WORD_ENTER(mb_c99_str_21__4, "c99-str! block", "src/mirth/codegen.mth", 333, 18);
+    WORD_ENTER(mb_c99_str_21__4, "c99-str! block", "src/mirth/codegen.mth", 335, 18);
     mw_prim_drop();
-    WORD_ATOM(333, 18, "");
+    WORD_ATOM(335, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44645,15 +44286,15 @@ static void mb_c99_str_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(333, 34, "put");
+    WORD_ATOM(335, 34, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__4);
 }
 
 static void mb_c99_str_21__5 (void) {
-    WORD_ENTER(mb_c99_str_21__5, "c99-str! block", "src/mirth/codegen.mth", 334, 18);
+    WORD_ENTER(mb_c99_str_21__5, "c99-str! block", "src/mirth/codegen.mth", 336, 18);
     mw_prim_drop();
-    WORD_ATOM(334, 18, "");
+    WORD_ATOM(336, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44664,25 +44305,25 @@ static void mb_c99_str_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(334, 36, "put");
+    WORD_ATOM(336, 36, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__5);
 }
 
 static void mb_c99_str_21__6 (void) {
-    WORD_ENTER(mb_c99_str_21__6, "c99-str! block", "src/mirth/codegen.mth", 336, 13);
+    WORD_ENTER(mb_c99_str_21__6, "c99-str! block", "src/mirth/codegen.mth", 338, 13);
     mw_prim_drop();
-    WORD_ATOM(336, 13, "dup");
+    WORD_ATOM(338, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(336, 17, "num-bytes");
+    WORD_ATOM(338, 17, "num-bytes");
     mw_prim_str_num_bytes();
-    WORD_ATOM(336, 27, "");
+    WORD_ATOM(338, 27, "");
     push_i64(4090LL);
-    WORD_ATOM(336, 32, ">");
+    WORD_ATOM(338, 32, ">");
     mw_Int_3E_();
-    WORD_ATOM(336, 34, "if");
+    WORD_ATOM(338, 34, "if");
     if (pop_u64()) {
-        WORD_ATOM(337, 17, "");
+        WORD_ATOM(339, 17, "");
         {
             static bool vready = false;
             static VAL v;
@@ -44693,31 +44334,31 @@ static void mb_c99_str_21__6 (void) {
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(337, 42, "put");
+        WORD_ATOM(339, 42, "put");
         mw_Str_2B_C99_2E_put();
-        WORD_ATOM(338, 17, "c99-nest");
+        WORD_ATOM(340, 17, "c99-nest");
         push_u64(0);
         push_fnptr(&mb_c99_str_21__8);
         mw_prim_pack_cons();
         mw_c99_nest();
-        WORD_ATOM(344, 17, "c99-line");
+        WORD_ATOM(346, 17, "c99-line");
         push_u64(0);
         push_fnptr(&mb_c99_str_21__12);
         mw_prim_pack_cons();
         mw_c99_line();
-        WORD_ATOM(345, 17, "c99-line");
+        WORD_ATOM(347, 17, "c99-line");
         push_u64(0);
         push_fnptr(&mb_c99_str_21__13);
         mw_prim_pack_cons();
         mw_c99_line();
     } else {
-        WORD_ATOM(346, 17, "c99-line");
+        WORD_ATOM(348, 17, "c99-line");
         push_u64(0);
         push_fnptr(&mb_c99_str_21__15);
         mw_prim_pack_cons();
         mw_c99_line();
     }
-    WORD_ATOM(348, 13, "c99-line");
+    WORD_ATOM(350, 13, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__16);
     mw_prim_pack_cons();
@@ -44726,32 +44367,32 @@ static void mb_c99_str_21__6 (void) {
 }
 
 static void mb_c99_str_21__8 (void) {
-    WORD_ENTER(mb_c99_str_21__8, "c99-str! block", "src/mirth/codegen.mth", 339, 21);
+    WORD_ENTER(mb_c99_str_21__8, "c99-str! block", "src/mirth/codegen.mth", 341, 21);
     mw_prim_drop();
-    WORD_ATOM(339, 21, "c99-indent");
+    WORD_ATOM(341, 21, "c99-indent");
     mw_c99_indent();
-    WORD_ATOM(339, 32, "dup");
+    WORD_ATOM(341, 32, "dup");
     mw_prim_dup();
-    WORD_ATOM(339, 36, "str-bytes-for");
+    WORD_ATOM(341, 36, "str-bytes-for");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__9);
     mw_prim_pack_cons();
     mw_str_bytes_for();
-    WORD_ATOM(342, 23, "line");
+    WORD_ATOM(344, 23, "line");
     mw__2B_C99_2E_line();
     WORD_EXIT(mb_c99_str_21__8);
 }
 
 static void mb_c99_str_21__9 (void) {
-    WORD_ENTER(mb_c99_str_21__9, "c99-str! block", "src/mirth/codegen.mth", 340, 25);
+    WORD_ENTER(mb_c99_str_21__9, "c99-str! block", "src/mirth/codegen.mth", 342, 25);
     mw_prim_drop();
-    WORD_ATOM(340, 25, ">Int");
+    WORD_ATOM(342, 25, ">Int");
     mw_Byte_3E_Int();
-    WORD_ATOM(340, 30, "dup");
+    WORD_ATOM(342, 30, "dup");
     mw_prim_dup();
-    WORD_ATOM(340, 34, "put");
+    WORD_ATOM(342, 34, "put");
     mw_Int_2B_C99_2E_put();
-    WORD_ATOM(340, 38, "");
+    WORD_ATOM(342, 38, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44762,29 +44403,29 @@ static void mb_c99_str_21__9 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(340, 42, "put");
+    WORD_ATOM(342, 42, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(341, 25, "");
+    WORD_ATOM(343, 25, "");
     push_i64(10LL);
-    WORD_ATOM(341, 28, "=");
+    WORD_ATOM(343, 28, "=");
     mw_prim_int_eq();
-    WORD_ATOM(341, 30, "if");
+    WORD_ATOM(343, 30, "if");
     if (pop_u64()) {
-        WORD_ATOM(341, 33, "line");
+        WORD_ATOM(343, 33, "line");
         mw__2B_C99_2E_line();
-        WORD_ATOM(341, 38, "c99-indent");
+        WORD_ATOM(343, 38, "c99-indent");
         mw_c99_indent();
     } else {
-        WORD_ATOM(341, 50, "id");
+        WORD_ATOM(343, 50, "id");
         mw_prim_id();
     }
     WORD_EXIT(mb_c99_str_21__9);
 }
 
 static void mb_c99_str_21__12 (void) {
-    WORD_ENTER(mb_c99_str_21__12, "c99-str! block", "src/mirth/codegen.mth", 344, 26);
+    WORD_ENTER(mb_c99_str_21__12, "c99-str! block", "src/mirth/codegen.mth", 346, 26);
     mw_prim_drop();
-    WORD_ATOM(344, 26, "");
+    WORD_ATOM(346, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44795,15 +44436,15 @@ static void mb_c99_str_21__12 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(344, 31, "put");
+    WORD_ATOM(346, 31, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__12);
 }
 
 static void mb_c99_str_21__13 (void) {
-    WORD_ENTER(mb_c99_str_21__13, "c99-str! block", "src/mirth/codegen.mth", 345, 26);
+    WORD_ENTER(mb_c99_str_21__13, "c99-str! block", "src/mirth/codegen.mth", 347, 26);
     mw_prim_drop();
-    WORD_ATOM(345, 26, "");
+    WORD_ATOM(347, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44814,15 +44455,15 @@ static void mb_c99_str_21__13 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(345, 49, "put");
+    WORD_ATOM(347, 49, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(345, 53, "dup");
+    WORD_ATOM(347, 53, "dup");
     mw_prim_dup();
-    WORD_ATOM(345, 57, "num-bytes");
+    WORD_ATOM(347, 57, "num-bytes");
     mw_prim_str_num_bytes();
-    WORD_ATOM(345, 67, "put");
+    WORD_ATOM(347, 67, "put");
     mw_Int_2B_C99_2E_put();
-    WORD_ATOM(345, 71, "");
+    WORD_ATOM(347, 71, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44833,15 +44474,15 @@ static void mb_c99_str_21__13 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(345, 76, "put");
+    WORD_ATOM(347, 76, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__13);
 }
 
 static void mb_c99_str_21__15 (void) {
-    WORD_ENTER(mb_c99_str_21__15, "c99-str! block", "src/mirth/codegen.mth", 346, 26);
+    WORD_ENTER(mb_c99_str_21__15, "c99-str! block", "src/mirth/codegen.mth", 348, 26);
     mw_prim_drop();
-    WORD_ATOM(346, 26, "");
+    WORD_ATOM(348, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44852,13 +44493,13 @@ static void mb_c99_str_21__15 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(346, 39, "put");
+    WORD_ATOM(348, 39, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(346, 43, "dup");
+    WORD_ATOM(348, 43, "dup");
     mw_prim_dup();
-    WORD_ATOM(346, 47, "put-cstr");
+    WORD_ATOM(348, 47, "put-cstr");
     mw__2B_C99_2E_put_cstr();
-    WORD_ATOM(346, 56, "");
+    WORD_ATOM(348, 56, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44869,15 +44510,15 @@ static void mb_c99_str_21__15 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(346, 61, "put");
+    WORD_ATOM(348, 61, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(346, 65, "dup");
+    WORD_ATOM(348, 65, "dup");
     mw_prim_dup();
-    WORD_ATOM(346, 69, "num-bytes");
+    WORD_ATOM(348, 69, "num-bytes");
     mw_prim_str_num_bytes();
-    WORD_ATOM(346, 79, "put");
+    WORD_ATOM(348, 79, "put");
     mw_Int_2B_C99_2E_put();
-    WORD_ATOM(346, 83, "");
+    WORD_ATOM(348, 83, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44888,15 +44529,15 @@ static void mb_c99_str_21__15 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(346, 88, "put");
+    WORD_ATOM(348, 88, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__15);
 }
 
 static void mb_c99_str_21__16 (void) {
-    WORD_ENTER(mb_c99_str_21__16, "c99-str! block", "src/mirth/codegen.mth", 348, 22);
+    WORD_ENTER(mb_c99_str_21__16, "c99-str! block", "src/mirth/codegen.mth", 350, 22);
     mw_prim_drop();
-    WORD_ATOM(348, 22, "");
+    WORD_ATOM(350, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44907,15 +44548,15 @@ static void mb_c99_str_21__16 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(348, 39, "put");
+    WORD_ATOM(350, 39, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__16);
 }
 
 static void mb_c99_str_21__17 (void) {
-    WORD_ENTER(mb_c99_str_21__17, "c99-str! block", "src/mirth/codegen.mth", 350, 18);
+    WORD_ENTER(mb_c99_str_21__17, "c99-str! block", "src/mirth/codegen.mth", 352, 18);
     mw_prim_drop();
-    WORD_ATOM(350, 18, "");
+    WORD_ATOM(352, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44926,15 +44567,15 @@ static void mb_c99_str_21__17 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(350, 22, "put");
+    WORD_ATOM(352, 22, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__17);
 }
 
 static void mb_c99_str_21__18 (void) {
-    WORD_ENTER(mb_c99_str_21__18, "c99-str! block", "src/mirth/codegen.mth", 351, 18);
+    WORD_ENTER(mb_c99_str_21__18, "c99-str! block", "src/mirth/codegen.mth", 353, 18);
     mw_prim_drop();
-    WORD_ATOM(351, 18, "");
+    WORD_ATOM(353, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44945,15 +44586,15 @@ static void mb_c99_str_21__18 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(351, 35, "put");
+    WORD_ATOM(353, 35, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__18);
 }
 
 static void mb_c99_str_21__19 (void) {
-    WORD_ENTER(mb_c99_str_21__19, "c99-str! block", "src/mirth/codegen.mth", 352, 18);
+    WORD_ENTER(mb_c99_str_21__19, "c99-str! block", "src/mirth/codegen.mth", 354, 18);
     mw_prim_drop();
-    WORD_ATOM(352, 18, "");
+    WORD_ATOM(354, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44964,15 +44605,15 @@ static void mb_c99_str_21__19 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(352, 31, "put");
+    WORD_ATOM(354, 31, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__19);
 }
 
 static void mb_c99_str_21__20 (void) {
-    WORD_ENTER(mb_c99_str_21__20, "c99-str! block", "src/mirth/codegen.mth", 354, 14);
+    WORD_ENTER(mb_c99_str_21__20, "c99-str! block", "src/mirth/codegen.mth", 356, 14);
     mw_prim_drop();
-    WORD_ATOM(354, 14, "");
+    WORD_ATOM(356, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44983,15 +44624,15 @@ static void mb_c99_str_21__20 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(354, 18, "put");
+    WORD_ATOM(356, 18, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__20);
 }
 
 static void mb_c99_prim_21__3 (void) {
-    WORD_ENTER(mb_c99_prim_21__3, "c99-prim! block", "src/mirth/codegen.mth", 385, 26);
+    WORD_ENTER(mb_c99_prim_21__3, "c99-prim! block", "src/mirth/codegen.mth", 387, 26);
     mw_prim_drop();
-    WORD_ATOM(385, 26, "");
+    WORD_ATOM(387, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45002,22 +44643,22 @@ static void mb_c99_prim_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(385, 30, "put");
+    WORD_ATOM(387, 30, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__3);
 }
 
 static void mb_c99_prim_21__4 (void) {
-    WORD_ENTER(mb_c99_prim_21__4, "c99-prim! block", "src/mirth/codegen.mth", 387, 21);
+    WORD_ENTER(mb_c99_prim_21__4, "c99-prim! block", "src/mirth/codegen.mth", 389, 21);
     mw_prim_drop();
-    WORD_ATOM(387, 21, "c99-line");
+    WORD_ATOM(389, 21, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_prim_21__5);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(388, 21, "c99-arg-run!");
+    WORD_ATOM(390, 21, "c99-arg-run!");
     mw_c99_arg_run_21_();
-    WORD_ATOM(389, 21, "c99-line");
+    WORD_ATOM(391, 21, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_prim_21__6);
     mw_prim_pack_cons();
@@ -45026,9 +44667,9 @@ static void mb_c99_prim_21__4 (void) {
 }
 
 static void mb_c99_prim_21__5 (void) {
-    WORD_ENTER(mb_c99_prim_21__5, "c99-prim! block", "src/mirth/codegen.mth", 387, 30);
+    WORD_ENTER(mb_c99_prim_21__5, "c99-prim! block", "src/mirth/codegen.mth", 389, 30);
     mw_prim_drop();
-    WORD_ATOM(387, 30, "");
+    WORD_ATOM(389, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45039,13 +44680,13 @@ static void mb_c99_prim_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(387, 38, "put");
+    WORD_ATOM(389, 38, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(387, 42, "depth@");
+    WORD_ATOM(389, 42, "depth@");
     mw__2B_C99_2E_depth_40_();
-    WORD_ATOM(387, 49, "put");
+    WORD_ATOM(389, 49, "put");
     mw_Int_2B_C99_2E_put();
-    WORD_ATOM(387, 53, "");
+    WORD_ATOM(389, 53, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45056,15 +44697,15 @@ static void mb_c99_prim_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(387, 71, "put");
+    WORD_ATOM(389, 71, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__5);
 }
 
 static void mb_c99_prim_21__6 (void) {
-    WORD_ENTER(mb_c99_prim_21__6, "c99-prim! block", "src/mirth/codegen.mth", 389, 30);
+    WORD_ENTER(mb_c99_prim_21__6, "c99-prim! block", "src/mirth/codegen.mth", 391, 30);
     mw_prim_drop();
-    WORD_ATOM(389, 30, "");
+    WORD_ATOM(391, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45075,13 +44716,13 @@ static void mb_c99_prim_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(389, 45, "put");
+    WORD_ATOM(391, 45, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(389, 49, "depth@");
+    WORD_ATOM(391, 49, "depth@");
     mw__2B_C99_2E_depth_40_();
-    WORD_ATOM(389, 56, "put");
+    WORD_ATOM(391, 56, "put");
     mw_Int_2B_C99_2E_put();
-    WORD_ATOM(389, 60, "");
+    WORD_ATOM(391, 60, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45092,15 +44733,15 @@ static void mb_c99_prim_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(389, 65, "put");
+    WORD_ATOM(391, 65, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__6);
 }
 
 static void mb_c99_prim_21__7 (void) {
-    WORD_ENTER(mb_c99_prim_21__7, "c99-prim! block", "src/mirth/codegen.mth", 391, 26);
+    WORD_ENTER(mb_c99_prim_21__7, "c99-prim! block", "src/mirth/codegen.mth", 393, 26);
     mw_prim_drop();
-    WORD_ATOM(391, 26, "");
+    WORD_ATOM(393, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45111,15 +44752,15 @@ static void mb_c99_prim_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(391, 30, "put");
+    WORD_ATOM(393, 30, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__7);
 }
 
 static void mb_c99_prim_21__11 (void) {
-    WORD_ENTER(mb_c99_prim_21__11, "c99-prim! block", "src/mirth/codegen.mth", 399, 26);
+    WORD_ENTER(mb_c99_prim_21__11, "c99-prim! block", "src/mirth/codegen.mth", 401, 26);
     mw_prim_drop();
-    WORD_ATOM(399, 26, "");
+    WORD_ATOM(401, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45130,22 +44771,22 @@ static void mb_c99_prim_21__11 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(399, 30, "put");
+    WORD_ATOM(401, 30, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__11);
 }
 
 static void mb_c99_prim_21__12 (void) {
-    WORD_ENTER(mb_c99_prim_21__12, "c99-prim! block", "src/mirth/codegen.mth", 401, 21);
+    WORD_ENTER(mb_c99_prim_21__12, "c99-prim! block", "src/mirth/codegen.mth", 403, 21);
     mw_prim_drop();
-    WORD_ATOM(401, 21, "c99-line");
+    WORD_ATOM(403, 21, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_prim_21__13);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(402, 21, "c99-arg-run!");
+    WORD_ATOM(404, 21, "c99-arg-run!");
     mw_c99_arg_run_21_();
-    WORD_ATOM(403, 21, "c99-line");
+    WORD_ATOM(405, 21, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_prim_21__14);
     mw_prim_pack_cons();
@@ -45154,9 +44795,9 @@ static void mb_c99_prim_21__12 (void) {
 }
 
 static void mb_c99_prim_21__13 (void) {
-    WORD_ENTER(mb_c99_prim_21__13, "c99-prim! block", "src/mirth/codegen.mth", 401, 30);
+    WORD_ENTER(mb_c99_prim_21__13, "c99-prim! block", "src/mirth/codegen.mth", 403, 30);
     mw_prim_drop();
-    WORD_ATOM(401, 30, "");
+    WORD_ATOM(403, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45167,13 +44808,13 @@ static void mb_c99_prim_21__13 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(401, 38, "put");
+    WORD_ATOM(403, 38, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(401, 42, "depth@");
+    WORD_ATOM(403, 42, "depth@");
     mw__2B_C99_2E_depth_40_();
-    WORD_ATOM(401, 49, "put");
+    WORD_ATOM(403, 49, "put");
     mw_Int_2B_C99_2E_put();
-    WORD_ATOM(401, 53, "");
+    WORD_ATOM(403, 53, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45184,15 +44825,15 @@ static void mb_c99_prim_21__13 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(401, 74, "put");
+    WORD_ATOM(403, 74, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__13);
 }
 
 static void mb_c99_prim_21__14 (void) {
-    WORD_ENTER(mb_c99_prim_21__14, "c99-prim! block", "src/mirth/codegen.mth", 403, 30);
+    WORD_ENTER(mb_c99_prim_21__14, "c99-prim! block", "src/mirth/codegen.mth", 405, 30);
     mw_prim_drop();
-    WORD_ATOM(403, 30, "");
+    WORD_ATOM(405, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45203,13 +44844,13 @@ static void mb_c99_prim_21__14 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(403, 48, "put");
+    WORD_ATOM(405, 48, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(403, 52, "depth@");
+    WORD_ATOM(405, 52, "depth@");
     mw__2B_C99_2E_depth_40_();
-    WORD_ATOM(403, 59, "put");
+    WORD_ATOM(405, 59, "put");
     mw_Int_2B_C99_2E_put();
-    WORD_ATOM(403, 63, "");
+    WORD_ATOM(405, 63, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45220,15 +44861,15 @@ static void mb_c99_prim_21__14 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(403, 68, "put");
+    WORD_ATOM(405, 68, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__14);
 }
 
 static void mb_c99_prim_21__15 (void) {
-    WORD_ENTER(mb_c99_prim_21__15, "c99-prim! block", "src/mirth/codegen.mth", 405, 26);
+    WORD_ENTER(mb_c99_prim_21__15, "c99-prim! block", "src/mirth/codegen.mth", 407, 26);
     mw_prim_drop();
-    WORD_ATOM(405, 26, "");
+    WORD_ATOM(407, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45239,15 +44880,15 @@ static void mb_c99_prim_21__15 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(405, 30, "put");
+    WORD_ATOM(407, 30, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__15);
 }
 
 static void mb_c99_prim_21__19 (void) {
-    WORD_ENTER(mb_c99_prim_21__19, "c99-prim! block", "src/mirth/codegen.mth", 413, 26);
+    WORD_ENTER(mb_c99_prim_21__19, "c99-prim! block", "src/mirth/codegen.mth", 415, 26);
     mw_prim_drop();
-    WORD_ATOM(413, 26, "");
+    WORD_ATOM(415, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45258,25 +44899,25 @@ static void mb_c99_prim_21__19 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(413, 45, "put");
+    WORD_ATOM(415, 45, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__19);
 }
 
 static void mb_c99_prim_21__20 (void) {
-    WORD_ENTER(mb_c99_prim_21__20, "c99-prim! block", "src/mirth/codegen.mth", 414, 26);
+    WORD_ENTER(mb_c99_prim_21__20, "c99-prim! block", "src/mirth/codegen.mth", 416, 26);
     mw_prim_drop();
-    WORD_ATOM(414, 26, "swap");
+    WORD_ATOM(416, 26, "swap");
     mw_prim_swap();
-    WORD_ATOM(414, 31, "c99-arg-run!");
+    WORD_ATOM(416, 31, "c99-arg-run!");
     mw_c99_arg_run_21_();
     WORD_EXIT(mb_c99_prim_21__20);
 }
 
 static void mb_c99_prim_21__21 (void) {
-    WORD_ENTER(mb_c99_prim_21__21, "c99-prim! block", "src/mirth/codegen.mth", 415, 26);
+    WORD_ENTER(mb_c99_prim_21__21, "c99-prim! block", "src/mirth/codegen.mth", 417, 26);
     mw_prim_drop();
-    WORD_ATOM(415, 26, "");
+    WORD_ATOM(417, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45287,23 +44928,23 @@ static void mb_c99_prim_21__21 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(415, 37, "put");
+    WORD_ATOM(417, 37, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__21);
 }
 
 static void mb_c99_prim_21__22 (void) {
-    WORD_ENTER(mb_c99_prim_21__22, "c99-prim! block", "src/mirth/codegen.mth", 416, 26);
+    WORD_ENTER(mb_c99_prim_21__22, "c99-prim! block", "src/mirth/codegen.mth", 418, 26);
     mw_prim_drop();
-    WORD_ATOM(416, 26, "c99-arg-run!");
+    WORD_ATOM(418, 26, "c99-arg-run!");
     mw_c99_arg_run_21_();
     WORD_EXIT(mb_c99_prim_21__22);
 }
 
 static void mb_c99_prim_21__23 (void) {
-    WORD_ENTER(mb_c99_prim_21__23, "c99-prim! block", "src/mirth/codegen.mth", 417, 26);
+    WORD_ENTER(mb_c99_prim_21__23, "c99-prim! block", "src/mirth/codegen.mth", 419, 26);
     mw_prim_drop();
-    WORD_ATOM(417, 26, "");
+    WORD_ATOM(419, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45314,15 +44955,15 @@ static void mb_c99_prim_21__23 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(417, 30, "put");
+    WORD_ATOM(419, 30, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__23);
 }
 
 static void mb_c99_prim_21__27 (void) {
-    WORD_ENTER(mb_c99_prim_21__27, "c99-prim! block", "src/mirth/codegen.mth", 425, 26);
+    WORD_ENTER(mb_c99_prim_21__27, "c99-prim! block", "src/mirth/codegen.mth", 427, 26);
     mw_prim_drop();
-    WORD_ATOM(425, 26, "");
+    WORD_ATOM(427, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45333,32 +44974,32 @@ static void mb_c99_prim_21__27 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(425, 39, "put");
+    WORD_ATOM(427, 39, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__27);
 }
 
 static void mb_c99_prim_21__28 (void) {
-    WORD_ENTER(mb_c99_prim_21__28, "c99-prim! block", "src/mirth/codegen.mth", 427, 21);
+    WORD_ENTER(mb_c99_prim_21__28, "c99-prim! block", "src/mirth/codegen.mth", 429, 21);
     mw_prim_drop();
-    WORD_ATOM(427, 21, "swap");
+    WORD_ATOM(429, 21, "swap");
     mw_prim_swap();
-    WORD_ATOM(427, 26, "c99-arg-run!");
+    WORD_ATOM(429, 26, "c99-arg-run!");
     mw_c99_arg_run_21_();
-    WORD_ATOM(428, 21, "c99-line");
+    WORD_ATOM(430, 21, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_prim_21__29);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(429, 21, "c99-arg-run!");
+    WORD_ATOM(431, 21, "c99-arg-run!");
     mw_c99_arg_run_21_();
     WORD_EXIT(mb_c99_prim_21__28);
 }
 
 static void mb_c99_prim_21__29 (void) {
-    WORD_ENTER(mb_c99_prim_21__29, "c99-prim! block", "src/mirth/codegen.mth", 428, 30);
+    WORD_ENTER(mb_c99_prim_21__29, "c99-prim! block", "src/mirth/codegen.mth", 430, 30);
     mw_prim_drop();
-    WORD_ATOM(428, 30, "");
+    WORD_ATOM(430, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45369,15 +45010,15 @@ static void mb_c99_prim_21__29 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(428, 56, "put");
+    WORD_ATOM(430, 56, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__29);
 }
 
 static void mb_c99_prim_21__30 (void) {
-    WORD_ENTER(mb_c99_prim_21__30, "c99-prim! block", "src/mirth/codegen.mth", 431, 26);
+    WORD_ENTER(mb_c99_prim_21__30, "c99-prim! block", "src/mirth/codegen.mth", 433, 26);
     mw_prim_drop();
-    WORD_ATOM(431, 26, "");
+    WORD_ATOM(433, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45388,17 +45029,17 @@ static void mb_c99_prim_21__30 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(431, 30, "put");
+    WORD_ATOM(433, 30, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__30);
 }
 
 static void mb_c99_match_21__3 (void) {
-    WORD_ENTER(mb_c99_match_21__3, "c99-match! block", "src/mirth/codegen.mth", 516, 19);
+    WORD_ENTER(mb_c99_match_21__3, "c99-match! block", "src/mirth/codegen.mth", 518, 19);
     mw_prim_drop();
-    WORD_ATOM(516, 19, "token");
+    WORD_ATOM(518, 19, "token");
     mw_Match_2E_token();
-    WORD_ATOM(516, 25, "");
+    WORD_ATOM(518, 25, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45409,15 +45050,15 @@ static void mb_c99_match_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(516, 71, "emit-fatal-error!");
+    WORD_ATOM(518, 71, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_c99_match_21__3);
 }
 
 static void mb_c99_match_21__5 (void) {
-    WORD_ENTER(mb_c99_match_21__5, "c99-match! block", "src/mirth/codegen.mth", 518, 22);
+    WORD_ENTER(mb_c99_match_21__5, "c99-match! block", "src/mirth/codegen.mth", 520, 22);
     mw_prim_drop();
-    WORD_ATOM(518, 22, "");
+    WORD_ATOM(520, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45428,15 +45069,15 @@ static void mb_c99_match_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(518, 63, "put");
+    WORD_ATOM(520, 63, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_match_21__5);
 }
 
 static void mb_c99_match_21__7 (void) {
-    WORD_ENTER(mb_c99_match_21__7, "c99-match! block", "src/mirth/codegen.mth", 519, 22);
+    WORD_ENTER(mb_c99_match_21__7, "c99-match! block", "src/mirth/codegen.mth", 521, 22);
     mw_prim_drop();
-    WORD_ATOM(519, 22, "");
+    WORD_ATOM(521, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45447,26 +45088,26 @@ static void mb_c99_match_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(519, 54, "put");
+    WORD_ATOM(521, 54, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_match_21__7);
 }
 
 static void mb_c99_match_21__8 (void) {
-    WORD_ENTER(mb_c99_match_21__8, "c99-match! block", "src/mirth/codegen.mth", 522, 13);
+    WORD_ENTER(mb_c99_match_21__8, "c99-match! block", "src/mirth/codegen.mth", 524, 13);
     mw_prim_drop();
-    WORD_ATOM(522, 13, "dup");
+    WORD_ATOM(524, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(522, 17, "cases");
+    WORD_ATOM(524, 17, "cases");
     mw_Match_2E_cases();
-    WORD_ATOM(522, 23, "for");
+    WORD_ATOM(524, 23, "for");
     push_u64(0);
     push_fnptr(&mb_c99_match_21__9);
     mw_prim_pack_cons();
     mw_List_2E_for();
-    WORD_ATOM(523, 13, "has-default-case?");
+    WORD_ATOM(525, 13, "has-default-case?");
     mw_Match_2E_has_default_case_3F_();
-    WORD_ATOM(523, 31, "else");
+    WORD_ATOM(525, 31, "else");
     push_u64(0);
     push_fnptr(&mb_c99_match_21__10);
     mw_prim_pack_cons();
@@ -45475,17 +45116,17 @@ static void mb_c99_match_21__8 (void) {
 }
 
 static void mb_c99_match_21__9 (void) {
-    WORD_ENTER(mb_c99_match_21__9, "c99-match! block", "src/mirth/codegen.mth", 522, 27);
+    WORD_ENTER(mb_c99_match_21__9, "c99-match! block", "src/mirth/codegen.mth", 524, 27);
     mw_prim_drop();
-    WORD_ATOM(522, 27, "c99-case!");
+    WORD_ATOM(524, 27, "c99-case!");
     mw_c99_case_21_();
     WORD_EXIT(mb_c99_match_21__9);
 }
 
 static void mb_c99_match_21__10 (void) {
-    WORD_ENTER(mb_c99_match_21__10, "c99-match! block", "src/mirth/codegen.mth", 524, 17);
+    WORD_ENTER(mb_c99_match_21__10, "c99-match! block", "src/mirth/codegen.mth", 526, 17);
     mw_prim_drop();
-    WORD_ATOM(524, 17, "c99-line");
+    WORD_ATOM(526, 17, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_match_21__11);
     mw_prim_pack_cons();
@@ -45494,9 +45135,9 @@ static void mb_c99_match_21__10 (void) {
 }
 
 static void mb_c99_match_21__11 (void) {
-    WORD_ENTER(mb_c99_match_21__11, "c99-match! block", "src/mirth/codegen.mth", 524, 26);
+    WORD_ENTER(mb_c99_match_21__11, "c99-match! block", "src/mirth/codegen.mth", 526, 26);
     mw_prim_drop();
-    WORD_ATOM(524, 26, "");
+    WORD_ATOM(526, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45507,15 +45148,15 @@ static void mb_c99_match_21__11 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(524, 118, "put");
+    WORD_ATOM(526, 118, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_match_21__11);
 }
 
 static void mb_c99_match_21__12 (void) {
-    WORD_ENTER(mb_c99_match_21__12, "c99-match! block", "src/mirth/codegen.mth", 527, 18);
+    WORD_ENTER(mb_c99_match_21__12, "c99-match! block", "src/mirth/codegen.mth", 529, 18);
     mw_prim_drop();
-    WORD_ATOM(527, 18, "");
+    WORD_ATOM(529, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45526,15 +45167,15 @@ static void mb_c99_match_21__12 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(527, 22, "put");
+    WORD_ATOM(529, 22, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_match_21__12);
 }
 
 static void mb_c99_lambda_21__1 (void) {
-    WORD_ENTER(mb_c99_lambda_21__1, "c99-lambda! block", "src/mirth/codegen.mth", 499, 14);
+    WORD_ENTER(mb_c99_lambda_21__1, "c99-lambda! block", "src/mirth/codegen.mth", 501, 14);
     mw_prim_drop();
-    WORD_ATOM(499, 14, "");
+    WORD_ATOM(501, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45545,32 +45186,32 @@ static void mb_c99_lambda_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(499, 18, "put");
+    WORD_ATOM(501, 18, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_lambda_21__1);
 }
 
 static void mb_c99_lambda_21__2 (void) {
-    WORD_ENTER(mb_c99_lambda_21__2, "c99-lambda! block", "src/mirth/codegen.mth", 501, 9);
+    WORD_ENTER(mb_c99_lambda_21__2, "c99-lambda! block", "src/mirth/codegen.mth", 503, 9);
     mw_prim_drop();
-    WORD_ATOM(501, 9, "dup");
+    WORD_ATOM(503, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(501, 13, "params");
+    WORD_ATOM(503, 13, "params");
     mw_Lambda_2E_params();
-    WORD_ATOM(501, 20, "reverse-for");
+    WORD_ATOM(503, 20, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__3);
     mw_prim_pack_cons();
     mw_List_2E_reverse_for();
-    WORD_ATOM(504, 9, "dup");
+    WORD_ATOM(506, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(504, 13, "body");
+    WORD_ATOM(506, 13, "body");
     mw_Lambda_2E_body();
-    WORD_ATOM(504, 18, "c99-arrow!");
+    WORD_ATOM(506, 18, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(505, 9, "params");
+    WORD_ATOM(507, 9, "params");
     mw_Lambda_2E_params();
-    WORD_ATOM(505, 16, "reverse-for");
+    WORD_ATOM(507, 16, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__5);
     mw_prim_pack_cons();
@@ -45579,9 +45220,9 @@ static void mb_c99_lambda_21__2 (void) {
 }
 
 static void mb_c99_lambda_21__3 (void) {
-    WORD_ENTER(mb_c99_lambda_21__3, "c99-lambda! block", "src/mirth/codegen.mth", 502, 13);
+    WORD_ENTER(mb_c99_lambda_21__3, "c99-lambda! block", "src/mirth/codegen.mth", 504, 13);
     mw_prim_drop();
-    WORD_ATOM(502, 13, "c99-line");
+    WORD_ATOM(504, 13, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__4);
     mw_prim_pack_cons();
@@ -45590,9 +45231,9 @@ static void mb_c99_lambda_21__3 (void) {
 }
 
 static void mb_c99_lambda_21__4 (void) {
-    WORD_ENTER(mb_c99_lambda_21__4, "c99-lambda! block", "src/mirth/codegen.mth", 502, 22);
+    WORD_ENTER(mb_c99_lambda_21__4, "c99-lambda! block", "src/mirth/codegen.mth", 504, 22);
     mw_prim_drop();
-    WORD_ATOM(502, 22, "");
+    WORD_ATOM(504, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45603,11 +45244,11 @@ static void mb_c99_lambda_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(502, 29, "put");
+    WORD_ATOM(504, 29, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(502, 33, "put");
+    WORD_ATOM(504, 33, "put");
     mw_Param_2B_C99_2E_put();
-    WORD_ATOM(502, 37, "");
+    WORD_ATOM(504, 37, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45618,15 +45259,15 @@ static void mb_c99_lambda_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(502, 55, "put");
+    WORD_ATOM(504, 55, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_lambda_21__4);
 }
 
 static void mb_c99_lambda_21__5 (void) {
-    WORD_ENTER(mb_c99_lambda_21__5, "c99-lambda! block", "src/mirth/codegen.mth", 506, 13);
+    WORD_ENTER(mb_c99_lambda_21__5, "c99-lambda! block", "src/mirth/codegen.mth", 508, 13);
     mw_prim_drop();
-    WORD_ATOM(506, 13, "c99-line");
+    WORD_ATOM(508, 13, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__6);
     mw_prim_pack_cons();
@@ -45635,9 +45276,9 @@ static void mb_c99_lambda_21__5 (void) {
 }
 
 static void mb_c99_lambda_21__6 (void) {
-    WORD_ENTER(mb_c99_lambda_21__6, "c99-lambda! block", "src/mirth/codegen.mth", 506, 22);
+    WORD_ENTER(mb_c99_lambda_21__6, "c99-lambda! block", "src/mirth/codegen.mth", 508, 22);
     mw_prim_drop();
-    WORD_ATOM(506, 22, "");
+    WORD_ATOM(508, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45648,11 +45289,11 @@ static void mb_c99_lambda_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(506, 32, "put");
+    WORD_ATOM(508, 32, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(506, 36, "put");
+    WORD_ATOM(508, 36, "put");
     mw_Param_2B_C99_2E_put();
-    WORD_ATOM(506, 40, "");
+    WORD_ATOM(508, 40, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45663,15 +45304,15 @@ static void mb_c99_lambda_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(506, 45, "put");
+    WORD_ATOM(508, 45, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_lambda_21__6);
 }
 
 static void mb_c99_lambda_21__7 (void) {
-    WORD_ENTER(mb_c99_lambda_21__7, "c99-lambda! block", "src/mirth/codegen.mth", 509, 14);
+    WORD_ENTER(mb_c99_lambda_21__7, "c99-lambda! block", "src/mirth/codegen.mth", 511, 14);
     mw_prim_drop();
-    WORD_ATOM(509, 14, "");
+    WORD_ATOM(511, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45682,15 +45323,15 @@ static void mb_c99_lambda_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(509, 18, "put");
+    WORD_ATOM(511, 18, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_lambda_21__7);
 }
 
 static void mb_c99_block_push_21__3 (void) {
-    WORD_ENTER(mb_c99_block_push_21__3, "c99-block-push! block", "src/mirth/codegen.mth", 481, 22);
+    WORD_ENTER(mb_c99_block_push_21__3, "c99-block-push! block", "src/mirth/codegen.mth", 483, 22);
     mw_prim_drop();
-    WORD_ATOM(481, 22, "");
+    WORD_ATOM(483, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45701,11 +45342,11 @@ static void mb_c99_block_push_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(481, 37, "put");
+    WORD_ATOM(483, 37, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(481, 41, "put");
+    WORD_ATOM(483, 41, "put");
     mw_Block_2B_C99_2E_put();
-    WORD_ATOM(481, 45, "");
+    WORD_ATOM(483, 45, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45716,15 +45357,15 @@ static void mb_c99_block_push_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(481, 50, "put");
+    WORD_ATOM(483, 50, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_block_push_21__3);
 }
 
 static void mb_c99_block_push_21__4 (void) {
-    WORD_ENTER(mb_c99_block_push_21__4, "c99-block-push! block", "src/mirth/codegen.mth", 482, 22);
+    WORD_ENTER(mb_c99_block_push_21__4, "c99-block-push! block", "src/mirth/codegen.mth", 484, 22);
     mw_prim_drop();
-    WORD_ATOM(482, 22, "");
+    WORD_ATOM(484, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45735,23 +45376,23 @@ static void mb_c99_block_push_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(482, 45, "put");
+    WORD_ATOM(484, 45, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_block_push_21__4);
 }
 
 static void mb__2B_C99_2E_put_cstr_1 (void) {
-    WORD_ENTER(mb__2B_C99_2E_put_cstr_1, "+C99.put-cstr block", "src/mirth/codegen.mth", 358, 28);
+    WORD_ENTER(mb__2B_C99_2E_put_cstr_1, "+C99.put-cstr block", "src/mirth/codegen.mth", 360, 28);
     mw_prim_drop();
-    WORD_ATOM(358, 28, "c99-string-byte!");
+    WORD_ATOM(360, 28, "c99-string-byte!");
     mw_c99_string_byte_21_();
     WORD_EXIT(mb__2B_C99_2E_put_cstr_1);
 }
 
 static void mb_c99_pack_ctx_21__1 (void) {
-    WORD_ENTER(mb_c99_pack_ctx_21__1, "c99-pack-ctx! block", "src/mirth/codegen.mth", 458, 14);
+    WORD_ENTER(mb_c99_pack_ctx_21__1, "c99-pack-ctx! block", "src/mirth/codegen.mth", 460, 14);
     mw_prim_drop();
-    WORD_ATOM(458, 14, "");
+    WORD_ATOM(460, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45762,17 +45403,17 @@ static void mb_c99_pack_ctx_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(458, 29, "put");
+    WORD_ATOM(460, 29, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_pack_ctx_21__1);
 }
 
 static void mb_c99_pack_ctx_21__2 (void) {
-    WORD_ENTER(mb_c99_pack_ctx_21__2, "c99-pack-ctx! block", "src/mirth/codegen.mth", 460, 9);
+    WORD_ENTER(mb_c99_pack_ctx_21__2, "c99-pack-ctx! block", "src/mirth/codegen.mth", 462, 9);
     mw_prim_drop();
-    WORD_ATOM(460, 9, "c99-var-push!");
+    WORD_ATOM(462, 9, "c99-var-push!");
     mw_c99_var_push_21_();
-    WORD_ATOM(461, 9, "c99-line");
+    WORD_ATOM(463, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_pack_ctx_21__3);
     mw_prim_pack_cons();
@@ -45781,9 +45422,9 @@ static void mb_c99_pack_ctx_21__2 (void) {
 }
 
 static void mb_c99_pack_ctx_21__3 (void) {
-    WORD_ENTER(mb_c99_pack_ctx_21__3, "c99-pack-ctx! block", "src/mirth/codegen.mth", 461, 18);
+    WORD_ENTER(mb_c99_pack_ctx_21__3, "c99-pack-ctx! block", "src/mirth/codegen.mth", 463, 18);
     mw_prim_drop();
-    WORD_ATOM(461, 18, "");
+    WORD_ATOM(463, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45794,15 +45435,15 @@ static void mb_c99_pack_ctx_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(461, 41, "put");
+    WORD_ATOM(463, 41, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_pack_ctx_21__3);
 }
 
 static void mb_c99_var_push_21__1 (void) {
-    WORD_ENTER(mb_c99_var_push_21__1, "c99-var-push! block", "src/mirth/codegen.mth", 494, 14);
+    WORD_ENTER(mb_c99_var_push_21__1, "c99-var-push! block", "src/mirth/codegen.mth", 496, 14);
     mw_prim_drop();
-    WORD_ATOM(494, 14, "");
+    WORD_ATOM(496, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45813,13 +45454,13 @@ static void mb_c99_var_push_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(494, 24, "put");
+    WORD_ATOM(496, 24, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(494, 28, "dup");
+    WORD_ATOM(496, 28, "dup");
     mw_prim_dup();
-    WORD_ATOM(494, 32, "put");
+    WORD_ATOM(496, 32, "put");
     mw_Var_2B_C99_2E_put();
-    WORD_ATOM(494, 36, "");
+    WORD_ATOM(496, 36, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45830,15 +45471,15 @@ static void mb_c99_var_push_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(494, 41, "put");
+    WORD_ATOM(496, 41, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_var_push_21__1);
 }
 
 static void mb_c99_var_push_21__2 (void) {
-    WORD_ENTER(mb_c99_var_push_21__2, "c99-var-push! block", "src/mirth/codegen.mth", 495, 14);
+    WORD_ENTER(mb_c99_var_push_21__2, "c99-var-push! block", "src/mirth/codegen.mth", 497, 14);
     mw_prim_drop();
-    WORD_ATOM(495, 14, "");
+    WORD_ATOM(497, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45849,13 +45490,13 @@ static void mb_c99_var_push_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(495, 28, "put");
+    WORD_ATOM(497, 28, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(495, 32, "dup");
+    WORD_ATOM(497, 32, "dup");
     mw_prim_dup();
-    WORD_ATOM(495, 36, "put");
+    WORD_ATOM(497, 36, "put");
     mw_Var_2B_C99_2E_put();
-    WORD_ATOM(495, 40, "");
+    WORD_ATOM(497, 40, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45866,20 +45507,20 @@ static void mb_c99_var_push_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(495, 45, "put");
+    WORD_ATOM(497, 45, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_var_push_21__2);
 }
 
 static void mb_c99_unpack_ctx_21__1 (void) {
-    WORD_ENTER(mb_c99_unpack_ctx_21__1, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 466, 9);
+    WORD_ENTER(mb_c99_unpack_ctx_21__1, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 468, 9);
     mw_prim_drop();
-    WORD_ATOM(466, 9, "c99-line");
+    WORD_ATOM(468, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_unpack_ctx_21__2);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(467, 9, "c99-line");
+    WORD_ATOM(469, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_unpack_ctx_21__3);
     mw_prim_pack_cons();
@@ -45888,9 +45529,9 @@ static void mb_c99_unpack_ctx_21__1 (void) {
 }
 
 static void mb_c99_unpack_ctx_21__2 (void) {
-    WORD_ENTER(mb_c99_unpack_ctx_21__2, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 466, 18);
+    WORD_ENTER(mb_c99_unpack_ctx_21__2, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 468, 18);
     mw_prim_drop();
-    WORD_ATOM(466, 18, "");
+    WORD_ATOM(468, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45901,15 +45542,15 @@ static void mb_c99_unpack_ctx_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(466, 43, "put");
+    WORD_ATOM(468, 43, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_unpack_ctx_21__2);
 }
 
 static void mb_c99_unpack_ctx_21__3 (void) {
-    WORD_ENTER(mb_c99_unpack_ctx_21__3, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 467, 18);
+    WORD_ENTER(mb_c99_unpack_ctx_21__3, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 469, 18);
     mw_prim_drop();
-    WORD_ATOM(467, 18, "");
+    WORD_ATOM(469, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45920,11 +45561,11 @@ static void mb_c99_unpack_ctx_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(467, 25, "put");
+    WORD_ATOM(469, 25, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(467, 29, "put");
+    WORD_ATOM(469, 29, "put");
     mw_Var_2B_C99_2E_put();
-    WORD_ATOM(467, 33, "");
+    WORD_ATOM(469, 33, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45935,15 +45576,15 @@ static void mb_c99_unpack_ctx_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(467, 51, "put");
+    WORD_ATOM(469, 51, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_unpack_ctx_21__3);
 }
 
 static void mb_c99_unpack_ctx_21__4 (void) {
-    WORD_ENTER(mb_c99_unpack_ctx_21__4, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 469, 14);
+    WORD_ENTER(mb_c99_unpack_ctx_21__4, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 471, 14);
     mw_prim_drop();
-    WORD_ATOM(469, 14, "");
+    WORD_ATOM(471, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45954,15 +45595,15 @@ static void mb_c99_unpack_ctx_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(469, 32, "put");
+    WORD_ATOM(471, 32, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_unpack_ctx_21__4);
 }
 
 static void mb_c99_decref_ctx_21__1 (void) {
-    WORD_ENTER(mb_c99_decref_ctx_21__1, "c99-decref-ctx! block", "src/mirth/codegen.mth", 473, 9);
+    WORD_ENTER(mb_c99_decref_ctx_21__1, "c99-decref-ctx! block", "src/mirth/codegen.mth", 475, 9);
     mw_prim_drop();
-    WORD_ATOM(473, 9, "c99-line");
+    WORD_ATOM(475, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_decref_ctx_21__2);
     mw_prim_pack_cons();
@@ -45971,9 +45612,9 @@ static void mb_c99_decref_ctx_21__1 (void) {
 }
 
 static void mb_c99_decref_ctx_21__2 (void) {
-    WORD_ENTER(mb_c99_decref_ctx_21__2, "c99-decref-ctx! block", "src/mirth/codegen.mth", 473, 18);
+    WORD_ENTER(mb_c99_decref_ctx_21__2, "c99-decref-ctx! block", "src/mirth/codegen.mth", 475, 18);
     mw_prim_drop();
-    WORD_ATOM(473, 18, "");
+    WORD_ATOM(475, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45984,11 +45625,11 @@ static void mb_c99_decref_ctx_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(473, 28, "put");
+    WORD_ATOM(475, 28, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(473, 32, "put");
+    WORD_ATOM(475, 32, "put");
     mw_Var_2B_C99_2E_put();
-    WORD_ATOM(473, 36, "");
+    WORD_ATOM(475, 36, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45999,15 +45640,15 @@ static void mb_c99_decref_ctx_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(473, 41, "put");
+    WORD_ATOM(475, 41, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_decref_ctx_21__2);
 }
 
 static void mb_c99_var_run_21__1 (void) {
-    WORD_ENTER(mb_c99_var_run_21__1, "c99-var-run! block", "src/mirth/codegen.mth", 489, 14);
+    WORD_ENTER(mb_c99_var_run_21__1, "c99-var-run! block", "src/mirth/codegen.mth", 491, 14);
     mw_prim_drop();
-    WORD_ATOM(489, 14, "");
+    WORD_ATOM(491, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46018,13 +45659,13 @@ static void mb_c99_var_run_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(489, 24, "put");
+    WORD_ATOM(491, 24, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(489, 28, "dup");
+    WORD_ATOM(491, 28, "dup");
     mw_prim_dup();
-    WORD_ATOM(489, 32, "put");
+    WORD_ATOM(491, 32, "put");
     mw_Var_2B_C99_2E_put();
-    WORD_ATOM(489, 36, "");
+    WORD_ATOM(491, 36, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46035,15 +45676,15 @@ static void mb_c99_var_run_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(489, 41, "put");
+    WORD_ATOM(491, 41, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_var_run_21__1);
 }
 
 static void mb_c99_var_run_21__2 (void) {
-    WORD_ENTER(mb_c99_var_run_21__2, "c99-var-run! block", "src/mirth/codegen.mth", 490, 14);
+    WORD_ENTER(mb_c99_var_run_21__2, "c99-var-run! block", "src/mirth/codegen.mth", 492, 14);
     mw_prim_drop();
-    WORD_ATOM(490, 14, "");
+    WORD_ATOM(492, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46054,13 +45695,13 @@ static void mb_c99_var_run_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(490, 27, "put");
+    WORD_ATOM(492, 27, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(490, 31, "dup");
+    WORD_ATOM(492, 31, "dup");
     mw_prim_dup();
-    WORD_ATOM(490, 35, "put");
+    WORD_ATOM(492, 35, "put");
     mw_Var_2B_C99_2E_put();
-    WORD_ATOM(490, 39, "");
+    WORD_ATOM(492, 39, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46071,19 +45712,19 @@ static void mb_c99_var_run_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(490, 44, "put");
+    WORD_ATOM(492, 44, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_var_run_21__2);
 }
 
 static void mb_c99_case_21__1 (void) {
-    WORD_ENTER(mb_c99_case_21__1, "c99-case! block", "src/mirth/codegen.mth", 533, 9);
+    WORD_ENTER(mb_c99_case_21__1, "c99-case! block", "src/mirth/codegen.mth", 535, 9);
     mw_prim_drop();
-    WORD_ATOM(533, 9, "body");
+    WORD_ATOM(535, 9, "body");
     mw_Case_2E_body();
-    WORD_ATOM(533, 14, "c99-arrow!");
+    WORD_ATOM(535, 14, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(534, 9, "c99-line");
+    WORD_ATOM(536, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_case_21__2);
     mw_prim_pack_cons();
@@ -46092,9 +45733,9 @@ static void mb_c99_case_21__1 (void) {
 }
 
 static void mb_c99_case_21__2 (void) {
-    WORD_ENTER(mb_c99_case_21__2, "c99-case! block", "src/mirth/codegen.mth", 534, 18);
+    WORD_ENTER(mb_c99_case_21__2, "c99-case! block", "src/mirth/codegen.mth", 536, 18);
     mw_prim_drop();
-    WORD_ATOM(534, 18, "");
+    WORD_ATOM(536, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46105,15 +45746,15 @@ static void mb_c99_case_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(534, 27, "put");
+    WORD_ATOM(536, 27, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_case_21__2);
 }
 
 static void mb_c99_pattern_21__2 (void) {
-    WORD_ENTER(mb_c99_pattern_21__2, "c99-pattern! block", "src/mirth/codegen.mth", 539, 18);
+    WORD_ENTER(mb_c99_pattern_21__2, "c99-pattern! block", "src/mirth/codegen.mth", 541, 18);
     mw_prim_drop();
-    WORD_ATOM(539, 18, "");
+    WORD_ATOM(541, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46124,15 +45765,15 @@ static void mb_c99_pattern_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(539, 29, "put");
+    WORD_ATOM(541, 29, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_pattern_21__2);
 }
 
 static void mb_c99_pattern_21__4 (void) {
-    WORD_ENTER(mb_c99_pattern_21__4, "c99-pattern! block", "src/mirth/codegen.mth", 542, 18);
+    WORD_ENTER(mb_c99_pattern_21__4, "c99-pattern! block", "src/mirth/codegen.mth", 544, 18);
     mw_prim_drop();
-    WORD_ATOM(542, 18, "");
+    WORD_ATOM(544, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46143,15 +45784,15 @@ static void mb_c99_pattern_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(542, 26, "put");
+    WORD_ATOM(544, 26, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(542, 30, "dup");
+    WORD_ATOM(544, 30, "dup");
     mw_prim_dup();
-    WORD_ATOM(542, 34, "value");
+    WORD_ATOM(544, 34, "value");
     mw_Tag_2E_value();
-    WORD_ATOM(542, 40, "put");
+    WORD_ATOM(544, 40, "put");
     mw_Int_2B_C99_2E_put();
-    WORD_ATOM(542, 44, "");
+    WORD_ATOM(544, 44, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46162,15 +45803,15 @@ static void mb_c99_pattern_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(542, 50, "put");
+    WORD_ATOM(544, 50, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_pattern_21__4);
 }
 
 static void mb_c99_pattern_21__5 (void) {
-    WORD_ENTER(mb_c99_pattern_21__5, "c99-pattern! block", "src/mirth/codegen.mth", 544, 13);
+    WORD_ENTER(mb_c99_pattern_21__5, "c99-pattern! block", "src/mirth/codegen.mth", 546, 13);
     mw_prim_drop();
-    WORD_ATOM(544, 13, "c99-line");
+    WORD_ATOM(546, 13, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_pattern_21__6);
     mw_prim_pack_cons();
@@ -46179,9 +45820,9 @@ static void mb_c99_pattern_21__5 (void) {
 }
 
 static void mb_c99_pattern_21__6 (void) {
-    WORD_ENTER(mb_c99_pattern_21__6, "c99-pattern! block", "src/mirth/codegen.mth", 544, 22);
+    WORD_ENTER(mb_c99_pattern_21__6, "c99-pattern! block", "src/mirth/codegen.mth", 546, 22);
     mw_prim_drop();
-    WORD_ATOM(544, 22, "");
+    WORD_ATOM(546, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46192,13 +45833,13 @@ static void mb_c99_pattern_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(544, 28, "put");
+    WORD_ATOM(546, 28, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(544, 32, "name");
+    WORD_ATOM(546, 32, "name");
     mw_Tag_2E_name();
-    WORD_ATOM(544, 37, "put");
+    WORD_ATOM(546, 37, "put");
     mw_Name_2B_C99_2E_put();
-    WORD_ATOM(544, 41, "");
+    WORD_ATOM(546, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46209,15 +45850,15 @@ static void mb_c99_pattern_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(544, 47, "put");
+    WORD_ATOM(546, 47, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_pattern_21__6);
 }
 
 static void mb_c99_word_sig_21__1 (void) {
-    WORD_ENTER(mb_c99_word_sig_21__1, "c99-word-sig! block", "src/mirth/codegen.mth", 550, 14);
+    WORD_ENTER(mb_c99_word_sig_21__1, "c99-word-sig! block", "src/mirth/codegen.mth", 552, 14);
     mw_prim_drop();
-    WORD_ATOM(550, 14, "");
+    WORD_ATOM(552, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46228,13 +45869,13 @@ static void mb_c99_word_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(550, 32, "put");
+    WORD_ATOM(552, 32, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(550, 36, "name");
+    WORD_ATOM(552, 36, "name");
     mw_Word_2E_name();
-    WORD_ATOM(550, 41, "put");
+    WORD_ATOM(552, 41, "put");
     mw_Name_2B_C99_2E_put();
-    WORD_ATOM(550, 45, "");
+    WORD_ATOM(552, 45, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46245,15 +45886,15 @@ static void mb_c99_word_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(550, 56, "put");
+    WORD_ATOM(552, 56, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_word_sig_21__1);
 }
 
 static void mb_c99_block_sig_21__1 (void) {
-    WORD_ENTER(mb_c99_block_sig_21__1, "c99-block-sig! block", "src/mirth/codegen.mth", 554, 14);
+    WORD_ENTER(mb_c99_block_sig_21__1, "c99-block-sig! block", "src/mirth/codegen.mth", 556, 14);
     mw_prim_drop();
-    WORD_ATOM(554, 14, "");
+    WORD_ATOM(556, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46264,11 +45905,11 @@ static void mb_c99_block_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(554, 29, "put");
+    WORD_ATOM(556, 29, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(554, 33, "put");
+    WORD_ATOM(556, 33, "put");
     mw_Block_2B_C99_2E_put();
-    WORD_ATOM(554, 37, "");
+    WORD_ATOM(556, 37, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46279,15 +45920,15 @@ static void mb_c99_block_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(554, 48, "put");
+    WORD_ATOM(556, 48, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_block_sig_21__1);
 }
 
 static void mb_c99_field_sig_21__1 (void) {
-    WORD_ENTER(mb_c99_field_sig_21__1, "c99-field-sig! block", "src/mirth/codegen.mth", 558, 14);
+    WORD_ENTER(mb_c99_field_sig_21__1, "c99-field-sig! block", "src/mirth/codegen.mth", 560, 14);
     mw_prim_drop();
-    WORD_ATOM(558, 14, "");
+    WORD_ATOM(560, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46298,13 +45939,13 @@ static void mb_c99_field_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(558, 32, "put");
+    WORD_ATOM(560, 32, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(558, 36, "name");
+    WORD_ATOM(560, 36, "name");
     mw_Field_2E_name();
-    WORD_ATOM(558, 41, "put");
+    WORD_ATOM(560, 41, "put");
     mw_Name_2B_C99_2E_put();
-    WORD_ATOM(558, 45, "");
+    WORD_ATOM(560, 45, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46315,15 +45956,15 @@ static void mb_c99_field_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(558, 56, "put");
+    WORD_ATOM(560, 56, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_field_sig_21__1);
 }
 
 static void mb_c99_block_enter_21__1 (void) {
-    WORD_ENTER(mb_c99_block_enter_21__1, "c99-block-enter! block", "src/mirth/codegen.mth", 561, 14);
+    WORD_ENTER(mb_c99_block_enter_21__1, "c99-block-enter! block", "src/mirth/codegen.mth", 563, 14);
     mw_prim_drop();
-    WORD_ATOM(561, 14, "");
+    WORD_ATOM(563, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46334,13 +45975,13 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(561, 28, "put");
+    WORD_ATOM(563, 28, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(562, 9, "dup");
+    WORD_ATOM(564, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(562, 13, "put");
+    WORD_ATOM(564, 13, "put");
     mw_Block_2B_C99_2E_put();
-    WORD_ATOM(562, 17, "");
+    WORD_ATOM(564, 17, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46351,19 +45992,19 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(562, 22, "put");
+    WORD_ATOM(564, 22, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(563, 9, "dup");
+    WORD_ATOM(565, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(563, 13, "arrow");
+    WORD_ATOM(565, 13, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(563, 19, "home");
+    WORD_ATOM(565, 19, "home");
     mw_Arrow_2E_home();
-    WORD_ATOM(563, 24, "match");
+    WORD_ATOM(565, 24, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mp_NONE();
-            WORD_ATOM(564, 21, "");
+            WORD_ATOM(566, 21, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -46377,11 +46018,11 @@ static void mb_c99_block_enter_21__1 (void) {
             break;
         case 1LL:
             mp_SOME();
-            WORD_ATOM(565, 21, "name");
+            WORD_ATOM(567, 21, "name");
             mw_Word_2E_name();
-            WORD_ATOM(565, 26, ">Str");
+            WORD_ATOM(567, 26, ">Str");
             mw_Name_3E_Str();
-            WORD_ATOM(565, 31, "");
+            WORD_ATOM(567, 31, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -46392,14 +46033,14 @@ static void mb_c99_block_enter_21__1 (void) {
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(565, 40, "cat");
+            WORD_ATOM(567, 40, "cat");
             mw_prim_str_cat();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
     }
-    WORD_ATOM(566, 11, "put-cstr");
+    WORD_ATOM(568, 11, "put-cstr");
     mw__2B_C99_2E_put_cstr();
-    WORD_ATOM(566, 20, "");
+    WORD_ATOM(568, 20, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46410,67 +46051,67 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(566, 25, "put");
-    mw_Str_2B_C99_2E_put();
-    WORD_ATOM(567, 9, "dup");
-    mw_prim_dup();
-    WORD_ATOM(567, 13, "token");
-    mw_Block_2E_token();
-    WORD_ATOM(567, 19, ".module");
-    mw_Token_2E_module();
-    WORD_ATOM(567, 27, "source-path");
-    mw_Module_2E_source_path();
-    WORD_ATOM(567, 39, ">Str");
-    mw_Path_3E_Str();
-    WORD_ATOM(567, 44, "put-cstr");
-    mw__2B_C99_2E_put_cstr();
-    WORD_ATOM(567, 53, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr(", ", 2);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(567, 58, "put");
-    mw_Str_2B_C99_2E_put();
-    WORD_ATOM(568, 9, "dup");
-    mw_prim_dup();
-    WORD_ATOM(568, 13, "token");
-    mw_Block_2E_token();
-    WORD_ATOM(568, 19, "row");
-    mw_Token_2E_row();
-    WORD_ATOM(568, 23, ">Int");
-    mw_Row_3E_Int();
-    WORD_ATOM(568, 28, "put");
-    mw_Int_2B_C99_2E_put();
-    WORD_ATOM(568, 32, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr(", ", 2);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(568, 37, "put");
+    WORD_ATOM(568, 25, "put");
     mw_Str_2B_C99_2E_put();
     WORD_ATOM(569, 9, "dup");
     mw_prim_dup();
     WORD_ATOM(569, 13, "token");
     mw_Block_2E_token();
-    WORD_ATOM(569, 19, "col");
-    mw_Token_2E_col();
-    WORD_ATOM(569, 23, ">Int");
-    mw_Col_3E_Int();
-    WORD_ATOM(569, 28, "put");
+    WORD_ATOM(569, 19, ".module");
+    mw_Token_2E_module();
+    WORD_ATOM(569, 27, "source-path");
+    mw_Module_2E_source_path();
+    WORD_ATOM(569, 39, ">Str");
+    mw_Path_3E_Str();
+    WORD_ATOM(569, 44, "put-cstr");
+    mw__2B_C99_2E_put_cstr();
+    WORD_ATOM(569, 53, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr(", ", 2);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(569, 58, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(570, 9, "dup");
+    mw_prim_dup();
+    WORD_ATOM(570, 13, "token");
+    mw_Block_2E_token();
+    WORD_ATOM(570, 19, "row");
+    mw_Token_2E_row();
+    WORD_ATOM(570, 23, ">Int");
+    mw_Row_3E_Int();
+    WORD_ATOM(570, 28, "put");
     mw_Int_2B_C99_2E_put();
-    WORD_ATOM(569, 32, "");
+    WORD_ATOM(570, 32, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr(", ", 2);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(570, 37, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(571, 9, "dup");
+    mw_prim_dup();
+    WORD_ATOM(571, 13, "token");
+    mw_Block_2E_token();
+    WORD_ATOM(571, 19, "col");
+    mw_Token_2E_col();
+    WORD_ATOM(571, 23, ">Int");
+    mw_Col_3E_Int();
+    WORD_ATOM(571, 28, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(571, 32, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46481,15 +46122,15 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(569, 37, "put");
+    WORD_ATOM(571, 37, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_block_enter_21__1);
 }
 
 static void mb_c99_block_exit_21__1 (void) {
-    WORD_ENTER(mb_c99_block_exit_21__1, "c99-block-exit! block", "src/mirth/codegen.mth", 573, 14);
+    WORD_ENTER(mb_c99_block_exit_21__1, "c99-block-exit! block", "src/mirth/codegen.mth", 575, 14);
     mw_prim_drop();
-    WORD_ATOM(573, 14, "");
+    WORD_ATOM(575, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46500,11 +46141,11 @@ static void mb_c99_block_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(573, 27, "put");
+    WORD_ATOM(575, 27, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(573, 31, "put");
+    WORD_ATOM(575, 31, "put");
     mw_Block_2B_C99_2E_put();
-    WORD_ATOM(573, 35, "");
+    WORD_ATOM(575, 35, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46515,15 +46156,15 @@ static void mb_c99_block_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(573, 40, "put");
+    WORD_ATOM(575, 40, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_block_exit_21__1);
 }
 
 static void mb_c99_block_def_21__1 (void) {
-    WORD_ENTER(mb_c99_block_def_21__1, "c99-block-def! block", "src/mirth/codegen.mth", 577, 14);
+    WORD_ENTER(mb_c99_block_def_21__1, "c99-block-def! block", "src/mirth/codegen.mth", 579, 14);
     mw_prim_drop();
-    WORD_ATOM(577, 14, "");
+    WORD_ATOM(579, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46534,13 +46175,13 @@ static void mb_c99_block_def_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(577, 29, "put");
+    WORD_ATOM(579, 29, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(577, 33, "dup");
+    WORD_ATOM(579, 33, "dup");
     mw_prim_dup();
-    WORD_ATOM(577, 37, "put");
+    WORD_ATOM(579, 37, "put");
     mw_Block_2B_C99_2E_put();
-    WORD_ATOM(577, 41, "");
+    WORD_ATOM(579, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46551,45 +46192,45 @@ static void mb_c99_block_def_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(577, 53, "put");
+    WORD_ATOM(579, 53, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_block_def_21__1);
 }
 
 static void mb_c99_block_def_21__2 (void) {
-    WORD_ENTER(mb_c99_block_def_21__2, "c99-block-def! block", "src/mirth/codegen.mth", 579, 9);
+    WORD_ENTER(mb_c99_block_def_21__2, "c99-block-def! block", "src/mirth/codegen.mth", 581, 9);
     mw_prim_drop();
-    WORD_ATOM(579, 9, "dup");
-    mw_prim_dup();
-    WORD_ATOM(579, 13, "c99-block-enter!");
-    mw_c99_block_enter_21_();
-    WORD_ATOM(580, 9, "dup");
-    mw_prim_dup();
-    WORD_ATOM(580, 13, "arrow");
-    mw_Block_2E_arrow();
     WORD_ATOM(581, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(581, 13, "ctx");
-    mw_Arrow_2E_ctx();
-    WORD_ATOM(581, 17, "c99-unpack-ctx!");
-    mw_c99_unpack_ctx_21_();
+    WORD_ATOM(581, 13, "c99-block-enter!");
+    mw_c99_block_enter_21_();
     WORD_ATOM(582, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(582, 13, "c99-arrow!");
-    mw_c99_arrow_21_();
-    WORD_ATOM(583, 9, "ctx");
+    WORD_ATOM(582, 13, "arrow");
+    mw_Block_2E_arrow();
+    WORD_ATOM(583, 9, "dup");
+    mw_prim_dup();
+    WORD_ATOM(583, 13, "ctx");
     mw_Arrow_2E_ctx();
-    WORD_ATOM(583, 13, "c99-decref-ctx!");
+    WORD_ATOM(583, 17, "c99-unpack-ctx!");
+    mw_c99_unpack_ctx_21_();
+    WORD_ATOM(584, 9, "dup");
+    mw_prim_dup();
+    WORD_ATOM(584, 13, "c99-arrow!");
+    mw_c99_arrow_21_();
+    WORD_ATOM(585, 9, "ctx");
+    mw_Arrow_2E_ctx();
+    WORD_ATOM(585, 13, "c99-decref-ctx!");
     mw_c99_decref_ctx_21_();
-    WORD_ATOM(584, 9, "c99-block-exit!");
+    WORD_ATOM(586, 9, "c99-block-exit!");
     mw_c99_block_exit_21_();
     WORD_EXIT(mb_c99_block_def_21__2);
 }
 
 static void mb_c99_block_def_21__3 (void) {
-    WORD_ENTER(mb_c99_block_def_21__3, "c99-block-def! block", "src/mirth/codegen.mth", 586, 14);
+    WORD_ENTER(mb_c99_block_def_21__3, "c99-block-def! block", "src/mirth/codegen.mth", 588, 14);
     mw_prim_drop();
-    WORD_ATOM(586, 14, "");
+    WORD_ATOM(588, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46600,15 +46241,15 @@ static void mb_c99_block_def_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(586, 18, "put");
+    WORD_ATOM(588, 18, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_block_def_21__3);
 }
 
 static void mb_c99_word_enter_21__1 (void) {
-    WORD_ENTER(mb_c99_word_enter_21__1, "c99-word-enter! block", "src/mirth/codegen.mth", 598, 14);
+    WORD_ENTER(mb_c99_word_enter_21__1, "c99-word-enter! block", "src/mirth/codegen.mth", 600, 14);
     mw_prim_drop();
-    WORD_ATOM(598, 14, "");
+    WORD_ATOM(600, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46619,9 +46260,9 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(598, 28, "put");
+    WORD_ATOM(600, 28, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(599, 9, "");
+    WORD_ATOM(601, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46632,15 +46273,15 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(599, 15, "put");
+    WORD_ATOM(601, 15, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(599, 19, "dup");
+    WORD_ATOM(601, 19, "dup");
     mw_prim_dup();
-    WORD_ATOM(599, 23, "name");
+    WORD_ATOM(601, 23, "name");
     mw_Word_2E_name();
-    WORD_ATOM(599, 28, "put");
+    WORD_ATOM(601, 28, "put");
     mw_Name_2B_C99_2E_put();
-    WORD_ATOM(599, 32, "");
+    WORD_ATOM(601, 32, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46651,65 +46292,17 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(599, 37, "put");
-    mw_Str_2B_C99_2E_put();
-    WORD_ATOM(600, 9, "dup");
-    mw_prim_dup();
-    WORD_ATOM(600, 13, "name");
-    mw_Word_2E_name();
-    WORD_ATOM(600, 18, ">Str");
-    mw_Name_3E_Str();
-    WORD_ATOM(600, 23, "put-cstr");
-    mw__2B_C99_2E_put_cstr();
-    WORD_ATOM(600, 32, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr(", ", 2);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(600, 37, "put");
-    mw_Str_2B_C99_2E_put();
-    WORD_ATOM(601, 9, "dup");
-    mw_prim_dup();
-    WORD_ATOM(601, 13, "body");
-    mw_Word_2E_body();
-    WORD_ATOM(601, 18, ".module");
-    mw_Token_2E_module();
-    WORD_ATOM(601, 26, "source-path");
-    mw_Module_2E_source_path();
-    WORD_ATOM(601, 38, ">Str");
-    mw_Path_3E_Str();
-    WORD_ATOM(601, 43, "put-cstr");
-    mw__2B_C99_2E_put_cstr();
-    WORD_ATOM(601, 52, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr(", ", 2);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(601, 57, "put");
+    WORD_ATOM(601, 37, "put");
     mw_Str_2B_C99_2E_put();
     WORD_ATOM(602, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(602, 13, "body");
-    mw_Word_2E_body();
-    WORD_ATOM(602, 18, "row");
-    mw_Token_2E_row();
-    WORD_ATOM(602, 22, ">Int");
-    mw_Row_3E_Int();
-    WORD_ATOM(602, 27, "put");
-    mw_Int_2B_C99_2E_put();
-    WORD_ATOM(602, 31, "");
+    WORD_ATOM(602, 13, "name");
+    mw_Word_2E_name();
+    WORD_ATOM(602, 18, ">Str");
+    mw_Name_3E_Str();
+    WORD_ATOM(602, 23, "put-cstr");
+    mw__2B_C99_2E_put_cstr();
+    WORD_ATOM(602, 32, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46720,19 +46313,67 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(602, 36, "put");
+    WORD_ATOM(602, 37, "put");
     mw_Str_2B_C99_2E_put();
     WORD_ATOM(603, 9, "dup");
     mw_prim_dup();
     WORD_ATOM(603, 13, "body");
     mw_Word_2E_body();
-    WORD_ATOM(603, 18, "col");
-    mw_Token_2E_col();
-    WORD_ATOM(603, 22, ">Int");
-    mw_Col_3E_Int();
-    WORD_ATOM(603, 27, "put");
+    WORD_ATOM(603, 18, ".module");
+    mw_Token_2E_module();
+    WORD_ATOM(603, 26, "source-path");
+    mw_Module_2E_source_path();
+    WORD_ATOM(603, 38, ">Str");
+    mw_Path_3E_Str();
+    WORD_ATOM(603, 43, "put-cstr");
+    mw__2B_C99_2E_put_cstr();
+    WORD_ATOM(603, 52, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr(", ", 2);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(603, 57, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(604, 9, "dup");
+    mw_prim_dup();
+    WORD_ATOM(604, 13, "body");
+    mw_Word_2E_body();
+    WORD_ATOM(604, 18, "row");
+    mw_Token_2E_row();
+    WORD_ATOM(604, 22, ">Int");
+    mw_Row_3E_Int();
+    WORD_ATOM(604, 27, "put");
     mw_Int_2B_C99_2E_put();
-    WORD_ATOM(603, 31, "");
+    WORD_ATOM(604, 31, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr(", ", 2);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(604, 36, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(605, 9, "dup");
+    mw_prim_dup();
+    WORD_ATOM(605, 13, "body");
+    mw_Word_2E_body();
+    WORD_ATOM(605, 18, "col");
+    mw_Token_2E_col();
+    WORD_ATOM(605, 22, ">Int");
+    mw_Col_3E_Int();
+    WORD_ATOM(605, 27, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(605, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46743,15 +46384,15 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(603, 36, "put");
+    WORD_ATOM(605, 36, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_word_enter_21__1);
 }
 
 static void mb_c99_word_exit_21__1 (void) {
-    WORD_ENTER(mb_c99_word_exit_21__1, "c99-word-exit! block", "src/mirth/codegen.mth", 607, 14);
+    WORD_ENTER(mb_c99_word_exit_21__1, "c99-word-exit! block", "src/mirth/codegen.mth", 609, 14);
     mw_prim_drop();
-    WORD_ATOM(607, 14, "");
+    WORD_ATOM(609, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46762,9 +46403,9 @@ static void mb_c99_word_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(607, 27, "put");
+    WORD_ATOM(609, 27, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(608, 9, "");
+    WORD_ATOM(610, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46775,15 +46416,15 @@ static void mb_c99_word_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(608, 15, "put");
+    WORD_ATOM(610, 15, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(608, 19, "dup");
+    WORD_ATOM(610, 19, "dup");
     mw_prim_dup();
-    WORD_ATOM(608, 23, "name");
+    WORD_ATOM(610, 23, "name");
     mw_Word_2E_name();
-    WORD_ATOM(608, 28, "put");
+    WORD_ATOM(610, 28, "put");
     mw_Name_2B_C99_2E_put();
-    WORD_ATOM(608, 32, "");
+    WORD_ATOM(610, 32, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46794,23 +46435,23 @@ static void mb_c99_word_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(608, 37, "put");
+    WORD_ATOM(610, 37, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_word_exit_21__1);
 }
 
 static void mb_c99_word_def_21__1 (void) {
-    WORD_ENTER(mb_c99_word_def_21__1, "c99-word-def! block", "src/mirth/codegen.mth", 613, 14);
+    WORD_ENTER(mb_c99_word_def_21__1, "c99-word-def! block", "src/mirth/codegen.mth", 615, 14);
     mw_prim_drop();
-    WORD_ATOM(613, 14, "dup");
+    WORD_ATOM(615, 14, "dup");
     mw_prim_dup();
-    WORD_ATOM(613, 18, "name");
+    WORD_ATOM(615, 18, "name");
     mw_Word_2E_name();
-    WORD_ATOM(613, 23, "sig");
+    WORD_ATOM(615, 23, "sig");
     mw_Name_2B_C99_2E_sig();
-    WORD_ATOM(613, 27, "put");
+    WORD_ATOM(615, 27, "put");
     mw_Str_2B_C99_2E_put();
-    WORD_ATOM(613, 31, "");
+    WORD_ATOM(615, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46821,35 +46462,35 @@ static void mb_c99_word_def_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(613, 36, "put");
+    WORD_ATOM(615, 36, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_word_def_21__1);
 }
 
 static void mb_c99_word_def_21__2 (void) {
-    WORD_ENTER(mb_c99_word_def_21__2, "c99-word-def! block", "src/mirth/codegen.mth", 615, 9);
+    WORD_ENTER(mb_c99_word_def_21__2, "c99-word-def! block", "src/mirth/codegen.mth", 617, 9);
     mw_prim_drop();
-    WORD_ATOM(615, 9, "dup");
-    mw_prim_dup();
-    WORD_ATOM(615, 13, "c99-word-enter!");
-    mw_c99_word_enter_21_();
-    WORD_ATOM(616, 9, "dup");
-    mw_prim_dup();
-    WORD_ATOM(616, 13, "arrow");
-    mw_Word_2E_arrow();
-    WORD_ATOM(616, 19, "c99-arrow!");
-    mw_c99_arrow_21_();
     WORD_ATOM(617, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(617, 13, "c99-word-exit!");
+    WORD_ATOM(617, 13, "c99-word-enter!");
+    mw_c99_word_enter_21_();
+    WORD_ATOM(618, 9, "dup");
+    mw_prim_dup();
+    WORD_ATOM(618, 13, "arrow");
+    mw_Word_2E_arrow();
+    WORD_ATOM(618, 19, "c99-arrow!");
+    mw_c99_arrow_21_();
+    WORD_ATOM(619, 9, "dup");
+    mw_prim_dup();
+    WORD_ATOM(619, 13, "c99-word-exit!");
     mw_c99_word_exit_21_();
     WORD_EXIT(mb_c99_word_def_21__2);
 }
 
 static void mb_c99_word_def_21__3 (void) {
-    WORD_ENTER(mb_c99_word_def_21__3, "c99-word-def! block", "src/mirth/codegen.mth", 619, 14);
+    WORD_ENTER(mb_c99_word_def_21__3, "c99-word-def! block", "src/mirth/codegen.mth", 621, 14);
     mw_prim_drop();
-    WORD_ATOM(619, 14, "");
+    WORD_ATOM(621, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46860,7 +46501,7 @@ static void mb_c99_word_def_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(619, 18, "put");
+    WORD_ATOM(621, 18, "put");
     mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_word_def_21__3);
 }

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -4198,15 +4198,24 @@ void co_NEED_5F_BLOCK() {
     decref(cdr);
     push_value(car);
 }
-static void mw_MKC99_unsafe (void) {
+static void mw_MKC99 (void) {
     VAL tag = MKU64(0LL);
-    VAL car = (tag);
+    VAL car = (pop_value());
+    car = mkcons(car, pop_value());
+    car = mkcons(car, pop_value());
+    car = mkcons(car, tag);
     push_resource(car);
 }
-void co_MKC99_unsafe() {
+void co_MKC99() {
     VAL car = pop_resource();
     VAL cdr;
-    decref(car);
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
+    push_value(car);
 }
 static void mw_TYPE_5F_ELAB (void) {
     VAL tag = MKU64(0LL);
@@ -6381,18 +6390,6 @@ void mw_needs_stack() {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_c99_file_var() {
-    static VAL v = {0};
-    push_ptr(&v);
-}
-void mw_c99_depth_var() {
-    static VAL v = {0};
-    push_ptr(&v);
-}
-void mw_c99_buffer_var() {
-    static VAL v = {0};
-    push_ptr(&v);
-}
 void mw_ab_home() {
     static VAL v = {0};
     push_ptr(&v);
@@ -6814,15 +6811,15 @@ static void mw_need_match (void);
 static void mw_need_lambda (void);
 static void mw_need_block_push (void);
 static void mw_need_block_run (void);
+static void mw__2B_C99_2F_MKC99 (void);
+static void mw__2B_C99_2E_depth_40_ (void);
+static void mw__2B_C99_2E_depth_21_ (void);
 static void mw_Str_2B_C99_2E_ (void);
 static void mw_Int_2B_C99_2E_n (void);
 static void mw_Byte_2B_C99_2E_b (void);
-static void mw__2B_C99_2E_depth_40_ (void);
-static void mw__2B_C99_2E_depth_21_ (void);
 static void mw_codegen_start_21_ (void);
 static void mw_codegen_flush_21_ (void);
 static void mw_codegen_end_21_ (void);
-static void mw_with_c99 (void);
 static void mw_run_output_c99_21_ (void);
 static void mw__2B_C99_2E_lf (void);
 static void mw_Str_2B_C99_3B_ (void);
@@ -7680,7 +7677,6 @@ static void mb_table_new_21__13 (void);
 static void mb_table_new_21__14 (void);
 static void mb_table_new_21__15 (void);
 static void mb_table_new_21__16 (void);
-static void mb_run_output_c99_21__3 (void);
 static void mb_field_new_21__1 (void);
 static void mb_field_new_21__2 (void);
 static void mb_Word_2E_ctx_type_1 (void);
@@ -7707,9 +7703,7 @@ static void mb_determine_transitive_needs_21__2 (void);
 static void mb_need_atom_run_1 (void);
 static void mb_need_args_push_1 (void);
 static void mb_need_match_1 (void);
-static void mb_Str_2B_C99_2E__1 (void);
-static void mb_Str_2B_C99_2E__2 (void);
-static void mb_codegen_flush_21__1 (void);
+static void mb_Str_2B_C99_2E__3 (void);
 static void mb_c99_tags_21__1 (void);
 static void mb_c99_buffers_21__1 (void);
 static void mb_c99_variables_21__1 (void);
@@ -18358,87 +18352,111 @@ static void mw_need_block_run (void){
     mw_need_arrow_run();
     WORD_EXIT(mw_need_block_run);
 }
-static void mw_Str_2B_C99_2E_ (void){
-    WORD_ENTER(mw_Str_2B_C99_2E_, "Str+C99.", "src/mirth/codegen.mth", 139, 5);
-    WORD_ATOM(139, 5, "c99-buffer-var");
-    mw_c99_buffer_var();
-    WORD_ATOM(139, 20, "modify");
-    push_u64(0);
-    push_fnptr(&mb_Str_2B_C99_2E__1);
-    mw_prim_pack_cons();
-    mw_modify();
-    WORD_ATOM(140, 5, "swap");
+static void mw__2B_C99_2F_MKC99 (void){
+    WORD_ENTER(mw__2B_C99_2F_MKC99, "+C99/MKC99", "src/mirth/codegen.mth", 133, 39);
+    WORD_ATOM(133, 39, "MKC99");
+    switch (get_top_resource_data_tag()) {
+        case 0LL:
+            co_MKC99();
+            WORD_ATOM(133, 48, "id");
+            mw_prim_id();
+            break;
+        default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
+    
+}    WORD_EXIT(mw__2B_C99_2F_MKC99);
+}
+static void mw__2B_C99_2E_depth_40_ (void){
+    WORD_ENTER(mw__2B_C99_2E_depth_40_, "+C99.depth@", "src/mirth/codegen.mth", 135, 36);
+    WORD_ATOM(135, 36, "/MKC99");
+    mw__2B_C99_2F_MKC99();
+    WORD_ATOM(135, 43, "over");
+    mw_over();
+    WORD_ATOM(135, 48, "dip");
+    {
+        VAL d2 = pop_value();
+        WORD_ATOM(135, 52, "MKC99");
+        mw_MKC99();
+        push_value(d2);
+    }
+    WORD_EXIT(mw__2B_C99_2E_depth_40_);
+}
+static void mw__2B_C99_2E_depth_21_ (void){
+    WORD_ENTER(mw__2B_C99_2E_depth_21_, "+C99.depth!", "src/mirth/codegen.mth", 136, 36);
+    WORD_ATOM(136, 36, "dip");
+    {
+        VAL d2 = pop_value();
+        WORD_ATOM(136, 40, "/MKC99");
+        mw__2B_C99_2F_MKC99();
+        WORD_ATOM(136, 47, "nip");
+        mw_nip();
+        push_value(d2);
+    }
+    WORD_ATOM(136, 52, "swap");
     mw_prim_swap();
-    WORD_ATOM(140, 10, "cat");
+    WORD_ATOM(136, 57, "MKC99");
+    mw_MKC99();
+    WORD_EXIT(mw__2B_C99_2E_depth_21_);
+}
+static void mw_Str_2B_C99_2E_ (void){
+    WORD_ENTER(mw_Str_2B_C99_2E_, "Str+C99.", "src/mirth/codegen.mth", 138, 5);
+    WORD_ATOM(138, 5, "dip");
+    {
+        VAL d2 = pop_value();
+        WORD_ATOM(138, 9, "/MKC99");
+        mw__2B_C99_2F_MKC99();
+        push_value(d2);
+    }
+    WORD_ATOM(138, 17, "cat");
     mw_prim_str_cat();
-    WORD_ATOM(141, 5, "c99-buffer-var");
-    mw_c99_buffer_var();
-    WORD_ATOM(141, 20, "!");
-    mw_prim_mut_set();
-    WORD_ATOM(142, 5, "c99-buffer-var");
-    mw_c99_buffer_var();
-    WORD_ATOM(142, 20, "@");
-    mw_prim_mut_get();
-    WORD_ATOM(142, 22, "num-bytes");
+    WORD_ATOM(139, 5, "dup");
+    mw_prim_dup();
+    WORD_ATOM(139, 9, "num-bytes");
     mw_prim_str_num_bytes();
-    WORD_ATOM(142, 32, "");
+    WORD_ATOM(139, 19, "dip");
+    {
+        VAL d2 = pop_value();
+        WORD_ATOM(139, 23, "MKC99");
+        mw_MKC99();
+        push_value(d2);
+    }
+    WORD_ATOM(140, 5, "");
     push_i64(512LL);
-    WORD_ATOM(142, 36, ">");
+    WORD_ATOM(140, 9, ">");
     mw_Int_3E_();
-    WORD_ATOM(142, 38, "then");
+    WORD_ATOM(140, 11, "then");
     push_u64(0);
-    push_fnptr(&mb_Str_2B_C99_2E__2);
+    push_fnptr(&mb_Str_2B_C99_2E__3);
     mw_prim_pack_cons();
     mw_Bool_2E_then();
     WORD_EXIT(mw_Str_2B_C99_2E_);
 }
 static void mw_Int_2B_C99_2E_n (void){
-    WORD_ENTER(mw_Int_2B_C99_2E_n, "Int+C99.n", "src/mirth/codegen.mth", 143, 34);
-    WORD_ATOM(143, 34, "int-to-str");
+    WORD_ENTER(mw_Int_2B_C99_2E_n, "Int+C99.n", "src/mirth/codegen.mth", 142, 34);
+    WORD_ATOM(142, 34, "int-to-str");
     mw_prim_int_to_str();
-    WORD_ATOM(143, 45, ".");
+    WORD_ATOM(142, 45, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mw_Int_2B_C99_2E_n);
 }
 static void mw_Byte_2B_C99_2E_b (void){
-    WORD_ENTER(mw_Byte_2B_C99_2E_b, "Byte+C99.b", "src/mirth/codegen.mth", 144, 36);
-    WORD_ATOM(144, 36, "to-ascii-str");
+    WORD_ENTER(mw_Byte_2B_C99_2E_b, "Byte+C99.b", "src/mirth/codegen.mth", 143, 36);
+    WORD_ATOM(143, 36, "to-ascii-str");
     mw_Byte_2E_to_ascii_str();
-    WORD_ATOM(144, 49, "unwrap");
+    WORD_ATOM(143, 49, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(144, 56, ".");
+    WORD_ATOM(143, 56, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mw_Byte_2B_C99_2E_b);
 }
-static void mw__2B_C99_2E_depth_40_ (void){
-    WORD_ENTER(mw__2B_C99_2E_depth_40_, "+C99.depth@", "src/mirth/codegen.mth", 145, 36);
-    WORD_ATOM(145, 36, "c99-depth-var");
-    mw_c99_depth_var();
-    WORD_ATOM(145, 50, "@");
-    mw_prim_mut_get();
-    WORD_EXIT(mw__2B_C99_2E_depth_40_);
-}
-static void mw__2B_C99_2E_depth_21_ (void){
-    WORD_ENTER(mw__2B_C99_2E_depth_21_, "+C99.depth!", "src/mirth/codegen.mth", 146, 36);
-    WORD_ATOM(146, 36, "c99-depth-var");
-    mw_c99_depth_var();
-    WORD_ATOM(146, 50, "!");
-    mw_prim_mut_set();
-    WORD_EXIT(mw__2B_C99_2E_depth_21_);
-}
 static void mw_codegen_start_21_ (void){
-    WORD_ENTER(mw_codegen_start_21_, "codegen-start!", "src/mirth/codegen.mth", 149, 5);
-    WORD_ATOM(149, 5, "c99-file-var");
-    mw_c99_file_var();
-    WORD_ATOM(149, 18, "!");
-    mw_prim_mut_set();
-    WORD_ATOM(150, 5, "");
+    WORD_ENTER(mw_codegen_start_21_, "codegen-start!", "src/mirth/codegen.mth", 146, 5);
+    WORD_ATOM(146, 5, ">Str");
+    mw_Path_3E_Str();
+    WORD_ATOM(146, 10, "create-file!");
+    mw_create_file_21_();
+    WORD_ATOM(146, 23, "");
     push_i64(0LL);
-    WORD_ATOM(150, 7, "c99-depth-var");
-    mw_c99_depth_var();
-    WORD_ATOM(150, 21, "!");
-    mw_prim_mut_set();
-    WORD_ATOM(151, 5, "");
+    WORD_ATOM(146, 25, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18449,79 +18467,105 @@ static void mw_codegen_start_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(151, 8, "c99-buffer-var");
-    mw_c99_buffer_var();
-    WORD_ATOM(151, 23, "!");
-    mw_prim_mut_set();
+    WORD_ATOM(146, 28, "MKC99");
+    mw_MKC99();
     WORD_EXIT(mw_codegen_start_21_);
 }
 static void mw_codegen_flush_21_ (void){
-    WORD_ENTER(mw_codegen_flush_21_, "codegen-flush!", "src/mirth/codegen.mth", 154, 5);
-    WORD_ATOM(154, 5, "c99-file-var");
-    mw_c99_file_var();
-    WORD_ATOM(154, 18, "@");
-    mw_prim_mut_get();
-    WORD_ATOM(155, 5, "c99-buffer-var");
-    mw_c99_buffer_var();
-    WORD_ATOM(155, 20, "modify");
-    push_u64(0);
-    push_fnptr(&mb_codegen_flush_21__1);
-    mw_prim_pack_cons();
-    mw_modify();
-    WORD_ATOM(156, 5, "write!");
+    WORD_ENTER(mw_codegen_flush_21_, "codegen-flush!", "src/mirth/codegen.mth", 149, 5);
+    WORD_ATOM(149, 5, "/MKC99");
+    mw__2B_C99_2F_MKC99();
+    WORD_ATOM(149, 12, "dip");
+    {
+        VAL d2 = pop_value();
+        WORD_ATOM(149, 16, "over");
+        mw_over();
+        push_value(d2);
+    }
+    WORD_ATOM(149, 22, "write!");
     mw_Str_2E_write_21_();
+    WORD_ATOM(149, 29, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("", 0);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(149, 32, "MKC99");
+    mw_MKC99();
     WORD_EXIT(mw_codegen_flush_21_);
 }
 static void mw_codegen_end_21_ (void){
-    WORD_ENTER(mw_codegen_end_21_, "codegen-end!", "src/mirth/codegen.mth", 159, 5);
-    WORD_ATOM(159, 5, "codegen-flush!");
+    WORD_ENTER(mw_codegen_end_21_, "codegen-end!", "src/mirth/codegen.mth", 152, 5);
+    WORD_ATOM(152, 5, "codegen-flush!");
     mw_codegen_flush_21_();
-    WORD_ATOM(160, 5, "c99-file-var");
-    mw_c99_file_var();
-    WORD_ATOM(160, 18, "@");
-    mw_prim_mut_get();
-    WORD_ATOM(160, 20, "close-file!");
+    WORD_ATOM(153, 5, "/MKC99");
+    mw__2B_C99_2F_MKC99();
+    WORD_ATOM(153, 12, "drop2");
+    mw_drop2();
+    WORD_ATOM(153, 18, "close-file!");
     mw_close_file_21_();
     WORD_EXIT(mw_codegen_end_21_);
 }
-static void mw_with_c99 (void){
-    WORD_ENTER(mw_with_c99, "with-c99", "src/mirth/codegen.mth", 162, 46);
-    WORD_ATOM(162, 46, "prim-unsafe-cast");
-    mw_prim_unsafe_cast();
-    WORD_ATOM(162, 63, "run");
-    mw_prim_run();
-    WORD_EXIT(mw_with_c99);
-}
 static void mw_run_output_c99_21_ (void){
-    WORD_ENTER(mw_run_output_c99_21_, "run-output-c99!", "src/mirth/codegen.mth", 165, 5);
-    WORD_ATOM(165, 5, "num-errors");
+    WORD_ENTER(mw_run_output_c99_21_, "run-output-c99!", "src/mirth/codegen.mth", 156, 5);
+    WORD_ATOM(156, 5, "num-errors");
     mw_num_errors();
-    WORD_ATOM(165, 16, "@");
+    WORD_ATOM(156, 16, "@");
     mw_prim_mut_get();
-    WORD_ATOM(165, 18, "0>");
+    WORD_ATOM(156, 18, "0>");
     mw_0_3E_();
-    WORD_ATOM(165, 21, "if");
+    WORD_ATOM(156, 21, "if");
     if (pop_u64()) {
-        WORD_ATOM(166, 9, "drop2");
+        WORD_ATOM(157, 9, "drop2");
         mw_drop2();
     } else {
-        WORD_ATOM(168, 9, "reset-needs!");
+        WORD_ATOM(159, 9, "reset-needs!");
         mw_reset_needs_21_();
-        WORD_ATOM(169, 9, "over");
+        WORD_ATOM(160, 9, "over");
         mw_over();
-        WORD_ATOM(169, 14, "determine-arrow-needs!");
+        WORD_ATOM(160, 14, "determine-arrow-needs!");
         mw_determine_arrow_needs_21_();
-        WORD_ATOM(171, 9, "with-c99");
-        push_u64(0);
-        push_fnptr(&mb_run_output_c99_21__3);
-        mw_prim_pack_cons();
-        mw_with_c99();
+        WORD_ATOM(162, 9, "to-output-path");
+        mw_Path_2E_to_output_path();
+        WORD_ATOM(163, 9, "codegen-start!");
+        mw_codegen_start_21_();
+        WORD_ATOM(164, 9, "c99-header!");
+        mw_c99_header_21_();
+        WORD_ATOM(165, 9, "c99-tags!");
+        mw_c99_tags_21_();
+        WORD_ATOM(166, 9, "c99-buffers!");
+        mw_c99_buffers_21_();
+        WORD_ATOM(167, 9, "c99-variables!");
+        mw_c99_variables_21_();
+        WORD_ATOM(168, 9, "c99-externals!");
+        mw_c99_externals_21_();
+        WORD_ATOM(169, 9, "c99-word-sigs!");
+        mw_c99_word_sigs_21_();
+        WORD_ATOM(170, 9, "c99-block-sigs!");
+        mw_c99_block_sigs_21_();
+        WORD_ATOM(171, 9, "c99-field-sigs!");
+        mw_c99_field_sigs_21_();
+        WORD_ATOM(172, 9, "c99-main!");
+        mw_c99_main_21_();
+        WORD_ATOM(173, 9, "c99-field-defs!");
+        mw_c99_field_defs_21_();
+        WORD_ATOM(174, 9, "c99-word-defs!");
+        mw_c99_word_defs_21_();
+        WORD_ATOM(175, 9, "c99-block-defs!");
+        mw_c99_block_defs_21_();
+        WORD_ATOM(176, 9, "codegen-end!");
+        mw_codegen_end_21_();
     }
     WORD_EXIT(mw_run_output_c99_21_);
 }
 static void mw__2B_C99_2E_lf (void){
-    WORD_ENTER(mw__2B_C99_2E_lf, "+C99.lf", "src/mirth/codegen.mth", 190, 28);
-    WORD_ATOM(190, 28, "");
+    WORD_ENTER(mw__2B_C99_2E_lf, "+C99.lf", "src/mirth/codegen.mth", 179, 28);
+    WORD_ATOM(179, 28, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18532,39 +18576,39 @@ static void mw__2B_C99_2E_lf (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(190, 33, ".");
+    WORD_ATOM(179, 33, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mw__2B_C99_2E_lf);
 }
 static void mw_Str_2B_C99_3B_ (void){
-    WORD_ENTER(mw_Str_2B_C99_3B_, "Str+C99;", "src/mirth/codegen.mth", 191, 33);
-    WORD_ATOM(191, 33, ".");
+    WORD_ENTER(mw_Str_2B_C99_3B_, "Str+C99;", "src/mirth/codegen.mth", 180, 33);
+    WORD_ATOM(180, 33, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(191, 35, ".lf");
+    WORD_ATOM(180, 35, ".lf");
     mw__2B_C99_2E_lf();
     WORD_EXIT(mw_Str_2B_C99_3B_);
 }
 static void mw_Str_2B_C99_3B__3B_ (void){
-    WORD_ENTER(mw_Str_2B_C99_3B__3B_, "Str+C99;;", "src/mirth/codegen.mth", 192, 34);
-    WORD_ATOM(192, 34, ".");
+    WORD_ENTER(mw_Str_2B_C99_3B__3B_, "Str+C99;;", "src/mirth/codegen.mth", 181, 34);
+    WORD_ATOM(181, 34, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(192, 36, ".lf");
+    WORD_ATOM(181, 36, ".lf");
     mw__2B_C99_2E_lf();
-    WORD_ATOM(192, 40, ".lf");
+    WORD_ATOM(181, 40, ".lf");
     mw__2B_C99_2E_lf();
     WORD_EXIT(mw_Str_2B_C99_3B__3B_);
 }
 static void mw_Name_2B_C99_2E_name (void){
-    WORD_ENTER(mw_Name_2B_C99_2E_name, "Name+C99.name", "src/mirth/codegen.mth", 193, 39);
-    WORD_ATOM(193, 39, "mangled");
+    WORD_ENTER(mw_Name_2B_C99_2E_name, "Name+C99.name", "src/mirth/codegen.mth", 182, 39);
+    WORD_ATOM(182, 39, "mangled");
     mw_Name_2E_mangled();
-    WORD_ATOM(193, 47, ".");
+    WORD_ATOM(182, 47, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mw_Name_2B_C99_2E_name);
 }
 static void mw_Name_2B_C99_2E_w (void){
-    WORD_ENTER(mw_Name_2B_C99_2E_w, "Name+C99.w", "src/mirth/codegen.mth", 194, 36);
-    WORD_ATOM(194, 36, "");
+    WORD_ENTER(mw_Name_2B_C99_2E_w, "Name+C99.w", "src/mirth/codegen.mth", 183, 36);
+    WORD_ATOM(183, 36, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18575,11 +18619,11 @@ static void mw_Name_2B_C99_2E_w (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(194, 54, ".");
+    WORD_ATOM(183, 54, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(194, 56, ".name");
+    WORD_ATOM(183, 56, ".name");
     mw_Name_2B_C99_2E_name();
-    WORD_ATOM(194, 62, "");
+    WORD_ATOM(183, 62, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18590,13 +18634,13 @@ static void mw_Name_2B_C99_2E_w (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(194, 72, ".");
+    WORD_ATOM(183, 72, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mw_Name_2B_C99_2E_w);
 }
 static void mw_c99_header_21_ (void){
-    WORD_ENTER(mw_c99_header_21_, "c99-header!", "src/mirth/codegen.mth", 199, 32);
-    WORD_ATOM(199, 32, "c99-header-str");
+    WORD_ENTER(mw_c99_header_21_, "c99-header!", "src/mirth/codegen.mth", 188, 32);
+    WORD_ATOM(188, 32, "c99-header-str");
     {
         static bool vready = false;
         static VAL v;
@@ -19803,32 +19847,32 @@ static uint8_t b[] = {                47,42,32,77,73,82,84,72,32,72,69,65,68,69,
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(199, 47, ".");
+    WORD_ATOM(188, 47, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(199, 49, ".lf");
+    WORD_ATOM(188, 49, ".lf");
     mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_header_21_);
 }
 static void mw_c99_buffers_21_ (void){
-    WORD_ENTER(mw_c99_buffers_21_, "c99-buffers!", "src/mirth/codegen.mth", 201, 33);
-    WORD_ATOM(201, 33, "Buffer.for");
+    WORD_ENTER(mw_c99_buffers_21_, "c99-buffers!", "src/mirth/codegen.mth", 190, 33);
+    WORD_ATOM(190, 33, "Buffer.for");
     push_u64(0);
     push_fnptr(&mb_c99_buffers_21__1);
     mw_prim_pack_cons();
     mw_Buffer_2E_for();
-    WORD_ATOM(201, 57, ".lf");
+    WORD_ATOM(190, 57, ".lf");
     mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_buffers_21_);
 }
 static void mw_c99_buffer_21_ (void){
-    WORD_ENTER(mw_c99_buffer_21_, "c99-buffer!", "src/mirth/codegen.mth", 203, 5);
-    WORD_ATOM(203, 5, "dup");
+    WORD_ENTER(mw_c99_buffer_21_, "c99-buffer!", "src/mirth/codegen.mth", 192, 5);
+    WORD_ATOM(192, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(203, 9, "name");
+    WORD_ATOM(192, 9, "name");
     mw_Buffer_2E_name();
-    WORD_ATOM(203, 14, ".w");
+    WORD_ATOM(192, 14, ".w");
     mw_Name_2B_C99_2E_w();
-    WORD_ATOM(203, 17, "");
+    WORD_ATOM(192, 17, "");
     {
         static bool vready = false;
         static VAL v;
@@ -19839,9 +19883,9 @@ static void mw_c99_buffer_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(203, 22, ";");
+    WORD_ATOM(192, 22, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(204, 5, "");
+    WORD_ATOM(193, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -19852,15 +19896,15 @@ static void mw_c99_buffer_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(204, 29, ".");
+    WORD_ATOM(193, 29, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(204, 31, "dup");
+    WORD_ATOM(193, 31, "dup");
     mw_prim_dup();
-    WORD_ATOM(204, 35, "size");
+    WORD_ATOM(193, 35, "size");
     mw_Buffer_2E_size();
-    WORD_ATOM(204, 40, ".n");
+    WORD_ATOM(193, 40, ".n");
     mw_Int_2B_C99_2E_n();
-    WORD_ATOM(204, 43, "");
+    WORD_ATOM(193, 43, "");
     {
         static bool vready = false;
         static VAL v;
@@ -19871,9 +19915,9 @@ static void mw_c99_buffer_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(204, 54, ";");
+    WORD_ATOM(193, 54, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(205, 5, "");
+    WORD_ATOM(194, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -19884,9 +19928,9 @@ static void mw_c99_buffer_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(205, 25, ";");
+    WORD_ATOM(194, 25, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(206, 5, "");
+    WORD_ATOM(195, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -19897,26 +19941,26 @@ static void mw_c99_buffer_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(206, 9, ";");
+    WORD_ATOM(195, 9, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(207, 5, "drop");
+    WORD_ATOM(196, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_buffer_21_);
 }
 static void mw_c99_variables_21_ (void){
-    WORD_ENTER(mw_c99_variables_21_, "c99-variables!", "src/mirth/codegen.mth", 209, 35);
-    WORD_ATOM(209, 35, "Variable.for");
+    WORD_ENTER(mw_c99_variables_21_, "c99-variables!", "src/mirth/codegen.mth", 198, 35);
+    WORD_ATOM(198, 35, "Variable.for");
     push_u64(0);
     push_fnptr(&mb_c99_variables_21__1);
     mw_prim_pack_cons();
     mw_Variable_2E_for();
-    WORD_ATOM(209, 63, ".lf");
+    WORD_ATOM(198, 63, ".lf");
     mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_variables_21_);
 }
 static void mw_c99_variable_21_ (void){
-    WORD_ENTER(mw_c99_variable_21_, "c99-variable!", "src/mirth/codegen.mth", 211, 5);
-    WORD_ATOM(211, 5, "");
+    WORD_ENTER(mw_c99_variable_21_, "c99-variable!", "src/mirth/codegen.mth", 200, 5);
+    WORD_ATOM(200, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -19927,13 +19971,13 @@ static void mw_c99_variable_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(211, 16, ".");
+    WORD_ATOM(200, 16, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(211, 18, "name");
+    WORD_ATOM(200, 18, "name");
     mw_Variable_2E_name();
-    WORD_ATOM(211, 23, ".name");
+    WORD_ATOM(200, 23, ".name");
     mw_Name_2B_C99_2E_name();
-    WORD_ATOM(211, 29, "");
+    WORD_ATOM(200, 29, "");
     {
         static bool vready = false;
         static VAL v;
@@ -19944,9 +19988,9 @@ static void mw_c99_variable_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(211, 36, ";");
+    WORD_ATOM(200, 36, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(212, 5, "");
+    WORD_ATOM(201, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -19957,9 +20001,9 @@ static void mw_c99_variable_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(212, 31, ";");
+    WORD_ATOM(201, 31, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(213, 5, "");
+    WORD_ATOM(202, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -19970,9 +20014,9 @@ static void mw_c99_variable_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(213, 25, ";");
+    WORD_ATOM(202, 25, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(214, 5, "");
+    WORD_ATOM(203, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -19983,30 +20027,30 @@ static void mw_c99_variable_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(214, 9, ";");
+    WORD_ATOM(203, 9, ";");
     mw_Str_2B_C99_3B_();
     WORD_EXIT(mw_c99_variable_21_);
 }
 static void mw_c99_tags_21_ (void){
-    WORD_ENTER(mw_c99_tags_21_, "c99-tags!", "src/mirth/codegen.mth", 216, 30);
-    WORD_ATOM(216, 30, "Tag.for");
+    WORD_ENTER(mw_c99_tags_21_, "c99-tags!", "src/mirth/codegen.mth", 205, 30);
+    WORD_ATOM(205, 30, "Tag.for");
     push_u64(0);
     push_fnptr(&mb_c99_tags_21__1);
     mw_prim_pack_cons();
     mw_Tag_2E_for();
-    WORD_ATOM(216, 48, ".lf");
+    WORD_ATOM(205, 48, ".lf");
     mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_tags_21_);
 }
 static void mw_c99_tag_21_ (void){
-    WORD_ENTER(mw_c99_tag_21_, "c99-tag!", "src/mirth/codegen.mth", 218, 5);
-    WORD_ATOM(218, 5, "dup");
+    WORD_ENTER(mw_c99_tag_21_, "c99-tag!", "src/mirth/codegen.mth", 207, 5);
+    WORD_ATOM(207, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(218, 9, "name");
+    WORD_ATOM(207, 9, "name");
     mw_Tag_2E_name();
-    WORD_ATOM(218, 14, ".w");
+    WORD_ATOM(207, 14, ".w");
     mw_Name_2B_C99_2E_w();
-    WORD_ATOM(218, 17, "");
+    WORD_ATOM(207, 17, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20017,18 +20061,18 @@ static void mw_c99_tag_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(218, 22, ";");
+    WORD_ATOM(207, 22, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(219, 5, "dup");
+    WORD_ATOM(208, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(219, 9, "is-transparent?");
+    WORD_ATOM(208, 9, "is-transparent?");
     mw_Tag_2E_is_transparent_3F_();
-    WORD_ATOM(219, 25, "if");
+    WORD_ATOM(208, 25, "if");
     if (pop_u64()) {
-        WORD_ATOM(220, 9, "id");
+        WORD_ATOM(209, 9, "id");
         mw_prim_id();
     } else {
-        WORD_ATOM(221, 9, "");
+        WORD_ATOM(210, 9, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20039,15 +20083,15 @@ static void mw_c99_tag_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(221, 32, ".");
+        WORD_ATOM(210, 32, ".");
         mw_Str_2B_C99_2E_();
-        WORD_ATOM(221, 34, "dup");
+        WORD_ATOM(210, 34, "dup");
         mw_prim_dup();
-        WORD_ATOM(221, 38, "value");
+        WORD_ATOM(210, 38, "value");
         mw_Tag_2E_value();
-        WORD_ATOM(221, 44, ".n");
+        WORD_ATOM(210, 44, ".n");
         mw_Int_2B_C99_2E_n();
-        WORD_ATOM(221, 47, "");
+        WORD_ATOM(210, 47, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20058,9 +20102,9 @@ static void mw_c99_tag_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(221, 54, ";");
+        WORD_ATOM(210, 54, ";");
         mw_Str_2B_C99_3B_();
-        WORD_ATOM(222, 9, "");
+        WORD_ATOM(211, 9, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20071,27 +20115,27 @@ static void mw_c99_tag_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(222, 27, ".");
+        WORD_ATOM(211, 27, ".");
         mw_Str_2B_C99_2E_();
-        WORD_ATOM(223, 9, "dup");
+        WORD_ATOM(212, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(223, 13, "num-type-inputs");
+        WORD_ATOM(212, 13, "num-type-inputs");
         mw_Tag_2E_num_type_inputs();
-        WORD_ATOM(223, 29, "repeat");
+        WORD_ATOM(212, 29, "repeat");
         push_u64(0);
         push_fnptr(&mb_c99_tag_21__3);
         mw_prim_pack_cons();
         mw_repeat();
-        WORD_ATOM(227, 9, "dup");
+        WORD_ATOM(216, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(227, 13, "num-resource-inputs");
+        WORD_ATOM(216, 13, "num-resource-inputs");
         mw_Tag_2E_num_resource_inputs();
-        WORD_ATOM(227, 33, "repeat");
+        WORD_ATOM(216, 33, "repeat");
         push_u64(0);
         push_fnptr(&mb_c99_tag_21__4);
         mw_prim_pack_cons();
         mw_repeat();
-        WORD_ATOM(231, 9, "");
+        WORD_ATOM(220, 9, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20102,15 +20146,15 @@ static void mw_c99_tag_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(231, 17, ";");
+        WORD_ATOM(220, 17, ";");
         mw_Str_2B_C99_3B_();
-        WORD_ATOM(232, 9, "dup");
+        WORD_ATOM(221, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(232, 13, "outputs-resource?");
+        WORD_ATOM(221, 13, "outputs-resource?");
         mw_Tag_2E_outputs_resource_3F_();
-        WORD_ATOM(232, 31, "if");
+        WORD_ATOM(221, 31, "if");
         if (pop_u64()) {
-            WORD_ATOM(233, 13, "");
+            WORD_ATOM(222, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20121,10 +20165,10 @@ static void mw_c99_tag_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(233, 39, ";");
+            WORD_ATOM(222, 39, ";");
             mw_Str_2B_C99_3B_();
         } else {
-            WORD_ATOM(234, 13, "");
+            WORD_ATOM(223, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20135,11 +20179,11 @@ static void mw_c99_tag_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(234, 36, ";");
+            WORD_ATOM(223, 36, ";");
             mw_Str_2B_C99_3B_();
         }
     }
-    WORD_ATOM(237, 5, "");
+    WORD_ATOM(226, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20150,9 +20194,9 @@ static void mw_c99_tag_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(237, 9, ";");
+    WORD_ATOM(226, 9, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(239, 5, "");
+    WORD_ATOM(228, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20163,15 +20207,15 @@ static void mw_c99_tag_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(239, 16, ".");
+    WORD_ATOM(228, 16, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(239, 18, "dup");
+    WORD_ATOM(228, 18, "dup");
     mw_prim_dup();
-    WORD_ATOM(239, 22, "name");
+    WORD_ATOM(228, 22, "name");
     mw_Tag_2E_name();
-    WORD_ATOM(239, 27, ".name");
+    WORD_ATOM(228, 27, ".name");
     mw_Name_2B_C99_2E_name();
-    WORD_ATOM(239, 33, "");
+    WORD_ATOM(228, 33, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20182,24 +20226,24 @@ static void mw_c99_tag_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(239, 40, ";");
+    WORD_ATOM(228, 40, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(240, 5, "dup");
+    WORD_ATOM(229, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(240, 9, "is-transparent?");
+    WORD_ATOM(229, 9, "is-transparent?");
     mw_Tag_2E_is_transparent_3F_();
-    WORD_ATOM(240, 25, "if");
+    WORD_ATOM(229, 25, "if");
     if (pop_u64()) {
-        WORD_ATOM(241, 9, "id");
+        WORD_ATOM(230, 9, "id");
         mw_prim_id();
     } else {
-        WORD_ATOM(242, 9, "dup");
+        WORD_ATOM(231, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(242, 13, "outputs-resource?");
+        WORD_ATOM(231, 13, "outputs-resource?");
         mw_Tag_2E_outputs_resource_3F_();
-        WORD_ATOM(242, 31, "if");
+        WORD_ATOM(231, 31, "if");
         if (pop_u64()) {
-            WORD_ATOM(243, 13, "");
+            WORD_ATOM(232, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20210,10 +20254,10 @@ static void mw_c99_tag_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(243, 45, ";");
+            WORD_ATOM(232, 45, ";");
             mw_Str_2B_C99_3B_();
         } else {
-            WORD_ATOM(244, 13, "");
+            WORD_ATOM(233, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20224,10 +20268,10 @@ static void mw_c99_tag_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(244, 42, ";");
+            WORD_ATOM(233, 42, ";");
             mw_Str_2B_C99_3B_();
         }
-        WORD_ATOM(246, 9, "");
+        WORD_ATOM(235, 9, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20238,9 +20282,9 @@ static void mw_c99_tag_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(246, 24, ";");
+        WORD_ATOM(235, 24, ";");
         mw_Str_2B_C99_3B_();
-        WORD_ATOM(247, 9, "");
+        WORD_ATOM(236, 9, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20251,27 +20295,27 @@ static void mw_c99_tag_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(248, 9, "over");
+        WORD_ATOM(237, 9, "over");
         mw_over();
-        WORD_ATOM(248, 14, "num-resource-inputs");
+        WORD_ATOM(237, 14, "num-resource-inputs");
         mw_Tag_2E_num_resource_inputs();
-        WORD_ATOM(248, 34, "repeat");
+        WORD_ATOM(237, 34, "repeat");
         push_u64(0);
         push_fnptr(&mb_c99_tag_21__11);
         mw_prim_pack_cons();
         mw_repeat();
-        WORD_ATOM(253, 9, "over");
+        WORD_ATOM(242, 9, "over");
         mw_over();
-        WORD_ATOM(253, 14, "num-type-inputs");
+        WORD_ATOM(242, 14, "num-type-inputs");
         mw_Tag_2E_num_type_inputs();
-        WORD_ATOM(253, 30, "repeat");
+        WORD_ATOM(242, 30, "repeat");
         push_u64(0);
         push_fnptr(&mb_c99_tag_21__12);
         mw_prim_pack_cons();
         mw_repeat();
-        WORD_ATOM(258, 9, ".");
+        WORD_ATOM(247, 9, ".");
         mw_Str_2B_C99_2E_();
-        WORD_ATOM(258, 11, "");
+        WORD_ATOM(247, 11, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20282,10 +20326,10 @@ static void mw_c99_tag_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(258, 19, ";");
+        WORD_ATOM(247, 19, ";");
         mw_Str_2B_C99_3B_();
     }
-    WORD_ATOM(260, 5, "");
+    WORD_ATOM(249, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20296,40 +20340,40 @@ static void mw_c99_tag_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(260, 9, ";");
+    WORD_ATOM(249, 9, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(262, 5, "drop");
+    WORD_ATOM(251, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_tag_21_);
 }
 static void mw_c99_externals_21_ (void){
-    WORD_ENTER(mw_c99_externals_21_, "c99-externals!", "src/mirth/codegen.mth", 265, 5);
-    WORD_ATOM(265, 5, "External.for");
+    WORD_ENTER(mw_c99_externals_21_, "c99-externals!", "src/mirth/codegen.mth", 254, 5);
+    WORD_ATOM(254, 5, "External.for");
     push_u64(0);
     push_fnptr(&mb_c99_externals_21__1);
     mw_prim_pack_cons();
     mw_External_2E_for();
-    WORD_ATOM(265, 33, ".lf");
+    WORD_ATOM(254, 33, ".lf");
     mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_externals_21_);
 }
 static void mw_c99_external_21_ (void){
-    WORD_ENTER(mw_c99_external_21_, "c99-external!", "src/mirth/codegen.mth", 268, 5);
-    WORD_ATOM(268, 5, "dup");
+    WORD_ENTER(mw_c99_external_21_, "c99-external!", "src/mirth/codegen.mth", 257, 5);
+    WORD_ATOM(257, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(268, 9, "sig");
+    WORD_ATOM(257, 9, "sig");
     mw_External_2E_sig();
-    WORD_ATOM(268, 13, "sig-arity");
+    WORD_ATOM(257, 13, "sig-arity");
     mw_Token_2E_sig_arity();
-    WORD_ATOM(269, 5, "dup");
+    WORD_ATOM(258, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(269, 9, "");
+    WORD_ATOM(258, 9, "");
     push_i64(2LL);
-    WORD_ATOM(269, 11, ">=");
+    WORD_ATOM(258, 11, ">=");
     mw_Int_3E__3D_();
-    WORD_ATOM(269, 14, "if");
+    WORD_ATOM(258, 14, "if");
     if (pop_u64()) {
-        WORD_ATOM(270, 9, "");
+        WORD_ATOM(259, 9, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20340,18 +20384,18 @@ static void mw_c99_external_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(270, 62, "panic!");
+        WORD_ATOM(259, 62, "panic!");
         mw_prim_panic();
     } else {
-        WORD_ATOM(272, 9, "dup");
+        WORD_ATOM(261, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(272, 13, "");
+        WORD_ATOM(261, 13, "");
         push_i64(1LL);
-        WORD_ATOM(272, 15, ">=");
+        WORD_ATOM(261, 15, ">=");
         mw_Int_3E__3D_();
-        WORD_ATOM(272, 18, "if");
+        WORD_ATOM(261, 18, "if");
         if (pop_u64()) {
-            WORD_ATOM(273, 13, "");
+            WORD_ATOM(262, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20362,10 +20406,10 @@ static void mw_c99_external_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(273, 24, ".");
+            WORD_ATOM(262, 24, ".");
             mw_Str_2B_C99_2E_();
         } else {
-            WORD_ATOM(274, 13, "");
+            WORD_ATOM(263, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20376,16 +20420,16 @@ static void mw_c99_external_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(274, 21, ".");
+            WORD_ATOM(263, 21, ".");
             mw_Str_2B_C99_2E_();
         }
     }
-    WORD_ATOM(278, 5, "dip2");
+    WORD_ATOM(267, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_c99_external_21__5);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(280, 5, "");
+    WORD_ATOM(269, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20396,17 +20440,17 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(280, 10, ".");
+    WORD_ATOM(269, 10, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(281, 5, "over");
+    WORD_ATOM(270, 5, "over");
     mw_over();
-    WORD_ATOM(281, 10, "dup");
+    WORD_ATOM(270, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(281, 14, "0>");
+    WORD_ATOM(270, 14, "0>");
     mw_0_3E_();
-    WORD_ATOM(281, 17, "if");
+    WORD_ATOM(270, 17, "if");
     if (pop_u64()) {
-        WORD_ATOM(281, 20, "");
+        WORD_ATOM(270, 20, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20417,19 +20461,19 @@ static void mw_c99_external_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(281, 30, ".");
+        WORD_ATOM(270, 30, ".");
         mw_Str_2B_C99_2E_();
-        WORD_ATOM(281, 32, "1-");
+        WORD_ATOM(270, 32, "1-");
         mw_prim_int_pred();
-        WORD_ATOM(281, 35, "repeat");
+        WORD_ATOM(270, 35, "repeat");
         push_u64(0);
         push_fnptr(&mb_c99_external_21__7);
         mw_prim_pack_cons();
         mw_repeat();
     } else {
-        WORD_ATOM(281, 58, "drop");
+        WORD_ATOM(270, 58, "drop");
         mw_prim_drop();
-        WORD_ATOM(281, 63, "");
+        WORD_ATOM(270, 63, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20440,10 +20484,10 @@ static void mw_c99_external_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(281, 70, ".");
+        WORD_ATOM(270, 70, ".");
         mw_Str_2B_C99_2E_();
     }
-    WORD_ATOM(282, 5, "");
+    WORD_ATOM(271, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20454,9 +20498,9 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(282, 10, ";");
+    WORD_ATOM(271, 10, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(284, 5, "");
+    WORD_ATOM(273, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20467,14 +20511,14 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(284, 23, ".");
+    WORD_ATOM(273, 23, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(284, 25, "dip2");
+    WORD_ATOM(273, 25, "dip2");
     push_u64(0);
     push_fnptr(&mb_c99_external_21__9);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(284, 46, "");
+    WORD_ATOM(273, 46, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20485,22 +20529,22 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(284, 58, ";");
+    WORD_ATOM(273, 58, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(285, 5, "over");
+    WORD_ATOM(274, 5, "over");
     mw_over();
-    WORD_ATOM(285, 10, "countdown");
+    WORD_ATOM(274, 10, "countdown");
     push_u64(0);
     push_fnptr(&mb_c99_external_21__10);
     mw_prim_pack_cons();
     mw_countdown();
-    WORD_ATOM(286, 5, "dup");
+    WORD_ATOM(275, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(286, 9, "0>");
+    WORD_ATOM(275, 9, "0>");
     mw_0_3E_();
-    WORD_ATOM(286, 12, "if");
+    WORD_ATOM(275, 12, "if");
     if (pop_u64()) {
-        WORD_ATOM(286, 15, "");
+        WORD_ATOM(275, 15, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20512,7 +20556,7 @@ static void mw_c99_external_21_ (void){
             incref(v);
         }
     } else {
-        WORD_ATOM(286, 32, "");
+        WORD_ATOM(275, 32, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20524,14 +20568,14 @@ static void mw_c99_external_21_ (void){
             incref(v);
         }
     }
-    WORD_ATOM(286, 40, ".");
+    WORD_ATOM(275, 40, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(287, 5, "dip2");
+    WORD_ATOM(276, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_c99_external_21__13);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(288, 5, "");
+    WORD_ATOM(277, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20542,29 +20586,29 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(288, 9, ".");
+    WORD_ATOM(277, 9, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(289, 5, "dip");
+    WORD_ATOM(278, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(289, 9, "dup");
+        WORD_ATOM(278, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(289, 13, "0>");
+        WORD_ATOM(278, 13, "0>");
         mw_0_3E_();
-        WORD_ATOM(289, 16, "if");
+        WORD_ATOM(278, 16, "if");
         if (pop_u64()) {
-            WORD_ATOM(290, 9, "dup");
+            WORD_ATOM(279, 9, "dup");
             mw_prim_dup();
-            WORD_ATOM(290, 13, "1-");
+            WORD_ATOM(279, 13, "1-");
             mw_prim_int_pred();
-            WORD_ATOM(290, 16, "dup");
+            WORD_ATOM(279, 16, "dup");
             mw_prim_dup();
-            WORD_ATOM(290, 20, "count");
+            WORD_ATOM(279, 20, "count");
             push_u64(0);
             push_fnptr(&mb_c99_external_21__16);
             mw_prim_pack_cons();
             mw_count();
-            WORD_ATOM(290, 43, "");
+            WORD_ATOM(279, 43, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20575,17 +20619,17 @@ static void mw_c99_external_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(290, 47, ".");
+            WORD_ATOM(279, 47, ".");
             mw_Str_2B_C99_2E_();
-            WORD_ATOM(290, 49, ".n");
+            WORD_ATOM(279, 49, ".n");
             mw_Int_2B_C99_2E_n();
         } else {
-            WORD_ATOM(291, 9, "id");
+            WORD_ATOM(280, 9, "id");
             mw_prim_id();
         }
         push_value(d2);
     }
-    WORD_ATOM(293, 5, "");
+    WORD_ATOM(282, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20596,15 +20640,15 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(293, 9, ".");
+    WORD_ATOM(282, 9, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(294, 5, "dup");
+    WORD_ATOM(283, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(294, 9, "0>");
+    WORD_ATOM(283, 9, "0>");
     mw_0_3E_();
-    WORD_ATOM(294, 12, "if");
+    WORD_ATOM(283, 12, "if");
     if (pop_u64()) {
-        WORD_ATOM(294, 15, "");
+        WORD_ATOM(283, 15, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20616,7 +20660,7 @@ static void mw_c99_external_21_ (void){
             incref(v);
         }
     } else {
-        WORD_ATOM(294, 21, "");
+        WORD_ATOM(283, 21, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20628,9 +20672,9 @@ static void mw_c99_external_21_ (void){
             incref(v);
         }
     }
-    WORD_ATOM(294, 26, ";");
+    WORD_ATOM(283, 26, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(295, 5, "");
+    WORD_ATOM(284, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20641,41 +20685,41 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(295, 9, ";");
+    WORD_ATOM(284, 9, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(296, 5, "drop3");
+    WORD_ATOM(285, 5, "drop3");
     mw_drop3();
     WORD_EXIT(mw_c99_external_21_);
 }
 static void mw_c99_nest (void){
-    WORD_ENTER(mw_c99_nest, "c99-nest", "src/mirth/codegen.mth", 299, 5);
-    WORD_ATOM(299, 5, "depth@");
+    WORD_ENTER(mw_c99_nest, "c99-nest", "src/mirth/codegen.mth", 288, 5);
+    WORD_ATOM(288, 5, "depth@");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(299, 5, "depth@");
+        WORD_ATOM(288, 5, "depth@");
         mw__2B_C99_2E_depth_40_();
-        WORD_ATOM(299, 12, "1+");
+        WORD_ATOM(288, 12, "1+");
         mw_prim_int_succ();
-        WORD_ATOM(299, 15, "depth!");
+        WORD_ATOM(288, 15, "depth!");
         mw__2B_C99_2E_depth_21_();
-        WORD_ATOM(300, 5, "f");
+        WORD_ATOM(289, 5, "f");
         incref(var_f);
         run_value(var_f);
-        WORD_ATOM(301, 5, "depth@");
+        WORD_ATOM(290, 5, "depth@");
         mw__2B_C99_2E_depth_40_();
-        WORD_ATOM(301, 12, "1-");
+        WORD_ATOM(290, 12, "1-");
         mw_prim_int_pred();
-        WORD_ATOM(301, 15, "depth!");
+        WORD_ATOM(290, 15, "depth!");
         mw__2B_C99_2E_depth_21_();
         decref(var_f);
     }
     WORD_EXIT(mw_c99_nest);
 }
 static void mw_c99_indent (void){
-    WORD_ENTER(mw_c99_indent, "c99-indent", "src/mirth/codegen.mth", 303, 31);
-    WORD_ATOM(303, 31, "depth@");
+    WORD_ENTER(mw_c99_indent, "c99-indent", "src/mirth/codegen.mth", 292, 31);
+    WORD_ATOM(292, 31, "depth@");
     mw__2B_C99_2E_depth_40_();
-    WORD_ATOM(303, 38, "repeat");
+    WORD_ATOM(292, 38, "repeat");
     push_u64(0);
     push_fnptr(&mb_c99_indent_1);
     mw_prim_pack_cons();
@@ -20683,31 +20727,31 @@ static void mw_c99_indent (void){
     WORD_EXIT(mw_c99_indent);
 }
 static void mw_c99_line (void){
-    WORD_ENTER(mw_c99_line, "c99-line", "src/mirth/codegen.mth", 304, 59);
-    WORD_ATOM(304, 59, "c99-indent");
+    WORD_ENTER(mw_c99_line, "c99-line", "src/mirth/codegen.mth", 293, 59);
+    WORD_ATOM(293, 59, "c99-indent");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(304, 59, "c99-indent");
+        WORD_ATOM(293, 59, "c99-indent");
         mw_c99_indent();
-        WORD_ATOM(304, 70, "f");
+        WORD_ATOM(293, 70, "f");
         incref(var_f);
         run_value(var_f);
-        WORD_ATOM(304, 72, ".lf");
+        WORD_ATOM(293, 72, ".lf");
         mw__2B_C99_2E_lf();
         decref(var_f);
     }
     WORD_EXIT(mw_c99_line);
 }
 static void mw_c99_call_21_ (void){
-    WORD_ENTER(mw_c99_call_21_, "c99-call!", "src/mirth/codegen.mth", 307, 5);
-    WORD_ATOM(307, 5, "dip");
+    WORD_ENTER(mw_c99_call_21_, "c99-call!", "src/mirth/codegen.mth", 296, 5);
+    WORD_ATOM(296, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(307, 9, "c99-args-push!");
+        WORD_ATOM(296, 9, "c99-args-push!");
         mw_c99_args_push_21_();
         push_value(d2);
     }
-    WORD_ATOM(308, 5, "c99-line");
+    WORD_ATOM(297, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_call_21__2);
     mw_prim_pack_cons();
@@ -20715,10 +20759,10 @@ static void mw_c99_call_21_ (void){
     WORD_EXIT(mw_c99_call_21_);
 }
 static void mw_c99_arrow_21_ (void){
-    WORD_ENTER(mw_c99_arrow_21_, "c99-arrow!", "src/mirth/codegen.mth", 310, 37);
-    WORD_ATOM(310, 37, "atoms");
+    WORD_ENTER(mw_c99_arrow_21_, "c99-arrow!", "src/mirth/codegen.mth", 299, 37);
+    WORD_ATOM(299, 37, "atoms");
     mw_Arrow_2E_atoms();
-    WORD_ATOM(310, 43, "for");
+    WORD_ATOM(299, 43, "for");
     push_u64(0);
     push_fnptr(&mb_c99_arrow_21__1);
     mw_prim_pack_cons();
@@ -20726,126 +20770,126 @@ static void mw_c99_arrow_21_ (void){
     WORD_EXIT(mw_c99_arrow_21_);
 }
 static void mw_c99_atom_21_ (void){
-    WORD_ENTER(mw_c99_atom_21_, "c99-atom!", "src/mirth/codegen.mth", 312, 5);
-    WORD_ATOM(312, 5, "c99-line");
+    WORD_ENTER(mw_c99_atom_21_, "c99-atom!", "src/mirth/codegen.mth", 301, 5);
+    WORD_ATOM(301, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_atom_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(317, 5, "sip");
+    WORD_ATOM(306, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_c99_atom_21__4);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(317, 15, "op");
+    WORD_ATOM(306, 15, "op");
     mw_Atom_2E_op();
-    WORD_ATOM(318, 5, "c99-args-op!");
+    WORD_ATOM(307, 5, "c99-args-op!");
     mw_c99_args_op_21_();
     WORD_EXIT(mw_c99_atom_21_);
 }
 static void mw_c99_args_op_21_ (void){
-    WORD_ENTER(mw_c99_args_op_21_, "c99-args-op!", "src/mirth/codegen.mth", 321, 5);
-    WORD_ATOM(321, 5, "OP_NONE");
+    WORD_ENTER(mw_c99_args_op_21_, "c99-args-op!", "src/mirth/codegen.mth", 310, 5);
+    WORD_ATOM(310, 5, "OP_NONE");
     switch (get_top_data_tag()) {
         case 0LL:
             co_OP_5F_NONE();
-            WORD_ATOM(321, 20, "drop");
+            WORD_ATOM(310, 20, "drop");
             mw_prim_drop();
             break;
         case 8LL:
             co_OP_5F_INT();
-            WORD_ATOM(322, 20, "nip");
+            WORD_ATOM(311, 20, "nip");
             mw_nip();
-            WORD_ATOM(322, 24, "c99-int!");
+            WORD_ATOM(311, 24, "c99-int!");
             mw_c99_int_21_();
             break;
         case 9LL:
             co_OP_5F_STR();
-            WORD_ATOM(323, 20, "nip");
+            WORD_ATOM(312, 20, "nip");
             mw_nip();
-            WORD_ATOM(323, 24, "c99-str!");
+            WORD_ATOM(312, 24, "c99-str!");
             mw_c99_str_21_();
             break;
         case 6LL:
             co_OP_5F_CONSTANT();
-            WORD_ATOM(324, 20, "nip");
+            WORD_ATOM(313, 20, "nip");
             mw_nip();
-            WORD_ATOM(324, 24, "c99-constant!");
+            WORD_ATOM(313, 24, "c99-constant!");
             mw_c99_constant_21_();
             break;
         case 2LL:
             co_OP_5F_WORD();
-            WORD_ATOM(325, 20, "name");
+            WORD_ATOM(314, 20, "name");
             mw_Word_2E_name();
-            WORD_ATOM(325, 25, "c99-call!");
+            WORD_ATOM(314, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 3LL:
             co_OP_5F_EXTERNAL();
-            WORD_ATOM(326, 20, "name");
+            WORD_ATOM(315, 20, "name");
             mw_External_2E_name();
-            WORD_ATOM(326, 25, "c99-call!");
+            WORD_ATOM(315, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 4LL:
             co_OP_5F_BUFFER();
-            WORD_ATOM(327, 20, "name");
+            WORD_ATOM(316, 20, "name");
             mw_Buffer_2E_name();
-            WORD_ATOM(327, 25, "c99-call!");
+            WORD_ATOM(316, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 5LL:
             co_OP_5F_VARIABLE();
-            WORD_ATOM(328, 20, "name");
+            WORD_ATOM(317, 20, "name");
             mw_Variable_2E_name();
-            WORD_ATOM(328, 25, "c99-call!");
+            WORD_ATOM(317, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 7LL:
             co_OP_5F_FIELD();
-            WORD_ATOM(329, 20, "name");
+            WORD_ATOM(318, 20, "name");
             mw_Field_2E_name();
-            WORD_ATOM(329, 25, "c99-call!");
+            WORD_ATOM(318, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 10LL:
             co_OP_5F_TAG();
-            WORD_ATOM(330, 20, "name");
+            WORD_ATOM(319, 20, "name");
             mw_Tag_2E_name();
-            WORD_ATOM(330, 25, "c99-call!");
+            WORD_ATOM(319, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 1LL:
             co_OP_5F_PRIM();
-            WORD_ATOM(331, 20, "c99-prim!");
+            WORD_ATOM(320, 20, "c99-prim!");
             mw_c99_prim_21_();
             break;
         case 11LL:
             co_OP_5F_MATCH();
-            WORD_ATOM(332, 20, "nip");
+            WORD_ATOM(321, 20, "nip");
             mw_nip();
-            WORD_ATOM(332, 24, "c99-match!");
+            WORD_ATOM(321, 24, "c99-match!");
             mw_c99_match_21_();
             break;
         case 12LL:
             co_OP_5F_LAMBDA();
-            WORD_ATOM(333, 20, "nip");
+            WORD_ATOM(322, 20, "nip");
             mw_nip();
-            WORD_ATOM(333, 24, "c99-lambda!");
+            WORD_ATOM(322, 24, "c99-lambda!");
             mw_c99_lambda_21_();
             break;
         case 13LL:
             co_OP_5F_VAR();
-            WORD_ATOM(334, 20, "nip");
+            WORD_ATOM(323, 20, "nip");
             mw_nip();
-            WORD_ATOM(334, 24, "c99-var!");
+            WORD_ATOM(323, 24, "c99-var!");
             mw_c99_var_21_();
             break;
         case 14LL:
             co_OP_5F_BLOCK();
-            WORD_ATOM(335, 20, "nip");
+            WORD_ATOM(324, 20, "nip");
             mw_nip();
-            WORD_ATOM(335, 24, "c99-block-push!");
+            WORD_ATOM(324, 24, "c99-block-push!");
             mw_c99_block_push_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -20853,8 +20897,8 @@ static void mw_c99_args_op_21_ (void){
 }    WORD_EXIT(mw_c99_args_op_21_);
 }
 static void mw_c99_int_21_ (void){
-    WORD_ENTER(mw_c99_int_21_, "c99-int!", "src/mirth/codegen.mth", 338, 5);
-    WORD_ATOM(338, 5, "c99-line");
+    WORD_ENTER(mw_c99_int_21_, "c99-int!", "src/mirth/codegen.mth", 327, 5);
+    WORD_ATOM(327, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_int_21__1);
     mw_prim_pack_cons();
@@ -20862,29 +20906,29 @@ static void mw_c99_int_21_ (void){
     WORD_EXIT(mw_c99_int_21_);
 }
 static void mw_c99_str_21_ (void){
-    WORD_ENTER(mw_c99_str_21_, "c99-str!", "src/mirth/codegen.mth", 341, 5);
-    WORD_ATOM(341, 5, "c99-line");
+    WORD_ENTER(mw_c99_str_21_, "c99-str!", "src/mirth/codegen.mth", 330, 5);
+    WORD_ATOM(330, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(342, 5, "c99-nest");
+    WORD_ATOM(331, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(365, 5, "c99-line");
+    WORD_ATOM(354, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__20);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(366, 5, "drop");
+    WORD_ATOM(355, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_str_21_);
 }
 static void mw__2E_str (void){
-    WORD_ENTER(mw__2E_str, ".str", "src/mirth/codegen.mth", 368, 29);
-    WORD_ATOM(368, 29, "");
+    WORD_ENTER(mw__2E_str, ".str", "src/mirth/codegen.mth", 357, 29);
+    WORD_ATOM(357, 29, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20895,14 +20939,14 @@ static void mw__2E_str (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(368, 34, ".");
+    WORD_ATOM(357, 34, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(368, 36, "str-bytes-for");
+    WORD_ATOM(357, 36, "str-bytes-for");
     push_u64(0);
     push_fnptr(&mb__2E_str_1);
     mw_prim_pack_cons();
     mw_str_bytes_for();
-    WORD_ATOM(368, 68, "");
+    WORD_ATOM(357, 68, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20913,17 +20957,17 @@ static void mw__2E_str (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(368, 73, ".");
+    WORD_ATOM(357, 73, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mw__2E_str);
 }
 static void mw_c99_string_byte_21_ (void){
-    WORD_ENTER(mw_c99_string_byte_21_, "c99-string-byte!", "src/mirth/codegen.mth", 371, 5);
-    WORD_ATOM(371, 5, "B'\\'");
+    WORD_ENTER(mw_c99_string_byte_21_, "c99-string-byte!", "src/mirth/codegen.mth", 360, 5);
+    WORD_ATOM(360, 5, "B'\\'");
     switch (get_top_data_tag()) {
         case 92LL:
             co_B_27__5C__27_();
-            WORD_ATOM(371, 13, "");
+            WORD_ATOM(360, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20934,12 +20978,12 @@ static void mw_c99_string_byte_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(371, 20, ".");
+            WORD_ATOM(360, 20, ".");
             mw_Str_2B_C99_2E_();
             break;
         case 34LL:
             co_BQUOTE();
-            WORD_ATOM(372, 15, "");
+            WORD_ATOM(361, 15, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20950,12 +20994,12 @@ static void mw_c99_string_byte_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(372, 22, ".");
+            WORD_ATOM(361, 22, ".");
             mw_Str_2B_C99_2E_();
             break;
         case 9LL:
             co_BHT();
-            WORD_ATOM(373, 12, "");
+            WORD_ATOM(362, 12, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20966,12 +21010,12 @@ static void mw_c99_string_byte_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(373, 18, ".");
+            WORD_ATOM(362, 18, ".");
             mw_Str_2B_C99_2E_();
             break;
         case 10LL:
             co_BLF();
-            WORD_ATOM(374, 12, "");
+            WORD_ATOM(363, 12, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20982,12 +21026,12 @@ static void mw_c99_string_byte_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(374, 18, ".");
+            WORD_ATOM(363, 18, ".");
             mw_Str_2B_C99_2E_();
             break;
         case 13LL:
             co_BCR();
-            WORD_ATOM(375, 12, "");
+            WORD_ATOM(364, 12, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20998,24 +21042,24 @@ static void mw_c99_string_byte_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(375, 18, ".");
+            WORD_ATOM(364, 18, ".");
             mw_Str_2B_C99_2E_();
             break;
         default:
-            WORD_ATOM(377, 9, "dup");
+            WORD_ATOM(366, 9, "dup");
             mw_prim_dup();
-            WORD_ATOM(377, 13, "BSPACE");
+            WORD_ATOM(366, 13, "BSPACE");
             mw_BSPACE();
-            WORD_ATOM(377, 20, "B'~'");
+            WORD_ATOM(366, 20, "B'~'");
             mw_B_27__7E__27_();
-            WORD_ATOM(377, 25, "in-range");
+            WORD_ATOM(366, 25, "in-range");
             mw_Byte_2E_in_range();
-            WORD_ATOM(377, 34, "if");
+            WORD_ATOM(366, 34, "if");
             if (pop_u64()) {
-                WORD_ATOM(378, 13, ".b");
+                WORD_ATOM(367, 13, ".b");
                 mw_Byte_2B_C99_2E_b();
             } else {
-                WORD_ATOM(379, 13, "");
+                WORD_ATOM(368, 13, "");
                 {
                     static bool vready = false;
                     static VAL v;
@@ -21026,18 +21070,18 @@ static void mw_c99_string_byte_21_ (void){
                     push_value(v);
                     incref(v);
                 }
-                WORD_ATOM(379, 19, ".");
+                WORD_ATOM(368, 19, ".");
                 mw_Str_2B_C99_2E_();
-                WORD_ATOM(379, 21, "to-hexdigits");
+                WORD_ATOM(368, 21, "to-hexdigits");
                 mw_Byte_2E_to_hexdigits();
-                WORD_ATOM(379, 34, "dip");
+                WORD_ATOM(368, 34, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(379, 38, ".b");
+                    WORD_ATOM(368, 38, ".b");
                     mw_Byte_2B_C99_2E_b();
                     push_value(d5);
                 }
-                WORD_ATOM(379, 42, ".b");
+                WORD_ATOM(368, 42, ".b");
                 mw_Byte_2B_C99_2E_b();
             }
             break;
@@ -21045,30 +21089,30 @@ static void mw_c99_string_byte_21_ (void){
 }    WORD_EXIT(mw_c99_string_byte_21_);
 }
 static void mw_c99_constant_21_ (void){
-    WORD_ENTER(mw_c99_constant_21_, "c99-constant!", "src/mirth/codegen.mth", 384, 5);
-    WORD_ATOM(384, 5, "value");
+    WORD_ENTER(mw_c99_constant_21_, "c99-constant!", "src/mirth/codegen.mth", 373, 5);
+    WORD_ATOM(373, 5, "value");
     mw_Constant_2E_value();
-    WORD_ATOM(384, 11, "c99-value!");
+    WORD_ATOM(373, 11, "c99-value!");
     mw_c99_value_21_();
     WORD_EXIT(mw_c99_constant_21_);
 }
 static void mw_c99_value_21_ (void){
-    WORD_ENTER(mw_c99_value_21_, "c99-value!", "src/mirth/codegen.mth", 387, 5);
-    WORD_ATOM(387, 5, "VALUE_INT");
+    WORD_ENTER(mw_c99_value_21_, "c99-value!", "src/mirth/codegen.mth", 376, 5);
+    WORD_ATOM(376, 5, "VALUE_INT");
     switch (get_top_data_tag()) {
         case 0LL:
             co_VALUE_5F_INT();
-            WORD_ATOM(387, 18, "c99-int!");
+            WORD_ATOM(376, 18, "c99-int!");
             mw_c99_int_21_();
             break;
         case 1LL:
             co_VALUE_5F_STR();
-            WORD_ATOM(388, 18, "c99-str!");
+            WORD_ATOM(377, 18, "c99-str!");
             mw_c99_str_21_();
             break;
         case 2LL:
             co_VALUE_5F_BLOCK();
-            WORD_ATOM(389, 20, "c99-block-push!");
+            WORD_ATOM(378, 20, "c99-block-push!");
             mw_c99_block_push_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -21076,157 +21120,157 @@ static void mw_c99_value_21_ (void){
 }    WORD_EXIT(mw_c99_value_21_);
 }
 static void mw_c99_prim_21_ (void){
-    WORD_ENTER(mw_c99_prim_21_, "c99-prim!", "src/mirth/codegen.mth", 392, 5);
-    WORD_ATOM(392, 5, "PRIM_CORE_DIP");
+    WORD_ENTER(mw_c99_prim_21_, "c99-prim!", "src/mirth/codegen.mth", 381, 5);
+    WORD_ATOM(381, 5, "PRIM_CORE_DIP");
     switch (get_top_data_tag()) {
         case 4LL:
             co_PRIM_5F_CORE_5F_DIP();
-            WORD_ATOM(393, 9, "match");
+            WORD_ATOM(382, 9, "match");
             switch (get_top_data_tag()) {
                 case 1LL:
                     co_L1();
-                    WORD_ATOM(395, 17, "c99-line");
+                    WORD_ATOM(384, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__3);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(396, 17, "c99-nest");
+                    WORD_ATOM(385, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__4);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(401, 17, "c99-line");
+                    WORD_ATOM(390, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__7);
                     mw_prim_pack_cons();
                     mw_c99_line();
                     break;
                 default:
-                    WORD_ATOM(403, 17, "PRIM_CORE_DIP");
+                    WORD_ATOM(392, 17, "PRIM_CORE_DIP");
                     mw_PRIM_5F_CORE_5F_DIP();
-                    WORD_ATOM(403, 31, "c99-prim-default!");
+                    WORD_ATOM(392, 31, "c99-prim-default!");
                     mw_c99_prim_default_21_();
                     break;
             
 }            break;
         case 13LL:
             co_PRIM_5F_CORE_5F_RDIP();
-            WORD_ATOM(407, 9, "match");
+            WORD_ATOM(396, 9, "match");
             switch (get_top_data_tag()) {
                 case 1LL:
                     co_L1();
-                    WORD_ATOM(409, 17, "c99-line");
+                    WORD_ATOM(398, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__11);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(410, 17, "c99-nest");
+                    WORD_ATOM(399, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__12);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(415, 17, "c99-line");
+                    WORD_ATOM(404, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__15);
                     mw_prim_pack_cons();
                     mw_c99_line();
                     break;
                 default:
-                    WORD_ATOM(417, 17, "PRIM_CORE_RDIP");
+                    WORD_ATOM(406, 17, "PRIM_CORE_RDIP");
                     mw_PRIM_5F_CORE_5F_RDIP();
-                    WORD_ATOM(417, 32, "c99-prim-default!");
+                    WORD_ATOM(406, 32, "c99-prim-default!");
                     mw_c99_prim_default_21_();
                     break;
             
 }            break;
         case 5LL:
             co_PRIM_5F_CORE_5F_IF();
-            WORD_ATOM(421, 9, "match");
+            WORD_ATOM(410, 9, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
                     co_L2();
-                    WORD_ATOM(423, 17, "c99-line");
+                    WORD_ATOM(412, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__19);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(424, 17, "c99-nest");
+                    WORD_ATOM(413, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__20);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(425, 17, "c99-line");
+                    WORD_ATOM(414, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__21);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(426, 17, "c99-nest");
+                    WORD_ATOM(415, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__22);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(427, 17, "c99-line");
+                    WORD_ATOM(416, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__23);
                     mw_prim_pack_cons();
                     mw_c99_line();
                     break;
                 default:
-                    WORD_ATOM(429, 17, "PRIM_CORE_IF");
+                    WORD_ATOM(418, 17, "PRIM_CORE_IF");
                     mw_PRIM_5F_CORE_5F_IF();
-                    WORD_ATOM(429, 30, "c99-prim-default!");
+                    WORD_ATOM(418, 30, "c99-prim-default!");
                     mw_c99_prim_default_21_();
                     break;
             
 }            break;
         case 6LL:
             co_PRIM_5F_CORE_5F_WHILE();
-            WORD_ATOM(433, 9, "match");
+            WORD_ATOM(422, 9, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
                     co_L2();
-                    WORD_ATOM(435, 17, "c99-line");
+                    WORD_ATOM(424, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__27);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(436, 17, "c99-nest");
+                    WORD_ATOM(425, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__28);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(441, 17, "c99-line");
+                    WORD_ATOM(430, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__30);
                     mw_prim_pack_cons();
                     mw_c99_line();
                     break;
                 default:
-                    WORD_ATOM(444, 17, "PRIM_CORE_WHILE");
+                    WORD_ATOM(433, 17, "PRIM_CORE_WHILE");
                     mw_PRIM_5F_CORE_5F_WHILE();
-                    WORD_ATOM(444, 33, "c99-prim-default!");
+                    WORD_ATOM(433, 33, "c99-prim-default!");
                     mw_c99_prim_default_21_();
                     break;
             
 }            break;
         default:
-            WORD_ATOM(447, 10, "c99-prim-default!");
+            WORD_ATOM(436, 10, "c99-prim-default!");
             mw_c99_prim_default_21_();
             break;
     
 }    WORD_EXIT(mw_c99_prim_21_);
 }
 static void mw_c99_prim_default_21_ (void){
-    WORD_ENTER(mw_c99_prim_default_21_, "c99-prim-default!", "src/mirth/codegen.mth", 450, 5);
-    WORD_ATOM(450, 5, "name");
+    WORD_ENTER(mw_c99_prim_default_21_, "c99-prim-default!", "src/mirth/codegen.mth", 439, 5);
+    WORD_ATOM(439, 5, "name");
     mw_Prim_2E_name();
-    WORD_ATOM(450, 10, "c99-call!");
+    WORD_ATOM(439, 10, "c99-call!");
     mw_c99_call_21_();
     WORD_EXIT(mw_c99_prim_default_21_);
 }
 static void mw_c99_args_push_21_ (void){
-    WORD_ENTER(mw_c99_args_push_21_, "c99-args-push!", "src/mirth/codegen.mth", 453, 5);
-    WORD_ATOM(453, 5, "for");
+    WORD_ENTER(mw_c99_args_push_21_, "c99-args-push!", "src/mirth/codegen.mth", 442, 5);
+    WORD_ATOM(442, 5, "for");
     push_u64(0);
     push_fnptr(&mb_c99_args_push_21__1);
     mw_prim_pack_cons();
@@ -21234,30 +21278,30 @@ static void mw_c99_args_push_21_ (void){
     WORD_EXIT(mw_c99_args_push_21_);
 }
 static void mw_c99_arg_push_21_ (void){
-    WORD_ENTER(mw_c99_arg_push_21_, "c99-arg-push!", "src/mirth/codegen.mth", 456, 5);
-    WORD_ATOM(456, 5, "ARG_BLOCK");
-    WORD_ATOM(456, 18, "c99-block-push!");
+    WORD_ENTER(mw_c99_arg_push_21_, "c99-arg-push!", "src/mirth/codegen.mth", 445, 5);
+    WORD_ATOM(445, 5, "ARG_BLOCK");
+    WORD_ATOM(445, 18, "c99-block-push!");
     mw_c99_block_push_21_();
     WORD_EXIT(mw_c99_arg_push_21_);
 }
 static void mw_c99_arg_run_21_ (void){
-    WORD_ENTER(mw_c99_arg_run_21_, "c99-arg-run!", "src/mirth/codegen.mth", 459, 5);
-    WORD_ATOM(459, 5, "ARG_BLOCK");
-    WORD_ATOM(459, 18, "c99-block-run!");
+    WORD_ENTER(mw_c99_arg_run_21_, "c99-arg-run!", "src/mirth/codegen.mth", 448, 5);
+    WORD_ATOM(448, 5, "ARG_BLOCK");
+    WORD_ATOM(448, 18, "c99-block-run!");
     mw_c99_block_run_21_();
     WORD_EXIT(mw_c99_arg_run_21_);
 }
 static void mw_c99_block_run_21_ (void){
-    WORD_ENTER(mw_c99_block_run_21_, "c99-block-run!", "src/mirth/codegen.mth", 462, 5);
-    WORD_ATOM(462, 5, "arrow");
+    WORD_ENTER(mw_c99_block_run_21_, "c99-block-run!", "src/mirth/codegen.mth", 451, 5);
+    WORD_ATOM(451, 5, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(462, 11, "c99-arrow!");
+    WORD_ATOM(451, 11, "c99-arrow!");
     mw_c99_arrow_21_();
     WORD_EXIT(mw_c99_block_run_21_);
 }
 static void mw_Var_2B_C99_2E_var (void){
-    WORD_ENTER(mw_Var_2B_C99_2E_var, "Var+C99.var", "src/mirth/codegen.mth", 464, 36);
-    WORD_ATOM(464, 36, "");
+    WORD_ENTER(mw_Var_2B_C99_2E_var, "Var+C99.var", "src/mirth/codegen.mth", 453, 36);
+    WORD_ATOM(453, 36, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21268,32 +21312,32 @@ static void mw_Var_2B_C99_2E_var (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(464, 43, ".");
+    WORD_ATOM(453, 43, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(464, 45, "name");
+    WORD_ATOM(453, 45, "name");
     mw_Var_2E_name();
-    WORD_ATOM(464, 50, ".name");
+    WORD_ATOM(453, 50, ".name");
     mw_Name_2B_C99_2E_name();
     WORD_EXIT(mw_Var_2B_C99_2E_var);
 }
 static void mw_Param_2B_C99_2E_param (void){
-    WORD_ENTER(mw_Param_2B_C99_2E_param, "Param+C99.param", "src/mirth/codegen.mth", 465, 42);
-    WORD_ATOM(465, 42, ">Var");
+    WORD_ENTER(mw_Param_2B_C99_2E_param, "Param+C99.param", "src/mirth/codegen.mth", 454, 42);
+    WORD_ATOM(454, 42, ">Var");
     mw_Param_3E_Var();
-    WORD_ATOM(465, 47, ".var");
+    WORD_ATOM(454, 47, ".var");
     mw_Var_2B_C99_2E_var();
     WORD_EXIT(mw_Param_2B_C99_2E_param);
 }
 static void mw_c99_pack_ctx_21_ (void){
-    WORD_ENTER(mw_c99_pack_ctx_21_, "c99-pack-ctx!", "src/mirth/codegen.mth", 468, 5);
-    WORD_ATOM(468, 5, "c99-line");
+    WORD_ENTER(mw_c99_pack_ctx_21_, "c99-pack-ctx!", "src/mirth/codegen.mth", 457, 5);
+    WORD_ATOM(457, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_pack_ctx_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(469, 5, "physical-vars");
+    WORD_ATOM(458, 5, "physical-vars");
     mw_Ctx_2E_physical_vars();
-    WORD_ATOM(469, 19, "for");
+    WORD_ATOM(458, 19, "for");
     push_u64(0);
     push_fnptr(&mb_c99_pack_ctx_21__2);
     mw_prim_pack_cons();
@@ -21301,15 +21345,15 @@ static void mw_c99_pack_ctx_21_ (void){
     WORD_EXIT(mw_c99_pack_ctx_21_);
 }
 static void mw_c99_unpack_ctx_21_ (void){
-    WORD_ENTER(mw_c99_unpack_ctx_21_, "c99-unpack-ctx!", "src/mirth/codegen.mth", 475, 5);
-    WORD_ATOM(475, 5, "physical-vars");
+    WORD_ENTER(mw_c99_unpack_ctx_21_, "c99-unpack-ctx!", "src/mirth/codegen.mth", 464, 5);
+    WORD_ATOM(464, 5, "physical-vars");
     mw_Ctx_2E_physical_vars();
-    WORD_ATOM(475, 19, "reverse-for");
+    WORD_ATOM(464, 19, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_c99_unpack_ctx_21__1);
     mw_prim_pack_cons();
     mw_List_2E_reverse_for();
-    WORD_ATOM(479, 5, "c99-line");
+    WORD_ATOM(468, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_unpack_ctx_21__4);
     mw_prim_pack_cons();
@@ -21317,10 +21361,10 @@ static void mw_c99_unpack_ctx_21_ (void){
     WORD_EXIT(mw_c99_unpack_ctx_21_);
 }
 static void mw_c99_decref_ctx_21_ (void){
-    WORD_ENTER(mw_c99_decref_ctx_21_, "c99-decref-ctx!", "src/mirth/codegen.mth", 482, 5);
-    WORD_ATOM(482, 5, "physical-vars");
+    WORD_ENTER(mw_c99_decref_ctx_21_, "c99-decref-ctx!", "src/mirth/codegen.mth", 471, 5);
+    WORD_ATOM(471, 5, "physical-vars");
     mw_Ctx_2E_physical_vars();
-    WORD_ATOM(482, 19, "reverse-for");
+    WORD_ATOM(471, 19, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_c99_decref_ctx_21__1);
     mw_prim_pack_cons();
@@ -21328,34 +21372,34 @@ static void mw_c99_decref_ctx_21_ (void){
     WORD_EXIT(mw_c99_decref_ctx_21_);
 }
 static void mw_c99_block_push_21_ (void){
-    WORD_ENTER(mw_c99_block_push_21_, "c99-block-push!", "src/mirth/codegen.mth", 487, 5);
-    WORD_ATOM(487, 5, "dup");
+    WORD_ENTER(mw_c99_block_push_21_, "c99-block-push!", "src/mirth/codegen.mth", 476, 5);
+    WORD_ATOM(476, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(487, 9, "block-to-run-var");
+    WORD_ATOM(476, 9, "block-to-run-var");
     mw_block_to_run_var();
-    WORD_ATOM(487, 26, "match");
+    WORD_ATOM(476, 26, "match");
     switch (get_top_data_tag()) {
         case 1LL:
             co_SOME();
-            WORD_ATOM(488, 17, "nip");
+            WORD_ATOM(477, 17, "nip");
             mw_nip();
-            WORD_ATOM(488, 21, "c99-var-push!");
+            WORD_ATOM(477, 21, "c99-var-push!");
             mw_c99_var_push_21_();
             break;
         case 0LL:
             co_NONE();
-            WORD_ATOM(490, 13, "dup");
+            WORD_ATOM(479, 13, "dup");
             mw_prim_dup();
-            WORD_ATOM(490, 17, "ctx");
+            WORD_ATOM(479, 17, "ctx");
             mw_Block_2E_ctx();
-            WORD_ATOM(490, 21, "c99-pack-ctx!");
+            WORD_ATOM(479, 21, "c99-pack-ctx!");
             mw_c99_pack_ctx_21_();
-            WORD_ATOM(491, 13, "c99-line");
+            WORD_ATOM(480, 13, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_block_push_21__3);
             mw_prim_pack_cons();
             mw_c99_line();
-            WORD_ATOM(492, 13, "c99-line");
+            WORD_ATOM(481, 13, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_block_push_21__4);
             mw_prim_pack_cons();
@@ -21366,66 +21410,66 @@ static void mw_c99_block_push_21_ (void){
 }    WORD_EXIT(mw_c99_block_push_21_);
 }
 static void mw_c99_var_21_ (void){
-    WORD_ENTER(mw_c99_var_21_, "c99-var!", "src/mirth/codegen.mth", 496, 5);
-    WORD_ATOM(496, 5, "dup");
+    WORD_ENTER(mw_c99_var_21_, "c99-var!", "src/mirth/codegen.mth", 485, 5);
+    WORD_ATOM(485, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(496, 9, "auto-run?");
+    WORD_ATOM(485, 9, "auto-run?");
     mw_Var_2E_auto_run_3F_();
-    WORD_ATOM(496, 19, "if");
+    WORD_ATOM(485, 19, "if");
     if (pop_u64()) {
-        WORD_ATOM(496, 22, "c99-var-run!");
+        WORD_ATOM(485, 22, "c99-var-run!");
         mw_c99_var_run_21_();
     } else {
-        WORD_ATOM(496, 36, "c99-var-push!");
+        WORD_ATOM(485, 36, "c99-var-push!");
         mw_c99_var_push_21_();
     }
     WORD_EXIT(mw_c99_var_21_);
 }
 static void mw_c99_var_run_21_ (void){
-    WORD_ENTER(mw_c99_var_run_21_, "c99-var-run!", "src/mirth/codegen.mth", 499, 5);
-    WORD_ATOM(499, 5, "c99-line");
+    WORD_ENTER(mw_c99_var_run_21_, "c99-var-run!", "src/mirth/codegen.mth", 488, 5);
+    WORD_ATOM(488, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_var_run_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(500, 5, "c99-line");
+    WORD_ATOM(489, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_var_run_21__2);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(501, 5, "drop");
+    WORD_ATOM(490, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_var_run_21_);
 }
 static void mw_c99_var_push_21_ (void){
-    WORD_ENTER(mw_c99_var_push_21_, "c99-var-push!", "src/mirth/codegen.mth", 504, 5);
-    WORD_ATOM(504, 5, "c99-line");
+    WORD_ENTER(mw_c99_var_push_21_, "c99-var-push!", "src/mirth/codegen.mth", 493, 5);
+    WORD_ATOM(493, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_var_push_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(505, 5, "c99-line");
+    WORD_ATOM(494, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_var_push_21__2);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(506, 5, "drop");
+    WORD_ATOM(495, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_var_push_21_);
 }
 static void mw_c99_lambda_21_ (void){
-    WORD_ENTER(mw_c99_lambda_21_, "c99-lambda!", "src/mirth/codegen.mth", 509, 5);
-    WORD_ATOM(509, 5, "c99-line");
+    WORD_ENTER(mw_c99_lambda_21_, "c99-lambda!", "src/mirth/codegen.mth", 498, 5);
+    WORD_ATOM(498, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(510, 5, "c99-nest");
+    WORD_ATOM(499, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(519, 5, "c99-line");
+    WORD_ATOM(508, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__7);
     mw_prim_pack_cons();
@@ -21433,73 +21477,73 @@ static void mw_c99_lambda_21_ (void){
     WORD_EXIT(mw_c99_lambda_21_);
 }
 static void mw_c99_match_21_ (void){
-    WORD_ENTER(mw_c99_match_21_, "c99-match!", "src/mirth/codegen.mth", 522, 5);
-    WORD_ATOM(522, 5, "dup");
+    WORD_ENTER(mw_c99_match_21_, "c99-match!", "src/mirth/codegen.mth", 511, 5);
+    WORD_ATOM(511, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(522, 9, "is-transparent?");
+    WORD_ATOM(511, 9, "is-transparent?");
     mw_Match_2E_is_transparent_3F_();
-    WORD_ATOM(522, 25, "if");
+    WORD_ATOM(511, 25, "if");
     if (pop_u64()) {
-        WORD_ATOM(523, 9, "cases");
+        WORD_ATOM(512, 9, "cases");
         mw_Match_2E_cases();
-        WORD_ATOM(523, 15, "first");
+        WORD_ATOM(512, 15, "first");
         mw_List_2E_first();
-        WORD_ATOM(523, 21, "unwrap");
+        WORD_ATOM(512, 21, "unwrap");
         mw_Maybe_2E_unwrap();
-        WORD_ATOM(523, 28, "body");
+        WORD_ATOM(512, 28, "body");
         mw_Case_2E_body();
-        WORD_ATOM(523, 33, "c99-arrow!");
+        WORD_ATOM(512, 33, "c99-arrow!");
         mw_c99_arrow_21_();
     } else {
-        WORD_ATOM(525, 9, "dup");
+        WORD_ATOM(514, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(525, 13, "scrutinee-data?");
+        WORD_ATOM(514, 13, "scrutinee-data?");
         mw_Match_2E_scrutinee_data_3F_();
-        WORD_ATOM(526, 9, "unwrap-or");
+        WORD_ATOM(515, 9, "unwrap-or");
         push_u64(0);
         push_fnptr(&mb_c99_match_21__3);
         mw_prim_pack_cons();
         mw_Maybe_2E_unwrap_or();
-        WORD_ATOM(527, 9, "is-resource?");
+        WORD_ATOM(516, 9, "is-resource?");
         mw_Data_2E_is_resource_3F_();
-        WORD_ATOM(527, 22, "if");
+        WORD_ATOM(516, 22, "if");
         if (pop_u64()) {
-            WORD_ATOM(528, 13, "c99-line");
+            WORD_ATOM(517, 13, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_match_21__5);
             mw_prim_pack_cons();
             mw_c99_line();
         } else {
-            WORD_ATOM(529, 13, "c99-line");
+            WORD_ATOM(518, 13, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_match_21__7);
             mw_prim_pack_cons();
             mw_c99_line();
         }
-        WORD_ATOM(531, 9, "c99-nest");
+        WORD_ATOM(520, 9, "c99-nest");
         push_u64(0);
         push_fnptr(&mb_c99_match_21__8);
         mw_prim_pack_cons();
         mw_c99_nest();
-        WORD_ATOM(537, 9, "c99-line");
+        WORD_ATOM(526, 9, "c99-line");
         push_u64(0);
         push_fnptr(&mb_c99_match_21__12);
         mw_prim_pack_cons();
         mw_c99_line();
-        WORD_ATOM(537, 22, ".");
+        WORD_ATOM(526, 22, ".");
         mw_Str_2B_C99_2E_();
     }
     WORD_EXIT(mw_c99_match_21_);
 }
 static void mw_c99_case_21_ (void){
-    WORD_ENTER(mw_c99_case_21_, "c99-case!", "src/mirth/codegen.mth", 541, 5);
-    WORD_ATOM(541, 5, "dup");
+    WORD_ENTER(mw_c99_case_21_, "c99-case!", "src/mirth/codegen.mth", 530, 5);
+    WORD_ATOM(530, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(541, 9, "pattern");
+    WORD_ATOM(530, 9, "pattern");
     mw_Case_2E_pattern();
-    WORD_ATOM(541, 17, "c99-pattern!");
+    WORD_ATOM(530, 17, "c99-pattern!");
     mw_c99_pattern_21_();
-    WORD_ATOM(542, 5, "c99-nest");
+    WORD_ATOM(531, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_case_21__1);
     mw_prim_pack_cons();
@@ -21507,12 +21551,12 @@ static void mw_c99_case_21_ (void){
     WORD_EXIT(mw_c99_case_21_);
 }
 static void mw_c99_pattern_21_ (void){
-    WORD_ENTER(mw_c99_pattern_21_, "c99-pattern!", "src/mirth/codegen.mth", 548, 5);
-    WORD_ATOM(548, 5, "PATTERN_UNDERSCORE");
+    WORD_ENTER(mw_c99_pattern_21_, "c99-pattern!", "src/mirth/codegen.mth", 537, 5);
+    WORD_ATOM(537, 5, "PATTERN_UNDERSCORE");
     switch (get_top_data_tag()) {
         case 0LL:
             co_PATTERN_5F_UNDERSCORE();
-            WORD_ATOM(549, 9, "c99-line");
+            WORD_ATOM(538, 9, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_pattern_21__2);
             mw_prim_pack_cons();
@@ -21520,12 +21564,12 @@ static void mw_c99_pattern_21_ (void){
             break;
         case 1LL:
             co_PATTERN_5F_TAG();
-            WORD_ATOM(552, 9, "c99-line");
+            WORD_ATOM(541, 9, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_pattern_21__4);
             mw_prim_pack_cons();
             mw_c99_line();
-            WORD_ATOM(553, 9, "c99-nest");
+            WORD_ATOM(542, 9, "c99-nest");
             push_u64(0);
             push_fnptr(&mb_c99_pattern_21__5);
             mw_prim_pack_cons();
@@ -21536,19 +21580,19 @@ static void mw_c99_pattern_21_ (void){
 }    WORD_EXIT(mw_c99_pattern_21_);
 }
 static void mw_c99_word_sigs_21_ (void){
-    WORD_ENTER(mw_c99_word_sigs_21_, "c99-word-sigs!", "src/mirth/codegen.mth", 558, 35);
-    WORD_ATOM(558, 35, "for-needed-words");
+    WORD_ENTER(mw_c99_word_sigs_21_, "c99-word-sigs!", "src/mirth/codegen.mth", 547, 35);
+    WORD_ATOM(547, 35, "for-needed-words");
     push_u64(0);
     push_fnptr(&mb_c99_word_sigs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_words();
-    WORD_ATOM(558, 67, ".lf");
+    WORD_ATOM(547, 67, ".lf");
     mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_word_sigs_21_);
 }
 static void mw_c99_word_sig_21_ (void){
-    WORD_ENTER(mw_c99_word_sig_21_, "c99-word-sig!", "src/mirth/codegen.mth", 560, 5);
-    WORD_ATOM(560, 5, "c99-line");
+    WORD_ENTER(mw_c99_word_sig_21_, "c99-word-sig!", "src/mirth/codegen.mth", 549, 5);
+    WORD_ATOM(549, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_sig_21__1);
     mw_prim_pack_cons();
@@ -21556,19 +21600,19 @@ static void mw_c99_word_sig_21_ (void){
     WORD_EXIT(mw_c99_word_sig_21_);
 }
 static void mw_c99_block_sigs_21_ (void){
-    WORD_ENTER(mw_c99_block_sigs_21_, "c99-block-sigs!", "src/mirth/codegen.mth", 562, 36);
-    WORD_ATOM(562, 36, "for-needed-blocks");
+    WORD_ENTER(mw_c99_block_sigs_21_, "c99-block-sigs!", "src/mirth/codegen.mth", 551, 36);
+    WORD_ATOM(551, 36, "for-needed-blocks");
     push_u64(0);
     push_fnptr(&mb_c99_block_sigs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_blocks();
-    WORD_ATOM(562, 70, ".lf");
+    WORD_ATOM(551, 70, ".lf");
     mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_block_sigs_21_);
 }
 static void mw_c99_block_sig_21_ (void){
-    WORD_ENTER(mw_c99_block_sig_21_, "c99-block-sig!", "src/mirth/codegen.mth", 564, 5);
-    WORD_ATOM(564, 5, "c99-line");
+    WORD_ENTER(mw_c99_block_sig_21_, "c99-block-sig!", "src/mirth/codegen.mth", 553, 5);
+    WORD_ATOM(553, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_sig_21__1);
     mw_prim_pack_cons();
@@ -21576,19 +21620,19 @@ static void mw_c99_block_sig_21_ (void){
     WORD_EXIT(mw_c99_block_sig_21_);
 }
 static void mw_c99_field_sigs_21_ (void){
-    WORD_ENTER(mw_c99_field_sigs_21_, "c99-field-sigs!", "src/mirth/codegen.mth", 566, 36);
-    WORD_ATOM(566, 36, "Field.for");
+    WORD_ENTER(mw_c99_field_sigs_21_, "c99-field-sigs!", "src/mirth/codegen.mth", 555, 36);
+    WORD_ATOM(555, 36, "Field.for");
     push_u64(0);
     push_fnptr(&mb_c99_field_sigs_21__1);
     mw_prim_pack_cons();
     mw_Field_2E_for();
-    WORD_ATOM(566, 62, ".lf");
+    WORD_ATOM(555, 62, ".lf");
     mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_field_sigs_21_);
 }
 static void mw_c99_field_sig_21_ (void){
-    WORD_ENTER(mw_c99_field_sig_21_, "c99-field-sig!", "src/mirth/codegen.mth", 568, 5);
-    WORD_ATOM(568, 5, "c99-line");
+    WORD_ENTER(mw_c99_field_sig_21_, "c99-field-sig!", "src/mirth/codegen.mth", 557, 5);
+    WORD_ATOM(557, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_field_sig_21__1);
     mw_prim_pack_cons();
@@ -21596,19 +21640,19 @@ static void mw_c99_field_sig_21_ (void){
     WORD_EXIT(mw_c99_field_sig_21_);
 }
 static void mw_c99_block_enter_21_ (void){
-    WORD_ENTER(mw_c99_block_enter_21_, "c99-block-enter!", "src/mirth/codegen.mth", 571, 5);
-    WORD_ATOM(571, 5, "c99-line");
+    WORD_ENTER(mw_c99_block_enter_21_, "c99-block-enter!", "src/mirth/codegen.mth", 560, 5);
+    WORD_ATOM(560, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_enter_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(580, 5, "drop");
+    WORD_ATOM(569, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_block_enter_21_);
 }
 static void mw_c99_block_exit_21_ (void){
-    WORD_ENTER(mw_c99_block_exit_21_, "c99-block-exit!", "src/mirth/codegen.mth", 583, 5);
-    WORD_ATOM(583, 5, "c99-line");
+    WORD_ENTER(mw_c99_block_exit_21_, "c99-block-exit!", "src/mirth/codegen.mth", 572, 5);
+    WORD_ATOM(572, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_exit_21__1);
     mw_prim_pack_cons();
@@ -21616,40 +21660,40 @@ static void mw_c99_block_exit_21_ (void){
     WORD_EXIT(mw_c99_block_exit_21_);
 }
 static void mw_c99_block_defs_21_ (void){
-    WORD_ENTER(mw_c99_block_defs_21_, "c99-block-defs!", "src/mirth/codegen.mth", 585, 36);
-    WORD_ATOM(585, 36, "for-needed-blocks");
+    WORD_ENTER(mw_c99_block_defs_21_, "c99-block-defs!", "src/mirth/codegen.mth", 574, 36);
+    WORD_ATOM(574, 36, "for-needed-blocks");
     push_u64(0);
     push_fnptr(&mb_c99_block_defs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_blocks();
-    WORD_ATOM(585, 70, ".lf");
+    WORD_ATOM(574, 70, ".lf");
     mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_block_defs_21_);
 }
 static void mw_c99_block_def_21_ (void){
-    WORD_ENTER(mw_c99_block_def_21_, "c99-block-def!", "src/mirth/codegen.mth", 587, 5);
-    WORD_ATOM(587, 5, "c99-line");
+    WORD_ENTER(mw_c99_block_def_21_, "c99-block-def!", "src/mirth/codegen.mth", 576, 5);
+    WORD_ATOM(576, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_def_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(588, 5, "c99-nest");
+    WORD_ATOM(577, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_block_def_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(596, 5, "c99-line");
+    WORD_ATOM(585, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_def_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(596, 21, ".lf");
+    WORD_ATOM(585, 21, ".lf");
     mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_block_def_21_);
 }
 static void mw_Block_2B_C99_2E_block (void){
-    WORD_ENTER(mw_Block_2B_C99_2E_block, "Block+C99.block", "src/mirth/codegen.mth", 599, 5);
-    WORD_ATOM(599, 5, "");
+    WORD_ENTER(mw_Block_2B_C99_2E_block, "Block+C99.block", "src/mirth/codegen.mth", 588, 5);
+    WORD_ATOM(588, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21660,34 +21704,34 @@ static void mw_Block_2B_C99_2E_block (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(599, 11, ".");
+    WORD_ATOM(588, 11, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(600, 5, "dup");
+    WORD_ATOM(589, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(600, 9, "arrow");
+    WORD_ATOM(589, 9, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(600, 15, "dup");
+    WORD_ATOM(589, 15, "dup");
     mw_prim_dup();
-    WORD_ATOM(600, 19, "home");
+    WORD_ATOM(589, 19, "home");
     mw_Arrow_2E_home();
-    WORD_ATOM(600, 24, "match");
+    WORD_ATOM(589, 24, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             co_NONE();
-            WORD_ATOM(601, 17, "drop");
+            WORD_ATOM(590, 17, "drop");
             mw_prim_drop();
-            WORD_ATOM(601, 22, "Block.id");
+            WORD_ATOM(590, 22, "Block.id");
             mw_Block_2E_id();
-            WORD_ATOM(601, 31, ".n");
+            WORD_ATOM(590, 31, ".n");
             mw_Int_2B_C99_2E_n();
             break;
         case 1LL:
             co_SOME();
-            WORD_ATOM(603, 13, "name");
+            WORD_ATOM(592, 13, "name");
             mw_Word_2E_name();
-            WORD_ATOM(603, 18, ".name");
+            WORD_ATOM(592, 18, ".name");
             mw_Name_2B_C99_2E_name();
-            WORD_ATOM(603, 24, "");
+            WORD_ATOM(592, 24, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -21698,13 +21742,13 @@ static void mw_Block_2B_C99_2E_block (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(603, 28, ".");
+            WORD_ATOM(592, 28, ".");
             mw_Str_2B_C99_2E_();
-            WORD_ATOM(604, 13, "homeidx");
+            WORD_ATOM(593, 13, "homeidx");
             mw_Arrow_2E_homeidx();
-            WORD_ATOM(604, 21, ".n");
+            WORD_ATOM(593, 21, ".n");
             mw_Int_2B_C99_2E_n();
-            WORD_ATOM(604, 24, "drop");
+            WORD_ATOM(593, 24, "drop");
             mw_prim_drop();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -21712,73 +21756,73 @@ static void mw_Block_2B_C99_2E_block (void){
 }    WORD_EXIT(mw_Block_2B_C99_2E_block);
 }
 static void mw_c99_word_enter_21_ (void){
-    WORD_ENTER(mw_c99_word_enter_21_, "c99-word-enter!", "src/mirth/codegen.mth", 608, 5);
-    WORD_ATOM(608, 5, "c99-line");
+    WORD_ENTER(mw_c99_word_enter_21_, "c99-word-enter!", "src/mirth/codegen.mth", 597, 5);
+    WORD_ATOM(597, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_enter_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(614, 5, "drop");
+    WORD_ATOM(603, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_word_enter_21_);
 }
 static void mw_c99_word_exit_21_ (void){
-    WORD_ENTER(mw_c99_word_exit_21_, "c99-word-exit!", "src/mirth/codegen.mth", 617, 5);
-    WORD_ATOM(617, 5, "c99-line");
+    WORD_ENTER(mw_c99_word_exit_21_, "c99-word-exit!", "src/mirth/codegen.mth", 606, 5);
+    WORD_ATOM(606, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_exit_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(619, 5, "drop");
+    WORD_ATOM(608, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_word_exit_21_);
 }
 static void mw_c99_word_defs_21_ (void){
-    WORD_ENTER(mw_c99_word_defs_21_, "c99-word-defs!", "src/mirth/codegen.mth", 621, 35);
-    WORD_ATOM(621, 35, "for-needed-words");
+    WORD_ENTER(mw_c99_word_defs_21_, "c99-word-defs!", "src/mirth/codegen.mth", 610, 35);
+    WORD_ATOM(610, 35, "for-needed-words");
     push_u64(0);
     push_fnptr(&mb_c99_word_defs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_words();
-    WORD_ATOM(621, 67, ".lf");
+    WORD_ATOM(610, 67, ".lf");
     mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_word_defs_21_);
 }
 static void mw_c99_word_def_21_ (void){
-    WORD_ENTER(mw_c99_word_def_21_, "c99-word-def!", "src/mirth/codegen.mth", 623, 5);
-    WORD_ATOM(623, 5, "c99-line");
+    WORD_ENTER(mw_c99_word_def_21_, "c99-word-def!", "src/mirth/codegen.mth", 612, 5);
+    WORD_ATOM(612, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_def_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(624, 5, "c99-nest");
+    WORD_ATOM(613, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_word_def_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(629, 5, "c99-line");
+    WORD_ATOM(618, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_def_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(630, 5, "drop");
+    WORD_ATOM(619, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_word_def_21_);
 }
 static void mw_c99_field_defs_21_ (void){
-    WORD_ENTER(mw_c99_field_defs_21_, "c99-field-defs!", "src/mirth/codegen.mth", 632, 36);
-    WORD_ATOM(632, 36, "Field.for");
+    WORD_ENTER(mw_c99_field_defs_21_, "c99-field-defs!", "src/mirth/codegen.mth", 621, 36);
+    WORD_ATOM(621, 36, "Field.for");
     push_u64(0);
     push_fnptr(&mb_c99_field_defs_21__1);
     mw_prim_pack_cons();
     mw_Field_2E_for();
-    WORD_ATOM(632, 62, ".lf");
+    WORD_ATOM(621, 62, ".lf");
     mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_field_defs_21_);
 }
 static void mw_c99_field_def_21_ (void){
-    WORD_ENTER(mw_c99_field_def_21_, "c99-field-def!", "src/mirth/codegen.mth", 634, 5);
-    WORD_ATOM(634, 5, "");
+    WORD_ENTER(mw_c99_field_def_21_, "c99-field-def!", "src/mirth/codegen.mth", 623, 5);
+    WORD_ATOM(623, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21789,15 +21833,15 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(634, 29, ".");
+    WORD_ATOM(623, 29, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(634, 31, "dup");
+    WORD_ATOM(623, 31, "dup");
     mw_prim_dup();
-    WORD_ATOM(634, 35, "name");
+    WORD_ATOM(623, 35, "name");
     mw_Field_2E_name();
-    WORD_ATOM(634, 40, ".name");
+    WORD_ATOM(623, 40, ".name");
     mw_Name_2B_C99_2E_name();
-    WORD_ATOM(634, 46, "");
+    WORD_ATOM(623, 46, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21808,9 +21852,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(634, 62, ";");
+    WORD_ATOM(623, 62, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(635, 5, "");
+    WORD_ATOM(624, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21821,9 +21865,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(635, 37, ";");
+    WORD_ATOM(624, 37, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(636, 5, "");
+    WORD_ATOM(625, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21834,13 +21878,13 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(636, 23, ".");
+    WORD_ATOM(625, 23, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(636, 25, "TABLE_MAX_SIZE");
+    WORD_ATOM(625, 25, "TABLE_MAX_SIZE");
     mw_TABLE_5F_MAX_5F_SIZE();
-    WORD_ATOM(636, 40, ".n");
+    WORD_ATOM(625, 40, ".n");
     mw_Int_2B_C99_2E_n();
-    WORD_ATOM(636, 43, "");
+    WORD_ATOM(625, 43, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21851,9 +21895,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(636, 47, ";");
+    WORD_ATOM(625, 47, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(637, 5, "");
+    WORD_ATOM(626, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21864,9 +21908,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(637, 50, ";");
+    WORD_ATOM(626, 50, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(638, 5, "");
+    WORD_ATOM(627, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21877,9 +21921,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(638, 70, ";");
+    WORD_ATOM(627, 70, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(639, 5, "");
+    WORD_ATOM(628, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21890,9 +21934,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(639, 23, ";");
+    WORD_ATOM(628, 23, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(640, 5, "");
+    WORD_ATOM(629, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21903,15 +21947,15 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(640, 9, ";;");
+    WORD_ATOM(629, 9, ";;");
     mw_Str_2B_C99_3B__3B_();
-    WORD_ATOM(643, 5, "dup");
+    WORD_ATOM(632, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(643, 9, "name");
+    WORD_ATOM(632, 9, "name");
     mw_Field_2E_name();
-    WORD_ATOM(643, 14, ".w");
+    WORD_ATOM(632, 14, ".w");
     mw_Name_2B_C99_2E_w();
-    WORD_ATOM(643, 17, "");
+    WORD_ATOM(632, 17, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21922,9 +21966,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(643, 21, ";");
+    WORD_ATOM(632, 21, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(644, 5, "");
+    WORD_ATOM(633, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21935,9 +21979,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(644, 45, ";");
+    WORD_ATOM(633, 45, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(645, 5, "");
+    WORD_ATOM(634, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21948,15 +21992,15 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(645, 30, ".");
+    WORD_ATOM(634, 30, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(645, 32, "dup");
+    WORD_ATOM(634, 32, "dup");
     mw_prim_dup();
-    WORD_ATOM(645, 36, "name");
+    WORD_ATOM(634, 36, "name");
     mw_Field_2E_name();
-    WORD_ATOM(645, 41, ".name");
+    WORD_ATOM(634, 41, ".name");
     mw_Name_2B_C99_2E_name();
-    WORD_ATOM(645, 47, "");
+    WORD_ATOM(634, 47, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21967,9 +22011,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(645, 58, ";");
+    WORD_ATOM(634, 58, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(646, 5, "");
+    WORD_ATOM(635, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21980,9 +22024,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(646, 24, ";");
+    WORD_ATOM(635, 24, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(647, 5, "");
+    WORD_ATOM(636, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21993,25 +22037,25 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(647, 9, ";;");
+    WORD_ATOM(636, 9, ";;");
     mw_Str_2B_C99_3B__3B_();
-    WORD_ATOM(649, 5, "drop");
+    WORD_ATOM(638, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_field_def_21_);
 }
 static void mw_c99_main_21_ (void){
-    WORD_ENTER(mw_c99_main_21_, "c99-main!", "src/mirth/codegen.mth", 652, 5);
-    WORD_ATOM(652, 5, "c99-line");
+    WORD_ENTER(mw_c99_main_21_, "c99-main!", "src/mirth/codegen.mth", 641, 5);
+    WORD_ATOM(641, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(653, 5, "c99-nest");
+    WORD_ATOM(642, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(666, 5, "c99-line");
+    WORD_ATOM(655, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__8);
     mw_prim_pack_cons();
@@ -43334,46 +43378,6 @@ static void mb_table_new_21__16 (void) {
     WORD_EXIT(mb_table_new_21__16);
 }
 
-static void mb_run_output_c99_21__3 (void) {
-    WORD_ENTER(mb_run_output_c99_21__3, "run-output-c99! block", "src/mirth/codegen.mth", 172, 13);
-    mw_prim_drop();
-    WORD_ATOM(172, 13, "to-output-path");
-    mw_Path_2E_to_output_path();
-    WORD_ATOM(172, 28, ">Str");
-    mw_Path_3E_Str();
-    WORD_ATOM(173, 13, "create-file!");
-    mw_create_file_21_();
-    WORD_ATOM(173, 26, "codegen-start!");
-    mw_codegen_start_21_();
-    WORD_ATOM(174, 13, "c99-header!");
-    mw_c99_header_21_();
-    WORD_ATOM(175, 13, "c99-tags!");
-    mw_c99_tags_21_();
-    WORD_ATOM(176, 13, "c99-buffers!");
-    mw_c99_buffers_21_();
-    WORD_ATOM(177, 13, "c99-variables!");
-    mw_c99_variables_21_();
-    WORD_ATOM(178, 13, "c99-externals!");
-    mw_c99_externals_21_();
-    WORD_ATOM(179, 13, "c99-word-sigs!");
-    mw_c99_word_sigs_21_();
-    WORD_ATOM(180, 13, "c99-block-sigs!");
-    mw_c99_block_sigs_21_();
-    WORD_ATOM(181, 13, "c99-field-sigs!");
-    mw_c99_field_sigs_21_();
-    WORD_ATOM(182, 13, "c99-main!");
-    mw_c99_main_21_();
-    WORD_ATOM(183, 13, "c99-field-defs!");
-    mw_c99_field_defs_21_();
-    WORD_ATOM(184, 13, "c99-word-defs!");
-    mw_c99_word_defs_21_();
-    WORD_ATOM(185, 13, "c99-block-defs!");
-    mw_c99_block_defs_21_();
-    WORD_ATOM(186, 13, "codegen-end!");
-    mw_codegen_end_21_();
-    WORD_EXIT(mb_run_output_c99_21__3);
-}
-
 static void mb_field_new_21__1 (void) {
     WORD_ENTER(mb_field_new_21__1, "field-new! block", "src/mirth/elab.mth", 1224, 16);
     mw_prim_drop();
@@ -43717,108 +43721,74 @@ static void mb_need_match_1 (void) {
     WORD_EXIT(mb_need_match_1);
 }
 
-static void mb_Str_2B_C99_2E__1 (void) {
-    WORD_ENTER(mb_Str_2B_C99_2E__1, "Str+C99. block", "src/mirth/codegen.mth", 139, 27);
+static void mb_Str_2B_C99_2E__3 (void) {
+    WORD_ENTER(mb_Str_2B_C99_2E__3, "Str+C99. block", "src/mirth/codegen.mth", 140, 16);
     mw_prim_drop();
-    WORD_ATOM(139, 27, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr("", 0);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_EXIT(mb_Str_2B_C99_2E__1);
-}
-
-static void mb_Str_2B_C99_2E__2 (void) {
-    WORD_ENTER(mb_Str_2B_C99_2E__2, "Str+C99. block", "src/mirth/codegen.mth", 142, 43);
-    mw_prim_drop();
-    WORD_ATOM(142, 43, "codegen-flush!");
+    WORD_ATOM(140, 16, "codegen-flush!");
     mw_codegen_flush_21_();
-    WORD_EXIT(mb_Str_2B_C99_2E__2);
-}
-
-static void mb_codegen_flush_21__1 (void) {
-    WORD_ENTER(mb_codegen_flush_21__1, "codegen-flush! block", "src/mirth/codegen.mth", 155, 27);
-    mw_prim_drop();
-    WORD_ATOM(155, 27, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr("", 0);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_EXIT(mb_codegen_flush_21__1);
+    WORD_EXIT(mb_Str_2B_C99_2E__3);
 }
 
 static void mb_c99_tags_21__1 (void) {
-    WORD_ENTER(mb_c99_tags_21__1, "c99-tags! block", "src/mirth/codegen.mth", 216, 38);
+    WORD_ENTER(mb_c99_tags_21__1, "c99-tags! block", "src/mirth/codegen.mth", 205, 38);
     mw_prim_drop();
-    WORD_ATOM(216, 38, "c99-tag!");
+    WORD_ATOM(205, 38, "c99-tag!");
     mw_c99_tag_21_();
     WORD_EXIT(mb_c99_tags_21__1);
 }
 
 static void mb_c99_buffers_21__1 (void) {
-    WORD_ENTER(mb_c99_buffers_21__1, "c99-buffers! block", "src/mirth/codegen.mth", 201, 44);
+    WORD_ENTER(mb_c99_buffers_21__1, "c99-buffers! block", "src/mirth/codegen.mth", 190, 44);
     mw_prim_drop();
-    WORD_ATOM(201, 44, "c99-buffer!");
+    WORD_ATOM(190, 44, "c99-buffer!");
     mw_c99_buffer_21_();
     WORD_EXIT(mb_c99_buffers_21__1);
 }
 
 static void mb_c99_variables_21__1 (void) {
-    WORD_ENTER(mb_c99_variables_21__1, "c99-variables! block", "src/mirth/codegen.mth", 209, 48);
+    WORD_ENTER(mb_c99_variables_21__1, "c99-variables! block", "src/mirth/codegen.mth", 198, 48);
     mw_prim_drop();
-    WORD_ATOM(209, 48, "c99-variable!");
+    WORD_ATOM(198, 48, "c99-variable!");
     mw_c99_variable_21_();
     WORD_EXIT(mb_c99_variables_21__1);
 }
 
 static void mb_c99_externals_21__1 (void) {
-    WORD_ENTER(mb_c99_externals_21__1, "c99-externals! block", "src/mirth/codegen.mth", 265, 18);
+    WORD_ENTER(mb_c99_externals_21__1, "c99-externals! block", "src/mirth/codegen.mth", 254, 18);
     mw_prim_drop();
-    WORD_ATOM(265, 18, "c99-external!");
+    WORD_ATOM(254, 18, "c99-external!");
     mw_c99_external_21_();
     WORD_EXIT(mb_c99_externals_21__1);
 }
 
 static void mb_c99_word_sigs_21__1 (void) {
-    WORD_ENTER(mb_c99_word_sigs_21__1, "c99-word-sigs! block", "src/mirth/codegen.mth", 558, 52);
+    WORD_ENTER(mb_c99_word_sigs_21__1, "c99-word-sigs! block", "src/mirth/codegen.mth", 547, 52);
     mw_prim_drop();
-    WORD_ATOM(558, 52, "c99-word-sig!");
+    WORD_ATOM(547, 52, "c99-word-sig!");
     mw_c99_word_sig_21_();
     WORD_EXIT(mb_c99_word_sigs_21__1);
 }
 
 static void mb_c99_block_sigs_21__1 (void) {
-    WORD_ENTER(mb_c99_block_sigs_21__1, "c99-block-sigs! block", "src/mirth/codegen.mth", 562, 54);
+    WORD_ENTER(mb_c99_block_sigs_21__1, "c99-block-sigs! block", "src/mirth/codegen.mth", 551, 54);
     mw_prim_drop();
-    WORD_ATOM(562, 54, "c99-block-sig!");
+    WORD_ATOM(551, 54, "c99-block-sig!");
     mw_c99_block_sig_21_();
     WORD_EXIT(mb_c99_block_sigs_21__1);
 }
 
 static void mb_c99_field_sigs_21__1 (void) {
-    WORD_ENTER(mb_c99_field_sigs_21__1, "c99-field-sigs! block", "src/mirth/codegen.mth", 566, 46);
+    WORD_ENTER(mb_c99_field_sigs_21__1, "c99-field-sigs! block", "src/mirth/codegen.mth", 555, 46);
     mw_prim_drop();
-    WORD_ATOM(566, 46, "c99-field-sig!");
+    WORD_ATOM(555, 46, "c99-field-sig!");
     mw_c99_field_sig_21_();
     WORD_EXIT(mb_c99_field_sigs_21__1);
 }
 
 static void mb_c99_main_21__1 (void) {
-    WORD_ENTER(mb_c99_main_21__1, "c99-main! block", "src/mirth/codegen.mth", 652, 14);
+    WORD_ENTER(mb_c99_main_21__1, "c99-main! block", "src/mirth/codegen.mth", 641, 14);
     mw_prim_drop();
-    WORD_ATOM(652, 14, "");
+    WORD_ATOM(641, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43829,37 +43799,37 @@ static void mb_c99_main_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(652, 51, ".");
+    WORD_ATOM(641, 51, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_main_21__1);
 }
 
 static void mb_c99_main_21__2 (void) {
-    WORD_ENTER(mb_c99_main_21__2, "c99-main! block", "src/mirth/codegen.mth", 654, 9);
+    WORD_ENTER(mb_c99_main_21__2, "c99-main! block", "src/mirth/codegen.mth", 643, 9);
     mw_prim_drop();
-    WORD_ATOM(654, 9, "c99-line");
+    WORD_ATOM(643, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(655, 9, "c99-line");
+    WORD_ATOM(644, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__4);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(656, 9, "c99-line");
+    WORD_ATOM(645, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__5);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(662, 9, "c99-arrow!");
+    WORD_ATOM(651, 9, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(663, 9, "c99-line");
+    WORD_ATOM(652, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__6);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(664, 9, "c99-line");
+    WORD_ATOM(653, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__7);
     mw_prim_pack_cons();
@@ -43868,9 +43838,9 @@ static void mb_c99_main_21__2 (void) {
 }
 
 static void mb_c99_main_21__3 (void) {
-    WORD_ENTER(mb_c99_main_21__3, "c99-main! block", "src/mirth/codegen.mth", 654, 18);
+    WORD_ENTER(mb_c99_main_21__3, "c99-main! block", "src/mirth/codegen.mth", 643, 18);
     mw_prim_drop();
-    WORD_ATOM(654, 18, "");
+    WORD_ATOM(643, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43881,15 +43851,15 @@ static void mb_c99_main_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(654, 40, ".");
+    WORD_ATOM(643, 40, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_main_21__3);
 }
 
 static void mb_c99_main_21__4 (void) {
-    WORD_ENTER(mb_c99_main_21__4, "c99-main! block", "src/mirth/codegen.mth", 655, 18);
+    WORD_ENTER(mb_c99_main_21__4, "c99-main! block", "src/mirth/codegen.mth", 644, 18);
     mw_prim_drop();
-    WORD_ATOM(655, 18, "");
+    WORD_ATOM(644, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43900,15 +43870,15 @@ static void mb_c99_main_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(655, 40, ".");
+    WORD_ATOM(644, 40, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_main_21__4);
 }
 
 static void mb_c99_main_21__5 (void) {
-    WORD_ENTER(mb_c99_main_21__5, "c99-main! block", "src/mirth/codegen.mth", 656, 18);
+    WORD_ENTER(mb_c99_main_21__5, "c99-main! block", "src/mirth/codegen.mth", 645, 18);
     mw_prim_drop();
-    WORD_ATOM(656, 18, "");
+    WORD_ATOM(645, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43919,9 +43889,9 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(656, 32, ".");
+    WORD_ATOM(645, 32, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(657, 13, "");
+    WORD_ATOM(646, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43932,9 +43902,9 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(657, 34, ".");
+    WORD_ATOM(646, 34, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(658, 13, "");
+    WORD_ATOM(647, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43945,21 +43915,21 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(658, 28, ".");
+    WORD_ATOM(647, 28, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(659, 13, "dup");
+    WORD_ATOM(648, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(659, 17, "token-start");
+    WORD_ATOM(648, 17, "token-start");
     mw_Arrow_2E_token_start();
-    WORD_ATOM(659, 29, ".module");
+    WORD_ATOM(648, 29, ".module");
     mw_Token_2E_module();
-    WORD_ATOM(659, 37, "source-path");
+    WORD_ATOM(648, 37, "source-path");
     mw_Module_2E_source_path();
-    WORD_ATOM(659, 49, ">Str");
+    WORD_ATOM(648, 49, ">Str");
     mw_Path_3E_Str();
-    WORD_ATOM(659, 54, ".str");
+    WORD_ATOM(648, 54, ".str");
     mw__2E_str();
-    WORD_ATOM(659, 59, "");
+    WORD_ATOM(648, 59, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43970,19 +43940,19 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(659, 64, ".");
+    WORD_ATOM(648, 64, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(660, 13, "dup");
+    WORD_ATOM(649, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(660, 17, "token-start");
+    WORD_ATOM(649, 17, "token-start");
     mw_Arrow_2E_token_start();
-    WORD_ATOM(660, 29, "row");
+    WORD_ATOM(649, 29, "row");
     mw_Token_2E_row();
-    WORD_ATOM(660, 33, ">Int");
+    WORD_ATOM(649, 33, ">Int");
     mw_Row_3E_Int();
-    WORD_ATOM(660, 38, ".n");
+    WORD_ATOM(649, 38, ".n");
     mw_Int_2B_C99_2E_n();
-    WORD_ATOM(660, 41, "");
+    WORD_ATOM(649, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43993,19 +43963,19 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(660, 46, ".");
+    WORD_ATOM(649, 46, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(661, 13, "dup");
+    WORD_ATOM(650, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(661, 17, "token-start");
+    WORD_ATOM(650, 17, "token-start");
     mw_Arrow_2E_token_start();
-    WORD_ATOM(661, 29, "col");
+    WORD_ATOM(650, 29, "col");
     mw_Token_2E_col();
-    WORD_ATOM(661, 33, ">Int");
+    WORD_ATOM(650, 33, ">Int");
     mw_Col_3E_Int();
-    WORD_ATOM(661, 38, ".n");
+    WORD_ATOM(650, 38, ".n");
     mw_Int_2B_C99_2E_n();
-    WORD_ATOM(661, 41, "");
+    WORD_ATOM(650, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44016,15 +43986,15 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(661, 46, ".");
+    WORD_ATOM(650, 46, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_main_21__5);
 }
 
 static void mb_c99_main_21__6 (void) {
-    WORD_ENTER(mb_c99_main_21__6, "c99-main! block", "src/mirth/codegen.mth", 663, 18);
+    WORD_ENTER(mb_c99_main_21__6, "c99-main! block", "src/mirth/codegen.mth", 652, 18);
     mw_prim_drop();
-    WORD_ATOM(663, 18, "");
+    WORD_ATOM(652, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44035,15 +44005,15 @@ static void mb_c99_main_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(663, 49, ".");
+    WORD_ATOM(652, 49, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_main_21__6);
 }
 
 static void mb_c99_main_21__7 (void) {
-    WORD_ENTER(mb_c99_main_21__7, "c99-main! block", "src/mirth/codegen.mth", 664, 18);
+    WORD_ENTER(mb_c99_main_21__7, "c99-main! block", "src/mirth/codegen.mth", 653, 18);
     mw_prim_drop();
-    WORD_ATOM(664, 18, "");
+    WORD_ATOM(653, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44054,15 +44024,15 @@ static void mb_c99_main_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(664, 30, ".");
+    WORD_ATOM(653, 30, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_main_21__7);
 }
 
 static void mb_c99_main_21__8 (void) {
-    WORD_ENTER(mb_c99_main_21__8, "c99-main! block", "src/mirth/codegen.mth", 666, 14);
+    WORD_ENTER(mb_c99_main_21__8, "c99-main! block", "src/mirth/codegen.mth", 655, 14);
     mw_prim_drop();
-    WORD_ATOM(666, 14, "");
+    WORD_ATOM(655, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44073,39 +44043,39 @@ static void mb_c99_main_21__8 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(666, 18, ".");
+    WORD_ATOM(655, 18, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_main_21__8);
 }
 
 static void mb_c99_field_defs_21__1 (void) {
-    WORD_ENTER(mb_c99_field_defs_21__1, "c99-field-defs! block", "src/mirth/codegen.mth", 632, 46);
+    WORD_ENTER(mb_c99_field_defs_21__1, "c99-field-defs! block", "src/mirth/codegen.mth", 621, 46);
     mw_prim_drop();
-    WORD_ATOM(632, 46, "c99-field-def!");
+    WORD_ATOM(621, 46, "c99-field-def!");
     mw_c99_field_def_21_();
     WORD_EXIT(mb_c99_field_defs_21__1);
 }
 
 static void mb_c99_word_defs_21__1 (void) {
-    WORD_ENTER(mb_c99_word_defs_21__1, "c99-word-defs! block", "src/mirth/codegen.mth", 621, 52);
+    WORD_ENTER(mb_c99_word_defs_21__1, "c99-word-defs! block", "src/mirth/codegen.mth", 610, 52);
     mw_prim_drop();
-    WORD_ATOM(621, 52, "c99-word-def!");
+    WORD_ATOM(610, 52, "c99-word-def!");
     mw_c99_word_def_21_();
     WORD_EXIT(mb_c99_word_defs_21__1);
 }
 
 static void mb_c99_block_defs_21__1 (void) {
-    WORD_ENTER(mb_c99_block_defs_21__1, "c99-block-defs! block", "src/mirth/codegen.mth", 585, 54);
+    WORD_ENTER(mb_c99_block_defs_21__1, "c99-block-defs! block", "src/mirth/codegen.mth", 574, 54);
     mw_prim_drop();
-    WORD_ATOM(585, 54, "c99-block-def!");
+    WORD_ATOM(574, 54, "c99-block-def!");
     mw_c99_block_def_21_();
     WORD_EXIT(mb_c99_block_defs_21__1);
 }
 
 static void mb_c99_tag_21__3 (void) {
-    WORD_ENTER(mb_c99_tag_21__3, "c99-tag! block", "src/mirth/codegen.mth", 224, 13);
+    WORD_ENTER(mb_c99_tag_21__3, "c99-tag! block", "src/mirth/codegen.mth", 213, 13);
     mw_prim_drop();
-    WORD_ATOM(224, 13, "");
+    WORD_ATOM(213, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44116,9 +44086,9 @@ static void mb_c99_tag_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(224, 29, ";");
+    WORD_ATOM(213, 29, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(225, 13, "");
+    WORD_ATOM(214, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44129,15 +44099,15 @@ static void mb_c99_tag_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(225, 38, ".");
+    WORD_ATOM(214, 38, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_tag_21__3);
 }
 
 static void mb_c99_tag_21__4 (void) {
-    WORD_ENTER(mb_c99_tag_21__4, "c99-tag! block", "src/mirth/codegen.mth", 228, 13);
+    WORD_ENTER(mb_c99_tag_21__4, "c99-tag! block", "src/mirth/codegen.mth", 217, 13);
     mw_prim_drop();
-    WORD_ATOM(228, 13, "");
+    WORD_ATOM(217, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44148,9 +44118,9 @@ static void mb_c99_tag_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(228, 32, ";");
+    WORD_ATOM(217, 32, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(229, 13, "");
+    WORD_ATOM(218, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44161,15 +44131,15 @@ static void mb_c99_tag_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(229, 38, ".");
+    WORD_ATOM(218, 38, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_tag_21__4);
 }
 
 static void mb_c99_tag_21__11 (void) {
-    WORD_ENTER(mb_c99_tag_21__11, "c99-tag! block", "src/mirth/codegen.mth", 249, 13);
+    WORD_ENTER(mb_c99_tag_21__11, "c99-tag! block", "src/mirth/codegen.mth", 238, 13);
     mw_prim_drop();
-    WORD_ATOM(249, 13, "");
+    WORD_ATOM(238, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44180,11 +44150,11 @@ static void mb_c99_tag_21__11 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(249, 52, ";");
+    WORD_ATOM(238, 52, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(250, 13, ".");
+    WORD_ATOM(239, 13, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(250, 15, "");
+    WORD_ATOM(239, 15, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44195,9 +44165,9 @@ static void mb_c99_tag_21__11 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(250, 23, ";");
+    WORD_ATOM(239, 23, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(251, 13, "");
+    WORD_ATOM(240, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44212,9 +44182,9 @@ static void mb_c99_tag_21__11 (void) {
 }
 
 static void mb_c99_tag_21__12 (void) {
-    WORD_ENTER(mb_c99_tag_21__12, "c99-tag! block", "src/mirth/codegen.mth", 254, 13);
+    WORD_ENTER(mb_c99_tag_21__12, "c99-tag! block", "src/mirth/codegen.mth", 243, 13);
     mw_prim_drop();
-    WORD_ATOM(254, 13, "");
+    WORD_ATOM(243, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44225,11 +44195,11 @@ static void mb_c99_tag_21__12 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(254, 52, ";");
+    WORD_ATOM(243, 52, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(255, 13, ".");
+    WORD_ATOM(244, 13, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(255, 15, "");
+    WORD_ATOM(244, 15, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44240,9 +44210,9 @@ static void mb_c99_tag_21__12 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(255, 23, ";");
+    WORD_ATOM(244, 23, ";");
     mw_Str_2B_C99_3B_();
-    WORD_ATOM(256, 13, "");
+    WORD_ATOM(245, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44257,23 +44227,23 @@ static void mb_c99_tag_21__12 (void) {
 }
 
 static void mb_c99_external_21__5 (void) {
-    WORD_ENTER(mb_c99_external_21__5, "c99-external! block", "src/mirth/codegen.mth", 278, 10);
+    WORD_ENTER(mb_c99_external_21__5, "c99-external! block", "src/mirth/codegen.mth", 267, 10);
     mw_prim_drop();
-    WORD_ATOM(278, 10, "dup");
+    WORD_ATOM(267, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(278, 14, "name");
+    WORD_ATOM(267, 14, "name");
     mw_External_2E_name();
-    WORD_ATOM(278, 19, ">Str");
+    WORD_ATOM(267, 19, ">Str");
     mw_Name_3E_Str();
-    WORD_ATOM(278, 24, ".");
+    WORD_ATOM(267, 24, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_external_21__5);
 }
 
 static void mb_c99_external_21__7 (void) {
-    WORD_ENTER(mb_c99_external_21__7, "c99-external! block", "src/mirth/codegen.mth", 281, 42);
+    WORD_ENTER(mb_c99_external_21__7, "c99-external! block", "src/mirth/codegen.mth", 270, 42);
     mw_prim_drop();
-    WORD_ATOM(281, 42, "");
+    WORD_ATOM(270, 42, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44284,27 +44254,27 @@ static void mb_c99_external_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(281, 54, ".");
+    WORD_ATOM(270, 54, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_external_21__7);
 }
 
 static void mb_c99_external_21__9 (void) {
-    WORD_ENTER(mb_c99_external_21__9, "c99-external! block", "src/mirth/codegen.mth", 284, 30);
+    WORD_ENTER(mb_c99_external_21__9, "c99-external! block", "src/mirth/codegen.mth", 273, 30);
     mw_prim_drop();
-    WORD_ATOM(284, 30, "dup");
+    WORD_ATOM(273, 30, "dup");
     mw_prim_dup();
-    WORD_ATOM(284, 34, "name");
+    WORD_ATOM(273, 34, "name");
     mw_External_2E_name();
-    WORD_ATOM(284, 39, ".name");
+    WORD_ATOM(273, 39, ".name");
     mw_Name_2B_C99_2E_name();
     WORD_EXIT(mb_c99_external_21__9);
 }
 
 static void mb_c99_external_21__10 (void) {
-    WORD_ENTER(mb_c99_external_21__10, "c99-external! block", "src/mirth/codegen.mth", 285, 20);
+    WORD_ENTER(mb_c99_external_21__10, "c99-external! block", "src/mirth/codegen.mth", 274, 20);
     mw_prim_drop();
-    WORD_ATOM(285, 20, "");
+    WORD_ATOM(274, 20, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44315,11 +44285,11 @@ static void mb_c99_external_21__10 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(285, 36, ".");
+    WORD_ATOM(274, 36, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(285, 38, ".n");
+    WORD_ATOM(274, 38, ".n");
     mw_Int_2B_C99_2E_n();
-    WORD_ATOM(285, 41, "");
+    WORD_ATOM(274, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44330,29 +44300,29 @@ static void mb_c99_external_21__10 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(285, 57, ";");
+    WORD_ATOM(274, 57, ";");
     mw_Str_2B_C99_3B_();
     WORD_EXIT(mb_c99_external_21__10);
 }
 
 static void mb_c99_external_21__13 (void) {
-    WORD_ENTER(mb_c99_external_21__13, "c99-external! block", "src/mirth/codegen.mth", 287, 10);
+    WORD_ENTER(mb_c99_external_21__13, "c99-external! block", "src/mirth/codegen.mth", 276, 10);
     mw_prim_drop();
-    WORD_ATOM(287, 10, "dup");
+    WORD_ATOM(276, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(287, 14, "name");
+    WORD_ATOM(276, 14, "name");
     mw_External_2E_name();
-    WORD_ATOM(287, 19, ">Str");
+    WORD_ATOM(276, 19, ">Str");
     mw_Name_3E_Str();
-    WORD_ATOM(287, 24, ".");
+    WORD_ATOM(276, 24, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_external_21__13);
 }
 
 static void mb_c99_external_21__16 (void) {
-    WORD_ENTER(mb_c99_external_21__16, "c99-external! block", "src/mirth/codegen.mth", 290, 26);
+    WORD_ENTER(mb_c99_external_21__16, "c99-external! block", "src/mirth/codegen.mth", 279, 26);
     mw_prim_drop();
-    WORD_ATOM(290, 26, "");
+    WORD_ATOM(279, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44363,11 +44333,11 @@ static void mb_c99_external_21__16 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(290, 30, ".");
+    WORD_ATOM(279, 30, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(290, 32, ".n");
+    WORD_ATOM(279, 32, ".n");
     mw_Int_2B_C99_2E_n();
-    WORD_ATOM(290, 35, "");
+    WORD_ATOM(279, 35, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44378,15 +44348,15 @@ static void mb_c99_external_21__16 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(290, 40, ".");
+    WORD_ATOM(279, 40, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_external_21__16);
 }
 
 static void mb_c99_indent_1 (void) {
-    WORD_ENTER(mb_c99_indent_1, "c99-indent block", "src/mirth/codegen.mth", 303, 45);
+    WORD_ENTER(mb_c99_indent_1, "c99-indent block", "src/mirth/codegen.mth", 292, 45);
     mw_prim_drop();
-    WORD_ATOM(303, 45, "");
+    WORD_ATOM(292, 45, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44397,15 +44367,15 @@ static void mb_c99_indent_1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(303, 52, ".");
+    WORD_ATOM(292, 52, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_indent_1);
 }
 
 static void mb_c99_call_21__2 (void) {
-    WORD_ENTER(mb_c99_call_21__2, "c99-call! block", "src/mirth/codegen.mth", 308, 14);
+    WORD_ENTER(mb_c99_call_21__2, "c99-call! block", "src/mirth/codegen.mth", 297, 14);
     mw_prim_drop();
-    WORD_ATOM(308, 14, "");
+    WORD_ATOM(297, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44416,11 +44386,11 @@ static void mb_c99_call_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(308, 20, ".");
+    WORD_ATOM(297, 20, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(308, 22, ".name");
+    WORD_ATOM(297, 22, ".name");
     mw_Name_2B_C99_2E_name();
-    WORD_ATOM(308, 28, "");
+    WORD_ATOM(297, 28, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44431,31 +44401,31 @@ static void mb_c99_call_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(308, 34, ".");
+    WORD_ATOM(297, 34, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_call_21__2);
 }
 
 static void mb_c99_args_push_21__1 (void) {
-    WORD_ENTER(mb_c99_args_push_21__1, "c99-args-push! block", "src/mirth/codegen.mth", 453, 9);
+    WORD_ENTER(mb_c99_args_push_21__1, "c99-args-push! block", "src/mirth/codegen.mth", 442, 9);
     mw_prim_drop();
-    WORD_ATOM(453, 9, "c99-arg-push!");
+    WORD_ATOM(442, 9, "c99-arg-push!");
     mw_c99_arg_push_21_();
     WORD_EXIT(mb_c99_args_push_21__1);
 }
 
 static void mb_c99_arrow_21__1 (void) {
-    WORD_ENTER(mb_c99_arrow_21__1, "c99-arrow! block", "src/mirth/codegen.mth", 310, 47);
+    WORD_ENTER(mb_c99_arrow_21__1, "c99-arrow! block", "src/mirth/codegen.mth", 299, 47);
     mw_prim_drop();
-    WORD_ATOM(310, 47, "c99-atom!");
+    WORD_ATOM(299, 47, "c99-atom!");
     mw_c99_atom_21_();
     WORD_EXIT(mb_c99_arrow_21__1);
 }
 
 static void mb_c99_atom_21__1 (void) {
-    WORD_ENTER(mb_c99_atom_21__1, "c99-atom! block", "src/mirth/codegen.mth", 312, 14);
+    WORD_ENTER(mb_c99_atom_21__1, "c99-atom! block", "src/mirth/codegen.mth", 301, 14);
     mw_prim_drop();
-    WORD_ATOM(312, 14, "");
+    WORD_ATOM(301, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44466,19 +44436,19 @@ static void mb_c99_atom_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(312, 27, ".");
+    WORD_ATOM(301, 27, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(313, 9, "dup");
+    WORD_ATOM(302, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(313, 13, "token");
+    WORD_ATOM(302, 13, "token");
     mw_Atom_2E_token();
-    WORD_ATOM(313, 19, "row");
+    WORD_ATOM(302, 19, "row");
     mw_Token_2E_row();
-    WORD_ATOM(313, 23, ">Int");
+    WORD_ATOM(302, 23, ">Int");
     mw_Row_3E_Int();
-    WORD_ATOM(313, 28, ".n");
+    WORD_ATOM(302, 28, ".n");
     mw_Int_2B_C99_2E_n();
-    WORD_ATOM(313, 31, "");
+    WORD_ATOM(302, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44489,19 +44459,19 @@ static void mb_c99_atom_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(313, 36, ".");
+    WORD_ATOM(302, 36, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(314, 9, "dup");
+    WORD_ATOM(303, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(314, 13, "token");
+    WORD_ATOM(303, 13, "token");
     mw_Atom_2E_token();
-    WORD_ATOM(314, 19, "col");
+    WORD_ATOM(303, 19, "col");
     mw_Token_2E_col();
-    WORD_ATOM(314, 23, ">Int");
+    WORD_ATOM(303, 23, ">Int");
     mw_Col_3E_Int();
-    WORD_ATOM(314, 28, ".n");
+    WORD_ATOM(303, 28, ".n");
     mw_Int_2B_C99_2E_n();
-    WORD_ATOM(314, 31, "");
+    WORD_ATOM(303, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44512,15 +44482,15 @@ static void mb_c99_atom_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(314, 36, ".");
+    WORD_ATOM(303, 36, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(315, 9, "dup");
+    WORD_ATOM(304, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(315, 13, "token");
+    WORD_ATOM(304, 13, "token");
     mw_Atom_2E_token();
-    WORD_ATOM(315, 19, "name?");
+    WORD_ATOM(304, 19, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(315, 25, "if-some");
+    WORD_ATOM(304, 25, "if-some");
     push_u64(0);
     push_fnptr(&mb_c99_atom_21__2);
     mw_prim_pack_cons();
@@ -44528,9 +44498,9 @@ static void mb_c99_atom_21__1 (void) {
     push_fnptr(&mb_c99_atom_21__3);
     mw_prim_pack_cons();
     mw_Maybe_2E_if_some();
-    WORD_ATOM(315, 43, ".str");
+    WORD_ATOM(304, 43, ".str");
     mw__2E_str();
-    WORD_ATOM(316, 9, "");
+    WORD_ATOM(305, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44541,23 +44511,23 @@ static void mb_c99_atom_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(316, 14, ".");
+    WORD_ATOM(305, 14, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_atom_21__1);
 }
 
 static void mb_c99_atom_21__2 (void) {
-    WORD_ENTER(mb_c99_atom_21__2, "c99-atom! block", "src/mirth/codegen.mth", 315, 33);
+    WORD_ENTER(mb_c99_atom_21__2, "c99-atom! block", "src/mirth/codegen.mth", 304, 33);
     mw_prim_drop();
-    WORD_ATOM(315, 33, ">Str");
+    WORD_ATOM(304, 33, ">Str");
     mw_Name_3E_Str();
     WORD_EXIT(mb_c99_atom_21__2);
 }
 
 static void mb_c99_atom_21__3 (void) {
-    WORD_ENTER(mb_c99_atom_21__3, "c99-atom! block", "src/mirth/codegen.mth", 315, 39);
+    WORD_ENTER(mb_c99_atom_21__3, "c99-atom! block", "src/mirth/codegen.mth", 304, 39);
     mw_prim_drop();
-    WORD_ATOM(315, 39, "");
+    WORD_ATOM(304, 39, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44572,25 +44542,25 @@ static void mb_c99_atom_21__3 (void) {
 }
 
 static void mb_c99_atom_21__4 (void) {
-    WORD_ENTER(mb_c99_atom_21__4, "c99-atom! block", "src/mirth/codegen.mth", 317, 9);
+    WORD_ENTER(mb_c99_atom_21__4, "c99-atom! block", "src/mirth/codegen.mth", 306, 9);
     mw_prim_drop();
-    WORD_ATOM(317, 9, "args");
+    WORD_ATOM(306, 9, "args");
     mw_Atom_2E_args();
     WORD_EXIT(mb_c99_atom_21__4);
 }
 
 static void mb__2E_str_1 (void) {
-    WORD_ENTER(mb__2E_str_1, ".str block", "src/mirth/codegen.mth", 368, 50);
+    WORD_ENTER(mb__2E_str_1, ".str block", "src/mirth/codegen.mth", 357, 50);
     mw_prim_drop();
-    WORD_ATOM(368, 50, "c99-string-byte!");
+    WORD_ATOM(357, 50, "c99-string-byte!");
     mw_c99_string_byte_21_();
     WORD_EXIT(mb__2E_str_1);
 }
 
 static void mb_c99_int_21__1 (void) {
-    WORD_ENTER(mb_c99_int_21__1, "c99-int! block", "src/mirth/codegen.mth", 338, 14);
+    WORD_ENTER(mb_c99_int_21__1, "c99-int! block", "src/mirth/codegen.mth", 327, 14);
     mw_prim_drop();
-    WORD_ATOM(338, 14, "");
+    WORD_ATOM(327, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44601,11 +44571,11 @@ static void mb_c99_int_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(338, 26, ".");
+    WORD_ATOM(327, 26, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(338, 28, ".n");
+    WORD_ATOM(327, 28, ".n");
     mw_Int_2B_C99_2E_n();
-    WORD_ATOM(338, 31, "");
+    WORD_ATOM(327, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44616,15 +44586,15 @@ static void mb_c99_int_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(338, 38, ".");
+    WORD_ATOM(327, 38, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_int_21__1);
 }
 
 static void mb_c99_str_21__1 (void) {
-    WORD_ENTER(mb_c99_str_21__1, "c99-str! block", "src/mirth/codegen.mth", 341, 14);
+    WORD_ENTER(mb_c99_str_21__1, "c99-str! block", "src/mirth/codegen.mth", 330, 14);
     mw_prim_drop();
-    WORD_ATOM(341, 14, "");
+    WORD_ATOM(330, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44635,45 +44605,45 @@ static void mb_c99_str_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(341, 18, ".");
+    WORD_ATOM(330, 18, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__1);
 }
 
 static void mb_c99_str_21__2 (void) {
-    WORD_ENTER(mb_c99_str_21__2, "c99-str! block", "src/mirth/codegen.mth", 343, 9);
+    WORD_ENTER(mb_c99_str_21__2, "c99-str! block", "src/mirth/codegen.mth", 332, 9);
     mw_prim_drop();
-    WORD_ATOM(343, 9, "c99-line");
+    WORD_ATOM(332, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(344, 9, "c99-line");
+    WORD_ATOM(333, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__4);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(345, 9, "c99-line");
+    WORD_ATOM(334, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__5);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(346, 9, "c99-nest");
+    WORD_ATOM(335, 9, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__6);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(361, 9, "c99-line");
+    WORD_ATOM(350, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__17);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(362, 9, "c99-line");
+    WORD_ATOM(351, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__18);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(363, 9, "c99-line");
+    WORD_ATOM(352, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__19);
     mw_prim_pack_cons();
@@ -44682,9 +44652,9 @@ static void mb_c99_str_21__2 (void) {
 }
 
 static void mb_c99_str_21__3 (void) {
-    WORD_ENTER(mb_c99_str_21__3, "c99-str! block", "src/mirth/codegen.mth", 343, 18);
+    WORD_ENTER(mb_c99_str_21__3, "c99-str! block", "src/mirth/codegen.mth", 332, 18);
     mw_prim_drop();
-    WORD_ATOM(343, 18, "");
+    WORD_ATOM(332, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44695,15 +44665,15 @@ static void mb_c99_str_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(343, 48, ".");
+    WORD_ATOM(332, 48, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__3);
 }
 
 static void mb_c99_str_21__4 (void) {
-    WORD_ENTER(mb_c99_str_21__4, "c99-str! block", "src/mirth/codegen.mth", 344, 18);
+    WORD_ENTER(mb_c99_str_21__4, "c99-str! block", "src/mirth/codegen.mth", 333, 18);
     mw_prim_drop();
-    WORD_ATOM(344, 18, "");
+    WORD_ATOM(333, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44714,15 +44684,15 @@ static void mb_c99_str_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(344, 34, ".");
+    WORD_ATOM(333, 34, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__4);
 }
 
 static void mb_c99_str_21__5 (void) {
-    WORD_ENTER(mb_c99_str_21__5, "c99-str! block", "src/mirth/codegen.mth", 345, 18);
+    WORD_ENTER(mb_c99_str_21__5, "c99-str! block", "src/mirth/codegen.mth", 334, 18);
     mw_prim_drop();
-    WORD_ATOM(345, 18, "");
+    WORD_ATOM(334, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44733,25 +44703,25 @@ static void mb_c99_str_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(345, 36, ".");
+    WORD_ATOM(334, 36, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__5);
 }
 
 static void mb_c99_str_21__6 (void) {
-    WORD_ENTER(mb_c99_str_21__6, "c99-str! block", "src/mirth/codegen.mth", 347, 13);
+    WORD_ENTER(mb_c99_str_21__6, "c99-str! block", "src/mirth/codegen.mth", 336, 13);
     mw_prim_drop();
-    WORD_ATOM(347, 13, "dup");
+    WORD_ATOM(336, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(347, 17, "num-bytes");
+    WORD_ATOM(336, 17, "num-bytes");
     mw_prim_str_num_bytes();
-    WORD_ATOM(347, 27, "");
+    WORD_ATOM(336, 27, "");
     push_i64(4090LL);
-    WORD_ATOM(347, 32, ">");
+    WORD_ATOM(336, 32, ">");
     mw_Int_3E_();
-    WORD_ATOM(347, 34, "if");
+    WORD_ATOM(336, 34, "if");
     if (pop_u64()) {
-        WORD_ATOM(348, 17, "");
+        WORD_ATOM(337, 17, "");
         {
             static bool vready = false;
             static VAL v;
@@ -44762,31 +44732,31 @@ static void mb_c99_str_21__6 (void) {
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(348, 42, ".");
+        WORD_ATOM(337, 42, ".");
         mw_Str_2B_C99_2E_();
-        WORD_ATOM(349, 17, "c99-nest");
+        WORD_ATOM(338, 17, "c99-nest");
         push_u64(0);
         push_fnptr(&mb_c99_str_21__8);
         mw_prim_pack_cons();
         mw_c99_nest();
-        WORD_ATOM(355, 17, "c99-line");
+        WORD_ATOM(344, 17, "c99-line");
         push_u64(0);
         push_fnptr(&mb_c99_str_21__12);
         mw_prim_pack_cons();
         mw_c99_line();
-        WORD_ATOM(356, 17, "c99-line");
+        WORD_ATOM(345, 17, "c99-line");
         push_u64(0);
         push_fnptr(&mb_c99_str_21__13);
         mw_prim_pack_cons();
         mw_c99_line();
     } else {
-        WORD_ATOM(357, 17, "c99-line");
+        WORD_ATOM(346, 17, "c99-line");
         push_u64(0);
         push_fnptr(&mb_c99_str_21__15);
         mw_prim_pack_cons();
         mw_c99_line();
     }
-    WORD_ATOM(359, 13, "c99-line");
+    WORD_ATOM(348, 13, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__16);
     mw_prim_pack_cons();
@@ -44795,32 +44765,32 @@ static void mb_c99_str_21__6 (void) {
 }
 
 static void mb_c99_str_21__8 (void) {
-    WORD_ENTER(mb_c99_str_21__8, "c99-str! block", "src/mirth/codegen.mth", 350, 21);
+    WORD_ENTER(mb_c99_str_21__8, "c99-str! block", "src/mirth/codegen.mth", 339, 21);
     mw_prim_drop();
-    WORD_ATOM(350, 21, "c99-indent");
+    WORD_ATOM(339, 21, "c99-indent");
     mw_c99_indent();
-    WORD_ATOM(350, 32, "dup");
+    WORD_ATOM(339, 32, "dup");
     mw_prim_dup();
-    WORD_ATOM(350, 36, "str-bytes-for");
+    WORD_ATOM(339, 36, "str-bytes-for");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__9);
     mw_prim_pack_cons();
     mw_str_bytes_for();
-    WORD_ATOM(353, 23, ".lf");
+    WORD_ATOM(342, 23, ".lf");
     mw__2B_C99_2E_lf();
     WORD_EXIT(mb_c99_str_21__8);
 }
 
 static void mb_c99_str_21__9 (void) {
-    WORD_ENTER(mb_c99_str_21__9, "c99-str! block", "src/mirth/codegen.mth", 351, 25);
+    WORD_ENTER(mb_c99_str_21__9, "c99-str! block", "src/mirth/codegen.mth", 340, 25);
     mw_prim_drop();
-    WORD_ATOM(351, 25, ">Int");
+    WORD_ATOM(340, 25, ">Int");
     mw_Byte_3E_Int();
-    WORD_ATOM(351, 30, "dup");
+    WORD_ATOM(340, 30, "dup");
     mw_prim_dup();
-    WORD_ATOM(351, 34, ".n");
+    WORD_ATOM(340, 34, ".n");
     mw_Int_2B_C99_2E_n();
-    WORD_ATOM(351, 37, "");
+    WORD_ATOM(340, 37, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44831,29 +44801,29 @@ static void mb_c99_str_21__9 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(351, 41, ".");
+    WORD_ATOM(340, 41, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(352, 25, "");
+    WORD_ATOM(341, 25, "");
     push_i64(10LL);
-    WORD_ATOM(352, 28, "=");
+    WORD_ATOM(341, 28, "=");
     mw_prim_int_eq();
-    WORD_ATOM(352, 30, "if");
+    WORD_ATOM(341, 30, "if");
     if (pop_u64()) {
-        WORD_ATOM(352, 33, ".lf");
+        WORD_ATOM(341, 33, ".lf");
         mw__2B_C99_2E_lf();
-        WORD_ATOM(352, 37, "c99-indent");
+        WORD_ATOM(341, 37, "c99-indent");
         mw_c99_indent();
     } else {
-        WORD_ATOM(352, 49, "id");
+        WORD_ATOM(341, 49, "id");
         mw_prim_id();
     }
     WORD_EXIT(mb_c99_str_21__9);
 }
 
 static void mb_c99_str_21__12 (void) {
-    WORD_ENTER(mb_c99_str_21__12, "c99-str! block", "src/mirth/codegen.mth", 355, 26);
+    WORD_ENTER(mb_c99_str_21__12, "c99-str! block", "src/mirth/codegen.mth", 344, 26);
     mw_prim_drop();
-    WORD_ATOM(355, 26, "");
+    WORD_ATOM(344, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44864,15 +44834,15 @@ static void mb_c99_str_21__12 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(355, 31, ".");
+    WORD_ATOM(344, 31, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__12);
 }
 
 static void mb_c99_str_21__13 (void) {
-    WORD_ENTER(mb_c99_str_21__13, "c99-str! block", "src/mirth/codegen.mth", 356, 26);
+    WORD_ENTER(mb_c99_str_21__13, "c99-str! block", "src/mirth/codegen.mth", 345, 26);
     mw_prim_drop();
-    WORD_ATOM(356, 26, "");
+    WORD_ATOM(345, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44883,15 +44853,15 @@ static void mb_c99_str_21__13 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(356, 49, ".");
+    WORD_ATOM(345, 49, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(356, 51, "dup");
+    WORD_ATOM(345, 51, "dup");
     mw_prim_dup();
-    WORD_ATOM(356, 55, "num-bytes");
+    WORD_ATOM(345, 55, "num-bytes");
     mw_prim_str_num_bytes();
-    WORD_ATOM(356, 65, ".n");
+    WORD_ATOM(345, 65, ".n");
     mw_Int_2B_C99_2E_n();
-    WORD_ATOM(356, 68, "");
+    WORD_ATOM(345, 68, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44902,15 +44872,15 @@ static void mb_c99_str_21__13 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(356, 73, ".");
+    WORD_ATOM(345, 73, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__13);
 }
 
 static void mb_c99_str_21__15 (void) {
-    WORD_ENTER(mb_c99_str_21__15, "c99-str! block", "src/mirth/codegen.mth", 357, 26);
+    WORD_ENTER(mb_c99_str_21__15, "c99-str! block", "src/mirth/codegen.mth", 346, 26);
     mw_prim_drop();
-    WORD_ATOM(357, 26, "");
+    WORD_ATOM(346, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44921,13 +44891,13 @@ static void mb_c99_str_21__15 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(357, 39, ".");
+    WORD_ATOM(346, 39, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(357, 41, "dup");
+    WORD_ATOM(346, 41, "dup");
     mw_prim_dup();
-    WORD_ATOM(357, 45, ".str");
+    WORD_ATOM(346, 45, ".str");
     mw__2E_str();
-    WORD_ATOM(357, 50, "");
+    WORD_ATOM(346, 50, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44938,15 +44908,15 @@ static void mb_c99_str_21__15 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(357, 55, ".");
+    WORD_ATOM(346, 55, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(357, 57, "dup");
+    WORD_ATOM(346, 57, "dup");
     mw_prim_dup();
-    WORD_ATOM(357, 61, "num-bytes");
+    WORD_ATOM(346, 61, "num-bytes");
     mw_prim_str_num_bytes();
-    WORD_ATOM(357, 71, ".n");
+    WORD_ATOM(346, 71, ".n");
     mw_Int_2B_C99_2E_n();
-    WORD_ATOM(357, 74, "");
+    WORD_ATOM(346, 74, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44957,15 +44927,15 @@ static void mb_c99_str_21__15 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(357, 79, ".");
+    WORD_ATOM(346, 79, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__15);
 }
 
 static void mb_c99_str_21__16 (void) {
-    WORD_ENTER(mb_c99_str_21__16, "c99-str! block", "src/mirth/codegen.mth", 359, 22);
+    WORD_ENTER(mb_c99_str_21__16, "c99-str! block", "src/mirth/codegen.mth", 348, 22);
     mw_prim_drop();
-    WORD_ATOM(359, 22, "");
+    WORD_ATOM(348, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44976,15 +44946,15 @@ static void mb_c99_str_21__16 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(359, 39, ".");
+    WORD_ATOM(348, 39, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__16);
 }
 
 static void mb_c99_str_21__17 (void) {
-    WORD_ENTER(mb_c99_str_21__17, "c99-str! block", "src/mirth/codegen.mth", 361, 18);
+    WORD_ENTER(mb_c99_str_21__17, "c99-str! block", "src/mirth/codegen.mth", 350, 18);
     mw_prim_drop();
-    WORD_ATOM(361, 18, "");
+    WORD_ATOM(350, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44995,15 +44965,15 @@ static void mb_c99_str_21__17 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(361, 22, ".");
+    WORD_ATOM(350, 22, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__17);
 }
 
 static void mb_c99_str_21__18 (void) {
-    WORD_ENTER(mb_c99_str_21__18, "c99-str! block", "src/mirth/codegen.mth", 362, 18);
+    WORD_ENTER(mb_c99_str_21__18, "c99-str! block", "src/mirth/codegen.mth", 351, 18);
     mw_prim_drop();
-    WORD_ATOM(362, 18, "");
+    WORD_ATOM(351, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45014,15 +44984,15 @@ static void mb_c99_str_21__18 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(362, 35, ".");
+    WORD_ATOM(351, 35, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__18);
 }
 
 static void mb_c99_str_21__19 (void) {
-    WORD_ENTER(mb_c99_str_21__19, "c99-str! block", "src/mirth/codegen.mth", 363, 18);
+    WORD_ENTER(mb_c99_str_21__19, "c99-str! block", "src/mirth/codegen.mth", 352, 18);
     mw_prim_drop();
-    WORD_ATOM(363, 18, "");
+    WORD_ATOM(352, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45033,15 +45003,15 @@ static void mb_c99_str_21__19 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(363, 31, ".");
+    WORD_ATOM(352, 31, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__19);
 }
 
 static void mb_c99_str_21__20 (void) {
-    WORD_ENTER(mb_c99_str_21__20, "c99-str! block", "src/mirth/codegen.mth", 365, 14);
+    WORD_ENTER(mb_c99_str_21__20, "c99-str! block", "src/mirth/codegen.mth", 354, 14);
     mw_prim_drop();
-    WORD_ATOM(365, 14, "");
+    WORD_ATOM(354, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45052,15 +45022,15 @@ static void mb_c99_str_21__20 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(365, 18, ".");
+    WORD_ATOM(354, 18, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__20);
 }
 
 static void mb_c99_prim_21__3 (void) {
-    WORD_ENTER(mb_c99_prim_21__3, "c99-prim! block", "src/mirth/codegen.mth", 395, 26);
+    WORD_ENTER(mb_c99_prim_21__3, "c99-prim! block", "src/mirth/codegen.mth", 384, 26);
     mw_prim_drop();
-    WORD_ATOM(395, 26, "");
+    WORD_ATOM(384, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45071,22 +45041,22 @@ static void mb_c99_prim_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(395, 30, ".");
+    WORD_ATOM(384, 30, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_prim_21__3);
 }
 
 static void mb_c99_prim_21__4 (void) {
-    WORD_ENTER(mb_c99_prim_21__4, "c99-prim! block", "src/mirth/codegen.mth", 397, 21);
+    WORD_ENTER(mb_c99_prim_21__4, "c99-prim! block", "src/mirth/codegen.mth", 386, 21);
     mw_prim_drop();
-    WORD_ATOM(397, 21, "c99-line");
+    WORD_ATOM(386, 21, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_prim_21__5);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(398, 21, "c99-arg-run!");
+    WORD_ATOM(387, 21, "c99-arg-run!");
     mw_c99_arg_run_21_();
-    WORD_ATOM(399, 21, "c99-line");
+    WORD_ATOM(388, 21, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_prim_21__6);
     mw_prim_pack_cons();
@@ -45095,9 +45065,9 @@ static void mb_c99_prim_21__4 (void) {
 }
 
 static void mb_c99_prim_21__5 (void) {
-    WORD_ENTER(mb_c99_prim_21__5, "c99-prim! block", "src/mirth/codegen.mth", 397, 30);
+    WORD_ENTER(mb_c99_prim_21__5, "c99-prim! block", "src/mirth/codegen.mth", 386, 30);
     mw_prim_drop();
-    WORD_ATOM(397, 30, "");
+    WORD_ATOM(386, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45108,13 +45078,13 @@ static void mb_c99_prim_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(397, 38, ".");
+    WORD_ATOM(386, 38, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(397, 40, "depth@");
+    WORD_ATOM(386, 40, "depth@");
     mw__2B_C99_2E_depth_40_();
-    WORD_ATOM(397, 47, ".n");
+    WORD_ATOM(386, 47, ".n");
     mw_Int_2B_C99_2E_n();
-    WORD_ATOM(397, 50, "");
+    WORD_ATOM(386, 50, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45125,15 +45095,15 @@ static void mb_c99_prim_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(397, 68, ".");
+    WORD_ATOM(386, 68, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_prim_21__5);
 }
 
 static void mb_c99_prim_21__6 (void) {
-    WORD_ENTER(mb_c99_prim_21__6, "c99-prim! block", "src/mirth/codegen.mth", 399, 30);
+    WORD_ENTER(mb_c99_prim_21__6, "c99-prim! block", "src/mirth/codegen.mth", 388, 30);
     mw_prim_drop();
-    WORD_ATOM(399, 30, "");
+    WORD_ATOM(388, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45144,13 +45114,13 @@ static void mb_c99_prim_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(399, 45, ".");
+    WORD_ATOM(388, 45, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(399, 47, "depth@");
+    WORD_ATOM(388, 47, "depth@");
     mw__2B_C99_2E_depth_40_();
-    WORD_ATOM(399, 54, ".n");
+    WORD_ATOM(388, 54, ".n");
     mw_Int_2B_C99_2E_n();
-    WORD_ATOM(399, 57, "");
+    WORD_ATOM(388, 57, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45161,15 +45131,15 @@ static void mb_c99_prim_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(399, 62, ".");
+    WORD_ATOM(388, 62, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_prim_21__6);
 }
 
 static void mb_c99_prim_21__7 (void) {
-    WORD_ENTER(mb_c99_prim_21__7, "c99-prim! block", "src/mirth/codegen.mth", 401, 26);
+    WORD_ENTER(mb_c99_prim_21__7, "c99-prim! block", "src/mirth/codegen.mth", 390, 26);
     mw_prim_drop();
-    WORD_ATOM(401, 26, "");
+    WORD_ATOM(390, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45180,15 +45150,15 @@ static void mb_c99_prim_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(401, 30, ".");
+    WORD_ATOM(390, 30, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_prim_21__7);
 }
 
 static void mb_c99_prim_21__11 (void) {
-    WORD_ENTER(mb_c99_prim_21__11, "c99-prim! block", "src/mirth/codegen.mth", 409, 26);
+    WORD_ENTER(mb_c99_prim_21__11, "c99-prim! block", "src/mirth/codegen.mth", 398, 26);
     mw_prim_drop();
-    WORD_ATOM(409, 26, "");
+    WORD_ATOM(398, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45199,22 +45169,22 @@ static void mb_c99_prim_21__11 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(409, 30, ".");
+    WORD_ATOM(398, 30, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_prim_21__11);
 }
 
 static void mb_c99_prim_21__12 (void) {
-    WORD_ENTER(mb_c99_prim_21__12, "c99-prim! block", "src/mirth/codegen.mth", 411, 21);
+    WORD_ENTER(mb_c99_prim_21__12, "c99-prim! block", "src/mirth/codegen.mth", 400, 21);
     mw_prim_drop();
-    WORD_ATOM(411, 21, "c99-line");
+    WORD_ATOM(400, 21, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_prim_21__13);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(412, 21, "c99-arg-run!");
+    WORD_ATOM(401, 21, "c99-arg-run!");
     mw_c99_arg_run_21_();
-    WORD_ATOM(413, 21, "c99-line");
+    WORD_ATOM(402, 21, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_prim_21__14);
     mw_prim_pack_cons();
@@ -45223,9 +45193,9 @@ static void mb_c99_prim_21__12 (void) {
 }
 
 static void mb_c99_prim_21__13 (void) {
-    WORD_ENTER(mb_c99_prim_21__13, "c99-prim! block", "src/mirth/codegen.mth", 411, 30);
+    WORD_ENTER(mb_c99_prim_21__13, "c99-prim! block", "src/mirth/codegen.mth", 400, 30);
     mw_prim_drop();
-    WORD_ATOM(411, 30, "");
+    WORD_ATOM(400, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45236,13 +45206,13 @@ static void mb_c99_prim_21__13 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(411, 38, ".");
+    WORD_ATOM(400, 38, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(411, 40, "depth@");
+    WORD_ATOM(400, 40, "depth@");
     mw__2B_C99_2E_depth_40_();
-    WORD_ATOM(411, 47, ".n");
+    WORD_ATOM(400, 47, ".n");
     mw_Int_2B_C99_2E_n();
-    WORD_ATOM(411, 50, "");
+    WORD_ATOM(400, 50, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45253,15 +45223,15 @@ static void mb_c99_prim_21__13 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(411, 71, ".");
+    WORD_ATOM(400, 71, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_prim_21__13);
 }
 
 static void mb_c99_prim_21__14 (void) {
-    WORD_ENTER(mb_c99_prim_21__14, "c99-prim! block", "src/mirth/codegen.mth", 413, 30);
+    WORD_ENTER(mb_c99_prim_21__14, "c99-prim! block", "src/mirth/codegen.mth", 402, 30);
     mw_prim_drop();
-    WORD_ATOM(413, 30, "");
+    WORD_ATOM(402, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45272,13 +45242,13 @@ static void mb_c99_prim_21__14 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(413, 48, ".");
+    WORD_ATOM(402, 48, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(413, 50, "depth@");
+    WORD_ATOM(402, 50, "depth@");
     mw__2B_C99_2E_depth_40_();
-    WORD_ATOM(413, 57, ".n");
+    WORD_ATOM(402, 57, ".n");
     mw_Int_2B_C99_2E_n();
-    WORD_ATOM(413, 60, "");
+    WORD_ATOM(402, 60, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45289,15 +45259,15 @@ static void mb_c99_prim_21__14 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(413, 65, ".");
+    WORD_ATOM(402, 65, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_prim_21__14);
 }
 
 static void mb_c99_prim_21__15 (void) {
-    WORD_ENTER(mb_c99_prim_21__15, "c99-prim! block", "src/mirth/codegen.mth", 415, 26);
+    WORD_ENTER(mb_c99_prim_21__15, "c99-prim! block", "src/mirth/codegen.mth", 404, 26);
     mw_prim_drop();
-    WORD_ATOM(415, 26, "");
+    WORD_ATOM(404, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45308,15 +45278,15 @@ static void mb_c99_prim_21__15 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(415, 30, ".");
+    WORD_ATOM(404, 30, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_prim_21__15);
 }
 
 static void mb_c99_prim_21__19 (void) {
-    WORD_ENTER(mb_c99_prim_21__19, "c99-prim! block", "src/mirth/codegen.mth", 423, 26);
+    WORD_ENTER(mb_c99_prim_21__19, "c99-prim! block", "src/mirth/codegen.mth", 412, 26);
     mw_prim_drop();
-    WORD_ATOM(423, 26, "");
+    WORD_ATOM(412, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45327,25 +45297,25 @@ static void mb_c99_prim_21__19 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(423, 45, ".");
+    WORD_ATOM(412, 45, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_prim_21__19);
 }
 
 static void mb_c99_prim_21__20 (void) {
-    WORD_ENTER(mb_c99_prim_21__20, "c99-prim! block", "src/mirth/codegen.mth", 424, 26);
+    WORD_ENTER(mb_c99_prim_21__20, "c99-prim! block", "src/mirth/codegen.mth", 413, 26);
     mw_prim_drop();
-    WORD_ATOM(424, 26, "swap");
+    WORD_ATOM(413, 26, "swap");
     mw_prim_swap();
-    WORD_ATOM(424, 31, "c99-arg-run!");
+    WORD_ATOM(413, 31, "c99-arg-run!");
     mw_c99_arg_run_21_();
     WORD_EXIT(mb_c99_prim_21__20);
 }
 
 static void mb_c99_prim_21__21 (void) {
-    WORD_ENTER(mb_c99_prim_21__21, "c99-prim! block", "src/mirth/codegen.mth", 425, 26);
+    WORD_ENTER(mb_c99_prim_21__21, "c99-prim! block", "src/mirth/codegen.mth", 414, 26);
     mw_prim_drop();
-    WORD_ATOM(425, 26, "");
+    WORD_ATOM(414, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45356,23 +45326,23 @@ static void mb_c99_prim_21__21 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(425, 37, ".");
+    WORD_ATOM(414, 37, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_prim_21__21);
 }
 
 static void mb_c99_prim_21__22 (void) {
-    WORD_ENTER(mb_c99_prim_21__22, "c99-prim! block", "src/mirth/codegen.mth", 426, 26);
+    WORD_ENTER(mb_c99_prim_21__22, "c99-prim! block", "src/mirth/codegen.mth", 415, 26);
     mw_prim_drop();
-    WORD_ATOM(426, 26, "c99-arg-run!");
+    WORD_ATOM(415, 26, "c99-arg-run!");
     mw_c99_arg_run_21_();
     WORD_EXIT(mb_c99_prim_21__22);
 }
 
 static void mb_c99_prim_21__23 (void) {
-    WORD_ENTER(mb_c99_prim_21__23, "c99-prim! block", "src/mirth/codegen.mth", 427, 26);
+    WORD_ENTER(mb_c99_prim_21__23, "c99-prim! block", "src/mirth/codegen.mth", 416, 26);
     mw_prim_drop();
-    WORD_ATOM(427, 26, "");
+    WORD_ATOM(416, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45383,15 +45353,15 @@ static void mb_c99_prim_21__23 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(427, 30, ".");
+    WORD_ATOM(416, 30, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_prim_21__23);
 }
 
 static void mb_c99_prim_21__27 (void) {
-    WORD_ENTER(mb_c99_prim_21__27, "c99-prim! block", "src/mirth/codegen.mth", 435, 26);
+    WORD_ENTER(mb_c99_prim_21__27, "c99-prim! block", "src/mirth/codegen.mth", 424, 26);
     mw_prim_drop();
-    WORD_ATOM(435, 26, "");
+    WORD_ATOM(424, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45402,32 +45372,32 @@ static void mb_c99_prim_21__27 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(435, 39, ".");
+    WORD_ATOM(424, 39, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_prim_21__27);
 }
 
 static void mb_c99_prim_21__28 (void) {
-    WORD_ENTER(mb_c99_prim_21__28, "c99-prim! block", "src/mirth/codegen.mth", 437, 21);
+    WORD_ENTER(mb_c99_prim_21__28, "c99-prim! block", "src/mirth/codegen.mth", 426, 21);
     mw_prim_drop();
-    WORD_ATOM(437, 21, "swap");
+    WORD_ATOM(426, 21, "swap");
     mw_prim_swap();
-    WORD_ATOM(437, 26, "c99-arg-run!");
+    WORD_ATOM(426, 26, "c99-arg-run!");
     mw_c99_arg_run_21_();
-    WORD_ATOM(438, 21, "c99-line");
+    WORD_ATOM(427, 21, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_prim_21__29);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(439, 21, "c99-arg-run!");
+    WORD_ATOM(428, 21, "c99-arg-run!");
     mw_c99_arg_run_21_();
     WORD_EXIT(mb_c99_prim_21__28);
 }
 
 static void mb_c99_prim_21__29 (void) {
-    WORD_ENTER(mb_c99_prim_21__29, "c99-prim! block", "src/mirth/codegen.mth", 438, 30);
+    WORD_ENTER(mb_c99_prim_21__29, "c99-prim! block", "src/mirth/codegen.mth", 427, 30);
     mw_prim_drop();
-    WORD_ATOM(438, 30, "");
+    WORD_ATOM(427, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45438,15 +45408,15 @@ static void mb_c99_prim_21__29 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(438, 56, ".");
+    WORD_ATOM(427, 56, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_prim_21__29);
 }
 
 static void mb_c99_prim_21__30 (void) {
-    WORD_ENTER(mb_c99_prim_21__30, "c99-prim! block", "src/mirth/codegen.mth", 441, 26);
+    WORD_ENTER(mb_c99_prim_21__30, "c99-prim! block", "src/mirth/codegen.mth", 430, 26);
     mw_prim_drop();
-    WORD_ATOM(441, 26, "");
+    WORD_ATOM(430, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45457,17 +45427,17 @@ static void mb_c99_prim_21__30 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(441, 30, ".");
+    WORD_ATOM(430, 30, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_prim_21__30);
 }
 
 static void mb_c99_match_21__3 (void) {
-    WORD_ENTER(mb_c99_match_21__3, "c99-match! block", "src/mirth/codegen.mth", 526, 19);
+    WORD_ENTER(mb_c99_match_21__3, "c99-match! block", "src/mirth/codegen.mth", 515, 19);
     mw_prim_drop();
-    WORD_ATOM(526, 19, "token");
+    WORD_ATOM(515, 19, "token");
     mw_Match_2E_token();
-    WORD_ATOM(526, 25, "");
+    WORD_ATOM(515, 25, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45478,15 +45448,15 @@ static void mb_c99_match_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(526, 71, "emit-fatal-error!");
+    WORD_ATOM(515, 71, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_c99_match_21__3);
 }
 
 static void mb_c99_match_21__5 (void) {
-    WORD_ENTER(mb_c99_match_21__5, "c99-match! block", "src/mirth/codegen.mth", 528, 22);
+    WORD_ENTER(mb_c99_match_21__5, "c99-match! block", "src/mirth/codegen.mth", 517, 22);
     mw_prim_drop();
-    WORD_ATOM(528, 22, "");
+    WORD_ATOM(517, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45497,15 +45467,15 @@ static void mb_c99_match_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(528, 63, ".");
+    WORD_ATOM(517, 63, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_match_21__5);
 }
 
 static void mb_c99_match_21__7 (void) {
-    WORD_ENTER(mb_c99_match_21__7, "c99-match! block", "src/mirth/codegen.mth", 529, 22);
+    WORD_ENTER(mb_c99_match_21__7, "c99-match! block", "src/mirth/codegen.mth", 518, 22);
     mw_prim_drop();
-    WORD_ATOM(529, 22, "");
+    WORD_ATOM(518, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45516,26 +45486,26 @@ static void mb_c99_match_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(529, 54, ".");
+    WORD_ATOM(518, 54, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_match_21__7);
 }
 
 static void mb_c99_match_21__8 (void) {
-    WORD_ENTER(mb_c99_match_21__8, "c99-match! block", "src/mirth/codegen.mth", 532, 13);
+    WORD_ENTER(mb_c99_match_21__8, "c99-match! block", "src/mirth/codegen.mth", 521, 13);
     mw_prim_drop();
-    WORD_ATOM(532, 13, "dup");
+    WORD_ATOM(521, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(532, 17, "cases");
+    WORD_ATOM(521, 17, "cases");
     mw_Match_2E_cases();
-    WORD_ATOM(532, 23, "for");
+    WORD_ATOM(521, 23, "for");
     push_u64(0);
     push_fnptr(&mb_c99_match_21__9);
     mw_prim_pack_cons();
     mw_List_2E_for();
-    WORD_ATOM(533, 13, "has-default-case?");
+    WORD_ATOM(522, 13, "has-default-case?");
     mw_Match_2E_has_default_case_3F_();
-    WORD_ATOM(533, 31, "else");
+    WORD_ATOM(522, 31, "else");
     push_u64(0);
     push_fnptr(&mb_c99_match_21__10);
     mw_prim_pack_cons();
@@ -45544,17 +45514,17 @@ static void mb_c99_match_21__8 (void) {
 }
 
 static void mb_c99_match_21__9 (void) {
-    WORD_ENTER(mb_c99_match_21__9, "c99-match! block", "src/mirth/codegen.mth", 532, 27);
+    WORD_ENTER(mb_c99_match_21__9, "c99-match! block", "src/mirth/codegen.mth", 521, 27);
     mw_prim_drop();
-    WORD_ATOM(532, 27, "c99-case!");
+    WORD_ATOM(521, 27, "c99-case!");
     mw_c99_case_21_();
     WORD_EXIT(mb_c99_match_21__9);
 }
 
 static void mb_c99_match_21__10 (void) {
-    WORD_ENTER(mb_c99_match_21__10, "c99-match! block", "src/mirth/codegen.mth", 534, 17);
+    WORD_ENTER(mb_c99_match_21__10, "c99-match! block", "src/mirth/codegen.mth", 523, 17);
     mw_prim_drop();
-    WORD_ATOM(534, 17, "c99-line");
+    WORD_ATOM(523, 17, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_match_21__11);
     mw_prim_pack_cons();
@@ -45563,9 +45533,9 @@ static void mb_c99_match_21__10 (void) {
 }
 
 static void mb_c99_match_21__11 (void) {
-    WORD_ENTER(mb_c99_match_21__11, "c99-match! block", "src/mirth/codegen.mth", 534, 26);
+    WORD_ENTER(mb_c99_match_21__11, "c99-match! block", "src/mirth/codegen.mth", 523, 26);
     mw_prim_drop();
-    WORD_ATOM(534, 26, "");
+    WORD_ATOM(523, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45576,15 +45546,15 @@ static void mb_c99_match_21__11 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(534, 118, ".");
+    WORD_ATOM(523, 118, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_match_21__11);
 }
 
 static void mb_c99_match_21__12 (void) {
-    WORD_ENTER(mb_c99_match_21__12, "c99-match! block", "src/mirth/codegen.mth", 537, 18);
+    WORD_ENTER(mb_c99_match_21__12, "c99-match! block", "src/mirth/codegen.mth", 526, 18);
     mw_prim_drop();
-    WORD_ATOM(537, 18, "");
+    WORD_ATOM(526, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45599,9 +45569,9 @@ static void mb_c99_match_21__12 (void) {
 }
 
 static void mb_c99_lambda_21__1 (void) {
-    WORD_ENTER(mb_c99_lambda_21__1, "c99-lambda! block", "src/mirth/codegen.mth", 509, 14);
+    WORD_ENTER(mb_c99_lambda_21__1, "c99-lambda! block", "src/mirth/codegen.mth", 498, 14);
     mw_prim_drop();
-    WORD_ATOM(509, 14, "");
+    WORD_ATOM(498, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45612,32 +45582,32 @@ static void mb_c99_lambda_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(509, 18, ".");
+    WORD_ATOM(498, 18, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_lambda_21__1);
 }
 
 static void mb_c99_lambda_21__2 (void) {
-    WORD_ENTER(mb_c99_lambda_21__2, "c99-lambda! block", "src/mirth/codegen.mth", 511, 9);
+    WORD_ENTER(mb_c99_lambda_21__2, "c99-lambda! block", "src/mirth/codegen.mth", 500, 9);
     mw_prim_drop();
-    WORD_ATOM(511, 9, "dup");
+    WORD_ATOM(500, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(511, 13, "params");
+    WORD_ATOM(500, 13, "params");
     mw_Lambda_2E_params();
-    WORD_ATOM(511, 20, "reverse-for");
+    WORD_ATOM(500, 20, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__3);
     mw_prim_pack_cons();
     mw_List_2E_reverse_for();
-    WORD_ATOM(514, 9, "dup");
+    WORD_ATOM(503, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(514, 13, "body");
+    WORD_ATOM(503, 13, "body");
     mw_Lambda_2E_body();
-    WORD_ATOM(514, 18, "c99-arrow!");
+    WORD_ATOM(503, 18, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(515, 9, "params");
+    WORD_ATOM(504, 9, "params");
     mw_Lambda_2E_params();
-    WORD_ATOM(515, 16, "reverse-for");
+    WORD_ATOM(504, 16, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__5);
     mw_prim_pack_cons();
@@ -45646,9 +45616,9 @@ static void mb_c99_lambda_21__2 (void) {
 }
 
 static void mb_c99_lambda_21__3 (void) {
-    WORD_ENTER(mb_c99_lambda_21__3, "c99-lambda! block", "src/mirth/codegen.mth", 512, 13);
+    WORD_ENTER(mb_c99_lambda_21__3, "c99-lambda! block", "src/mirth/codegen.mth", 501, 13);
     mw_prim_drop();
-    WORD_ATOM(512, 13, "c99-line");
+    WORD_ATOM(501, 13, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__4);
     mw_prim_pack_cons();
@@ -45657,9 +45627,9 @@ static void mb_c99_lambda_21__3 (void) {
 }
 
 static void mb_c99_lambda_21__4 (void) {
-    WORD_ENTER(mb_c99_lambda_21__4, "c99-lambda! block", "src/mirth/codegen.mth", 512, 22);
+    WORD_ENTER(mb_c99_lambda_21__4, "c99-lambda! block", "src/mirth/codegen.mth", 501, 22);
     mw_prim_drop();
-    WORD_ATOM(512, 22, "");
+    WORD_ATOM(501, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45670,11 +45640,11 @@ static void mb_c99_lambda_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(512, 29, ".");
+    WORD_ATOM(501, 29, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(512, 31, ".param");
+    WORD_ATOM(501, 31, ".param");
     mw_Param_2B_C99_2E_param();
-    WORD_ATOM(512, 38, "");
+    WORD_ATOM(501, 38, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45685,15 +45655,15 @@ static void mb_c99_lambda_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(512, 56, ".");
+    WORD_ATOM(501, 56, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_lambda_21__4);
 }
 
 static void mb_c99_lambda_21__5 (void) {
-    WORD_ENTER(mb_c99_lambda_21__5, "c99-lambda! block", "src/mirth/codegen.mth", 516, 13);
+    WORD_ENTER(mb_c99_lambda_21__5, "c99-lambda! block", "src/mirth/codegen.mth", 505, 13);
     mw_prim_drop();
-    WORD_ATOM(516, 13, "c99-line");
+    WORD_ATOM(505, 13, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__6);
     mw_prim_pack_cons();
@@ -45702,9 +45672,9 @@ static void mb_c99_lambda_21__5 (void) {
 }
 
 static void mb_c99_lambda_21__6 (void) {
-    WORD_ENTER(mb_c99_lambda_21__6, "c99-lambda! block", "src/mirth/codegen.mth", 516, 22);
+    WORD_ENTER(mb_c99_lambda_21__6, "c99-lambda! block", "src/mirth/codegen.mth", 505, 22);
     mw_prim_drop();
-    WORD_ATOM(516, 22, "");
+    WORD_ATOM(505, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45715,11 +45685,11 @@ static void mb_c99_lambda_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(516, 32, ".");
+    WORD_ATOM(505, 32, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(516, 34, ".param");
+    WORD_ATOM(505, 34, ".param");
     mw_Param_2B_C99_2E_param();
-    WORD_ATOM(516, 41, "");
+    WORD_ATOM(505, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45730,15 +45700,15 @@ static void mb_c99_lambda_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(516, 46, ".");
+    WORD_ATOM(505, 46, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_lambda_21__6);
 }
 
 static void mb_c99_lambda_21__7 (void) {
-    WORD_ENTER(mb_c99_lambda_21__7, "c99-lambda! block", "src/mirth/codegen.mth", 519, 14);
+    WORD_ENTER(mb_c99_lambda_21__7, "c99-lambda! block", "src/mirth/codegen.mth", 508, 14);
     mw_prim_drop();
-    WORD_ATOM(519, 14, "");
+    WORD_ATOM(508, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45749,15 +45719,15 @@ static void mb_c99_lambda_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(519, 18, ".");
+    WORD_ATOM(508, 18, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_lambda_21__7);
 }
 
 static void mb_c99_block_push_21__3 (void) {
-    WORD_ENTER(mb_c99_block_push_21__3, "c99-block-push! block", "src/mirth/codegen.mth", 491, 22);
+    WORD_ENTER(mb_c99_block_push_21__3, "c99-block-push! block", "src/mirth/codegen.mth", 480, 22);
     mw_prim_drop();
-    WORD_ATOM(491, 22, "");
+    WORD_ATOM(480, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45768,11 +45738,11 @@ static void mb_c99_block_push_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(491, 37, ".");
+    WORD_ATOM(480, 37, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(491, 39, ".block");
+    WORD_ATOM(480, 39, ".block");
     mw_Block_2B_C99_2E_block();
-    WORD_ATOM(491, 46, "");
+    WORD_ATOM(480, 46, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45783,15 +45753,15 @@ static void mb_c99_block_push_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(491, 51, ".");
+    WORD_ATOM(480, 51, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_block_push_21__3);
 }
 
 static void mb_c99_block_push_21__4 (void) {
-    WORD_ENTER(mb_c99_block_push_21__4, "c99-block-push! block", "src/mirth/codegen.mth", 492, 22);
+    WORD_ENTER(mb_c99_block_push_21__4, "c99-block-push! block", "src/mirth/codegen.mth", 481, 22);
     mw_prim_drop();
-    WORD_ATOM(492, 22, "");
+    WORD_ATOM(481, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45802,15 +45772,15 @@ static void mb_c99_block_push_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(492, 45, ".");
+    WORD_ATOM(481, 45, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_block_push_21__4);
 }
 
 static void mb_c99_pack_ctx_21__1 (void) {
-    WORD_ENTER(mb_c99_pack_ctx_21__1, "c99-pack-ctx! block", "src/mirth/codegen.mth", 468, 14);
+    WORD_ENTER(mb_c99_pack_ctx_21__1, "c99-pack-ctx! block", "src/mirth/codegen.mth", 457, 14);
     mw_prim_drop();
-    WORD_ATOM(468, 14, "");
+    WORD_ATOM(457, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45821,17 +45791,17 @@ static void mb_c99_pack_ctx_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(468, 29, ".");
+    WORD_ATOM(457, 29, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_pack_ctx_21__1);
 }
 
 static void mb_c99_pack_ctx_21__2 (void) {
-    WORD_ENTER(mb_c99_pack_ctx_21__2, "c99-pack-ctx! block", "src/mirth/codegen.mth", 470, 9);
+    WORD_ENTER(mb_c99_pack_ctx_21__2, "c99-pack-ctx! block", "src/mirth/codegen.mth", 459, 9);
     mw_prim_drop();
-    WORD_ATOM(470, 9, "c99-var-push!");
+    WORD_ATOM(459, 9, "c99-var-push!");
     mw_c99_var_push_21_();
-    WORD_ATOM(471, 9, "c99-line");
+    WORD_ATOM(460, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_pack_ctx_21__3);
     mw_prim_pack_cons();
@@ -45840,9 +45810,9 @@ static void mb_c99_pack_ctx_21__2 (void) {
 }
 
 static void mb_c99_pack_ctx_21__3 (void) {
-    WORD_ENTER(mb_c99_pack_ctx_21__3, "c99-pack-ctx! block", "src/mirth/codegen.mth", 471, 18);
+    WORD_ENTER(mb_c99_pack_ctx_21__3, "c99-pack-ctx! block", "src/mirth/codegen.mth", 460, 18);
     mw_prim_drop();
-    WORD_ATOM(471, 18, "");
+    WORD_ATOM(460, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45853,15 +45823,15 @@ static void mb_c99_pack_ctx_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(471, 41, ".");
+    WORD_ATOM(460, 41, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_pack_ctx_21__3);
 }
 
 static void mb_c99_var_push_21__1 (void) {
-    WORD_ENTER(mb_c99_var_push_21__1, "c99-var-push! block", "src/mirth/codegen.mth", 504, 14);
+    WORD_ENTER(mb_c99_var_push_21__1, "c99-var-push! block", "src/mirth/codegen.mth", 493, 14);
     mw_prim_drop();
-    WORD_ATOM(504, 14, "");
+    WORD_ATOM(493, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45872,13 +45842,13 @@ static void mb_c99_var_push_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(504, 24, ".");
+    WORD_ATOM(493, 24, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(504, 26, "dup");
+    WORD_ATOM(493, 26, "dup");
     mw_prim_dup();
-    WORD_ATOM(504, 30, ".var");
+    WORD_ATOM(493, 30, ".var");
     mw_Var_2B_C99_2E_var();
-    WORD_ATOM(504, 35, "");
+    WORD_ATOM(493, 35, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45889,15 +45859,15 @@ static void mb_c99_var_push_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(504, 40, ".");
+    WORD_ATOM(493, 40, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_var_push_21__1);
 }
 
 static void mb_c99_var_push_21__2 (void) {
-    WORD_ENTER(mb_c99_var_push_21__2, "c99-var-push! block", "src/mirth/codegen.mth", 505, 14);
+    WORD_ENTER(mb_c99_var_push_21__2, "c99-var-push! block", "src/mirth/codegen.mth", 494, 14);
     mw_prim_drop();
-    WORD_ATOM(505, 14, "");
+    WORD_ATOM(494, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45908,13 +45878,13 @@ static void mb_c99_var_push_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(505, 28, ".");
+    WORD_ATOM(494, 28, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(505, 30, "dup");
+    WORD_ATOM(494, 30, "dup");
     mw_prim_dup();
-    WORD_ATOM(505, 34, ".var");
+    WORD_ATOM(494, 34, ".var");
     mw_Var_2B_C99_2E_var();
-    WORD_ATOM(505, 39, "");
+    WORD_ATOM(494, 39, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45925,20 +45895,20 @@ static void mb_c99_var_push_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(505, 44, ".");
+    WORD_ATOM(494, 44, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_var_push_21__2);
 }
 
 static void mb_c99_unpack_ctx_21__1 (void) {
-    WORD_ENTER(mb_c99_unpack_ctx_21__1, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 476, 9);
+    WORD_ENTER(mb_c99_unpack_ctx_21__1, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 465, 9);
     mw_prim_drop();
-    WORD_ATOM(476, 9, "c99-line");
+    WORD_ATOM(465, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_unpack_ctx_21__2);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(477, 9, "c99-line");
+    WORD_ATOM(466, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_unpack_ctx_21__3);
     mw_prim_pack_cons();
@@ -45947,9 +45917,9 @@ static void mb_c99_unpack_ctx_21__1 (void) {
 }
 
 static void mb_c99_unpack_ctx_21__2 (void) {
-    WORD_ENTER(mb_c99_unpack_ctx_21__2, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 476, 18);
+    WORD_ENTER(mb_c99_unpack_ctx_21__2, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 465, 18);
     mw_prim_drop();
-    WORD_ATOM(476, 18, "");
+    WORD_ATOM(465, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45960,15 +45930,15 @@ static void mb_c99_unpack_ctx_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(476, 43, ".");
+    WORD_ATOM(465, 43, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_unpack_ctx_21__2);
 }
 
 static void mb_c99_unpack_ctx_21__3 (void) {
-    WORD_ENTER(mb_c99_unpack_ctx_21__3, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 477, 18);
+    WORD_ENTER(mb_c99_unpack_ctx_21__3, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 466, 18);
     mw_prim_drop();
-    WORD_ATOM(477, 18, "");
+    WORD_ATOM(466, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45979,11 +45949,11 @@ static void mb_c99_unpack_ctx_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(477, 25, ".");
+    WORD_ATOM(466, 25, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(477, 27, ".var");
+    WORD_ATOM(466, 27, ".var");
     mw_Var_2B_C99_2E_var();
-    WORD_ATOM(477, 32, "");
+    WORD_ATOM(466, 32, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45994,15 +45964,15 @@ static void mb_c99_unpack_ctx_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(477, 50, ".");
+    WORD_ATOM(466, 50, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_unpack_ctx_21__3);
 }
 
 static void mb_c99_unpack_ctx_21__4 (void) {
-    WORD_ENTER(mb_c99_unpack_ctx_21__4, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 479, 14);
+    WORD_ENTER(mb_c99_unpack_ctx_21__4, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 468, 14);
     mw_prim_drop();
-    WORD_ATOM(479, 14, "");
+    WORD_ATOM(468, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46013,15 +45983,15 @@ static void mb_c99_unpack_ctx_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(479, 32, ".");
+    WORD_ATOM(468, 32, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_unpack_ctx_21__4);
 }
 
 static void mb_c99_decref_ctx_21__1 (void) {
-    WORD_ENTER(mb_c99_decref_ctx_21__1, "c99-decref-ctx! block", "src/mirth/codegen.mth", 483, 9);
+    WORD_ENTER(mb_c99_decref_ctx_21__1, "c99-decref-ctx! block", "src/mirth/codegen.mth", 472, 9);
     mw_prim_drop();
-    WORD_ATOM(483, 9, "c99-line");
+    WORD_ATOM(472, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_decref_ctx_21__2);
     mw_prim_pack_cons();
@@ -46030,9 +46000,9 @@ static void mb_c99_decref_ctx_21__1 (void) {
 }
 
 static void mb_c99_decref_ctx_21__2 (void) {
-    WORD_ENTER(mb_c99_decref_ctx_21__2, "c99-decref-ctx! block", "src/mirth/codegen.mth", 483, 18);
+    WORD_ENTER(mb_c99_decref_ctx_21__2, "c99-decref-ctx! block", "src/mirth/codegen.mth", 472, 18);
     mw_prim_drop();
-    WORD_ATOM(483, 18, "");
+    WORD_ATOM(472, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46043,11 +46013,11 @@ static void mb_c99_decref_ctx_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(483, 28, ".");
+    WORD_ATOM(472, 28, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(483, 30, ".var");
+    WORD_ATOM(472, 30, ".var");
     mw_Var_2B_C99_2E_var();
-    WORD_ATOM(483, 35, "");
+    WORD_ATOM(472, 35, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46058,15 +46028,15 @@ static void mb_c99_decref_ctx_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(483, 40, ".");
+    WORD_ATOM(472, 40, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_decref_ctx_21__2);
 }
 
 static void mb_c99_var_run_21__1 (void) {
-    WORD_ENTER(mb_c99_var_run_21__1, "c99-var-run! block", "src/mirth/codegen.mth", 499, 14);
+    WORD_ENTER(mb_c99_var_run_21__1, "c99-var-run! block", "src/mirth/codegen.mth", 488, 14);
     mw_prim_drop();
-    WORD_ATOM(499, 14, "");
+    WORD_ATOM(488, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46077,13 +46047,13 @@ static void mb_c99_var_run_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(499, 24, ".");
+    WORD_ATOM(488, 24, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(499, 26, "dup");
+    WORD_ATOM(488, 26, "dup");
     mw_prim_dup();
-    WORD_ATOM(499, 30, ".var");
+    WORD_ATOM(488, 30, ".var");
     mw_Var_2B_C99_2E_var();
-    WORD_ATOM(499, 35, "");
+    WORD_ATOM(488, 35, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46094,15 +46064,15 @@ static void mb_c99_var_run_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(499, 40, ".");
+    WORD_ATOM(488, 40, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_var_run_21__1);
 }
 
 static void mb_c99_var_run_21__2 (void) {
-    WORD_ENTER(mb_c99_var_run_21__2, "c99-var-run! block", "src/mirth/codegen.mth", 500, 14);
+    WORD_ENTER(mb_c99_var_run_21__2, "c99-var-run! block", "src/mirth/codegen.mth", 489, 14);
     mw_prim_drop();
-    WORD_ATOM(500, 14, "");
+    WORD_ATOM(489, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46113,13 +46083,13 @@ static void mb_c99_var_run_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(500, 27, ".");
+    WORD_ATOM(489, 27, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(500, 29, "dup");
+    WORD_ATOM(489, 29, "dup");
     mw_prim_dup();
-    WORD_ATOM(500, 33, ".var");
+    WORD_ATOM(489, 33, ".var");
     mw_Var_2B_C99_2E_var();
-    WORD_ATOM(500, 38, "");
+    WORD_ATOM(489, 38, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46130,19 +46100,19 @@ static void mb_c99_var_run_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(500, 43, ".");
+    WORD_ATOM(489, 43, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_var_run_21__2);
 }
 
 static void mb_c99_case_21__1 (void) {
-    WORD_ENTER(mb_c99_case_21__1, "c99-case! block", "src/mirth/codegen.mth", 543, 9);
+    WORD_ENTER(mb_c99_case_21__1, "c99-case! block", "src/mirth/codegen.mth", 532, 9);
     mw_prim_drop();
-    WORD_ATOM(543, 9, "body");
+    WORD_ATOM(532, 9, "body");
     mw_Case_2E_body();
-    WORD_ATOM(543, 14, "c99-arrow!");
+    WORD_ATOM(532, 14, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(544, 9, "c99-line");
+    WORD_ATOM(533, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_case_21__2);
     mw_prim_pack_cons();
@@ -46151,9 +46121,9 @@ static void mb_c99_case_21__1 (void) {
 }
 
 static void mb_c99_case_21__2 (void) {
-    WORD_ENTER(mb_c99_case_21__2, "c99-case! block", "src/mirth/codegen.mth", 544, 18);
+    WORD_ENTER(mb_c99_case_21__2, "c99-case! block", "src/mirth/codegen.mth", 533, 18);
     mw_prim_drop();
-    WORD_ATOM(544, 18, "");
+    WORD_ATOM(533, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46164,15 +46134,15 @@ static void mb_c99_case_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(544, 27, ".");
+    WORD_ATOM(533, 27, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_case_21__2);
 }
 
 static void mb_c99_pattern_21__2 (void) {
-    WORD_ENTER(mb_c99_pattern_21__2, "c99-pattern! block", "src/mirth/codegen.mth", 549, 18);
+    WORD_ENTER(mb_c99_pattern_21__2, "c99-pattern! block", "src/mirth/codegen.mth", 538, 18);
     mw_prim_drop();
-    WORD_ATOM(549, 18, "");
+    WORD_ATOM(538, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46183,15 +46153,15 @@ static void mb_c99_pattern_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(549, 29, ".");
+    WORD_ATOM(538, 29, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_pattern_21__2);
 }
 
 static void mb_c99_pattern_21__4 (void) {
-    WORD_ENTER(mb_c99_pattern_21__4, "c99-pattern! block", "src/mirth/codegen.mth", 552, 18);
+    WORD_ENTER(mb_c99_pattern_21__4, "c99-pattern! block", "src/mirth/codegen.mth", 541, 18);
     mw_prim_drop();
-    WORD_ATOM(552, 18, "");
+    WORD_ATOM(541, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46202,15 +46172,15 @@ static void mb_c99_pattern_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(552, 26, ".");
+    WORD_ATOM(541, 26, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(552, 28, "dup");
+    WORD_ATOM(541, 28, "dup");
     mw_prim_dup();
-    WORD_ATOM(552, 32, "value");
+    WORD_ATOM(541, 32, "value");
     mw_Tag_2E_value();
-    WORD_ATOM(552, 38, ".n");
+    WORD_ATOM(541, 38, ".n");
     mw_Int_2B_C99_2E_n();
-    WORD_ATOM(552, 41, "");
+    WORD_ATOM(541, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46221,15 +46191,15 @@ static void mb_c99_pattern_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(552, 47, ".");
+    WORD_ATOM(541, 47, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_pattern_21__4);
 }
 
 static void mb_c99_pattern_21__5 (void) {
-    WORD_ENTER(mb_c99_pattern_21__5, "c99-pattern! block", "src/mirth/codegen.mth", 554, 13);
+    WORD_ENTER(mb_c99_pattern_21__5, "c99-pattern! block", "src/mirth/codegen.mth", 543, 13);
     mw_prim_drop();
-    WORD_ATOM(554, 13, "c99-line");
+    WORD_ATOM(543, 13, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_pattern_21__6);
     mw_prim_pack_cons();
@@ -46238,9 +46208,9 @@ static void mb_c99_pattern_21__5 (void) {
 }
 
 static void mb_c99_pattern_21__6 (void) {
-    WORD_ENTER(mb_c99_pattern_21__6, "c99-pattern! block", "src/mirth/codegen.mth", 554, 22);
+    WORD_ENTER(mb_c99_pattern_21__6, "c99-pattern! block", "src/mirth/codegen.mth", 543, 22);
     mw_prim_drop();
-    WORD_ATOM(554, 22, "");
+    WORD_ATOM(543, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46251,13 +46221,13 @@ static void mb_c99_pattern_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(554, 28, ".");
+    WORD_ATOM(543, 28, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(554, 30, "name");
+    WORD_ATOM(543, 30, "name");
     mw_Tag_2E_name();
-    WORD_ATOM(554, 35, ".name");
+    WORD_ATOM(543, 35, ".name");
     mw_Name_2B_C99_2E_name();
-    WORD_ATOM(554, 41, "");
+    WORD_ATOM(543, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46268,15 +46238,15 @@ static void mb_c99_pattern_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(554, 47, ".");
+    WORD_ATOM(543, 47, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_pattern_21__6);
 }
 
 static void mb_c99_word_sig_21__1 (void) {
-    WORD_ENTER(mb_c99_word_sig_21__1, "c99-word-sig! block", "src/mirth/codegen.mth", 560, 14);
+    WORD_ENTER(mb_c99_word_sig_21__1, "c99-word-sig! block", "src/mirth/codegen.mth", 549, 14);
     mw_prim_drop();
-    WORD_ATOM(560, 14, "");
+    WORD_ATOM(549, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46287,13 +46257,13 @@ static void mb_c99_word_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(560, 32, ".");
+    WORD_ATOM(549, 32, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(560, 34, "name");
+    WORD_ATOM(549, 34, "name");
     mw_Word_2E_name();
-    WORD_ATOM(560, 39, ".name");
+    WORD_ATOM(549, 39, ".name");
     mw_Name_2B_C99_2E_name();
-    WORD_ATOM(560, 45, "");
+    WORD_ATOM(549, 45, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46304,15 +46274,15 @@ static void mb_c99_word_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(560, 56, ".");
+    WORD_ATOM(549, 56, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_word_sig_21__1);
 }
 
 static void mb_c99_block_sig_21__1 (void) {
-    WORD_ENTER(mb_c99_block_sig_21__1, "c99-block-sig! block", "src/mirth/codegen.mth", 564, 14);
+    WORD_ENTER(mb_c99_block_sig_21__1, "c99-block-sig! block", "src/mirth/codegen.mth", 553, 14);
     mw_prim_drop();
-    WORD_ATOM(564, 14, "");
+    WORD_ATOM(553, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46323,11 +46293,11 @@ static void mb_c99_block_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(564, 29, ".");
+    WORD_ATOM(553, 29, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(564, 31, ".block");
+    WORD_ATOM(553, 31, ".block");
     mw_Block_2B_C99_2E_block();
-    WORD_ATOM(564, 38, "");
+    WORD_ATOM(553, 38, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46338,15 +46308,15 @@ static void mb_c99_block_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(564, 49, ".");
+    WORD_ATOM(553, 49, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_block_sig_21__1);
 }
 
 static void mb_c99_field_sig_21__1 (void) {
-    WORD_ENTER(mb_c99_field_sig_21__1, "c99-field-sig! block", "src/mirth/codegen.mth", 568, 14);
+    WORD_ENTER(mb_c99_field_sig_21__1, "c99-field-sig! block", "src/mirth/codegen.mth", 557, 14);
     mw_prim_drop();
-    WORD_ATOM(568, 14, "");
+    WORD_ATOM(557, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46357,13 +46327,13 @@ static void mb_c99_field_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(568, 32, ".");
+    WORD_ATOM(557, 32, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(568, 34, "name");
+    WORD_ATOM(557, 34, "name");
     mw_Field_2E_name();
-    WORD_ATOM(568, 39, ".name");
+    WORD_ATOM(557, 39, ".name");
     mw_Name_2B_C99_2E_name();
-    WORD_ATOM(568, 45, "");
+    WORD_ATOM(557, 45, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46374,15 +46344,15 @@ static void mb_c99_field_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(568, 56, ".");
+    WORD_ATOM(557, 56, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_field_sig_21__1);
 }
 
 static void mb_c99_block_enter_21__1 (void) {
-    WORD_ENTER(mb_c99_block_enter_21__1, "c99-block-enter! block", "src/mirth/codegen.mth", 571, 14);
+    WORD_ENTER(mb_c99_block_enter_21__1, "c99-block-enter! block", "src/mirth/codegen.mth", 560, 14);
     mw_prim_drop();
-    WORD_ATOM(571, 14, "");
+    WORD_ATOM(560, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46393,13 +46363,13 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(571, 28, ".");
+    WORD_ATOM(560, 28, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(572, 9, "dup");
+    WORD_ATOM(561, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(572, 13, ".block");
+    WORD_ATOM(561, 13, ".block");
     mw_Block_2B_C99_2E_block();
-    WORD_ATOM(572, 20, "");
+    WORD_ATOM(561, 20, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46410,19 +46380,19 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(572, 25, ".");
+    WORD_ATOM(561, 25, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(573, 9, "dup");
+    WORD_ATOM(562, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(573, 13, "arrow");
+    WORD_ATOM(562, 13, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(573, 19, "home");
+    WORD_ATOM(562, 19, "home");
     mw_Arrow_2E_home();
-    WORD_ATOM(573, 24, "match");
+    WORD_ATOM(562, 24, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             co_NONE();
-            WORD_ATOM(574, 21, "");
+            WORD_ATOM(563, 21, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -46436,11 +46406,11 @@ static void mb_c99_block_enter_21__1 (void) {
             break;
         case 1LL:
             co_SOME();
-            WORD_ATOM(575, 21, "name");
+            WORD_ATOM(564, 21, "name");
             mw_Word_2E_name();
-            WORD_ATOM(575, 26, ">Str");
+            WORD_ATOM(564, 26, ">Str");
             mw_Name_3E_Str();
-            WORD_ATOM(575, 31, "");
+            WORD_ATOM(564, 31, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -46451,14 +46421,14 @@ static void mb_c99_block_enter_21__1 (void) {
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(575, 40, "cat");
+            WORD_ATOM(564, 40, "cat");
             mw_prim_str_cat();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
     
-}    WORD_ATOM(576, 11, ".str");
+}    WORD_ATOM(565, 11, ".str");
     mw__2E_str();
-    WORD_ATOM(576, 16, "");
+    WORD_ATOM(565, 16, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46469,21 +46439,21 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(576, 21, ".");
+    WORD_ATOM(565, 21, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(577, 9, "dup");
+    WORD_ATOM(566, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(577, 13, "token");
+    WORD_ATOM(566, 13, "token");
     mw_Block_2E_token();
-    WORD_ATOM(577, 19, ".module");
+    WORD_ATOM(566, 19, ".module");
     mw_Token_2E_module();
-    WORD_ATOM(577, 27, "source-path");
+    WORD_ATOM(566, 27, "source-path");
     mw_Module_2E_source_path();
-    WORD_ATOM(577, 39, ">Str");
+    WORD_ATOM(566, 39, ">Str");
     mw_Path_3E_Str();
-    WORD_ATOM(577, 44, ".str");
+    WORD_ATOM(566, 44, ".str");
     mw__2E_str();
-    WORD_ATOM(577, 49, "");
+    WORD_ATOM(566, 49, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46494,19 +46464,19 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(577, 54, ".");
+    WORD_ATOM(566, 54, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(578, 9, "dup");
+    WORD_ATOM(567, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(578, 13, "token");
+    WORD_ATOM(567, 13, "token");
     mw_Block_2E_token();
-    WORD_ATOM(578, 19, "row");
+    WORD_ATOM(567, 19, "row");
     mw_Token_2E_row();
-    WORD_ATOM(578, 23, ">Int");
+    WORD_ATOM(567, 23, ">Int");
     mw_Row_3E_Int();
-    WORD_ATOM(578, 28, ".n");
+    WORD_ATOM(567, 28, ".n");
     mw_Int_2B_C99_2E_n();
-    WORD_ATOM(578, 31, "");
+    WORD_ATOM(567, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46517,19 +46487,19 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(578, 36, ".");
+    WORD_ATOM(567, 36, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(579, 9, "dup");
+    WORD_ATOM(568, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(579, 13, "token");
+    WORD_ATOM(568, 13, "token");
     mw_Block_2E_token();
-    WORD_ATOM(579, 19, "col");
+    WORD_ATOM(568, 19, "col");
     mw_Token_2E_col();
-    WORD_ATOM(579, 23, ">Int");
+    WORD_ATOM(568, 23, ">Int");
     mw_Col_3E_Int();
-    WORD_ATOM(579, 28, ".n");
+    WORD_ATOM(568, 28, ".n");
     mw_Int_2B_C99_2E_n();
-    WORD_ATOM(579, 31, "");
+    WORD_ATOM(568, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46540,15 +46510,15 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(579, 36, ".");
+    WORD_ATOM(568, 36, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_block_enter_21__1);
 }
 
 static void mb_c99_block_exit_21__1 (void) {
-    WORD_ENTER(mb_c99_block_exit_21__1, "c99-block-exit! block", "src/mirth/codegen.mth", 583, 14);
+    WORD_ENTER(mb_c99_block_exit_21__1, "c99-block-exit! block", "src/mirth/codegen.mth", 572, 14);
     mw_prim_drop();
-    WORD_ATOM(583, 14, "");
+    WORD_ATOM(572, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46559,11 +46529,11 @@ static void mb_c99_block_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(583, 27, ".");
+    WORD_ATOM(572, 27, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(583, 29, ".block");
+    WORD_ATOM(572, 29, ".block");
     mw_Block_2B_C99_2E_block();
-    WORD_ATOM(583, 36, "");
+    WORD_ATOM(572, 36, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46574,15 +46544,15 @@ static void mb_c99_block_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(583, 41, ".");
+    WORD_ATOM(572, 41, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_block_exit_21__1);
 }
 
 static void mb_c99_block_def_21__1 (void) {
-    WORD_ENTER(mb_c99_block_def_21__1, "c99-block-def! block", "src/mirth/codegen.mth", 587, 14);
+    WORD_ENTER(mb_c99_block_def_21__1, "c99-block-def! block", "src/mirth/codegen.mth", 576, 14);
     mw_prim_drop();
-    WORD_ATOM(587, 14, "");
+    WORD_ATOM(576, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46593,13 +46563,13 @@ static void mb_c99_block_def_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(587, 29, ".");
+    WORD_ATOM(576, 29, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(587, 31, "dup");
+    WORD_ATOM(576, 31, "dup");
     mw_prim_dup();
-    WORD_ATOM(587, 35, ".block");
+    WORD_ATOM(576, 35, ".block");
     mw_Block_2B_C99_2E_block();
-    WORD_ATOM(587, 42, "");
+    WORD_ATOM(576, 42, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46610,45 +46580,45 @@ static void mb_c99_block_def_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(587, 54, ".");
+    WORD_ATOM(576, 54, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_block_def_21__1);
 }
 
 static void mb_c99_block_def_21__2 (void) {
-    WORD_ENTER(mb_c99_block_def_21__2, "c99-block-def! block", "src/mirth/codegen.mth", 589, 9);
+    WORD_ENTER(mb_c99_block_def_21__2, "c99-block-def! block", "src/mirth/codegen.mth", 578, 9);
     mw_prim_drop();
-    WORD_ATOM(589, 9, "dup");
+    WORD_ATOM(578, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(589, 13, "c99-block-enter!");
+    WORD_ATOM(578, 13, "c99-block-enter!");
     mw_c99_block_enter_21_();
-    WORD_ATOM(590, 9, "dup");
+    WORD_ATOM(579, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(590, 13, "arrow");
+    WORD_ATOM(579, 13, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(591, 9, "dup");
+    WORD_ATOM(580, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(591, 13, "ctx");
+    WORD_ATOM(580, 13, "ctx");
     mw_Arrow_2E_ctx();
-    WORD_ATOM(591, 17, "c99-unpack-ctx!");
+    WORD_ATOM(580, 17, "c99-unpack-ctx!");
     mw_c99_unpack_ctx_21_();
-    WORD_ATOM(592, 9, "dup");
+    WORD_ATOM(581, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(592, 13, "c99-arrow!");
+    WORD_ATOM(581, 13, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(593, 9, "ctx");
+    WORD_ATOM(582, 9, "ctx");
     mw_Arrow_2E_ctx();
-    WORD_ATOM(593, 13, "c99-decref-ctx!");
+    WORD_ATOM(582, 13, "c99-decref-ctx!");
     mw_c99_decref_ctx_21_();
-    WORD_ATOM(594, 9, "c99-block-exit!");
+    WORD_ATOM(583, 9, "c99-block-exit!");
     mw_c99_block_exit_21_();
     WORD_EXIT(mb_c99_block_def_21__2);
 }
 
 static void mb_c99_block_def_21__3 (void) {
-    WORD_ENTER(mb_c99_block_def_21__3, "c99-block-def! block", "src/mirth/codegen.mth", 596, 14);
+    WORD_ENTER(mb_c99_block_def_21__3, "c99-block-def! block", "src/mirth/codegen.mth", 585, 14);
     mw_prim_drop();
-    WORD_ATOM(596, 14, "");
+    WORD_ATOM(585, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46659,15 +46629,15 @@ static void mb_c99_block_def_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(596, 18, ".");
+    WORD_ATOM(585, 18, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_block_def_21__3);
 }
 
 static void mb_c99_word_enter_21__1 (void) {
-    WORD_ENTER(mb_c99_word_enter_21__1, "c99-word-enter! block", "src/mirth/codegen.mth", 608, 14);
+    WORD_ENTER(mb_c99_word_enter_21__1, "c99-word-enter! block", "src/mirth/codegen.mth", 597, 14);
     mw_prim_drop();
-    WORD_ATOM(608, 14, "");
+    WORD_ATOM(597, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46678,9 +46648,9 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(608, 28, ".");
+    WORD_ATOM(597, 28, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(609, 9, "");
+    WORD_ATOM(598, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46691,15 +46661,15 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(609, 15, ".");
+    WORD_ATOM(598, 15, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(609, 17, "dup");
+    WORD_ATOM(598, 17, "dup");
     mw_prim_dup();
-    WORD_ATOM(609, 21, "name");
+    WORD_ATOM(598, 21, "name");
     mw_Word_2E_name();
-    WORD_ATOM(609, 26, ".name");
+    WORD_ATOM(598, 26, ".name");
     mw_Name_2B_C99_2E_name();
-    WORD_ATOM(609, 32, "");
+    WORD_ATOM(598, 32, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46710,17 +46680,17 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(609, 37, ".");
+    WORD_ATOM(598, 37, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(610, 9, "dup");
+    WORD_ATOM(599, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(610, 13, "name");
+    WORD_ATOM(599, 13, "name");
     mw_Word_2E_name();
-    WORD_ATOM(610, 18, ">Str");
+    WORD_ATOM(599, 18, ">Str");
     mw_Name_3E_Str();
-    WORD_ATOM(610, 23, ".str");
+    WORD_ATOM(599, 23, ".str");
     mw__2E_str();
-    WORD_ATOM(610, 28, "");
+    WORD_ATOM(599, 28, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46731,21 +46701,21 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(610, 33, ".");
+    WORD_ATOM(599, 33, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(611, 9, "dup");
+    WORD_ATOM(600, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(611, 13, "body");
+    WORD_ATOM(600, 13, "body");
     mw_Word_2E_body();
-    WORD_ATOM(611, 18, ".module");
+    WORD_ATOM(600, 18, ".module");
     mw_Token_2E_module();
-    WORD_ATOM(611, 26, "source-path");
+    WORD_ATOM(600, 26, "source-path");
     mw_Module_2E_source_path();
-    WORD_ATOM(611, 38, ">Str");
+    WORD_ATOM(600, 38, ">Str");
     mw_Path_3E_Str();
-    WORD_ATOM(611, 43, ".str");
+    WORD_ATOM(600, 43, ".str");
     mw__2E_str();
-    WORD_ATOM(611, 48, "");
+    WORD_ATOM(600, 48, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46756,19 +46726,19 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(611, 53, ".");
+    WORD_ATOM(600, 53, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(612, 9, "dup");
+    WORD_ATOM(601, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(612, 13, "body");
+    WORD_ATOM(601, 13, "body");
     mw_Word_2E_body();
-    WORD_ATOM(612, 18, "row");
+    WORD_ATOM(601, 18, "row");
     mw_Token_2E_row();
-    WORD_ATOM(612, 22, ">Int");
+    WORD_ATOM(601, 22, ">Int");
     mw_Row_3E_Int();
-    WORD_ATOM(612, 27, ".n");
+    WORD_ATOM(601, 27, ".n");
     mw_Int_2B_C99_2E_n();
-    WORD_ATOM(612, 30, "");
+    WORD_ATOM(601, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46779,19 +46749,19 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(612, 35, ".");
+    WORD_ATOM(601, 35, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(613, 9, "dup");
+    WORD_ATOM(602, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(613, 13, "body");
+    WORD_ATOM(602, 13, "body");
     mw_Word_2E_body();
-    WORD_ATOM(613, 18, "col");
+    WORD_ATOM(602, 18, "col");
     mw_Token_2E_col();
-    WORD_ATOM(613, 22, ">Int");
+    WORD_ATOM(602, 22, ">Int");
     mw_Col_3E_Int();
-    WORD_ATOM(613, 27, ".n");
+    WORD_ATOM(602, 27, ".n");
     mw_Int_2B_C99_2E_n();
-    WORD_ATOM(613, 30, "");
+    WORD_ATOM(602, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46802,15 +46772,15 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(613, 35, ".");
+    WORD_ATOM(602, 35, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_word_enter_21__1);
 }
 
 static void mb_c99_word_exit_21__1 (void) {
-    WORD_ENTER(mb_c99_word_exit_21__1, "c99-word-exit! block", "src/mirth/codegen.mth", 617, 14);
+    WORD_ENTER(mb_c99_word_exit_21__1, "c99-word-exit! block", "src/mirth/codegen.mth", 606, 14);
     mw_prim_drop();
-    WORD_ATOM(617, 14, "");
+    WORD_ATOM(606, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46821,9 +46791,9 @@ static void mb_c99_word_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(617, 27, ".");
+    WORD_ATOM(606, 27, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(618, 9, "");
+    WORD_ATOM(607, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46834,15 +46804,15 @@ static void mb_c99_word_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(618, 15, ".");
+    WORD_ATOM(607, 15, ".");
     mw_Str_2B_C99_2E_();
-    WORD_ATOM(618, 17, "dup");
+    WORD_ATOM(607, 17, "dup");
     mw_prim_dup();
-    WORD_ATOM(618, 21, "name");
+    WORD_ATOM(607, 21, "name");
     mw_Word_2E_name();
-    WORD_ATOM(618, 26, ".name");
+    WORD_ATOM(607, 26, ".name");
     mw_Name_2B_C99_2E_name();
-    WORD_ATOM(618, 32, "");
+    WORD_ATOM(607, 32, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46853,21 +46823,21 @@ static void mb_c99_word_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(618, 37, ".");
+    WORD_ATOM(607, 37, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_word_exit_21__1);
 }
 
 static void mb_c99_word_def_21__1 (void) {
-    WORD_ENTER(mb_c99_word_def_21__1, "c99-word-def! block", "src/mirth/codegen.mth", 623, 14);
+    WORD_ENTER(mb_c99_word_def_21__1, "c99-word-def! block", "src/mirth/codegen.mth", 612, 14);
     mw_prim_drop();
-    WORD_ATOM(623, 14, "dup");
+    WORD_ATOM(612, 14, "dup");
     mw_prim_dup();
-    WORD_ATOM(623, 18, "name");
+    WORD_ATOM(612, 18, "name");
     mw_Word_2E_name();
-    WORD_ATOM(623, 23, ".w");
+    WORD_ATOM(612, 23, ".w");
     mw_Name_2B_C99_2E_w();
-    WORD_ATOM(623, 26, "");
+    WORD_ATOM(612, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46878,35 +46848,35 @@ static void mb_c99_word_def_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(623, 30, ".");
+    WORD_ATOM(612, 30, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_word_def_21__1);
 }
 
 static void mb_c99_word_def_21__2 (void) {
-    WORD_ENTER(mb_c99_word_def_21__2, "c99-word-def! block", "src/mirth/codegen.mth", 625, 9);
+    WORD_ENTER(mb_c99_word_def_21__2, "c99-word-def! block", "src/mirth/codegen.mth", 614, 9);
     mw_prim_drop();
-    WORD_ATOM(625, 9, "dup");
+    WORD_ATOM(614, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(625, 13, "c99-word-enter!");
+    WORD_ATOM(614, 13, "c99-word-enter!");
     mw_c99_word_enter_21_();
-    WORD_ATOM(626, 9, "dup");
+    WORD_ATOM(615, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(626, 13, "arrow");
+    WORD_ATOM(615, 13, "arrow");
     mw_Word_2E_arrow();
-    WORD_ATOM(626, 19, "c99-arrow!");
+    WORD_ATOM(615, 19, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(627, 9, "dup");
+    WORD_ATOM(616, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(627, 13, "c99-word-exit!");
+    WORD_ATOM(616, 13, "c99-word-exit!");
     mw_c99_word_exit_21_();
     WORD_EXIT(mb_c99_word_def_21__2);
 }
 
 static void mb_c99_word_def_21__3 (void) {
-    WORD_ENTER(mb_c99_word_def_21__3, "c99-word-def! block", "src/mirth/codegen.mth", 629, 14);
+    WORD_ENTER(mb_c99_word_def_21__3, "c99-word-def! block", "src/mirth/codegen.mth", 618, 14);
     mw_prim_drop();
-    WORD_ATOM(629, 14, "");
+    WORD_ATOM(618, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46917,7 +46887,7 @@ static void mb_c99_word_def_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(629, 18, ".");
+    WORD_ATOM(618, 18, ".");
     mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_word_def_21__3);
 }

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -1198,7 +1198,7 @@ static void mw_F (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_F() {
+static void mp_F (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1208,49 +1208,49 @@ static void mw_T (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_T() {
+static void mp_T (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
 }
 static void mw_Int_3E_U64_unsafe (void) {
 }
-void co_Int_3E_U64_unsafe() {
+static void mp_Int_3E_U64_unsafe (void) {
 }
 static void mw_Int_3E_U32_unsafe (void) {
 }
-void co_Int_3E_U32_unsafe() {
+static void mp_Int_3E_U32_unsafe (void) {
 }
 static void mw_Int_3E_U16_unsafe (void) {
 }
-void co_Int_3E_U16_unsafe() {
+static void mp_Int_3E_U16_unsafe (void) {
 }
 static void mw_Int_3E_U8_unsafe (void) {
 }
-void co_Int_3E_U8_unsafe() {
+static void mp_Int_3E_U8_unsafe (void) {
 }
 static void mw_Int_3E_I64_unsafe (void) {
 }
-void co_Int_3E_I64_unsafe() {
+static void mp_Int_3E_I64_unsafe (void) {
 }
 static void mw_Int_3E_I32_unsafe (void) {
 }
-void co_Int_3E_I32_unsafe() {
+static void mp_Int_3E_I32_unsafe (void) {
 }
 static void mw_Int_3E_I16_unsafe (void) {
 }
-void co_Int_3E_I16_unsafe() {
+static void mp_Int_3E_I16_unsafe (void) {
 }
 static void mw_Int_3E_I8_unsafe (void) {
 }
-void co_Int_3E_I8_unsafe() {
+static void mp_Int_3E_I8_unsafe (void) {
 }
 static void mw_L0 (void) {
     VAL tag = MKU64(0LL);
     VAL car = (tag);
     push_value(car);
 }
-void co_L0() {
+static void mp_L0 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1261,7 +1261,7 @@ static void mw_L1 (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_L1() {
+static void mp_L1 (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -1275,7 +1275,7 @@ static void mw_L2 (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_L2() {
+static void mp_L2 (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -1292,7 +1292,7 @@ static void mw_L3 (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_L3() {
+static void mp_L3 (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -1311,7 +1311,7 @@ static void mw_LCAT (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_LCAT() {
+static void mp_LCAT (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -1328,7 +1328,7 @@ static void mw_L1_2B_ (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_L1_2B_() {
+static void mp_L1_2B_ (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -1342,7 +1342,7 @@ static void mw_L2_2B_ (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_L2_2B_() {
+static void mp_L2_2B_ (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -1359,7 +1359,7 @@ static void mw_L3_2B_ (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_L3_2B_() {
+static void mp_L3_2B_ (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -1378,7 +1378,7 @@ static void mw_LCAT_2B_ (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_LCAT_2B_() {
+static void mp_LCAT_2B_ (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -1394,7 +1394,7 @@ static void mw_NONE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_NONE() {
+static void mp_NONE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1405,7 +1405,7 @@ static void mw_SOME (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_SOME() {
+static void mp_SOME (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -1414,14 +1414,14 @@ void co_SOME() {
 }
 static void mw_Int_3E_RawPtr (void) {
 }
-void co_Int_3E_RawPtr() {
+static void mp_Int_3E_RawPtr (void) {
 }
 static void mw_OS_5F_UNKNOWN (void) {
     VAL tag = MKU64(0LL);
     VAL car = (tag);
     push_value(car);
 }
-void co_OS_5F_UNKNOWN() {
+static void mp_OS_5F_UNKNOWN (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1431,7 +1431,7 @@ static void mw_OS_5F_WINDOWS (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_OS_5F_WINDOWS() {
+static void mp_OS_5F_WINDOWS (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1441,7 +1441,7 @@ static void mw_OS_5F_LINUX (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_OS_5F_LINUX() {
+static void mp_OS_5F_LINUX (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1451,7 +1451,7 @@ static void mw_OS_5F_MACOS (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_OS_5F_MACOS() {
+static void mp_OS_5F_MACOS (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1461,7 +1461,7 @@ static void mw_LT (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_LT() {
+static void mp_LT (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1471,7 +1471,7 @@ static void mw_EQ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_EQ() {
+static void mp_EQ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1481,7 +1481,7 @@ static void mw_GT (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_GT() {
+static void mp_GT (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1491,7 +1491,7 @@ static void mw_BNUL (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BNUL() {
+static void mp_BNUL (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1501,7 +1501,7 @@ static void mw_BSOH (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BSOH() {
+static void mp_BSOH (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1511,7 +1511,7 @@ static void mw_BSTX (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BSTX() {
+static void mp_BSTX (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1521,7 +1521,7 @@ static void mw_BETX (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BETX() {
+static void mp_BETX (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1531,7 +1531,7 @@ static void mw_BEOT (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BEOT() {
+static void mp_BEOT (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1541,7 +1541,7 @@ static void mw_BENQ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BENQ() {
+static void mp_BENQ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1551,7 +1551,7 @@ static void mw_BACK (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BACK() {
+static void mp_BACK (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1561,7 +1561,7 @@ static void mw_BBEL (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BBEL() {
+static void mp_BBEL (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1571,7 +1571,7 @@ static void mw_BBS (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BBS() {
+static void mp_BBS (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1581,7 +1581,7 @@ static void mw_BHT (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BHT() {
+static void mp_BHT (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1591,7 +1591,7 @@ static void mw_BLF (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BLF() {
+static void mp_BLF (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1601,7 +1601,7 @@ static void mw_BVT (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BVT() {
+static void mp_BVT (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1611,7 +1611,7 @@ static void mw_BFF (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BFF() {
+static void mp_BFF (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1621,7 +1621,7 @@ static void mw_BCR (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BCR() {
+static void mp_BCR (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1631,7 +1631,7 @@ static void mw_BSO (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BSO() {
+static void mp_BSO (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1641,7 +1641,7 @@ static void mw_BSI (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BSI() {
+static void mp_BSI (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1651,7 +1651,7 @@ static void mw_BDLE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BDLE() {
+static void mp_BDLE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1661,7 +1661,7 @@ static void mw_BDC1 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BDC1() {
+static void mp_BDC1 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1671,7 +1671,7 @@ static void mw_BDC2 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BDC2() {
+static void mp_BDC2 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1681,7 +1681,7 @@ static void mw_BDC3 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BDC3() {
+static void mp_BDC3 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1691,7 +1691,7 @@ static void mw_BDC4 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BDC4() {
+static void mp_BDC4 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1701,7 +1701,7 @@ static void mw_BNAK (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BNAK() {
+static void mp_BNAK (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1711,7 +1711,7 @@ static void mw_BSYN (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BSYN() {
+static void mp_BSYN (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1721,7 +1721,7 @@ static void mw_BETB (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BETB() {
+static void mp_BETB (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1731,7 +1731,7 @@ static void mw_BCAN (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BCAN() {
+static void mp_BCAN (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1741,7 +1741,7 @@ static void mw_BEM (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BEM() {
+static void mp_BEM (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1751,7 +1751,7 @@ static void mw_BSUB (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BSUB() {
+static void mp_BSUB (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1761,7 +1761,7 @@ static void mw_BESC (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BESC() {
+static void mp_BESC (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1771,7 +1771,7 @@ static void mw_BFS (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BFS() {
+static void mp_BFS (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1781,7 +1781,7 @@ static void mw_BGS (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BGS() {
+static void mp_BGS (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1791,7 +1791,7 @@ static void mw_BRS (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BRS() {
+static void mp_BRS (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1801,7 +1801,7 @@ static void mw_BUS (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BUS() {
+static void mp_BUS (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1811,7 +1811,7 @@ static void mw_BSPACE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BSPACE() {
+static void mp_BSPACE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1821,7 +1821,7 @@ static void mw_B_27__21__27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27__21__27_() {
+static void mp_B_27__21__27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1831,7 +1831,7 @@ static void mw_BQUOTE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BQUOTE() {
+static void mp_BQUOTE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1841,7 +1841,7 @@ static void mw_BHASH (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BHASH() {
+static void mp_BHASH (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1851,7 +1851,7 @@ static void mw_B_27__24__27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27__24__27_() {
+static void mp_B_27__24__27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1861,7 +1861,7 @@ static void mw_B_27__25__27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27__25__27_() {
+static void mp_B_27__25__27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1871,7 +1871,7 @@ static void mw_B_27__26__27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27__26__27_() {
+static void mp_B_27__26__27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1881,7 +1881,7 @@ static void mw_BTICK (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BTICK() {
+static void mp_BTICK (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1891,7 +1891,7 @@ static void mw_BLPAREN (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BLPAREN() {
+static void mp_BLPAREN (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1901,7 +1901,7 @@ static void mw_BRPAREN (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BRPAREN() {
+static void mp_BRPAREN (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1911,7 +1911,7 @@ static void mw_B_27__2A__27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27__2A__27_() {
+static void mp_B_27__2A__27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1921,7 +1921,7 @@ static void mw_B_27__2B__27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27__2B__27_() {
+static void mp_B_27__2B__27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1931,7 +1931,7 @@ static void mw_BCOMMA (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BCOMMA() {
+static void mp_BCOMMA (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1941,7 +1941,7 @@ static void mw_B_27___27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27___27_() {
+static void mp_B_27___27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1951,7 +1951,7 @@ static void mw_B_27__2E__27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27__2E__27_() {
+static void mp_B_27__2E__27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1961,7 +1961,7 @@ static void mw_B_27__2F__27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27__2F__27_() {
+static void mp_B_27__2F__27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1971,7 +1971,7 @@ static void mw_B_27_0_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_0_27_() {
+static void mp_B_27_0_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1981,7 +1981,7 @@ static void mw_B_27_1_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_1_27_() {
+static void mp_B_27_1_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -1991,7 +1991,7 @@ static void mw_B_27_2_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_2_27_() {
+static void mp_B_27_2_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2001,7 +2001,7 @@ static void mw_B_27_3_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_3_27_() {
+static void mp_B_27_3_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2011,7 +2011,7 @@ static void mw_B_27_4_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_4_27_() {
+static void mp_B_27_4_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2021,7 +2021,7 @@ static void mw_B_27_5_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_5_27_() {
+static void mp_B_27_5_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2031,7 +2031,7 @@ static void mw_B_27_6_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_6_27_() {
+static void mp_B_27_6_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2041,7 +2041,7 @@ static void mw_B_27_7_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_7_27_() {
+static void mp_B_27_7_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2051,7 +2051,7 @@ static void mw_B_27_8_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_8_27_() {
+static void mp_B_27_8_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2061,7 +2061,7 @@ static void mw_B_27_9_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_9_27_() {
+static void mp_B_27_9_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2071,7 +2071,7 @@ static void mw_BCOLON (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BCOLON() {
+static void mp_BCOLON (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2081,7 +2081,7 @@ static void mw_B_27__3B__27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27__3B__27_() {
+static void mp_B_27__3B__27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2091,7 +2091,7 @@ static void mw_B_27__3C__27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27__3C__27_() {
+static void mp_B_27__3C__27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2101,7 +2101,7 @@ static void mw_B_27__3D__27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27__3D__27_() {
+static void mp_B_27__3D__27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2111,7 +2111,7 @@ static void mw_B_27__3E__27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27__3E__27_() {
+static void mp_B_27__3E__27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2121,7 +2121,7 @@ static void mw_B_27__3F__27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27__3F__27_() {
+static void mp_B_27__3F__27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2131,7 +2131,7 @@ static void mw_B_27__40__27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27__40__27_() {
+static void mp_B_27__40__27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2141,7 +2141,7 @@ static void mw_B_27_A_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_A_27_() {
+static void mp_B_27_A_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2151,7 +2151,7 @@ static void mw_B_27_B_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_B_27_() {
+static void mp_B_27_B_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2161,7 +2161,7 @@ static void mw_B_27_C_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_C_27_() {
+static void mp_B_27_C_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2171,7 +2171,7 @@ static void mw_B_27_D_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_D_27_() {
+static void mp_B_27_D_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2181,7 +2181,7 @@ static void mw_B_27_E_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_E_27_() {
+static void mp_B_27_E_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2191,7 +2191,7 @@ static void mw_B_27_F_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_F_27_() {
+static void mp_B_27_F_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2201,7 +2201,7 @@ static void mw_B_27_G_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_G_27_() {
+static void mp_B_27_G_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2211,7 +2211,7 @@ static void mw_B_27_H_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_H_27_() {
+static void mp_B_27_H_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2221,7 +2221,7 @@ static void mw_B_27_I_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_I_27_() {
+static void mp_B_27_I_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2231,7 +2231,7 @@ static void mw_B_27_J_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_J_27_() {
+static void mp_B_27_J_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2241,7 +2241,7 @@ static void mw_B_27_K_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_K_27_() {
+static void mp_B_27_K_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2251,7 +2251,7 @@ static void mw_B_27_L_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_L_27_() {
+static void mp_B_27_L_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2261,7 +2261,7 @@ static void mw_B_27_M_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_M_27_() {
+static void mp_B_27_M_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2271,7 +2271,7 @@ static void mw_B_27_N_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_N_27_() {
+static void mp_B_27_N_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2281,7 +2281,7 @@ static void mw_B_27_O_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_O_27_() {
+static void mp_B_27_O_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2291,7 +2291,7 @@ static void mw_B_27_P_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_P_27_() {
+static void mp_B_27_P_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2301,7 +2301,7 @@ static void mw_B_27_Q_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_Q_27_() {
+static void mp_B_27_Q_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2311,7 +2311,7 @@ static void mw_B_27_R_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_R_27_() {
+static void mp_B_27_R_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2321,7 +2321,7 @@ static void mw_B_27_S_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_S_27_() {
+static void mp_B_27_S_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2331,7 +2331,7 @@ static void mw_B_27_T_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_T_27_() {
+static void mp_B_27_T_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2341,7 +2341,7 @@ static void mw_B_27_U_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_U_27_() {
+static void mp_B_27_U_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2351,7 +2351,7 @@ static void mw_B_27_V_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_V_27_() {
+static void mp_B_27_V_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2361,7 +2361,7 @@ static void mw_B_27_W_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_W_27_() {
+static void mp_B_27_W_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2371,7 +2371,7 @@ static void mw_B_27_X_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_X_27_() {
+static void mp_B_27_X_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2381,7 +2381,7 @@ static void mw_B_27_Y_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_Y_27_() {
+static void mp_B_27_Y_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2391,7 +2391,7 @@ static void mw_B_27_Z_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_Z_27_() {
+static void mp_B_27_Z_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2401,7 +2401,7 @@ static void mw_BLSQUARE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BLSQUARE() {
+static void mp_BLSQUARE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2411,7 +2411,7 @@ static void mw_B_27__5C__27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27__5C__27_() {
+static void mp_B_27__5C__27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2421,7 +2421,7 @@ static void mw_BRSQUARE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BRSQUARE() {
+static void mp_BRSQUARE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2431,7 +2431,7 @@ static void mw_B_27__5E__27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27__5E__27_() {
+static void mp_B_27__5E__27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2441,7 +2441,7 @@ static void mw_B_27__5F__27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27__5F__27_() {
+static void mp_B_27__5F__27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2451,7 +2451,7 @@ static void mw_B_27__60__27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27__60__27_() {
+static void mp_B_27__60__27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2461,7 +2461,7 @@ static void mw_B_27_a_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_a_27_() {
+static void mp_B_27_a_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2471,7 +2471,7 @@ static void mw_B_27_b_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_b_27_() {
+static void mp_B_27_b_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2481,7 +2481,7 @@ static void mw_B_27_c_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_c_27_() {
+static void mp_B_27_c_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2491,7 +2491,7 @@ static void mw_B_27_d_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_d_27_() {
+static void mp_B_27_d_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2501,7 +2501,7 @@ static void mw_B_27_e_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_e_27_() {
+static void mp_B_27_e_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2511,7 +2511,7 @@ static void mw_B_27_f_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_f_27_() {
+static void mp_B_27_f_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2521,7 +2521,7 @@ static void mw_B_27_g_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_g_27_() {
+static void mp_B_27_g_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2531,7 +2531,7 @@ static void mw_B_27_h_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_h_27_() {
+static void mp_B_27_h_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2541,7 +2541,7 @@ static void mw_B_27_i_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_i_27_() {
+static void mp_B_27_i_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2551,7 +2551,7 @@ static void mw_B_27_j_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_j_27_() {
+static void mp_B_27_j_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2561,7 +2561,7 @@ static void mw_B_27_k_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_k_27_() {
+static void mp_B_27_k_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2571,7 +2571,7 @@ static void mw_B_27_l_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_l_27_() {
+static void mp_B_27_l_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2581,7 +2581,7 @@ static void mw_B_27_m_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_m_27_() {
+static void mp_B_27_m_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2591,7 +2591,7 @@ static void mw_B_27_n_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_n_27_() {
+static void mp_B_27_n_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2601,7 +2601,7 @@ static void mw_B_27_o_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_o_27_() {
+static void mp_B_27_o_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2611,7 +2611,7 @@ static void mw_B_27_p_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_p_27_() {
+static void mp_B_27_p_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2621,7 +2621,7 @@ static void mw_B_27_q_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_q_27_() {
+static void mp_B_27_q_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2631,7 +2631,7 @@ static void mw_B_27_r_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_r_27_() {
+static void mp_B_27_r_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2641,7 +2641,7 @@ static void mw_B_27_s_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_s_27_() {
+static void mp_B_27_s_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2651,7 +2651,7 @@ static void mw_B_27_t_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_t_27_() {
+static void mp_B_27_t_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2661,7 +2661,7 @@ static void mw_B_27_u_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_u_27_() {
+static void mp_B_27_u_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2671,7 +2671,7 @@ static void mw_B_27_v_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_v_27_() {
+static void mp_B_27_v_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2681,7 +2681,7 @@ static void mw_B_27_w_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_w_27_() {
+static void mp_B_27_w_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2691,7 +2691,7 @@ static void mw_B_27_x_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_x_27_() {
+static void mp_B_27_x_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2701,7 +2701,7 @@ static void mw_B_27_y_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_y_27_() {
+static void mp_B_27_y_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2711,7 +2711,7 @@ static void mw_B_27_z_27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27_z_27_() {
+static void mp_B_27_z_27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2721,7 +2721,7 @@ static void mw_BLCURLY (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BLCURLY() {
+static void mp_BLCURLY (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2731,7 +2731,7 @@ static void mw_B_27__7C__27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27__7C__27_() {
+static void mp_B_27__7C__27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2741,7 +2741,7 @@ static void mw_BRCURLY (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BRCURLY() {
+static void mp_BRCURLY (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2751,7 +2751,7 @@ static void mw_B_27__7E__27_ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_B_27__7E__27_() {
+static void mp_B_27__7E__27_ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2761,7 +2761,7 @@ static void mw_BDEL (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BDEL() {
+static void mp_BDEL (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2771,7 +2771,7 @@ static void mw_Bx80 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx80() {
+static void mp_Bx80 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2781,7 +2781,7 @@ static void mw_Bx81 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx81() {
+static void mp_Bx81 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2791,7 +2791,7 @@ static void mw_Bx82 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx82() {
+static void mp_Bx82 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2801,7 +2801,7 @@ static void mw_Bx83 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx83() {
+static void mp_Bx83 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2811,7 +2811,7 @@ static void mw_Bx84 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx84() {
+static void mp_Bx84 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2821,7 +2821,7 @@ static void mw_Bx85 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx85() {
+static void mp_Bx85 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2831,7 +2831,7 @@ static void mw_Bx86 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx86() {
+static void mp_Bx86 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2841,7 +2841,7 @@ static void mw_Bx87 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx87() {
+static void mp_Bx87 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2851,7 +2851,7 @@ static void mw_Bx88 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx88() {
+static void mp_Bx88 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2861,7 +2861,7 @@ static void mw_Bx89 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx89() {
+static void mp_Bx89 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2871,7 +2871,7 @@ static void mw_Bx8A (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx8A() {
+static void mp_Bx8A (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2881,7 +2881,7 @@ static void mw_Bx8B (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx8B() {
+static void mp_Bx8B (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2891,7 +2891,7 @@ static void mw_Bx8C (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx8C() {
+static void mp_Bx8C (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2901,7 +2901,7 @@ static void mw_Bx8D (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx8D() {
+static void mp_Bx8D (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2911,7 +2911,7 @@ static void mw_Bx8E (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx8E() {
+static void mp_Bx8E (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2921,7 +2921,7 @@ static void mw_Bx8F (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx8F() {
+static void mp_Bx8F (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2931,7 +2931,7 @@ static void mw_Bx90 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx90() {
+static void mp_Bx90 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2941,7 +2941,7 @@ static void mw_Bx91 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx91() {
+static void mp_Bx91 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2951,7 +2951,7 @@ static void mw_Bx92 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx92() {
+static void mp_Bx92 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2961,7 +2961,7 @@ static void mw_Bx93 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx93() {
+static void mp_Bx93 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2971,7 +2971,7 @@ static void mw_Bx94 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx94() {
+static void mp_Bx94 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2981,7 +2981,7 @@ static void mw_Bx95 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx95() {
+static void mp_Bx95 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -2991,7 +2991,7 @@ static void mw_Bx96 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx96() {
+static void mp_Bx96 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3001,7 +3001,7 @@ static void mw_Bx97 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx97() {
+static void mp_Bx97 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3011,7 +3011,7 @@ static void mw_Bx98 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx98() {
+static void mp_Bx98 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3021,7 +3021,7 @@ static void mw_Bx99 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx99() {
+static void mp_Bx99 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3031,7 +3031,7 @@ static void mw_Bx9A (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx9A() {
+static void mp_Bx9A (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3041,7 +3041,7 @@ static void mw_Bx9B (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx9B() {
+static void mp_Bx9B (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3051,7 +3051,7 @@ static void mw_Bx9C (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx9C() {
+static void mp_Bx9C (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3061,7 +3061,7 @@ static void mw_Bx9D (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx9D() {
+static void mp_Bx9D (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3071,7 +3071,7 @@ static void mw_Bx9E (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx9E() {
+static void mp_Bx9E (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3081,7 +3081,7 @@ static void mw_Bx9F (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_Bx9F() {
+static void mp_Bx9F (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3091,7 +3091,7 @@ static void mw_BxA0 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxA0() {
+static void mp_BxA0 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3101,7 +3101,7 @@ static void mw_BxA1 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxA1() {
+static void mp_BxA1 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3111,7 +3111,7 @@ static void mw_BxA2 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxA2() {
+static void mp_BxA2 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3121,7 +3121,7 @@ static void mw_BxA3 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxA3() {
+static void mp_BxA3 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3131,7 +3131,7 @@ static void mw_BxA4 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxA4() {
+static void mp_BxA4 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3141,7 +3141,7 @@ static void mw_BxA5 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxA5() {
+static void mp_BxA5 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3151,7 +3151,7 @@ static void mw_BxA6 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxA6() {
+static void mp_BxA6 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3161,7 +3161,7 @@ static void mw_BxA7 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxA7() {
+static void mp_BxA7 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3171,7 +3171,7 @@ static void mw_BxA8 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxA8() {
+static void mp_BxA8 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3181,7 +3181,7 @@ static void mw_BxA9 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxA9() {
+static void mp_BxA9 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3191,7 +3191,7 @@ static void mw_BxAA (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxAA() {
+static void mp_BxAA (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3201,7 +3201,7 @@ static void mw_BxAB (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxAB() {
+static void mp_BxAB (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3211,7 +3211,7 @@ static void mw_BxAC (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxAC() {
+static void mp_BxAC (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3221,7 +3221,7 @@ static void mw_BxAD (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxAD() {
+static void mp_BxAD (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3231,7 +3231,7 @@ static void mw_BxAE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxAE() {
+static void mp_BxAE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3241,7 +3241,7 @@ static void mw_BxAF (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxAF() {
+static void mp_BxAF (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3251,7 +3251,7 @@ static void mw_BxB0 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxB0() {
+static void mp_BxB0 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3261,7 +3261,7 @@ static void mw_BxB1 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxB1() {
+static void mp_BxB1 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3271,7 +3271,7 @@ static void mw_BxB2 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxB2() {
+static void mp_BxB2 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3281,7 +3281,7 @@ static void mw_BxB3 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxB3() {
+static void mp_BxB3 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3291,7 +3291,7 @@ static void mw_BxB4 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxB4() {
+static void mp_BxB4 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3301,7 +3301,7 @@ static void mw_BxB5 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxB5() {
+static void mp_BxB5 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3311,7 +3311,7 @@ static void mw_BxB6 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxB6() {
+static void mp_BxB6 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3321,7 +3321,7 @@ static void mw_BxB7 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxB7() {
+static void mp_BxB7 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3331,7 +3331,7 @@ static void mw_BxB8 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxB8() {
+static void mp_BxB8 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3341,7 +3341,7 @@ static void mw_BxB9 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxB9() {
+static void mp_BxB9 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3351,7 +3351,7 @@ static void mw_BxBA (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxBA() {
+static void mp_BxBA (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3361,7 +3361,7 @@ static void mw_BxBB (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxBB() {
+static void mp_BxBB (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3371,7 +3371,7 @@ static void mw_BxBC (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxBC() {
+static void mp_BxBC (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3381,7 +3381,7 @@ static void mw_BxBD (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxBD() {
+static void mp_BxBD (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3391,7 +3391,7 @@ static void mw_BxBE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxBE() {
+static void mp_BxBE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3401,7 +3401,7 @@ static void mw_BxBF (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxBF() {
+static void mp_BxBF (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3411,7 +3411,7 @@ static void mw_BxC0 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxC0() {
+static void mp_BxC0 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3421,7 +3421,7 @@ static void mw_BxC1 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxC1() {
+static void mp_BxC1 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3431,7 +3431,7 @@ static void mw_BxC2 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxC2() {
+static void mp_BxC2 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3441,7 +3441,7 @@ static void mw_BxC3 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxC3() {
+static void mp_BxC3 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3451,7 +3451,7 @@ static void mw_BxC4 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxC4() {
+static void mp_BxC4 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3461,7 +3461,7 @@ static void mw_BxC5 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxC5() {
+static void mp_BxC5 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3471,7 +3471,7 @@ static void mw_BxC6 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxC6() {
+static void mp_BxC6 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3481,7 +3481,7 @@ static void mw_BxC7 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxC7() {
+static void mp_BxC7 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3491,7 +3491,7 @@ static void mw_BxC8 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxC8() {
+static void mp_BxC8 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3501,7 +3501,7 @@ static void mw_BxC9 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxC9() {
+static void mp_BxC9 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3511,7 +3511,7 @@ static void mw_BxCA (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxCA() {
+static void mp_BxCA (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3521,7 +3521,7 @@ static void mw_BxCB (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxCB() {
+static void mp_BxCB (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3531,7 +3531,7 @@ static void mw_BxCC (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxCC() {
+static void mp_BxCC (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3541,7 +3541,7 @@ static void mw_BxCD (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxCD() {
+static void mp_BxCD (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3551,7 +3551,7 @@ static void mw_BxCE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxCE() {
+static void mp_BxCE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3561,7 +3561,7 @@ static void mw_BxCF (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxCF() {
+static void mp_BxCF (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3571,7 +3571,7 @@ static void mw_BxD0 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxD0() {
+static void mp_BxD0 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3581,7 +3581,7 @@ static void mw_BxD1 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxD1() {
+static void mp_BxD1 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3591,7 +3591,7 @@ static void mw_BxD2 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxD2() {
+static void mp_BxD2 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3601,7 +3601,7 @@ static void mw_BxD3 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxD3() {
+static void mp_BxD3 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3611,7 +3611,7 @@ static void mw_BxD4 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxD4() {
+static void mp_BxD4 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3621,7 +3621,7 @@ static void mw_BxD5 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxD5() {
+static void mp_BxD5 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3631,7 +3631,7 @@ static void mw_BxD6 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxD6() {
+static void mp_BxD6 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3641,7 +3641,7 @@ static void mw_BxD7 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxD7() {
+static void mp_BxD7 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3651,7 +3651,7 @@ static void mw_BxD8 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxD8() {
+static void mp_BxD8 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3661,7 +3661,7 @@ static void mw_BxD9 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxD9() {
+static void mp_BxD9 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3671,7 +3671,7 @@ static void mw_BxDA (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxDA() {
+static void mp_BxDA (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3681,7 +3681,7 @@ static void mw_BxDB (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxDB() {
+static void mp_BxDB (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3691,7 +3691,7 @@ static void mw_BxDC (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxDC() {
+static void mp_BxDC (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3701,7 +3701,7 @@ static void mw_BxDD (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxDD() {
+static void mp_BxDD (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3711,7 +3711,7 @@ static void mw_BxDE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxDE() {
+static void mp_BxDE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3721,7 +3721,7 @@ static void mw_BxDF (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxDF() {
+static void mp_BxDF (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3731,7 +3731,7 @@ static void mw_BxE0 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxE0() {
+static void mp_BxE0 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3741,7 +3741,7 @@ static void mw_BxE1 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxE1() {
+static void mp_BxE1 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3751,7 +3751,7 @@ static void mw_BxE2 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxE2() {
+static void mp_BxE2 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3761,7 +3761,7 @@ static void mw_BxE3 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxE3() {
+static void mp_BxE3 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3771,7 +3771,7 @@ static void mw_BxE4 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxE4() {
+static void mp_BxE4 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3781,7 +3781,7 @@ static void mw_BxE5 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxE5() {
+static void mp_BxE5 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3791,7 +3791,7 @@ static void mw_BxE6 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxE6() {
+static void mp_BxE6 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3801,7 +3801,7 @@ static void mw_BxE7 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxE7() {
+static void mp_BxE7 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3811,7 +3811,7 @@ static void mw_BxE8 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxE8() {
+static void mp_BxE8 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3821,7 +3821,7 @@ static void mw_BxE9 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxE9() {
+static void mp_BxE9 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3831,7 +3831,7 @@ static void mw_BxEA (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxEA() {
+static void mp_BxEA (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3841,7 +3841,7 @@ static void mw_BxEB (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxEB() {
+static void mp_BxEB (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3851,7 +3851,7 @@ static void mw_BxEC (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxEC() {
+static void mp_BxEC (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3861,7 +3861,7 @@ static void mw_BxED (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxED() {
+static void mp_BxED (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3871,7 +3871,7 @@ static void mw_BxEE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxEE() {
+static void mp_BxEE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3881,7 +3881,7 @@ static void mw_BxEF (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxEF() {
+static void mp_BxEF (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3891,7 +3891,7 @@ static void mw_BxF0 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxF0() {
+static void mp_BxF0 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3901,7 +3901,7 @@ static void mw_BxF1 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxF1() {
+static void mp_BxF1 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3911,7 +3911,7 @@ static void mw_BxF2 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxF2() {
+static void mp_BxF2 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3921,7 +3921,7 @@ static void mw_BxF3 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxF3() {
+static void mp_BxF3 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3931,7 +3931,7 @@ static void mw_BxF4 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxF4() {
+static void mp_BxF4 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3941,7 +3941,7 @@ static void mw_BxF5 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxF5() {
+static void mp_BxF5 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3951,7 +3951,7 @@ static void mw_BxF6 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxF6() {
+static void mp_BxF6 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3961,7 +3961,7 @@ static void mw_BxF7 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxF7() {
+static void mp_BxF7 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3971,7 +3971,7 @@ static void mw_BxF8 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxF8() {
+static void mp_BxF8 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3981,7 +3981,7 @@ static void mw_BxF9 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxF9() {
+static void mp_BxF9 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -3991,7 +3991,7 @@ static void mw_BxFA (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxFA() {
+static void mp_BxFA (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4001,7 +4001,7 @@ static void mw_BxFB (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxFB() {
+static void mp_BxFB (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4011,7 +4011,7 @@ static void mw_BxFC (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxFC() {
+static void mp_BxFC (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4021,7 +4021,7 @@ static void mw_BxFD (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxFD() {
+static void mp_BxFD (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4031,7 +4031,7 @@ static void mw_BxFE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxFE() {
+static void mp_BxFE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4041,18 +4041,18 @@ static void mw_BxFF (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_BxFF() {
+static void mp_BxFF (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
 }
 static void mw_Str_3E_Path (void) {
 }
-void co_Str_3E_Path() {
+static void mp_Str_3E_Path (void) {
 }
 static void mw_FILE (void) {
 }
-void co_FILE() {
+static void mp_FILE (void) {
 }
 static void mw_LAZY_5F_READY (void) {
     VAL tag = MKU64(0LL);
@@ -4060,7 +4060,7 @@ static void mw_LAZY_5F_READY (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_LAZY_5F_READY() {
+static void mp_LAZY_5F_READY (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4074,7 +4074,7 @@ static void mw_LAZY_5F_DELAY (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_LAZY_5F_DELAY() {
+static void mp_LAZY_5F_DELAY (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4088,21 +4088,21 @@ static void mw_LAZY_5F_WAIT (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_LAZY_5F_WAIT() {
+static void mp_LAZY_5F_WAIT (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
 }
 static void mw_CTX (void) {
 }
-void co_CTX() {
+static void mp_CTX (void) {
 }
 static void mw_PATTERN_5F_UNDERSCORE (void) {
     VAL tag = MKU64(0LL);
     VAL car = (tag);
     push_value(car);
 }
-void co_PATTERN_5F_UNDERSCORE() {
+static void mp_PATTERN_5F_UNDERSCORE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4113,7 +4113,7 @@ static void mw_PATTERN_5F_TAG (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_PATTERN_5F_TAG() {
+static void mp_PATTERN_5F_TAG (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4126,7 +4126,7 @@ static void mw_LEFT (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_LEFT() {
+static void mp_LEFT (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4139,7 +4139,7 @@ static void mw_RIGHT (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_RIGHT() {
+static void mp_RIGHT (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4151,7 +4151,7 @@ static void mw_STACK_5F_NIL (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_STACK_5F_NIL() {
+static void mp_STACK_5F_NIL (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4163,7 +4163,7 @@ static void mw_STACK_5F_CONS (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_STACK_5F_CONS() {
+static void mp_STACK_5F_CONS (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4178,7 +4178,7 @@ static void mw_NEED_5F_WORD (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_NEED_5F_WORD() {
+static void mp_NEED_5F_WORD (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4191,7 +4191,7 @@ static void mw_NEED_5F_BLOCK (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_NEED_5F_BLOCK() {
+static void mp_NEED_5F_BLOCK (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4206,7 +4206,7 @@ static void mw_MKC99 (void) {
     car = mkcons(car, tag);
     push_resource(car);
 }
-void co_MKC99() {
+static void mp_MKC99 (void) {
     VAL car = pop_resource();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4224,7 +4224,7 @@ static void mw_TYPE_5F_ELAB (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_TYPE_5F_ELAB() {
+static void mp_TYPE_5F_ELAB (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4238,7 +4238,7 @@ static void mw_OPSIG_5F_ID (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_OPSIG_5F_ID() {
+static void mp_OPSIG_5F_ID (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4249,7 +4249,7 @@ static void mw_OPSIG_5F_PUSH (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_OPSIG_5F_PUSH() {
+static void mp_OPSIG_5F_PUSH (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4262,7 +4262,7 @@ static void mw_OPSIG_5F_APPLY (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_OPSIG_5F_APPLY() {
+static void mp_OPSIG_5F_APPLY (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4271,14 +4271,14 @@ void co_OPSIG_5F_APPLY() {
 }
 static void mw_ARG_5F_BLOCK (void) {
 }
-void co_ARG_5F_BLOCK() {
+static void mp_ARG_5F_BLOCK (void) {
 }
 static void mw_OP_5F_NONE (void) {
     VAL tag = MKU64(0LL);
     VAL car = (tag);
     push_value(car);
 }
-void co_OP_5F_NONE() {
+static void mp_OP_5F_NONE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4289,7 +4289,7 @@ static void mw_OP_5F_PRIM (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_OP_5F_PRIM() {
+static void mp_OP_5F_PRIM (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4302,7 +4302,7 @@ static void mw_OP_5F_WORD (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_OP_5F_WORD() {
+static void mp_OP_5F_WORD (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4315,7 +4315,7 @@ static void mw_OP_5F_EXTERNAL (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_OP_5F_EXTERNAL() {
+static void mp_OP_5F_EXTERNAL (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4328,7 +4328,7 @@ static void mw_OP_5F_BUFFER (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_OP_5F_BUFFER() {
+static void mp_OP_5F_BUFFER (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4341,7 +4341,7 @@ static void mw_OP_5F_VARIABLE (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_OP_5F_VARIABLE() {
+static void mp_OP_5F_VARIABLE (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4354,7 +4354,7 @@ static void mw_OP_5F_CONSTANT (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_OP_5F_CONSTANT() {
+static void mp_OP_5F_CONSTANT (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4367,7 +4367,7 @@ static void mw_OP_5F_FIELD (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_OP_5F_FIELD() {
+static void mp_OP_5F_FIELD (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4380,7 +4380,7 @@ static void mw_OP_5F_INT (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_OP_5F_INT() {
+static void mp_OP_5F_INT (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4393,7 +4393,7 @@ static void mw_OP_5F_STR (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_OP_5F_STR() {
+static void mp_OP_5F_STR (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4406,7 +4406,7 @@ static void mw_OP_5F_TAG (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_OP_5F_TAG() {
+static void mp_OP_5F_TAG (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4419,7 +4419,7 @@ static void mw_OP_5F_MATCH (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_OP_5F_MATCH() {
+static void mp_OP_5F_MATCH (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4432,7 +4432,7 @@ static void mw_OP_5F_LAMBDA (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_OP_5F_LAMBDA() {
+static void mp_OP_5F_LAMBDA (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4445,7 +4445,7 @@ static void mw_OP_5F_VAR (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_OP_5F_VAR() {
+static void mp_OP_5F_VAR (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4458,7 +4458,7 @@ static void mw_OP_5F_BLOCK (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_OP_5F_BLOCK() {
+static void mp_OP_5F_BLOCK (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4467,14 +4467,14 @@ void co_OP_5F_BLOCK() {
 }
 static void mw_PARAM (void) {
 }
-void co_PARAM() {
+static void mp_PARAM (void) {
 }
 static void mw_TYPE_5F_ERROR (void) {
     VAL tag = MKU64(0LL);
     VAL car = (tag);
     push_value(car);
 }
-void co_TYPE_5F_ERROR() {
+static void mp_TYPE_5F_ERROR (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4484,7 +4484,7 @@ static void mw_TYPE_5F_DONT_5F_CARE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_TYPE_5F_DONT_5F_CARE() {
+static void mp_TYPE_5F_DONT_5F_CARE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4495,7 +4495,7 @@ static void mw_TPrim (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_TPrim() {
+static void mp_TPrim (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4508,7 +4508,7 @@ static void mw_TMeta (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_TMeta() {
+static void mp_TMeta (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4521,7 +4521,7 @@ static void mw_THole (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_THole() {
+static void mp_THole (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4534,7 +4534,7 @@ static void mw_TVar (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_TVar() {
+static void mp_TVar (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4547,7 +4547,7 @@ static void mw_TTable (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_TTable() {
+static void mp_TTable (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4560,7 +4560,7 @@ static void mw_TData (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_TData() {
+static void mp_TData (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4573,7 +4573,7 @@ static void mw_TTensor (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_TTensor() {
+static void mp_TTensor (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4586,7 +4586,7 @@ static void mw_TMorphism (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_TMorphism() {
+static void mp_TMorphism (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4600,7 +4600,7 @@ static void mw_TApp (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_TApp() {
+static void mp_TApp (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4615,7 +4615,7 @@ static void mw_TMut (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_TMut() {
+static void mp_TMut (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4628,7 +4628,7 @@ static void mw_TValue (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_TValue() {
+static void mp_TValue (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4641,7 +4641,7 @@ static void mw_VALUE_5F_INT (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_VALUE_5F_INT() {
+static void mp_VALUE_5F_INT (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4654,7 +4654,7 @@ static void mw_VALUE_5F_STR (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_VALUE_5F_STR() {
+static void mp_VALUE_5F_STR (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4667,7 +4667,7 @@ static void mw_VALUE_5F_BLOCK (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_VALUE_5F_BLOCK() {
+static void mp_VALUE_5F_BLOCK (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4679,7 +4679,7 @@ static void mw_PRIM_5F_TYPE_5F_TYPE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_TYPE_5F_TYPE() {
+static void mp_PRIM_5F_TYPE_5F_TYPE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4689,7 +4689,7 @@ static void mw_PRIM_5F_TYPE_5F_STACK (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_TYPE_5F_STACK() {
+static void mp_PRIM_5F_TYPE_5F_STACK (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4699,7 +4699,7 @@ static void mw_PRIM_5F_TYPE_5F_RESOURCE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_TYPE_5F_RESOURCE() {
+static void mp_PRIM_5F_TYPE_5F_RESOURCE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4709,7 +4709,7 @@ static void mw_PRIM_5F_TYPE_5F_INT (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_TYPE_5F_INT() {
+static void mp_PRIM_5F_TYPE_5F_INT (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4719,7 +4719,7 @@ static void mw_PRIM_5F_TYPE_5F_PTR (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_TYPE_5F_PTR() {
+static void mp_PRIM_5F_TYPE_5F_PTR (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4729,7 +4729,7 @@ static void mw_PRIM_5F_TYPE_5F_STR (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_TYPE_5F_STR() {
+static void mp_PRIM_5F_TYPE_5F_STR (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4739,25 +4739,25 @@ static void mw_PRIM_5F_TYPE_5F__2B_PLATFORM (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_TYPE_5F__2B_PLATFORM() {
+static void mp_PRIM_5F_TYPE_5F__2B_PLATFORM (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
 }
 static void mw_GAMMA (void) {
 }
-void co_GAMMA() {
+static void mp_GAMMA (void) {
 }
 static void mw_RESOURCE (void) {
 }
-void co_RESOURCE() {
+static void mp_RESOURCE (void) {
 }
 static void mw_STACK_5F_TYPE_5F_ERROR (void) {
     VAL tag = MKU64(0LL);
     VAL car = (tag);
     push_value(car);
 }
-void co_STACK_5F_TYPE_5F_ERROR() {
+static void mp_STACK_5F_TYPE_5F_ERROR (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4767,7 +4767,7 @@ static void mw_STACK_5F_TYPE_5F_DONT_5F_CARE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_STACK_5F_TYPE_5F_DONT_5F_CARE() {
+static void mp_STACK_5F_TYPE_5F_DONT_5F_CARE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4777,7 +4777,7 @@ static void mw_STACK_5F_TYPE_5F_UNIT (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_STACK_5F_TYPE_5F_UNIT() {
+static void mp_STACK_5F_TYPE_5F_UNIT (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4788,7 +4788,7 @@ static void mw_STVar (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_STVar() {
+static void mp_STVar (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4801,7 +4801,7 @@ static void mw_STMeta (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_STMeta() {
+static void mp_STMeta (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4815,7 +4815,7 @@ static void mw_STCons (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_STCons() {
+static void mp_STCons (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4831,7 +4831,7 @@ static void mw_STWith (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_STWith() {
+static void mp_STWith (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4847,7 +4847,7 @@ static void mw_ARROW_5F_TYPE (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_ARROW_5F_TYPE() {
+static void mp_ARROW_5F_TYPE (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4861,7 +4861,7 @@ static void mw_SUBST_5F_NIL (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_SUBST_5F_NIL() {
+static void mp_SUBST_5F_NIL (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4874,7 +4874,7 @@ static void mw_SUBST_5F_CON (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_SUBST_5F_CON() {
+static void mp_SUBST_5F_CON (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -4890,7 +4890,7 @@ static void mw_PRIM_5F_CORE_5F_ID (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_CORE_5F_ID() {
+static void mp_PRIM_5F_CORE_5F_ID (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4900,7 +4900,7 @@ static void mw_PRIM_5F_CORE_5F_DUP (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_CORE_5F_DUP() {
+static void mp_PRIM_5F_CORE_5F_DUP (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4910,7 +4910,7 @@ static void mw_PRIM_5F_CORE_5F_DROP (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_CORE_5F_DROP() {
+static void mp_PRIM_5F_CORE_5F_DROP (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4920,7 +4920,7 @@ static void mw_PRIM_5F_CORE_5F_SWAP (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_CORE_5F_SWAP() {
+static void mp_PRIM_5F_CORE_5F_SWAP (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4930,7 +4930,7 @@ static void mw_PRIM_5F_CORE_5F_DIP (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_CORE_5F_DIP() {
+static void mp_PRIM_5F_CORE_5F_DIP (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4940,7 +4940,7 @@ static void mw_PRIM_5F_CORE_5F_IF (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_CORE_5F_IF() {
+static void mp_PRIM_5F_CORE_5F_IF (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4950,7 +4950,7 @@ static void mw_PRIM_5F_CORE_5F_WHILE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_CORE_5F_WHILE() {
+static void mp_PRIM_5F_CORE_5F_WHILE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4960,7 +4960,7 @@ static void mw_PRIM_5F_CORE_5F_DEBUG (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_CORE_5F_DEBUG() {
+static void mp_PRIM_5F_CORE_5F_DEBUG (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4970,7 +4970,7 @@ static void mw_PRIM_5F_CORE_5F_PANIC (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_CORE_5F_PANIC() {
+static void mp_PRIM_5F_CORE_5F_PANIC (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4980,7 +4980,7 @@ static void mw_PRIM_5F_CORE_5F_RUN (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_CORE_5F_RUN() {
+static void mp_PRIM_5F_CORE_5F_RUN (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -4990,7 +4990,7 @@ static void mw_PRIM_5F_CORE_5F_MATCH (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_CORE_5F_MATCH() {
+static void mp_PRIM_5F_CORE_5F_MATCH (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5000,7 +5000,7 @@ static void mw_PRIM_5F_CORE_5F_LAMBDA (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_CORE_5F_LAMBDA() {
+static void mp_PRIM_5F_CORE_5F_LAMBDA (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5010,7 +5010,7 @@ static void mw_PRIM_5F_CORE_5F_RSWAP (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_CORE_5F_RSWAP() {
+static void mp_PRIM_5F_CORE_5F_RSWAP (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5020,7 +5020,7 @@ static void mw_PRIM_5F_CORE_5F_RDIP (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_CORE_5F_RDIP() {
+static void mp_PRIM_5F_CORE_5F_RDIP (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5030,7 +5030,7 @@ static void mw_PRIM_5F_UNSAFE_5F_CAST (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_UNSAFE_5F_CAST() {
+static void mp_PRIM_5F_UNSAFE_5F_CAST (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5040,7 +5040,7 @@ static void mw_PRIM_5F_INT_5F_EQ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_INT_5F_EQ() {
+static void mp_PRIM_5F_INT_5F_EQ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5050,7 +5050,7 @@ static void mw_PRIM_5F_INT_5F_LT (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_INT_5F_LT() {
+static void mp_PRIM_5F_INT_5F_LT (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5060,7 +5060,7 @@ static void mw_PRIM_5F_INT_5F_ADD (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_INT_5F_ADD() {
+static void mp_PRIM_5F_INT_5F_ADD (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5070,7 +5070,7 @@ static void mw_PRIM_5F_INT_5F_SUB (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_INT_5F_SUB() {
+static void mp_PRIM_5F_INT_5F_SUB (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5080,7 +5080,7 @@ static void mw_PRIM_5F_INT_5F_MUL (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_INT_5F_MUL() {
+static void mp_PRIM_5F_INT_5F_MUL (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5090,7 +5090,7 @@ static void mw_PRIM_5F_INT_5F_DIV (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_INT_5F_DIV() {
+static void mp_PRIM_5F_INT_5F_DIV (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5100,7 +5100,7 @@ static void mw_PRIM_5F_INT_5F_MOD (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_INT_5F_MOD() {
+static void mp_PRIM_5F_INT_5F_MOD (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5110,7 +5110,7 @@ static void mw_PRIM_5F_INT_5F_AND (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_INT_5F_AND() {
+static void mp_PRIM_5F_INT_5F_AND (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5120,7 +5120,7 @@ static void mw_PRIM_5F_INT_5F_OR (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_INT_5F_OR() {
+static void mp_PRIM_5F_INT_5F_OR (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5130,7 +5130,7 @@ static void mw_PRIM_5F_INT_5F_XOR (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_INT_5F_XOR() {
+static void mp_PRIM_5F_INT_5F_XOR (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5140,7 +5140,7 @@ static void mw_PRIM_5F_INT_5F_SHL (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_INT_5F_SHL() {
+static void mp_PRIM_5F_INT_5F_SHL (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5150,7 +5150,7 @@ static void mw_PRIM_5F_INT_5F_SHR (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_INT_5F_SHR() {
+static void mp_PRIM_5F_INT_5F_SHR (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5160,7 +5160,7 @@ static void mw_PRIM_5F_INT_5F_TO_5F_STR (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_INT_5F_TO_5F_STR() {
+static void mp_PRIM_5F_INT_5F_TO_5F_STR (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5170,7 +5170,7 @@ static void mw_PRIM_5F_PACK_5F_NIL (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_PACK_5F_NIL() {
+static void mp_PRIM_5F_PACK_5F_NIL (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5180,7 +5180,7 @@ static void mw_PRIM_5F_PACK_5F_CONS (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_PACK_5F_CONS() {
+static void mp_PRIM_5F_PACK_5F_CONS (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5190,7 +5190,7 @@ static void mw_PRIM_5F_PACK_5F_UNCONS (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_PACK_5F_UNCONS() {
+static void mp_PRIM_5F_PACK_5F_UNCONS (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5200,7 +5200,7 @@ static void mw_PRIM_5F_MUT_5F_NEW (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_MUT_5F_NEW() {
+static void mp_PRIM_5F_MUT_5F_NEW (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5210,7 +5210,7 @@ static void mw_PRIM_5F_MUT_5F_GET (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_MUT_5F_GET() {
+static void mp_PRIM_5F_MUT_5F_GET (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5220,7 +5220,7 @@ static void mw_PRIM_5F_MUT_5F_SET (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_MUT_5F_SET() {
+static void mp_PRIM_5F_MUT_5F_SET (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5230,7 +5230,7 @@ static void mw_PRIM_5F_MUT_5F_IS_5F_SET (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_MUT_5F_IS_5F_SET() {
+static void mp_PRIM_5F_MUT_5F_IS_5F_SET (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5240,7 +5240,7 @@ static void mw_PRIM_5F_PTR_5F_NIL (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_PTR_5F_NIL() {
+static void mp_PRIM_5F_PTR_5F_NIL (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5250,7 +5250,7 @@ static void mw_PRIM_5F_PTR_5F_ADD (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_PTR_5F_ADD() {
+static void mp_PRIM_5F_PTR_5F_ADD (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5260,7 +5260,7 @@ static void mw_PRIM_5F_PTR_5F_SIZE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_PTR_5F_SIZE() {
+static void mp_PRIM_5F_PTR_5F_SIZE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5270,7 +5270,7 @@ static void mw_PRIM_5F_PTR_5F_GET (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_PTR_5F_GET() {
+static void mp_PRIM_5F_PTR_5F_GET (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5280,7 +5280,7 @@ static void mw_PRIM_5F_PTR_5F_SET (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_PTR_5F_SET() {
+static void mp_PRIM_5F_PTR_5F_SET (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5290,7 +5290,7 @@ static void mw_PRIM_5F_PTR_5F_ALLOC (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_PTR_5F_ALLOC() {
+static void mp_PRIM_5F_PTR_5F_ALLOC (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5300,7 +5300,7 @@ static void mw_PRIM_5F_PTR_5F_REALLOC (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_PTR_5F_REALLOC() {
+static void mp_PRIM_5F_PTR_5F_REALLOC (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5310,7 +5310,7 @@ static void mw_PRIM_5F_PTR_5F_COPY (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_PTR_5F_COPY() {
+static void mp_PRIM_5F_PTR_5F_COPY (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5320,7 +5320,7 @@ static void mw_PRIM_5F_PTR_5F_FILL (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_PTR_5F_FILL() {
+static void mp_PRIM_5F_PTR_5F_FILL (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5330,7 +5330,7 @@ static void mw_PRIM_5F_PTR_5F_RAW (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_PTR_5F_RAW() {
+static void mp_PRIM_5F_PTR_5F_RAW (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5340,7 +5340,7 @@ static void mw_PRIM_5F_STR_5F_CMP (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_STR_5F_CMP() {
+static void mp_PRIM_5F_STR_5F_CMP (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5350,7 +5350,7 @@ static void mw_PRIM_5F_STR_5F_ALLOC (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_STR_5F_ALLOC() {
+static void mp_PRIM_5F_STR_5F_ALLOC (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5360,7 +5360,7 @@ static void mw_PRIM_5F_STR_5F_COPY (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_STR_5F_COPY() {
+static void mp_PRIM_5F_STR_5F_COPY (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5370,7 +5370,7 @@ static void mw_PRIM_5F_STR_5F_NUM_5F_BYTES (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_STR_5F_NUM_5F_BYTES() {
+static void mp_PRIM_5F_STR_5F_NUM_5F_BYTES (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5380,7 +5380,7 @@ static void mw_PRIM_5F_STR_5F_BASE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_STR_5F_BASE() {
+static void mp_PRIM_5F_STR_5F_BASE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5390,7 +5390,7 @@ static void mw_PRIM_5F_STR_5F_CAT (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_STR_5F_CAT() {
+static void mp_PRIM_5F_STR_5F_CAT (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5400,7 +5400,7 @@ static void mw_PRIM_5F_U8_5F_GET (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_U8_5F_GET() {
+static void mp_PRIM_5F_U8_5F_GET (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5410,7 +5410,7 @@ static void mw_PRIM_5F_U8_5F_SET (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_U8_5F_SET() {
+static void mp_PRIM_5F_U8_5F_SET (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5420,7 +5420,7 @@ static void mw_PRIM_5F_U16_5F_GET (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_U16_5F_GET() {
+static void mp_PRIM_5F_U16_5F_GET (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5430,7 +5430,7 @@ static void mw_PRIM_5F_U16_5F_SET (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_U16_5F_SET() {
+static void mp_PRIM_5F_U16_5F_SET (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5440,7 +5440,7 @@ static void mw_PRIM_5F_U32_5F_GET (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_U32_5F_GET() {
+static void mp_PRIM_5F_U32_5F_GET (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5450,7 +5450,7 @@ static void mw_PRIM_5F_U32_5F_SET (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_U32_5F_SET() {
+static void mp_PRIM_5F_U32_5F_SET (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5460,7 +5460,7 @@ static void mw_PRIM_5F_U64_5F_GET (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_U64_5F_GET() {
+static void mp_PRIM_5F_U64_5F_GET (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5470,7 +5470,7 @@ static void mw_PRIM_5F_U64_5F_SET (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_U64_5F_SET() {
+static void mp_PRIM_5F_U64_5F_SET (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5480,7 +5480,7 @@ static void mw_PRIM_5F_I8_5F_GET (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_I8_5F_GET() {
+static void mp_PRIM_5F_I8_5F_GET (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5490,7 +5490,7 @@ static void mw_PRIM_5F_I8_5F_SET (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_I8_5F_SET() {
+static void mp_PRIM_5F_I8_5F_SET (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5500,7 +5500,7 @@ static void mw_PRIM_5F_I16_5F_GET (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_I16_5F_GET() {
+static void mp_PRIM_5F_I16_5F_GET (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5510,7 +5510,7 @@ static void mw_PRIM_5F_I16_5F_SET (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_I16_5F_SET() {
+static void mp_PRIM_5F_I16_5F_SET (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5520,7 +5520,7 @@ static void mw_PRIM_5F_I32_5F_GET (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_I32_5F_GET() {
+static void mp_PRIM_5F_I32_5F_GET (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5530,7 +5530,7 @@ static void mw_PRIM_5F_I32_5F_SET (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_I32_5F_SET() {
+static void mp_PRIM_5F_I32_5F_SET (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5540,7 +5540,7 @@ static void mw_PRIM_5F_I64_5F_GET (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_I64_5F_GET() {
+static void mp_PRIM_5F_I64_5F_GET (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5550,7 +5550,7 @@ static void mw_PRIM_5F_I64_5F_SET (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_I64_5F_SET() {
+static void mp_PRIM_5F_I64_5F_SET (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5560,7 +5560,7 @@ static void mw_PRIM_5F_SYS_5F_OS (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_SYS_5F_OS() {
+static void mp_PRIM_5F_SYS_5F_OS (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5570,7 +5570,7 @@ static void mw_PRIM_5F_SYS_5F_ARGC (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_SYS_5F_ARGC() {
+static void mp_PRIM_5F_SYS_5F_ARGC (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5580,7 +5580,7 @@ static void mw_PRIM_5F_SYS_5F_ARGV (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_SYS_5F_ARGV() {
+static void mp_PRIM_5F_SYS_5F_ARGV (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5590,7 +5590,7 @@ static void mw_PRIM_5F_POSIX_5F_READ (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_POSIX_5F_READ() {
+static void mp_PRIM_5F_POSIX_5F_READ (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5600,7 +5600,7 @@ static void mw_PRIM_5F_POSIX_5F_WRITE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_POSIX_5F_WRITE() {
+static void mp_PRIM_5F_POSIX_5F_WRITE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5610,7 +5610,7 @@ static void mw_PRIM_5F_POSIX_5F_OPEN (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_POSIX_5F_OPEN() {
+static void mp_PRIM_5F_POSIX_5F_OPEN (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5620,7 +5620,7 @@ static void mw_PRIM_5F_POSIX_5F_CLOSE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_POSIX_5F_CLOSE() {
+static void mp_PRIM_5F_POSIX_5F_CLOSE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5630,7 +5630,7 @@ static void mw_PRIM_5F_POSIX_5F_EXIT (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_POSIX_5F_EXIT() {
+static void mp_PRIM_5F_POSIX_5F_EXIT (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5640,7 +5640,7 @@ static void mw_PRIM_5F_POSIX_5F_MMAP (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_POSIX_5F_MMAP() {
+static void mp_PRIM_5F_POSIX_5F_MMAP (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5650,7 +5650,7 @@ static void mw_PRIM_5F_SYNTAX_5F_MODULE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_SYNTAX_5F_MODULE() {
+static void mp_PRIM_5F_SYNTAX_5F_MODULE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5660,7 +5660,7 @@ static void mw_PRIM_5F_SYNTAX_5F_IMPORT (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_SYNTAX_5F_IMPORT() {
+static void mp_PRIM_5F_SYNTAX_5F_IMPORT (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5670,7 +5670,7 @@ static void mw_PRIM_5F_SYNTAX_5F_ALIAS (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_SYNTAX_5F_ALIAS() {
+static void mp_PRIM_5F_SYNTAX_5F_ALIAS (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5680,7 +5680,7 @@ static void mw_PRIM_5F_SYNTAX_5F_DEF (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_SYNTAX_5F_DEF() {
+static void mp_PRIM_5F_SYNTAX_5F_DEF (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5690,7 +5690,7 @@ static void mw_PRIM_5F_SYNTAX_5F_DEF_5F_MISSING (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_SYNTAX_5F_DEF_5F_MISSING() {
+static void mp_PRIM_5F_SYNTAX_5F_DEF_5F_MISSING (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5700,7 +5700,7 @@ static void mw_PRIM_5F_SYNTAX_5F_DEF_5F_TYPE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_SYNTAX_5F_DEF_5F_TYPE() {
+static void mp_PRIM_5F_SYNTAX_5F_DEF_5F_TYPE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5710,7 +5710,7 @@ static void mw_PRIM_5F_SYNTAX_5F_BUFFER (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_SYNTAX_5F_BUFFER() {
+static void mp_PRIM_5F_SYNTAX_5F_BUFFER (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5720,7 +5720,7 @@ static void mw_PRIM_5F_SYNTAX_5F_VARIABLE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_SYNTAX_5F_VARIABLE() {
+static void mp_PRIM_5F_SYNTAX_5F_VARIABLE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5730,7 +5730,7 @@ static void mw_PRIM_5F_SYNTAX_5F_DEF_5F_EXTERNAL (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_SYNTAX_5F_DEF_5F_EXTERNAL() {
+static void mp_PRIM_5F_SYNTAX_5F_DEF_5F_EXTERNAL (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5740,7 +5740,7 @@ static void mw_PRIM_5F_SYNTAX_5F_TARGET_5F_C99 (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_SYNTAX_5F_TARGET_5F_C99() {
+static void mp_PRIM_5F_SYNTAX_5F_TARGET_5F_C99 (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5750,7 +5750,7 @@ static void mw_PRIM_5F_SYNTAX_5F_EMBED_5F_STR (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_SYNTAX_5F_EMBED_5F_STR() {
+static void mp_PRIM_5F_SYNTAX_5F_EMBED_5F_STR (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5760,7 +5760,7 @@ static void mw_PRIM_5F_SYNTAX_5F_TABLE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_SYNTAX_5F_TABLE() {
+static void mp_PRIM_5F_SYNTAX_5F_TABLE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5770,7 +5770,7 @@ static void mw_PRIM_5F_SYNTAX_5F_FIELD (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_SYNTAX_5F_FIELD() {
+static void mp_PRIM_5F_SYNTAX_5F_FIELD (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5780,7 +5780,7 @@ static void mw_PRIM_5F_SYNTAX_5F_DATA (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_SYNTAX_5F_DATA() {
+static void mp_PRIM_5F_SYNTAX_5F_DATA (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5790,7 +5790,7 @@ static void mw_PRIM_5F_SYNTAX_5F_DASHES (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_SYNTAX_5F_DASHES() {
+static void mp_PRIM_5F_SYNTAX_5F_DASHES (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5800,7 +5800,7 @@ static void mw_PRIM_5F_SYNTAX_5F_ARROW (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_PRIM_5F_SYNTAX_5F_ARROW() {
+static void mp_PRIM_5F_SYNTAX_5F_ARROW (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5810,7 +5810,7 @@ static void mw_TOKEN_5F_NONE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_TOKEN_5F_NONE() {
+static void mp_TOKEN_5F_NONE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5820,7 +5820,7 @@ static void mw_TOKEN_5F_COMMA (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_TOKEN_5F_COMMA() {
+static void mp_TOKEN_5F_COMMA (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5830,7 +5830,7 @@ static void mw_TOKEN_5F_LPAREN_5F_OPEN (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_TOKEN_5F_LPAREN_5F_OPEN() {
+static void mp_TOKEN_5F_LPAREN_5F_OPEN (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5841,7 +5841,7 @@ static void mw_TOKEN_5F_LPAREN (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_TOKEN_5F_LPAREN() {
+static void mp_TOKEN_5F_LPAREN (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -5854,7 +5854,7 @@ static void mw_TOKEN_5F_RPAREN (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_TOKEN_5F_RPAREN() {
+static void mp_TOKEN_5F_RPAREN (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -5866,7 +5866,7 @@ static void mw_TOKEN_5F_LSQUARE_5F_OPEN (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_TOKEN_5F_LSQUARE_5F_OPEN() {
+static void mp_TOKEN_5F_LSQUARE_5F_OPEN (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5877,7 +5877,7 @@ static void mw_TOKEN_5F_LSQUARE (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_TOKEN_5F_LSQUARE() {
+static void mp_TOKEN_5F_LSQUARE (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -5890,7 +5890,7 @@ static void mw_TOKEN_5F_RSQUARE (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_TOKEN_5F_RSQUARE() {
+static void mp_TOKEN_5F_RSQUARE (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -5902,7 +5902,7 @@ static void mw_TOKEN_5F_LCURLY_5F_OPEN (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_TOKEN_5F_LCURLY_5F_OPEN() {
+static void mp_TOKEN_5F_LCURLY_5F_OPEN (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5913,7 +5913,7 @@ static void mw_TOKEN_5F_LCURLY (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_TOKEN_5F_LCURLY() {
+static void mp_TOKEN_5F_LCURLY (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -5926,7 +5926,7 @@ static void mw_TOKEN_5F_RCURLY (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_TOKEN_5F_RCURLY() {
+static void mp_TOKEN_5F_RCURLY (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -5939,7 +5939,7 @@ static void mw_TOKEN_5F_INT (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_TOKEN_5F_INT() {
+static void mp_TOKEN_5F_INT (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -5952,7 +5952,7 @@ static void mw_TOKEN_5F_STR (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_TOKEN_5F_STR() {
+static void mp_TOKEN_5F_STR (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -5965,7 +5965,7 @@ static void mw_TOKEN_5F_NAME (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_TOKEN_5F_NAME() {
+static void mp_TOKEN_5F_NAME (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -5977,7 +5977,7 @@ static void mw_DEF_5F_NONE (void) {
     VAL car = (tag);
     push_value(car);
 }
-void co_DEF_5F_NONE() {
+static void mp_DEF_5F_NONE (void) {
     VAL car = pop_value();
     VAL cdr;
     decref(car);
@@ -5988,7 +5988,7 @@ static void mw_DEF_5F_ALIAS (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_DEF_5F_ALIAS() {
+static void mp_DEF_5F_ALIAS (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -6001,7 +6001,7 @@ static void mw_DEF_5F_MODULE (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_DEF_5F_MODULE() {
+static void mp_DEF_5F_MODULE (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -6014,7 +6014,7 @@ static void mw_DEF_5F_TYPE (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_DEF_5F_TYPE() {
+static void mp_DEF_5F_TYPE (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -6027,7 +6027,7 @@ static void mw_DEF_5F_TAG (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_DEF_5F_TAG() {
+static void mp_DEF_5F_TAG (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -6040,7 +6040,7 @@ static void mw_DEF_5F_PRIM (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_DEF_5F_PRIM() {
+static void mp_DEF_5F_PRIM (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -6053,7 +6053,7 @@ static void mw_DEF_5F_WORD (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_DEF_5F_WORD() {
+static void mp_DEF_5F_WORD (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -6066,7 +6066,7 @@ static void mw_DEF_5F_BUFFER (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_DEF_5F_BUFFER() {
+static void mp_DEF_5F_BUFFER (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -6079,7 +6079,7 @@ static void mw_DEF_5F_VARIABLE (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_DEF_5F_VARIABLE() {
+static void mp_DEF_5F_VARIABLE (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -6092,7 +6092,7 @@ static void mw_DEF_5F_CONSTANT (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_DEF_5F_CONSTANT() {
+static void mp_DEF_5F_CONSTANT (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -6105,7 +6105,7 @@ static void mw_DEF_5F_EXTERNAL (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_DEF_5F_EXTERNAL() {
+static void mp_DEF_5F_EXTERNAL (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -6118,7 +6118,7 @@ static void mw_DEF_5F_FIELD (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_DEF_5F_FIELD() {
+static void mp_DEF_5F_FIELD (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -6127,15 +6127,15 @@ void co_DEF_5F_FIELD() {
 }
 static void mw_HASH (void) {
 }
-void co_HASH() {
+static void mp_HASH (void) {
 }
 static void mw_ROW (void) {
 }
-void co_ROW() {
+static void mp_ROW (void) {
 }
 static void mw_COL (void) {
 }
-void co_COL() {
+static void mp_COL (void) {
 }
 static void mw_LOCATION (void) {
     VAL tag = MKU64(0LL);
@@ -6145,7 +6145,7 @@ static void mw_LOCATION (void) {
     car = mkcons(car, tag);
     push_value(car);
 }
-void co_LOCATION() {
+static void mp_LOCATION (void) {
     VAL car = pop_value();
     VAL cdr;
     value_uncons_c(car, &car, &cdr);
@@ -6266,147 +6266,147 @@ static void mw_Module_2E_NUM (void) {
     push_ptr(&b);
 }
 
-void mw_STR_5F_BUF_5F_LEN() {
+static void mw_STR_5F_BUF_5F_LEN (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_SOURCE_5F_PATH_5F_ROOT() {
+static void mw_SOURCE_5F_PATH_5F_ROOT (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_OUTPUT_5F_PATH_5F_ROOT() {
+static void mw_OUTPUT_5F_PATH_5F_ROOT (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_DATA_5F_BOOL() {
+static void mw_DATA_5F_BOOL (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_TAG_5F_T() {
+static void mw_TAG_5F_T (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_TAG_5F_F() {
+static void mw_TAG_5F_F (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_DATA_5F_U64() {
+static void mw_DATA_5F_U64 (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_TAG_5F_U64() {
+static void mw_TAG_5F_U64 (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_DATA_5F_U32() {
+static void mw_DATA_5F_U32 (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_TAG_5F_U32() {
+static void mw_TAG_5F_U32 (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_DATA_5F_U16() {
+static void mw_DATA_5F_U16 (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_TAG_5F_U16() {
+static void mw_TAG_5F_U16 (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_DATA_5F_U8() {
+static void mw_DATA_5F_U8 (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_TAG_5F_U8() {
+static void mw_TAG_5F_U8 (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_DATA_5F_I64() {
+static void mw_DATA_5F_I64 (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_TAG_5F_I64() {
+static void mw_TAG_5F_I64 (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_DATA_5F_I32() {
+static void mw_DATA_5F_I32 (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_TAG_5F_I32() {
+static void mw_TAG_5F_I32 (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_DATA_5F_I16() {
+static void mw_DATA_5F_I16 (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_TAG_5F_I16() {
+static void mw_TAG_5F_I16 (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_DATA_5F_I8() {
+static void mw_DATA_5F_I8 (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_TAG_5F_I8() {
+static void mw_TAG_5F_I8 (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_input_isopen() {
+static void mw_input_isopen (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_input_length() {
+static void mw_input_length (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_input_offset() {
+static void mw_input_offset (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_input_handle() {
+static void mw_input_handle (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_lexer_module() {
+static void mw_lexer_module (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_lexer_row() {
+static void mw_lexer_row (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_lexer_col() {
+static void mw_lexer_col (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_lexer_stack() {
+static void mw_lexer_stack (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_needs_stack() {
+static void mw_needs_stack (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_ab_home() {
+static void mw_ab_home (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_ab_homeidx() {
+static void mw_ab_homeidx (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_ab_arrow() {
+static void mw_ab_arrow (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_num_warnings() {
+static void mw_num_warnings (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_num_errors() {
+static void mw_num_errors (void) {
     static VAL v = {0};
     push_ptr(&v);
 }
@@ -6814,18 +6814,17 @@ static void mw_need_block_run (void);
 static void mw__2B_C99_2F_MKC99 (void);
 static void mw__2B_C99_2E_depth_40_ (void);
 static void mw__2B_C99_2E_depth_21_ (void);
-static void mw_Str_2B_C99_2E_ (void);
-static void mw_Int_2B_C99_2E_n (void);
-static void mw_Byte_2B_C99_2E_b (void);
+static void mw_Str_2B_C99_2E_put (void);
+static void mw_Int_2B_C99_2E_put (void);
+static void mw_Byte_2B_C99_2E_put (void);
+static void mw__2B_C99_2E_line (void);
 static void mw_codegen_start_21_ (void);
 static void mw_codegen_flush_21_ (void);
 static void mw_codegen_end_21_ (void);
 static void mw_run_output_c99_21_ (void);
-static void mw__2B_C99_2E_lf (void);
-static void mw_Str_2B_C99_3B_ (void);
-static void mw_Str_2B_C99_3B__3B_ (void);
-static void mw_Name_2B_C99_2E_name (void);
-static void mw_Name_2B_C99_2E_w (void);
+static void mw_Name_2B_C99_2E_put (void);
+static void mw_Name_2B_C99_2E_sig (void);
+static void mw_Name_2B_C99_2E_cosig (void);
 static void mw_c99_header_21_ (void);
 static void mw_c99_buffers_21_ (void);
 static void mw_c99_buffer_21_ (void);
@@ -6844,7 +6843,7 @@ static void mw_c99_atom_21_ (void);
 static void mw_c99_args_op_21_ (void);
 static void mw_c99_int_21_ (void);
 static void mw_c99_str_21_ (void);
-static void mw__2E_str (void);
+static void mw__2B_C99_2E_put_cstr (void);
 static void mw_c99_string_byte_21_ (void);
 static void mw_c99_constant_21_ (void);
 static void mw_c99_value_21_ (void);
@@ -6854,8 +6853,8 @@ static void mw_c99_args_push_21_ (void);
 static void mw_c99_arg_push_21_ (void);
 static void mw_c99_arg_run_21_ (void);
 static void mw_c99_block_run_21_ (void);
-static void mw_Var_2B_C99_2E_var (void);
-static void mw_Param_2B_C99_2E_param (void);
+static void mw_Var_2B_C99_2E_put (void);
+static void mw_Param_2B_C99_2E_put (void);
 static void mw_c99_pack_ctx_21_ (void);
 static void mw_c99_unpack_ctx_21_ (void);
 static void mw_c99_decref_ctx_21_ (void);
@@ -6877,7 +6876,7 @@ static void mw_c99_block_enter_21_ (void);
 static void mw_c99_block_exit_21_ (void);
 static void mw_c99_block_defs_21_ (void);
 static void mw_c99_block_def_21_ (void);
-static void mw_Block_2B_C99_2E_block (void);
+static void mw_Block_2B_C99_2E_put (void);
 static void mw_c99_word_enter_21_ (void);
 static void mw_c99_word_exit_21_ (void);
 static void mw_c99_word_defs_21_ (void);
@@ -7703,7 +7702,7 @@ static void mb_determine_transitive_needs_21__2 (void);
 static void mb_need_atom_run_1 (void);
 static void mb_need_args_push_1 (void);
 static void mb_need_match_1 (void);
-static void mb_Str_2B_C99_2E__3 (void);
+static void mb_Str_2B_C99_2E_put_3 (void);
 static void mb_c99_tags_21__1 (void);
 static void mb_c99_buffers_21__1 (void);
 static void mb_c99_variables_21__1 (void);
@@ -7740,7 +7739,6 @@ static void mb_c99_atom_21__1 (void);
 static void mb_c99_atom_21__2 (void);
 static void mb_c99_atom_21__3 (void);
 static void mb_c99_atom_21__4 (void);
-static void mb__2E_str_1 (void);
 static void mb_c99_int_21__1 (void);
 static void mb_c99_str_21__1 (void);
 static void mb_c99_str_21__2 (void);
@@ -7794,6 +7792,7 @@ static void mb_c99_lambda_21__6 (void);
 static void mb_c99_lambda_21__7 (void);
 static void mb_c99_block_push_21__3 (void);
 static void mb_c99_block_push_21__4 (void);
+static void mb__2B_C99_2E_put_cstr_1 (void);
 static void mb_c99_pack_ctx_21__1 (void);
 static void mb_c99_pack_ctx_21__2 (void);
 static void mb_c99_pack_ctx_21__3 (void);
@@ -7948,8 +7947,7 @@ static VAL* fieldptr_Var_7E_name (size_t i) {
     return p+i;
 }
 
-static void mw_Var_7E_name (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Var_7E_name (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Var_7E_name(index);
     push_ptr(v);
 }
@@ -7962,8 +7960,7 @@ static VAL* fieldptr_Var_7E_type (size_t i) {
     return p+i;
 }
 
-static void mw_Var_7E_type (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Var_7E_type (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Var_7E_type(index);
     push_ptr(v);
 }
@@ -7976,8 +7973,7 @@ static VAL* fieldptr_Var_7E_auto_run_3F_ (size_t i) {
     return p+i;
 }
 
-static void mw_Var_7E_auto_run_3F_ (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Var_7E_auto_run_3F_ (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Var_7E_auto_run_3F_(index);
     push_ptr(v);
 }
@@ -7990,8 +7986,7 @@ static VAL* fieldptr_Data_7E_head_3F_ (size_t i) {
     return p+i;
 }
 
-static void mw_Data_7E_head_3F_ (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Data_7E_head_3F_ (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Data_7E_head_3F_(index);
     push_ptr(v);
 }
@@ -8004,8 +7999,7 @@ static VAL* fieldptr_Data_7E_name (size_t i) {
     return p+i;
 }
 
-static void mw_Data_7E_name (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Data_7E_name (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Data_7E_name(index);
     push_ptr(v);
 }
@@ -8018,8 +8012,7 @@ static VAL* fieldptr_Data_7E_arity (size_t i) {
     return p+i;
 }
 
-static void mw_Data_7E_arity (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Data_7E_arity (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Data_7E_arity(index);
     push_ptr(v);
 }
@@ -8032,8 +8025,7 @@ static VAL* fieldptr_Data_7E_tags (size_t i) {
     return p+i;
 }
 
-static void mw_Data_7E_tags (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Data_7E_tags (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Data_7E_tags(index);
     push_ptr(v);
 }
@@ -8046,8 +8038,7 @@ static VAL* fieldptr_Tag_7E_data (size_t i) {
     return p+i;
 }
 
-static void mw_Tag_7E_data (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Tag_7E_data (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Tag_7E_data(index);
     push_ptr(v);
 }
@@ -8060,8 +8051,7 @@ static VAL* fieldptr_Tag_7E_name (size_t i) {
     return p+i;
 }
 
-static void mw_Tag_7E_name (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Tag_7E_name (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Tag_7E_name(index);
     push_ptr(v);
 }
@@ -8074,8 +8064,7 @@ static VAL* fieldptr_Tag_7E_value (size_t i) {
     return p+i;
 }
 
-static void mw_Tag_7E_value (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Tag_7E_value (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Tag_7E_value(index);
     push_ptr(v);
 }
@@ -8088,8 +8077,7 @@ static VAL* fieldptr_Tag_7E_num_type_inputs (size_t i) {
     return p+i;
 }
 
-static void mw_Tag_7E_num_type_inputs (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Tag_7E_num_type_inputs (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Tag_7E_num_type_inputs(index);
     push_ptr(v);
 }
@@ -8102,8 +8090,7 @@ static VAL* fieldptr_Tag_7E_num_resource_inputs (size_t i) {
     return p+i;
 }
 
-static void mw_Tag_7E_num_resource_inputs (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Tag_7E_num_resource_inputs (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Tag_7E_num_resource_inputs(index);
     push_ptr(v);
 }
@@ -8116,8 +8103,7 @@ static VAL* fieldptr_Tag_7E_sig_3F_ (size_t i) {
     return p+i;
 }
 
-static void mw_Tag_7E_sig_3F_ (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Tag_7E_sig_3F_ (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Tag_7E_sig_3F_(index);
     push_ptr(v);
 }
@@ -8130,8 +8116,7 @@ static VAL* fieldptr_Tag_7E_ctx_type (size_t i) {
     return p+i;
 }
 
-static void mw_Tag_7E_ctx_type (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Tag_7E_ctx_type (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Tag_7E_ctx_type(index);
     push_ptr(v);
 }
@@ -8144,8 +8129,7 @@ static VAL* fieldptr_Match_7E_ctx (size_t i) {
     return p+i;
 }
 
-static void mw_Match_7E_ctx (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Match_7E_ctx (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Match_7E_ctx(index);
     push_ptr(v);
 }
@@ -8158,8 +8142,7 @@ static VAL* fieldptr_Match_7E_dom (size_t i) {
     return p+i;
 }
 
-static void mw_Match_7E_dom (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Match_7E_dom (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Match_7E_dom(index);
     push_ptr(v);
 }
@@ -8172,8 +8155,7 @@ static VAL* fieldptr_Match_7E_cod (size_t i) {
     return p+i;
 }
 
-static void mw_Match_7E_cod (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Match_7E_cod (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Match_7E_cod(index);
     push_ptr(v);
 }
@@ -8186,8 +8168,7 @@ static VAL* fieldptr_Match_7E_token (size_t i) {
     return p+i;
 }
 
-static void mw_Match_7E_token (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Match_7E_token (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Match_7E_token(index);
     push_ptr(v);
 }
@@ -8200,8 +8181,7 @@ static VAL* fieldptr_Match_7E_body (size_t i) {
     return p+i;
 }
 
-static void mw_Match_7E_body (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Match_7E_body (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Match_7E_body(index);
     push_ptr(v);
 }
@@ -8214,8 +8194,7 @@ static VAL* fieldptr_Match_7E_cases (size_t i) {
     return p+i;
 }
 
-static void mw_Match_7E_cases (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Match_7E_cases (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Match_7E_cases(index);
     push_ptr(v);
 }
@@ -8228,8 +8207,7 @@ static VAL* fieldptr_Case_7E_match (size_t i) {
     return p+i;
 }
 
-static void mw_Case_7E_match (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Case_7E_match (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Case_7E_match(index);
     push_ptr(v);
 }
@@ -8242,8 +8220,7 @@ static VAL* fieldptr_Case_7E_token (size_t i) {
     return p+i;
 }
 
-static void mw_Case_7E_token (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Case_7E_token (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Case_7E_token(index);
     push_ptr(v);
 }
@@ -8256,8 +8233,7 @@ static VAL* fieldptr_Case_7E_pattern (size_t i) {
     return p+i;
 }
 
-static void mw_Case_7E_pattern (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Case_7E_pattern (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Case_7E_pattern(index);
     push_ptr(v);
 }
@@ -8270,8 +8246,7 @@ static VAL* fieldptr_Case_7E_subst (size_t i) {
     return p+i;
 }
 
-static void mw_Case_7E_subst (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Case_7E_subst (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Case_7E_subst(index);
     push_ptr(v);
 }
@@ -8284,8 +8259,7 @@ static VAL* fieldptr_Case_7E_mid (size_t i) {
     return p+i;
 }
 
-static void mw_Case_7E_mid (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Case_7E_mid (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Case_7E_mid(index);
     push_ptr(v);
 }
@@ -8298,8 +8272,7 @@ static VAL* fieldptr_Case_7E_body (size_t i) {
     return p+i;
 }
 
-static void mw_Case_7E_body (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Case_7E_body (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Case_7E_body(index);
     push_ptr(v);
 }
@@ -8312,8 +8285,7 @@ static VAL* fieldptr_External_7E_name (size_t i) {
     return p+i;
 }
 
-static void mw_External_7E_name (void){
-    size_t index = (size_t)pop_u64();
+static void mw_External_7E_name (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_External_7E_name(index);
     push_ptr(v);
 }
@@ -8326,8 +8298,7 @@ static VAL* fieldptr_External_7E_sig (size_t i) {
     return p+i;
 }
 
-static void mw_External_7E_sig (void){
-    size_t index = (size_t)pop_u64();
+static void mw_External_7E_sig (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_External_7E_sig(index);
     push_ptr(v);
 }
@@ -8340,8 +8311,7 @@ static VAL* fieldptr_External_7E_ctx_type (size_t i) {
     return p+i;
 }
 
-static void mw_External_7E_ctx_type (void){
-    size_t index = (size_t)pop_u64();
+static void mw_External_7E_ctx_type (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_External_7E_ctx_type(index);
     push_ptr(v);
 }
@@ -8354,8 +8324,7 @@ static VAL* fieldptr_Word_7E_name (size_t i) {
     return p+i;
 }
 
-static void mw_Word_7E_name (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Word_7E_name (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Word_7E_name(index);
     push_ptr(v);
 }
@@ -8368,8 +8337,7 @@ static VAL* fieldptr_Word_7E_head (size_t i) {
     return p+i;
 }
 
-static void mw_Word_7E_head (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Word_7E_head (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Word_7E_head(index);
     push_ptr(v);
 }
@@ -8382,8 +8350,7 @@ static VAL* fieldptr_Word_7E_sig (size_t i) {
     return p+i;
 }
 
-static void mw_Word_7E_sig (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Word_7E_sig (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Word_7E_sig(index);
     push_ptr(v);
 }
@@ -8396,8 +8363,7 @@ static VAL* fieldptr_Word_7E_body (size_t i) {
     return p+i;
 }
 
-static void mw_Word_7E_body (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Word_7E_body (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Word_7E_body(index);
     push_ptr(v);
 }
@@ -8410,8 +8376,7 @@ static VAL* fieldptr_Word_7E_ctx_type (size_t i) {
     return p+i;
 }
 
-static void mw_Word_7E_ctx_type (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Word_7E_ctx_type (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Word_7E_ctx_type(index);
     push_ptr(v);
 }
@@ -8424,8 +8389,7 @@ static VAL* fieldptr_Word_7E_params (size_t i) {
     return p+i;
 }
 
-static void mw_Word_7E_params (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Word_7E_params (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Word_7E_params(index);
     push_ptr(v);
 }
@@ -8438,8 +8402,7 @@ static VAL* fieldptr_Word_7E_arrow (size_t i) {
     return p+i;
 }
 
-static void mw_Word_7E_arrow (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Word_7E_arrow (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Word_7E_arrow(index);
     push_ptr(v);
 }
@@ -8452,8 +8415,7 @@ static VAL* fieldptr_Buffer_7E_head (size_t i) {
     return p+i;
 }
 
-static void mw_Buffer_7E_head (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Buffer_7E_head (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Buffer_7E_head(index);
     push_ptr(v);
 }
@@ -8466,8 +8428,7 @@ static VAL* fieldptr_Buffer_7E_size (size_t i) {
     return p+i;
 }
 
-static void mw_Buffer_7E_size (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Buffer_7E_size (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Buffer_7E_size(index);
     push_ptr(v);
 }
@@ -8480,8 +8441,7 @@ static VAL* fieldptr_Buffer_7E_name (size_t i) {
     return p+i;
 }
 
-static void mw_Buffer_7E_name (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Buffer_7E_name (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Buffer_7E_name(index);
     push_ptr(v);
 }
@@ -8494,8 +8454,7 @@ static VAL* fieldptr_Variable_7E_head (size_t i) {
     return p+i;
 }
 
-static void mw_Variable_7E_head (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Variable_7E_head (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Variable_7E_head(index);
     push_ptr(v);
 }
@@ -8508,8 +8467,7 @@ static VAL* fieldptr_Variable_7E_name (size_t i) {
     return p+i;
 }
 
-static void mw_Variable_7E_name (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Variable_7E_name (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Variable_7E_name(index);
     push_ptr(v);
 }
@@ -8522,8 +8480,7 @@ static VAL* fieldptr_Variable_7E_type (size_t i) {
     return p+i;
 }
 
-static void mw_Variable_7E_type (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Variable_7E_type (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Variable_7E_type(index);
     push_ptr(v);
 }
@@ -8536,8 +8493,7 @@ static VAL* fieldptr_Constant_7E_head (size_t i) {
     return p+i;
 }
 
-static void mw_Constant_7E_head (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Constant_7E_head (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Constant_7E_head(index);
     push_ptr(v);
 }
@@ -8550,8 +8506,7 @@ static VAL* fieldptr_Constant_7E_name (size_t i) {
     return p+i;
 }
 
-static void mw_Constant_7E_name (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Constant_7E_name (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Constant_7E_name(index);
     push_ptr(v);
 }
@@ -8564,8 +8519,7 @@ static VAL* fieldptr_Constant_7E_value (size_t i) {
     return p+i;
 }
 
-static void mw_Constant_7E_value (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Constant_7E_value (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Constant_7E_value(index);
     push_ptr(v);
 }
@@ -8578,8 +8532,7 @@ static VAL* fieldptr_Table_7E_head (size_t i) {
     return p+i;
 }
 
-static void mw_Table_7E_head (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Table_7E_head (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Table_7E_head(index);
     push_ptr(v);
 }
@@ -8592,8 +8545,7 @@ static VAL* fieldptr_Table_7E_name (size_t i) {
     return p+i;
 }
 
-static void mw_Table_7E_name (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Table_7E_name (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Table_7E_name(index);
     push_ptr(v);
 }
@@ -8606,8 +8558,7 @@ static VAL* fieldptr_Table_7E_num_buffer (size_t i) {
     return p+i;
 }
 
-static void mw_Table_7E_num_buffer (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Table_7E_num_buffer (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Table_7E_num_buffer(index);
     push_ptr(v);
 }
@@ -8620,8 +8571,7 @@ static VAL* fieldptr_Table_7E_max_count (size_t i) {
     return p+i;
 }
 
-static void mw_Table_7E_max_count (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Table_7E_max_count (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Table_7E_max_count(index);
     push_ptr(v);
 }
@@ -8634,8 +8584,7 @@ static VAL* fieldptr_Field_7E_head (size_t i) {
     return p+i;
 }
 
-static void mw_Field_7E_head (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Field_7E_head (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Field_7E_head(index);
     push_ptr(v);
 }
@@ -8648,8 +8597,7 @@ static VAL* fieldptr_Field_7E_name (size_t i) {
     return p+i;
 }
 
-static void mw_Field_7E_name (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Field_7E_name (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Field_7E_name(index);
     push_ptr(v);
 }
@@ -8662,8 +8610,7 @@ static VAL* fieldptr_Field_7E_index_type (size_t i) {
     return p+i;
 }
 
-static void mw_Field_7E_index_type (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Field_7E_index_type (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Field_7E_index_type(index);
     push_ptr(v);
 }
@@ -8676,8 +8623,7 @@ static VAL* fieldptr_Field_7E_value_type (size_t i) {
     return p+i;
 }
 
-static void mw_Field_7E_value_type (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Field_7E_value_type (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Field_7E_value_type(index);
     push_ptr(v);
 }
@@ -8690,8 +8636,7 @@ static VAL* fieldptr_word_needed (size_t i) {
     return p+i;
 }
 
-static void mw_word_needed (void){
-    size_t index = (size_t)pop_u64();
+static void mw_word_needed (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_word_needed(index);
     push_ptr(v);
 }
@@ -8704,8 +8649,7 @@ static VAL* fieldptr_block_needed (size_t i) {
     return p+i;
 }
 
-static void mw_block_needed (void){
-    size_t index = (size_t)pop_u64();
+static void mw_block_needed (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_block_needed(index);
     push_ptr(v);
 }
@@ -8718,8 +8662,7 @@ static VAL* fieldptr_Arrow_7E_token_start (size_t i) {
     return p+i;
 }
 
-static void mw_Arrow_7E_token_start (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Arrow_7E_token_start (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Arrow_7E_token_start(index);
     push_ptr(v);
 }
@@ -8732,8 +8675,7 @@ static VAL* fieldptr_Arrow_7E_token_end (size_t i) {
     return p+i;
 }
 
-static void mw_Arrow_7E_token_end (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Arrow_7E_token_end (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Arrow_7E_token_end(index);
     push_ptr(v);
 }
@@ -8746,8 +8688,7 @@ static VAL* fieldptr_Arrow_7E_home (size_t i) {
     return p+i;
 }
 
-static void mw_Arrow_7E_home (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Arrow_7E_home (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Arrow_7E_home(index);
     push_ptr(v);
 }
@@ -8760,8 +8701,7 @@ static VAL* fieldptr_Arrow_7E_homeidx (size_t i) {
     return p+i;
 }
 
-static void mw_Arrow_7E_homeidx (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Arrow_7E_homeidx (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Arrow_7E_homeidx(index);
     push_ptr(v);
 }
@@ -8774,8 +8714,7 @@ static VAL* fieldptr_Arrow_7E_ctx (size_t i) {
     return p+i;
 }
 
-static void mw_Arrow_7E_ctx (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Arrow_7E_ctx (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Arrow_7E_ctx(index);
     push_ptr(v);
 }
@@ -8788,8 +8727,7 @@ static VAL* fieldptr_Arrow_7E_dom (size_t i) {
     return p+i;
 }
 
-static void mw_Arrow_7E_dom (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Arrow_7E_dom (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Arrow_7E_dom(index);
     push_ptr(v);
 }
@@ -8802,8 +8740,7 @@ static VAL* fieldptr_Arrow_7E_cod (size_t i) {
     return p+i;
 }
 
-static void mw_Arrow_7E_cod (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Arrow_7E_cod (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Arrow_7E_cod(index);
     push_ptr(v);
 }
@@ -8816,8 +8753,7 @@ static VAL* fieldptr_Arrow_7E_atoms (size_t i) {
     return p+i;
 }
 
-static void mw_Arrow_7E_atoms (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Arrow_7E_atoms (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Arrow_7E_atoms(index);
     push_ptr(v);
 }
@@ -8830,8 +8766,7 @@ static VAL* fieldptr_Atom_7E_token (size_t i) {
     return p+i;
 }
 
-static void mw_Atom_7E_token (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Atom_7E_token (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Atom_7E_token(index);
     push_ptr(v);
 }
@@ -8844,8 +8779,7 @@ static VAL* fieldptr_Atom_7E_ctx (size_t i) {
     return p+i;
 }
 
-static void mw_Atom_7E_ctx (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Atom_7E_ctx (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Atom_7E_ctx(index);
     push_ptr(v);
 }
@@ -8858,8 +8792,7 @@ static VAL* fieldptr_Atom_7E_op (size_t i) {
     return p+i;
 }
 
-static void mw_Atom_7E_op (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Atom_7E_op (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Atom_7E_op(index);
     push_ptr(v);
 }
@@ -8872,8 +8805,7 @@ static VAL* fieldptr_Atom_7E_args (size_t i) {
     return p+i;
 }
 
-static void mw_Atom_7E_args (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Atom_7E_args (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Atom_7E_args(index);
     push_ptr(v);
 }
@@ -8886,8 +8818,7 @@ static VAL* fieldptr_Atom_7E_dom (size_t i) {
     return p+i;
 }
 
-static void mw_Atom_7E_dom (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Atom_7E_dom (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Atom_7E_dom(index);
     push_ptr(v);
 }
@@ -8900,8 +8831,7 @@ static VAL* fieldptr_Atom_7E_cod (size_t i) {
     return p+i;
 }
 
-static void mw_Atom_7E_cod (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Atom_7E_cod (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Atom_7E_cod(index);
     push_ptr(v);
 }
@@ -8914,8 +8844,7 @@ static VAL* fieldptr_Atom_7E_subst (size_t i) {
     return p+i;
 }
 
-static void mw_Atom_7E_subst (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Atom_7E_subst (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Atom_7E_subst(index);
     push_ptr(v);
 }
@@ -8928,8 +8857,7 @@ static VAL* fieldptr_Lambda_7E_token (size_t i) {
     return p+i;
 }
 
-static void mw_Lambda_7E_token (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Lambda_7E_token (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Lambda_7E_token(index);
     push_ptr(v);
 }
@@ -8942,8 +8870,7 @@ static VAL* fieldptr_Lambda_7E_outer_ctx (size_t i) {
     return p+i;
 }
 
-static void mw_Lambda_7E_outer_ctx (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Lambda_7E_outer_ctx (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Lambda_7E_outer_ctx(index);
     push_ptr(v);
 }
@@ -8956,8 +8883,7 @@ static VAL* fieldptr_Lambda_7E_inner_ctx (size_t i) {
     return p+i;
 }
 
-static void mw_Lambda_7E_inner_ctx (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Lambda_7E_inner_ctx (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Lambda_7E_inner_ctx(index);
     push_ptr(v);
 }
@@ -8970,8 +8896,7 @@ static VAL* fieldptr_Lambda_7E_dom (size_t i) {
     return p+i;
 }
 
-static void mw_Lambda_7E_dom (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Lambda_7E_dom (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Lambda_7E_dom(index);
     push_ptr(v);
 }
@@ -8984,8 +8909,7 @@ static VAL* fieldptr_Lambda_7E_mid (size_t i) {
     return p+i;
 }
 
-static void mw_Lambda_7E_mid (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Lambda_7E_mid (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Lambda_7E_mid(index);
     push_ptr(v);
 }
@@ -8998,8 +8922,7 @@ static VAL* fieldptr_Lambda_7E_cod (size_t i) {
     return p+i;
 }
 
-static void mw_Lambda_7E_cod (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Lambda_7E_cod (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Lambda_7E_cod(index);
     push_ptr(v);
 }
@@ -9012,8 +8935,7 @@ static VAL* fieldptr_Lambda_7E_params (size_t i) {
     return p+i;
 }
 
-static void mw_Lambda_7E_params (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Lambda_7E_params (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Lambda_7E_params(index);
     push_ptr(v);
 }
@@ -9026,8 +8948,7 @@ static VAL* fieldptr_Lambda_7E_body (size_t i) {
     return p+i;
 }
 
-static void mw_Lambda_7E_body (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Lambda_7E_body (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Lambda_7E_body(index);
     push_ptr(v);
 }
@@ -9040,8 +8961,7 @@ static VAL* fieldptr_Block_7E_ctx (size_t i) {
     return p+i;
 }
 
-static void mw_Block_7E_ctx (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Block_7E_ctx (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Block_7E_ctx(index);
     push_ptr(v);
 }
@@ -9054,8 +8974,7 @@ static VAL* fieldptr_Block_7E_token (size_t i) {
     return p+i;
 }
 
-static void mw_Block_7E_token (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Block_7E_token (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Block_7E_token(index);
     push_ptr(v);
 }
@@ -9068,8 +8987,7 @@ static VAL* fieldptr_Block_7E_dom (size_t i) {
     return p+i;
 }
 
-static void mw_Block_7E_dom (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Block_7E_dom (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Block_7E_dom(index);
     push_ptr(v);
 }
@@ -9082,8 +9000,7 @@ static VAL* fieldptr_Block_7E_cod (size_t i) {
     return p+i;
 }
 
-static void mw_Block_7E_cod (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Block_7E_cod (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Block_7E_cod(index);
     push_ptr(v);
 }
@@ -9096,8 +9013,7 @@ static VAL* fieldptr_Block_7E_arrow (size_t i) {
     return p+i;
 }
 
-static void mw_Block_7E_arrow (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Block_7E_arrow (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Block_7E_arrow(index);
     push_ptr(v);
 }
@@ -9110,8 +9026,7 @@ static VAL* fieldptr_MetaVar_7E_type_3F_ (size_t i) {
     return p+i;
 }
 
-static void mw_MetaVar_7E_type_3F_ (void){
-    size_t index = (size_t)pop_u64();
+static void mw_MetaVar_7E_type_3F_ (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_MetaVar_7E_type_3F_(index);
     push_ptr(v);
 }
@@ -9124,8 +9039,7 @@ static VAL* fieldptr_Prim_7E_name (size_t i) {
     return p+i;
 }
 
-static void mw_Prim_7E_name (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Prim_7E_name (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Prim_7E_name(index);
     push_ptr(v);
 }
@@ -9138,8 +9052,7 @@ static VAL* fieldptr_Prim_7E_ctx (size_t i) {
     return p+i;
 }
 
-static void mw_Prim_7E_ctx (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Prim_7E_ctx (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Prim_7E_ctx(index);
     push_ptr(v);
 }
@@ -9152,8 +9065,7 @@ static VAL* fieldptr_Prim_7E_type (size_t i) {
     return p+i;
 }
 
-static void mw_Prim_7E_type (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Prim_7E_type (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Prim_7E_type(index);
     push_ptr(v);
 }
@@ -9166,8 +9078,7 @@ static VAL* fieldptr_Prim_7E_decl (size_t i) {
     return p+i;
 }
 
-static void mw_Prim_7E_decl (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Prim_7E_decl (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Prim_7E_decl(index);
     push_ptr(v);
 }
@@ -9180,8 +9091,7 @@ static VAL* fieldptr_Token_7E_value (size_t i) {
     return p+i;
 }
 
-static void mw_Token_7E_value (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Token_7E_value (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Token_7E_value(index);
     push_ptr(v);
 }
@@ -9194,8 +9104,7 @@ static VAL* fieldptr_Token_7E_module (size_t i) {
     return p+i;
 }
 
-static void mw_Token_7E_module (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Token_7E_module (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Token_7E_module(index);
     push_ptr(v);
 }
@@ -9208,8 +9117,7 @@ static VAL* fieldptr_Token_7E_row (size_t i) {
     return p+i;
 }
 
-static void mw_Token_7E_row (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Token_7E_row (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Token_7E_row(index);
     push_ptr(v);
 }
@@ -9222,8 +9130,7 @@ static VAL* fieldptr_Token_7E_col (size_t i) {
     return p+i;
 }
 
-static void mw_Token_7E_col (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Token_7E_col (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Token_7E_col(index);
     push_ptr(v);
 }
@@ -9236,8 +9143,7 @@ static VAL* fieldptr_Alias_7E_head (size_t i) {
     return p+i;
 }
 
-static void mw_Alias_7E_head (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Alias_7E_head (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Alias_7E_head(index);
     push_ptr(v);
 }
@@ -9250,8 +9156,7 @@ static VAL* fieldptr_Alias_7E_name (size_t i) {
     return p+i;
 }
 
-static void mw_Alias_7E_name (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Alias_7E_name (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Alias_7E_name(index);
     push_ptr(v);
 }
@@ -9264,8 +9169,7 @@ static VAL* fieldptr_Alias_7E_target (size_t i) {
     return p+i;
 }
 
-static void mw_Alias_7E_target (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Alias_7E_target (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Alias_7E_target(index);
     push_ptr(v);
 }
@@ -9278,8 +9182,7 @@ static VAL* fieldptr_Name_7E_Str (size_t i) {
     return p+i;
 }
 
-static void mw_Name_7E_Str (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Name_7E_Str (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Name_7E_Str(index);
     push_ptr(v);
 }
@@ -9292,8 +9195,7 @@ static VAL* fieldptr_Name_7E_Def (size_t i) {
     return p+i;
 }
 
-static void mw_Name_7E_Def (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Name_7E_Def (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Name_7E_Def(index);
     push_ptr(v);
 }
@@ -9306,8 +9208,7 @@ static VAL* fieldptr_Name_7E_mangled (size_t i) {
     return p+i;
 }
 
-static void mw_Name_7E_mangled (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Name_7E_mangled (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Name_7E_mangled(index);
     push_ptr(v);
 }
@@ -9320,8 +9221,7 @@ static VAL* fieldptr_Module_7E_name (size_t i) {
     return p+i;
 }
 
-static void mw_Module_7E_name (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Module_7E_name (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Module_7E_name(index);
     push_ptr(v);
 }
@@ -9334,8 +9234,7 @@ static VAL* fieldptr_Module_7E_path (size_t i) {
     return p+i;
 }
 
-static void mw_Module_7E_path (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Module_7E_path (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Module_7E_path(index);
     push_ptr(v);
 }
@@ -9348,8 +9247,7 @@ static VAL* fieldptr_Module_7E_start (size_t i) {
     return p+i;
 }
 
-static void mw_Module_7E_start (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Module_7E_start (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Module_7E_start(index);
     push_ptr(v);
 }
@@ -9362,8 +9260,7 @@ static VAL* fieldptr_Module_7E_end (size_t i) {
     return p+i;
 }
 
-static void mw_Module_7E_end (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Module_7E_end (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Module_7E_end(index);
     push_ptr(v);
 }
@@ -9376,14 +9273,13 @@ static VAL* fieldptr_Module_7E_imports (size_t i) {
     return p+i;
 }
 
-static void mw_Module_7E_imports (void){
-    size_t index = (size_t)pop_u64();
+static void mw_Module_7E_imports (void){    size_t index = (size_t)pop_u64();
     VAL *v = fieldptr_Module_7E_imports(index);
     push_ptr(v);
 }
 
 
-static void mw_L4_2B_ (void){
+static void mw_L4_2B_ (void) {
     WORD_ENTER(mw_L4_2B_, "L4+", "src/data/list.mth", 33, 50);
     WORD_ATOM(33, 50, "L2+");
     mw_L2_2B_();
@@ -9400,7 +9296,7 @@ static void mw_L4_2B_ (void){
     mw_LCAT_2B_();
     WORD_EXIT(mw_L4_2B_);
 }
-static void mw_L5_2B_ (void){
+static void mw_L5_2B_ (void) {
     WORD_ENTER(mw_L5_2B_, "L5+", "src/data/list.mth", 34, 50);
     WORD_ATOM(34, 50, "L3+");
     mw_L3_2B_();
@@ -9417,7 +9313,7 @@ static void mw_L5_2B_ (void){
     mw_LCAT_2B_();
     WORD_EXIT(mw_L5_2B_);
 }
-static void mw_L6_2B_ (void){
+static void mw_L6_2B_ (void) {
     WORD_ENTER(mw_L6_2B_, "L6+", "src/data/list.mth", 35, 50);
     WORD_ATOM(35, 50, "L3+");
     mw_L3_2B_();
@@ -9434,81 +9330,81 @@ static void mw_L6_2B_ (void){
     mw_LCAT_2B_();
     WORD_EXIT(mw_L6_2B_);
 }
-static void mw_List_2B__3E_List (void){
+static void mw_List_2B__3E_List (void) {
     WORD_ENTER(mw_List_2B__3E_List, "List+>List", "src/data/list.mth", 44, 5);
     WORD_ATOM(44, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_L1_2B_();
+            mp_L1_2B_();
             WORD_ATOM(44, 12, "L1");
             mw_L1();
             break;
         case 1LL:
-            co_L2_2B_();
+            mp_L2_2B_();
             WORD_ATOM(45, 12, "L2");
             mw_L2();
             break;
         case 2LL:
-            co_L3_2B_();
+            mp_L3_2B_();
             WORD_ATOM(46, 12, "L3");
             mw_L3();
             break;
         case 3LL:
-            co_LCAT_2B_();
+            mp_LCAT_2B_();
             WORD_ATOM(47, 14, "LCAT");
             mw_LCAT();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_List_2B__3E_List);
+    }
+    WORD_EXIT(mw_List_2B__3E_List);
 }
-static void mw_List_3E_List_2B_ (void){
+static void mw_List_3E_List_2B_ (void) {
     WORD_ENTER(mw_List_3E_List_2B_, "List>List+", "src/data/list.mth", 50, 5);
     WORD_ATOM(50, 5, "L0");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_L0();
+            mp_L0();
             WORD_ATOM(50, 11, "NONE");
             mw_NONE();
             break;
         case 1LL:
-            co_L1();
+            mp_L1();
             WORD_ATOM(51, 11, "L1+");
             mw_L1_2B_();
             WORD_ATOM(51, 15, "SOME");
             mw_SOME();
             break;
         case 2LL:
-            co_L2();
+            mp_L2();
             WORD_ATOM(52, 11, "L2+");
             mw_L2_2B_();
             WORD_ATOM(52, 15, "SOME");
             mw_SOME();
             break;
         case 3LL:
-            co_L3();
+            mp_L3();
             WORD_ATOM(53, 11, "L3+");
             mw_L3_2B_();
             WORD_ATOM(53, 15, "SOME");
             mw_SOME();
             break;
         case 4LL:
-            co_LCAT();
+            mp_LCAT();
             WORD_ATOM(54, 13, "LCAT+");
             mw_LCAT_2B_();
             WORD_ATOM(54, 19, "SOME");
             mw_SOME();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_List_3E_List_2B_);
+    }
+    WORD_EXIT(mw_List_3E_List_2B_);
 }
-static void mw_List_2E_is_empty (void){
+static void mw_List_2E_is_empty (void) {
     WORD_ENTER(mw_List_2E_is_empty, "List.is-empty", "src/data/list.mth", 57, 5);
     WORD_ATOM(57, 5, "L0");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_L0();
+            mp_L0();
             WORD_ATOM(57, 11, "T");
             mw_T();
             break;
@@ -9518,41 +9414,41 @@ static void mw_List_2E_is_empty (void){
             WORD_ATOM(58, 15, "F");
             mw_F();
             break;
-    
-}    WORD_EXIT(mw_List_2E_is_empty);
+    }
+    WORD_EXIT(mw_List_2E_is_empty);
 }
-static void mw_List_2E_len (void){
+static void mw_List_2E_len (void) {
     WORD_ENTER(mw_List_2E_len, "List.len", "src/data/list.mth", 61, 5);
     WORD_ATOM(61, 5, "L0");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_L0();
+            mp_L0();
             WORD_ATOM(61, 11, "");
             push_i64(0LL);
             break;
         case 1LL:
-            co_L1();
+            mp_L1();
             WORD_ATOM(62, 11, "drop");
             mw_prim_drop();
             WORD_ATOM(62, 16, "");
             push_i64(1LL);
             break;
         case 2LL:
-            co_L2();
+            mp_L2();
             WORD_ATOM(63, 11, "drop2");
             mw_drop2();
             WORD_ATOM(63, 17, "");
             push_i64(2LL);
             break;
         case 3LL:
-            co_L3();
+            mp_L3();
             WORD_ATOM(64, 11, "drop3");
             mw_drop3();
             WORD_ATOM(64, 17, "");
             push_i64(3LL);
             break;
         case 4LL:
-            co_LCAT();
+            mp_LCAT();
             WORD_ATOM(65, 13, "dip");
             {
                 VAL d4 = pop_value();
@@ -9562,36 +9458,36 @@ static void mw_List_2E_len (void){
             }
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_List_2E_len);
+    }
+    WORD_EXIT(mw_List_2E_len);
 }
-static void mw_List_2B__2E_len (void){
+static void mw_List_2B__2E_len (void) {
     WORD_ENTER(mw_List_2B__2E_len, "List+.len", "src/data/list.mth", 68, 5);
     WORD_ATOM(68, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_L1_2B_();
+            mp_L1_2B_();
             WORD_ATOM(68, 12, "drop");
             mw_prim_drop();
             WORD_ATOM(68, 17, "");
             push_i64(1LL);
             break;
         case 1LL:
-            co_L2_2B_();
+            mp_L2_2B_();
             WORD_ATOM(69, 12, "drop2");
             mw_drop2();
             WORD_ATOM(69, 18, "");
             push_i64(2LL);
             break;
         case 2LL:
-            co_L3_2B_();
+            mp_L3_2B_();
             WORD_ATOM(70, 12, "drop3");
             mw_drop3();
             WORD_ATOM(70, 18, "");
             push_i64(3LL);
             break;
         case 3LL:
-            co_LCAT_2B_();
+            mp_LCAT_2B_();
             WORD_ATOM(71, 14, "dip");
             {
                 VAL d4 = pop_value();
@@ -9601,35 +9497,35 @@ static void mw_List_2B__2E_len (void){
             }
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_List_2B__2E_len);
+    }
+    WORD_EXIT(mw_List_2B__2E_len);
 }
-static void mw_List_2E_cons_2B_ (void){
+static void mw_List_2E_cons_2B_ (void) {
     WORD_ENTER(mw_List_2E_cons_2B_, "List.cons+", "src/data/list.mth", 77, 5);
     WORD_ATOM(77, 5, "L0");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_L0();
+            mp_L0();
             WORD_ATOM(77, 11, "L1+");
             mw_L1_2B_();
             break;
         case 1LL:
-            co_L1();
+            mp_L1();
             WORD_ATOM(78, 11, "L2+");
             mw_L2_2B_();
             break;
         case 2LL:
-            co_L2();
+            mp_L2();
             WORD_ATOM(79, 11, "L3+");
             mw_L3_2B_();
             break;
         case 3LL:
-            co_L3();
+            mp_L3();
             WORD_ATOM(80, 11, "L4+");
             mw_L4_2B_();
             break;
         case 4LL:
-            co_LCAT();
+            mp_LCAT();
             WORD_ATOM(81, 13, "1+");
             mw_prim_int_succ();
             WORD_ATOM(81, 16, "dip");
@@ -9650,43 +9546,43 @@ static void mw_List_2E_cons_2B_ (void){
             mw_LCAT_2B_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_List_2E_cons_2B_);
+    }
+    WORD_EXIT(mw_List_2E_cons_2B_);
 }
-static void mw_snoc_2B_ (void){
+static void mw_snoc_2B_ (void) {
     WORD_ENTER(mw_snoc_2B_, "snoc+", "src/data/list.mth", 84, 5);
     WORD_ATOM(84, 5, "swap");
     mw_prim_swap();
     WORD_ATOM(84, 10, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_L0();
+            mp_L0();
             WORD_ATOM(85, 15, "L1+");
             mw_L1_2B_();
             break;
         case 1LL:
-            co_L1();
+            mp_L1();
             WORD_ATOM(86, 15, "swap");
             mw_prim_swap();
             WORD_ATOM(86, 20, "L2+");
             mw_L2_2B_();
             break;
         case 2LL:
-            co_L2();
+            mp_L2();
             WORD_ATOM(87, 15, "rotl");
             mw_rotl();
             WORD_ATOM(87, 20, "L3+");
             mw_L3_2B_();
             break;
         case 3LL:
-            co_L3();
+            mp_L3();
             WORD_ATOM(88, 15, "rot4l");
             mw_rot4l();
             WORD_ATOM(88, 21, "L4+");
             mw_L4_2B_();
             break;
         case 4LL:
-            co_LCAT();
+            mp_LCAT();
             WORD_ATOM(89, 17, "1+");
             mw_prim_int_succ();
             WORD_ATOM(89, 20, "dip");
@@ -9704,10 +9600,10 @@ static void mw_snoc_2B_ (void){
             mw_LCAT_2B_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_snoc_2B_);
+    }
+    WORD_EXIT(mw_snoc_2B_);
 }
-static void mw_List_2B__2E_cons_2B_ (void){
+static void mw_List_2B__2E_cons_2B_ (void) {
     WORD_ENTER(mw_List_2B__2E_cons_2B_, "List+.cons+", "src/data/list.mth", 92, 42);
     WORD_ATOM(92, 42, ">List");
     mw_List_2B__3E_List();
@@ -9715,7 +9611,7 @@ static void mw_List_2B__2E_cons_2B_ (void){
     mw_List_2E_cons_2B_();
     WORD_EXIT(mw_List_2B__2E_cons_2B_);
 }
-static void mw_List_2E_cons (void){
+static void mw_List_2E_cons (void) {
     WORD_ENTER(mw_List_2E_cons, "List.cons", "src/data/list.mth", 93, 38);
     WORD_ATOM(93, 38, "cons+");
     mw_List_2E_cons_2B_();
@@ -9723,7 +9619,7 @@ static void mw_List_2E_cons (void){
     mw_List_2B__3E_List();
     WORD_EXIT(mw_List_2E_cons);
 }
-static void mw_snoc_2B__2B_ (void){
+static void mw_snoc_2B__2B_ (void) {
     WORD_ENTER(mw_snoc_2B__2B_, "snoc++", "src/data/list.mth", 94, 37);
     WORD_ATOM(94, 37, "dip");
     {
@@ -9736,7 +9632,7 @@ static void mw_snoc_2B__2B_ (void){
     mw_snoc_2B_();
     WORD_EXIT(mw_snoc_2B__2B_);
 }
-static void mw_snoc (void){
+static void mw_snoc (void) {
     WORD_ENTER(mw_snoc, "snoc", "src/data/list.mth", 95, 33);
     WORD_ATOM(95, 33, "snoc+");
     mw_snoc_2B_();
@@ -9744,27 +9640,27 @@ static void mw_snoc (void){
     mw_List_2B__3E_List();
     WORD_EXIT(mw_snoc);
 }
-static void mw_List_2B__2E_uncons (void){
+static void mw_List_2B__2E_uncons (void) {
     WORD_ENTER(mw_List_2B__2E_uncons, "List+.uncons", "src/data/list.mth", 98, 5);
     WORD_ATOM(98, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_L1_2B_();
+            mp_L1_2B_();
             WORD_ATOM(98, 12, "L0");
             mw_L0();
             break;
         case 1LL:
-            co_L2_2B_();
+            mp_L2_2B_();
             WORD_ATOM(99, 12, "L1");
             mw_L1();
             break;
         case 2LL:
-            co_L3_2B_();
+            mp_L3_2B_();
             WORD_ATOM(100, 12, "L2");
             mw_L2();
             break;
         case 3LL:
-            co_LCAT_2B_();
+            mp_LCAT_2B_();
             WORD_ATOM(101, 14, "drop");
             mw_prim_drop();
             WORD_ATOM(101, 19, "dip");
@@ -9780,15 +9676,15 @@ static void mw_List_2B__2E_uncons (void){
             mw_List_2B__3E_List();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_List_2B__2E_uncons);
+    }
+    WORD_EXIT(mw_List_2B__2E_uncons);
 }
-static void mw_List_2B__2E_unsnoc (void){
+static void mw_List_2B__2E_unsnoc (void) {
     WORD_ENTER(mw_List_2B__2E_unsnoc, "List+.unsnoc", "src/data/list.mth", 104, 5);
     WORD_ATOM(104, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_L1_2B_();
+            mp_L1_2B_();
             WORD_ATOM(104, 12, "dip");
             {
                 VAL d4 = pop_value();
@@ -9798,7 +9694,7 @@ static void mw_List_2B__2E_unsnoc (void){
             }
             break;
         case 1LL:
-            co_L2_2B_();
+            mp_L2_2B_();
             WORD_ATOM(105, 12, "dip");
             {
                 VAL d4 = pop_value();
@@ -9808,7 +9704,7 @@ static void mw_List_2B__2E_unsnoc (void){
             }
             break;
         case 2LL:
-            co_L3_2B_();
+            mp_L3_2B_();
             WORD_ATOM(106, 12, "dip");
             {
                 VAL d4 = pop_value();
@@ -9818,7 +9714,7 @@ static void mw_List_2B__2E_unsnoc (void){
             }
             break;
         case 3LL:
-            co_LCAT_2B_();
+            mp_LCAT_2B_();
             WORD_ATOM(107, 14, "drop");
             mw_prim_drop();
             WORD_ATOM(107, 19, "unsnoc");
@@ -9834,10 +9730,10 @@ static void mw_List_2B__2E_unsnoc (void){
             }
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_List_2B__2E_unsnoc);
+    }
+    WORD_EXIT(mw_List_2B__2E_unsnoc);
 }
-static void mw_List_2E_cat (void){
+static void mw_List_2E_cat (void) {
     WORD_ENTER(mw_List_2E_cat, "List.cat", "src/data/list.mth", 110, 5);
     WORD_ATOM(110, 5, ">List+");
     mw_List_3E_List_2B_();
@@ -9848,7 +9744,7 @@ static void mw_List_2E_cat (void){
     mw_Maybe_2E_for();
     WORD_EXIT(mw_List_2E_cat);
 }
-static void mw_List_2B__2E_cat (void){
+static void mw_List_2B__2E_cat (void) {
     WORD_ENTER(mw_List_2B__2E_cat, "List+.cat", "src/data/list.mth", 113, 5);
     WORD_ATOM(113, 5, "swap");
     mw_prim_swap();
@@ -9861,7 +9757,7 @@ static void mw_List_2B__2E_cat (void){
     mw_Maybe_2E_for();
     WORD_EXIT(mw_List_2B__2E_cat);
 }
-static void mw_List_2E_cat_2B_ (void){
+static void mw_List_2E_cat_2B_ (void) {
     WORD_ENTER(mw_List_2E_cat_2B_, "List.cat+", "src/data/list.mth", 116, 5);
     WORD_ATOM(116, 5, ">List+");
     mw_List_3E_List_2B_();
@@ -9872,37 +9768,37 @@ static void mw_List_2E_cat_2B_ (void){
     mw_Maybe_2E_for();
     WORD_EXIT(mw_List_2E_cat_2B_);
 }
-static void mw_List_2B__2E_cat_2B_ (void){
+static void mw_List_2B__2E_cat_2B_ (void) {
     WORD_ENTER(mw_List_2B__2E_cat_2B_, "List+.cat+", "src/data/list.mth", 119, 5);
     WORD_ATOM(119, 5, "swap");
     mw_prim_swap();
     WORD_ATOM(119, 10, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_L1_2B_();
+            mp_L1_2B_();
             WORD_ATOM(120, 16, "swap");
             mw_prim_swap();
             WORD_ATOM(120, 21, "cons+");
             mw_List_2B__2E_cons_2B_();
             break;
         case 1LL:
-            co_L2_2B_();
+            mp_L2_2B_();
             WORD_ATOM(122, 13, "rotl");
             mw_rotl();
             WORD_ATOM(122, 18, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    co_L1_2B_();
+                    mp_L1_2B_();
                     WORD_ATOM(123, 24, "L3+");
                     mw_L3_2B_();
                     break;
                 case 1LL:
-                    co_L2_2B_();
+                    mp_L2_2B_();
                     WORD_ATOM(124, 24, "L4+");
                     mw_L4_2B_();
                     break;
                 case 2LL:
-                    co_L3_2B_();
+                    mp_L3_2B_();
                     WORD_ATOM(125, 24, "L5+");
                     mw_L5_2B_();
                     break;
@@ -9917,26 +9813,26 @@ static void mw_List_2B__2E_cat_2B_ (void){
                     WORD_ATOM(126, 31, "cat-aux");
                     mw_List_2B__2E_cat_aux();
                     break;
-            
-}            break;
+            }
+            break;
         case 2LL:
-            co_L3_2B_();
+            mp_L3_2B_();
             WORD_ATOM(129, 13, "rot4l");
             mw_rot4l();
             WORD_ATOM(129, 19, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    co_L1_2B_();
+                    mp_L1_2B_();
                     WORD_ATOM(130, 24, "L4+");
                     mw_L4_2B_();
                     break;
                 case 1LL:
-                    co_L2_2B_();
+                    mp_L2_2B_();
                     WORD_ATOM(131, 24, "L5+");
                     mw_L5_2B_();
                     break;
                 case 2LL:
-                    co_L3_2B_();
+                    mp_L3_2B_();
                     WORD_ATOM(132, 24, "L6+");
                     mw_L6_2B_();
                     break;
@@ -9951,15 +9847,15 @@ static void mw_List_2B__2E_cat_2B_ (void){
                     WORD_ATOM(133, 31, "cat-aux");
                     mw_List_2B__2E_cat_aux();
                     break;
-            
-}            break;
+            }
+            break;
         default:
             WORD_ATOM(136, 13, "swap");
             mw_prim_swap();
             WORD_ATOM(136, 18, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    co_L1_2B_();
+                    mp_L1_2B_();
                     WORD_ATOM(137, 24, "snoc++");
                     mw_snoc_2B__2B_();
                     break;
@@ -9967,12 +9863,12 @@ static void mw_List_2B__2E_cat_2B_ (void){
                     WORD_ATOM(138, 22, "cat-aux");
                     mw_List_2B__2E_cat_aux();
                     break;
-            
-}            break;
-    
-}    WORD_EXIT(mw_List_2B__2E_cat_2B_);
+            }
+            break;
+    }
+    WORD_EXIT(mw_List_2B__2E_cat_2B_);
 }
-static void mw_List_2B__2E_cat_aux (void){
+static void mw_List_2B__2E_cat_aux (void) {
     WORD_ENTER(mw_List_2B__2E_cat_aux, "List+.cat-aux", "src/data/list.mth", 143, 5);
     WORD_ATOM(143, 5, "rebalance");
     mw_List_2B__2E_rebalance();
@@ -9993,7 +9889,7 @@ static void mw_List_2B__2E_cat_aux (void){
     mw_LCAT_2B_();
     WORD_EXIT(mw_List_2B__2E_cat_aux);
 }
-static void mw_List_2B__2E_rebalance (void){
+static void mw_List_2B__2E_rebalance (void) {
     WORD_ENTER(mw_List_2B__2E_rebalance, "List+.rebalance", "src/data/list.mth", 146, 5);
     WORD_ATOM(146, 5, "dup2");
     mw_dup2();
@@ -10061,12 +9957,12 @@ static void mw_List_2B__2E_rebalance (void){
     }
     WORD_EXIT(mw_List_2B__2E_rebalance);
 }
-static void mw_List_2B__2E_split_half_left (void){
+static void mw_List_2B__2E_split_half_left (void) {
     WORD_ENTER(mw_List_2B__2E_split_half_left, "List+.split-half-left", "src/data/list.mth", 155, 5);
     WORD_ATOM(155, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_L1_2B_();
+            mp_L1_2B_();
             WORD_ATOM(155, 12, "L0");
             mw_L0();
             WORD_ATOM(155, 15, "dip");
@@ -10078,7 +9974,7 @@ static void mw_List_2B__2E_split_half_left (void){
             }
             break;
         case 1LL:
-            co_L2_2B_();
+            mp_L2_2B_();
             WORD_ATOM(156, 12, "L1");
             mw_L1();
             WORD_ATOM(156, 15, "dip");
@@ -10090,7 +9986,7 @@ static void mw_List_2B__2E_split_half_left (void){
             }
             break;
         case 2LL:
-            co_L3_2B_();
+            mp_L3_2B_();
             WORD_ATOM(157, 12, "L1");
             mw_L1();
             WORD_ATOM(157, 15, "dip");
@@ -10102,22 +9998,22 @@ static void mw_List_2B__2E_split_half_left (void){
             }
             break;
         case 3LL:
-            co_LCAT_2B_();
+            mp_LCAT_2B_();
             WORD_ATOM(158, 14, "drop");
             mw_prim_drop();
             WORD_ATOM(158, 19, "List+>List");
             mw_List_2B__3E_List();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_List_2B__2E_split_half_left);
+    }
+    WORD_EXIT(mw_List_2B__2E_split_half_left);
 }
-static void mw_List_2B__2E_split_half_right (void){
+static void mw_List_2B__2E_split_half_right (void) {
     WORD_ENTER(mw_List_2B__2E_split_half_right, "List+.split-half-right", "src/data/list.mth", 161, 5);
     WORD_ATOM(161, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_L1_2B_();
+            mp_L1_2B_();
             WORD_ATOM(161, 12, "L1+");
             mw_L1_2B_();
             WORD_ATOM(161, 16, "dip");
@@ -10129,7 +10025,7 @@ static void mw_List_2B__2E_split_half_right (void){
             }
             break;
         case 1LL:
-            co_L2_2B_();
+            mp_L2_2B_();
             WORD_ATOM(162, 12, "L1+");
             mw_L1_2B_();
             WORD_ATOM(162, 16, "dip");
@@ -10141,7 +10037,7 @@ static void mw_List_2B__2E_split_half_right (void){
             }
             break;
         case 2LL:
-            co_L3_2B_();
+            mp_L3_2B_();
             WORD_ATOM(163, 12, "L2+");
             mw_L2_2B_();
             WORD_ATOM(163, 16, "dip");
@@ -10153,7 +10049,7 @@ static void mw_List_2B__2E_split_half_right (void){
             }
             break;
         case 3LL:
-            co_LCAT_2B_();
+            mp_LCAT_2B_();
             WORD_ATOM(164, 14, "drop");
             mw_prim_drop();
             WORD_ATOM(164, 19, "dip");
@@ -10165,10 +10061,10 @@ static void mw_List_2B__2E_split_half_right (void){
             }
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_List_2B__2E_split_half_right);
+    }
+    WORD_EXIT(mw_List_2B__2E_split_half_right);
 }
-static void mw_List_2E_first (void){
+static void mw_List_2E_first (void) {
     WORD_ENTER(mw_List_2E_first, "List.first", "src/data/list.mth", 173, 38);
     WORD_ATOM(173, 38, "List>List+");
     mw_List_3E_List_2B_();
@@ -10179,7 +10075,7 @@ static void mw_List_2E_first (void){
     mw_Maybe_2E_map();
     WORD_EXIT(mw_List_2E_first);
 }
-static void mw_List_2E_last (void){
+static void mw_List_2E_last (void) {
     WORD_ENTER(mw_List_2E_last, "List.last", "src/data/list.mth", 174, 37);
     WORD_ATOM(174, 37, "List>List+");
     mw_List_3E_List_2B_();
@@ -10190,47 +10086,47 @@ static void mw_List_2E_last (void){
     mw_Maybe_2E_map();
     WORD_EXIT(mw_List_2E_last);
 }
-static void mw_List_2B__2E_first (void){
+static void mw_List_2B__2E_first (void) {
     WORD_ENTER(mw_List_2B__2E_first, "List+.first", "src/data/list.mth", 178, 5);
     WORD_ATOM(178, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_L1_2B_();
+            mp_L1_2B_();
             WORD_ATOM(178, 12, "id");
             mw_prim_id();
             break;
         case 1LL:
-            co_L2_2B_();
+            mp_L2_2B_();
             WORD_ATOM(179, 12, "drop");
             mw_prim_drop();
             break;
         case 2LL:
-            co_L3_2B_();
+            mp_L3_2B_();
             WORD_ATOM(180, 12, "drop2");
             mw_drop2();
             break;
         case 3LL:
-            co_LCAT_2B_();
+            mp_LCAT_2B_();
             WORD_ATOM(181, 14, "drop2");
             mw_drop2();
             WORD_ATOM(181, 20, "first");
             mw_List_2B__2E_first();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_List_2B__2E_first);
+    }
+    WORD_EXIT(mw_List_2B__2E_first);
 }
-static void mw_List_2B__2E_last (void){
+static void mw_List_2B__2E_last (void) {
     WORD_ENTER(mw_List_2B__2E_last, "List+.last", "src/data/list.mth", 184, 5);
     WORD_ATOM(184, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_L1_2B_();
+            mp_L1_2B_();
             WORD_ATOM(184, 12, "id");
             mw_prim_id();
             break;
         case 1LL:
-            co_L2_2B_();
+            mp_L2_2B_();
             WORD_ATOM(185, 12, "dip");
             {
                 VAL d4 = pop_value();
@@ -10240,7 +10136,7 @@ static void mw_List_2B__2E_last (void){
             }
             break;
         case 2LL:
-            co_L3_2B_();
+            mp_L3_2B_();
             WORD_ATOM(186, 12, "dip");
             {
                 VAL d4 = pop_value();
@@ -10250,7 +10146,7 @@ static void mw_List_2B__2E_last (void){
             }
             break;
         case 3LL:
-            co_LCAT_2B_();
+            mp_LCAT_2B_();
             WORD_ATOM(187, 14, "drop");
             mw_prim_drop();
             WORD_ATOM(187, 19, "nip");
@@ -10259,32 +10155,32 @@ static void mw_List_2B__2E_last (void){
             mw_List_2B__2E_last();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_List_2B__2E_last);
+    }
+    WORD_EXIT(mw_List_2B__2E_last);
 }
-static void mw_List_2E_reverse (void){
+static void mw_List_2E_reverse (void) {
     WORD_ENTER(mw_List_2E_reverse, "List.reverse", "src/data/list.mth", 197, 5);
     WORD_ATOM(197, 5, "L0");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_L0();
+            mp_L0();
             WORD_ATOM(197, 11, "L0");
             mw_L0();
             break;
         case 1LL:
-            co_L1();
+            mp_L1();
             WORD_ATOM(198, 11, "L1");
             mw_L1();
             break;
         case 2LL:
-            co_L2();
+            mp_L2();
             WORD_ATOM(199, 11, "swap");
             mw_prim_swap();
             WORD_ATOM(199, 16, "L2");
             mw_L2();
             break;
         case 3LL:
-            co_L3();
+            mp_L3();
             WORD_ATOM(200, 11, "rotr");
             mw_rotr();
             WORD_ATOM(200, 16, "swap");
@@ -10293,7 +10189,7 @@ static void mw_List_2E_reverse (void){
             mw_L3();
             break;
         case 4LL:
-            co_LCAT();
+            mp_LCAT();
             WORD_ATOM(201, 13, "dip");
             {
                 VAL d4 = pop_value();
@@ -10309,27 +10205,27 @@ static void mw_List_2E_reverse (void){
             mw_LCAT();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_List_2E_reverse);
+    }
+    WORD_EXIT(mw_List_2E_reverse);
 }
-static void mw_List_2B__2E_reverse (void){
+static void mw_List_2B__2E_reverse (void) {
     WORD_ENTER(mw_List_2B__2E_reverse, "List+.reverse", "src/data/list.mth", 205, 5);
     WORD_ATOM(205, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_L1_2B_();
+            mp_L1_2B_();
             WORD_ATOM(205, 12, "L1+");
             mw_L1_2B_();
             break;
         case 1LL:
-            co_L2_2B_();
+            mp_L2_2B_();
             WORD_ATOM(206, 12, "swap");
             mw_prim_swap();
             WORD_ATOM(206, 17, "L2+");
             mw_L2_2B_();
             break;
         case 2LL:
-            co_L3_2B_();
+            mp_L3_2B_();
             WORD_ATOM(207, 12, "rotr");
             mw_rotr();
             WORD_ATOM(207, 17, "swap");
@@ -10338,7 +10234,7 @@ static void mw_List_2B__2E_reverse (void){
             mw_L3_2B_();
             break;
         case 3LL:
-            co_LCAT_2B_();
+            mp_LCAT_2B_();
             WORD_ATOM(208, 14, "dip");
             {
                 VAL d4 = pop_value();
@@ -10354,10 +10250,10 @@ static void mw_List_2B__2E_reverse (void){
             mw_LCAT_2B_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_List_2B__2E_reverse);
+    }
+    WORD_EXIT(mw_List_2B__2E_reverse);
 }
-static void mw_List_2E_map (void){
+static void mw_List_2E_map (void) {
     WORD_ENTER(mw_List_2E_map, "List.map", "src/data/list.mth", 212, 5);
     WORD_ATOM(212, 5, "L0");
     {
@@ -10365,12 +10261,12 @@ static void mw_List_2E_map (void){
         WORD_ATOM(212, 5, "L0");
         switch (get_top_data_tag()) {
             case 0LL:
-                co_L0();
+                mp_L0();
                 WORD_ATOM(212, 11, "L0");
                 mw_L0();
                 break;
             case 1LL:
-                co_L1();
+                mp_L1();
                 WORD_ATOM(213, 11, "f");
                 incref(var_f);
                 run_value(var_f);
@@ -10378,7 +10274,7 @@ static void mw_List_2E_map (void){
                 mw_L1();
                 break;
             case 2LL:
-                co_L2();
+                mp_L2();
                 WORD_ATOM(214, 11, "dip");
                 {
                     VAL d5 = pop_value();
@@ -10403,7 +10299,7 @@ static void mw_List_2E_map (void){
                 mw_L2();
                 break;
             case 3LL:
-                co_L3();
+                mp_L3();
                 WORD_ATOM(215, 11, "dip");
                 {
                     VAL d5 = pop_value();
@@ -10453,7 +10349,7 @@ static void mw_List_2E_map (void){
                 mw_L3();
                 break;
             case 4LL:
-                co_LCAT();
+                mp_LCAT();
                 WORD_ATOM(216, 13, "dip");
                 {
                     VAL d5 = pop_value();
@@ -10485,12 +10381,12 @@ static void mw_List_2E_map (void){
                 mw_LCAT();
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-        
-}        decref(var_f);
+        }
+        decref(var_f);
     }
     WORD_EXIT(mw_List_2E_map);
 }
-static void mw_List_2B__2E_map (void){
+static void mw_List_2B__2E_map (void) {
     WORD_ENTER(mw_List_2B__2E_map, "List+.map", "src/data/list.mth", 220, 5);
     WORD_ATOM(220, 5, "L1+");
     {
@@ -10498,7 +10394,7 @@ static void mw_List_2B__2E_map (void){
         WORD_ATOM(220, 5, "L1+");
         switch (get_top_data_tag()) {
             case 0LL:
-                co_L1_2B_();
+                mp_L1_2B_();
                 WORD_ATOM(220, 12, "f");
                 incref(var_f);
                 run_value(var_f);
@@ -10506,7 +10402,7 @@ static void mw_List_2B__2E_map (void){
                 mw_L1_2B_();
                 break;
             case 1LL:
-                co_L2_2B_();
+                mp_L2_2B_();
                 WORD_ATOM(221, 12, "dip");
                 {
                     VAL d5 = pop_value();
@@ -10531,7 +10427,7 @@ static void mw_List_2B__2E_map (void){
                 mw_L2_2B_();
                 break;
             case 2LL:
-                co_L3_2B_();
+                mp_L3_2B_();
                 WORD_ATOM(222, 12, "dip");
                 {
                     VAL d5 = pop_value();
@@ -10581,7 +10477,7 @@ static void mw_List_2B__2E_map (void){
                 mw_L3_2B_();
                 break;
             case 3LL:
-                co_LCAT_2B_();
+                mp_LCAT_2B_();
                 WORD_ATOM(223, 14, "dip");
                 {
                     VAL d5 = pop_value();
@@ -10613,12 +10509,12 @@ static void mw_List_2B__2E_map (void){
                 mw_LCAT_2B_();
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-        
-}        decref(var_f);
+        }
+        decref(var_f);
     }
     WORD_EXIT(mw_List_2B__2E_map);
 }
-static void mw_List_2E_for (void){
+static void mw_List_2E_for (void) {
     WORD_ENTER(mw_List_2E_for, "List.for", "src/data/list.mth", 227, 5);
     WORD_ATOM(227, 5, "L0");
     {
@@ -10626,18 +10522,18 @@ static void mw_List_2E_for (void){
         WORD_ATOM(227, 5, "L0");
         switch (get_top_data_tag()) {
             case 0LL:
-                co_L0();
+                mp_L0();
                 WORD_ATOM(227, 11, "id");
                 mw_prim_id();
                 break;
             case 1LL:
-                co_L1();
+                mp_L1();
                 WORD_ATOM(228, 11, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 2LL:
-                co_L2();
+                mp_L2();
                 WORD_ATOM(229, 11, "dip");
                 {
                     VAL d5 = pop_value();
@@ -10651,7 +10547,7 @@ static void mw_List_2E_for (void){
                 run_value(var_f);
                 break;
             case 3LL:
-                co_L3();
+                mp_L3();
                 WORD_ATOM(230, 11, "dip");
                 {
                     VAL d5 = pop_value();
@@ -10673,7 +10569,7 @@ static void mw_List_2E_for (void){
                 run_value(var_f);
                 break;
             case 4LL:
-                co_LCAT();
+                mp_LCAT();
                 WORD_ATOM(231, 13, "drop");
                 mw_prim_drop();
                 WORD_ATOM(231, 18, "dip");
@@ -10691,12 +10587,12 @@ static void mw_List_2E_for (void){
                 mw_List_2B__2E_for();
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-        
-}        decref(var_f);
+        }
+        decref(var_f);
     }
     WORD_EXIT(mw_List_2E_for);
 }
-static void mw_List_2B__2E_for (void){
+static void mw_List_2B__2E_for (void) {
     WORD_ENTER(mw_List_2B__2E_for, "List+.for", "src/data/list.mth", 235, 5);
     WORD_ATOM(235, 5, "L1+");
     {
@@ -10704,13 +10600,13 @@ static void mw_List_2B__2E_for (void){
         WORD_ATOM(235, 5, "L1+");
         switch (get_top_data_tag()) {
             case 0LL:
-                co_L1_2B_();
+                mp_L1_2B_();
                 WORD_ATOM(235, 12, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 1LL:
-                co_L2_2B_();
+                mp_L2_2B_();
                 WORD_ATOM(236, 12, "dip");
                 {
                     VAL d5 = pop_value();
@@ -10724,7 +10620,7 @@ static void mw_List_2B__2E_for (void){
                 run_value(var_f);
                 break;
             case 2LL:
-                co_L3_2B_();
+                mp_L3_2B_();
                 WORD_ATOM(237, 12, "dip");
                 {
                     VAL d5 = pop_value();
@@ -10746,7 +10642,7 @@ static void mw_List_2B__2E_for (void){
                 run_value(var_f);
                 break;
             case 3LL:
-                co_LCAT_2B_();
+                mp_LCAT_2B_();
                 WORD_ATOM(238, 14, "drop");
                 mw_prim_drop();
                 WORD_ATOM(238, 19, "dip");
@@ -10764,12 +10660,12 @@ static void mw_List_2B__2E_for (void){
                 mw_List_2B__2E_for();
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-        
-}        decref(var_f);
+        }
+        decref(var_f);
     }
     WORD_EXIT(mw_List_2B__2E_for);
 }
-static void mw_List_2E_reverse_for (void){
+static void mw_List_2E_reverse_for (void) {
     WORD_ENTER(mw_List_2E_reverse_for, "List.reverse-for", "src/data/list.mth", 242, 5);
     WORD_ATOM(242, 5, "L0");
     {
@@ -10777,18 +10673,18 @@ static void mw_List_2E_reverse_for (void){
         WORD_ATOM(242, 5, "L0");
         switch (get_top_data_tag()) {
             case 0LL:
-                co_L0();
+                mp_L0();
                 WORD_ATOM(242, 11, "id");
                 mw_prim_id();
                 break;
             case 1LL:
-                co_L1();
+                mp_L1();
                 WORD_ATOM(243, 11, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 2LL:
-                co_L2();
+                mp_L2();
                 WORD_ATOM(244, 11, "swap");
                 mw_prim_swap();
                 WORD_ATOM(244, 16, "dip");
@@ -10804,7 +10700,7 @@ static void mw_List_2E_reverse_for (void){
                 run_value(var_f);
                 break;
             case 3LL:
-                co_L3();
+                mp_L3();
                 WORD_ATOM(245, 11, "rotr");
                 mw_rotr();
                 WORD_ATOM(245, 16, "dip2");
@@ -10826,7 +10722,7 @@ static void mw_List_2E_reverse_for (void){
                 run_value(var_f);
                 break;
             case 4LL:
-                co_LCAT();
+                mp_LCAT();
                 WORD_ATOM(246, 13, "drop");
                 mw_prim_drop();
                 WORD_ATOM(246, 18, "swap");
@@ -10846,12 +10742,12 @@ static void mw_List_2E_reverse_for (void){
                 mw_List_2B__2E_reverse_for();
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-        
-}        decref(var_f);
+        }
+        decref(var_f);
     }
     WORD_EXIT(mw_List_2E_reverse_for);
 }
-static void mw_List_2B__2E_reverse_for (void){
+static void mw_List_2B__2E_reverse_for (void) {
     WORD_ENTER(mw_List_2B__2E_reverse_for, "List+.reverse-for", "src/data/list.mth", 250, 5);
     WORD_ATOM(250, 5, "L1+");
     {
@@ -10859,13 +10755,13 @@ static void mw_List_2B__2E_reverse_for (void){
         WORD_ATOM(250, 5, "L1+");
         switch (get_top_data_tag()) {
             case 0LL:
-                co_L1_2B_();
+                mp_L1_2B_();
                 WORD_ATOM(250, 12, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 1LL:
-                co_L2_2B_();
+                mp_L2_2B_();
                 WORD_ATOM(251, 12, "swap");
                 mw_prim_swap();
                 WORD_ATOM(251, 17, "dip");
@@ -10881,7 +10777,7 @@ static void mw_List_2B__2E_reverse_for (void){
                 run_value(var_f);
                 break;
             case 2LL:
-                co_L3_2B_();
+                mp_L3_2B_();
                 WORD_ATOM(252, 12, "rotr");
                 mw_rotr();
                 WORD_ATOM(252, 17, "dip2");
@@ -10903,7 +10799,7 @@ static void mw_List_2B__2E_reverse_for (void){
                 run_value(var_f);
                 break;
             case 3LL:
-                co_LCAT_2B_();
+                mp_LCAT_2B_();
                 WORD_ATOM(253, 14, "drop");
                 mw_prim_drop();
                 WORD_ATOM(253, 19, "swap");
@@ -10923,12 +10819,12 @@ static void mw_List_2B__2E_reverse_for (void){
                 mw_List_2B__2E_reverse_for();
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-        
-}        decref(var_f);
+        }
+        decref(var_f);
     }
     WORD_EXIT(mw_List_2B__2E_reverse_for);
 }
-static void mw_List_2E_filter (void){
+static void mw_List_2E_filter (void) {
     WORD_ENTER(mw_List_2E_filter, "List.filter", "src/data/list.mth", 268, 5);
     WORD_ATOM(268, 5, "List>List+");
     {
@@ -10938,24 +10834,24 @@ static void mw_List_2E_filter (void){
         WORD_ATOM(268, 16, "match");
         switch (get_top_data_tag()) {
             case 0LL:
-                co_NONE();
+                mp_NONE();
                 WORD_ATOM(269, 17, "L0");
                 mw_L0();
                 break;
             case 1LL:
-                co_SOME();
+                mp_SOME();
                 WORD_ATOM(270, 17, "filter");
                 incref(var_f);
                 push_value(var_f);
                 mw_List_2B__2E_filter();
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-        
-}        decref(var_f);
+        }
+        decref(var_f);
     }
     WORD_EXIT(mw_List_2E_filter);
 }
-static void mw_List_2B__2E_filter (void){
+static void mw_List_2B__2E_filter (void) {
     WORD_ENTER(mw_List_2B__2E_filter, "List+.filter", "src/data/list.mth", 275, 5);
     WORD_ATOM(275, 5, "LCAT+");
     {
@@ -10963,7 +10859,7 @@ static void mw_List_2B__2E_filter (void){
         WORD_ATOM(275, 5, "LCAT+");
         switch (get_top_data_tag()) {
             case 3LL:
-                co_LCAT_2B_();
+                mp_LCAT_2B_();
                 WORD_ATOM(275, 14, "drop");
                 mw_prim_drop();
                 WORD_ATOM(275, 19, "dip");
@@ -11020,12 +10916,12 @@ static void mw_List_2B__2E_filter (void){
                     mw_List_2E_filter();
                 }
                 break;
-        
-}        decref(var_f);
+        }
+        decref(var_f);
     }
     WORD_EXIT(mw_List_2B__2E_filter);
 }
-static void mw_List_2E_filter_some (void){
+static void mw_List_2E_filter_some (void) {
     WORD_ENTER(mw_List_2E_filter_some, "List.filter-some", "src/data/list.mth", 284, 5);
     WORD_ATOM(284, 5, "List>List+");
     {
@@ -11050,7 +10946,7 @@ static void mw_List_2E_filter_some (void){
     }
     WORD_EXIT(mw_List_2E_filter_some);
 }
-static void mw_List_2B__2E_filter_some (void){
+static void mw_List_2B__2E_filter_some (void) {
     WORD_ENTER(mw_List_2B__2E_filter_some, "List+.filter-some", "src/data/list.mth", 287, 5);
     WORD_ATOM(287, 5, "LCAT+");
     {
@@ -11058,7 +10954,7 @@ static void mw_List_2B__2E_filter_some (void){
         WORD_ATOM(287, 5, "LCAT+");
         switch (get_top_data_tag()) {
             case 3LL:
-                co_LCAT_2B_();
+                mp_LCAT_2B_();
                 WORD_ATOM(287, 14, "drop");
                 mw_prim_drop();
                 WORD_ATOM(287, 19, "dip");
@@ -11112,12 +11008,12 @@ static void mw_List_2B__2E_filter_some (void){
                 mw_prim_pack_cons();
                 mw_Maybe_2E_if_some();
                 break;
-        
-}        decref(var_p);
+        }
+        decref(var_p);
     }
     WORD_EXIT(mw_List_2B__2E_filter_some);
 }
-static void mw_List_2E_find (void){
+static void mw_List_2E_find (void) {
     WORD_ENTER(mw_List_2E_find, "List.find", "src/data/list.mth", 292, 5);
     WORD_ATOM(292, 5, "List>List+");
     {
@@ -11127,24 +11023,24 @@ static void mw_List_2E_find (void){
         WORD_ATOM(292, 16, "match");
         switch (get_top_data_tag()) {
             case 0LL:
-                co_NONE();
+                mp_NONE();
                 WORD_ATOM(293, 17, "NONE");
                 mw_NONE();
                 break;
             case 1LL:
-                co_SOME();
+                mp_SOME();
                 WORD_ATOM(294, 17, "find");
                 incref(var_f);
                 push_value(var_f);
                 mw_List_2B__2E_find();
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-        
-}        decref(var_f);
+        }
+        decref(var_f);
     }
     WORD_EXIT(mw_List_2E_find);
 }
-static void mw_List_2B__2E_find (void){
+static void mw_List_2B__2E_find (void) {
     WORD_ENTER(mw_List_2B__2E_find, "List+.find", "src/data/list.mth", 299, 5);
     WORD_ATOM(299, 5, "LCAT+");
     {
@@ -11152,7 +11048,7 @@ static void mw_List_2B__2E_find (void){
         WORD_ATOM(299, 5, "LCAT+");
         switch (get_top_data_tag()) {
             case 3LL:
-                co_LCAT_2B_();
+                mp_LCAT_2B_();
                 WORD_ATOM(300, 9, "drop");
                 mw_prim_drop();
                 WORD_ATOM(300, 14, "dip");
@@ -11169,22 +11065,22 @@ static void mw_List_2B__2E_find (void){
                 WORD_ATOM(301, 9, "match");
                 switch (get_top_data_tag()) {
                     case 1LL:
-                        co_SOME();
+                        mp_SOME();
                         WORD_ATOM(302, 21, "nip");
                         mw_nip();
                         WORD_ATOM(302, 25, "SOME");
                         mw_SOME();
                         break;
                     case 0LL:
-                        co_NONE();
+                        mp_NONE();
                         WORD_ATOM(303, 21, "find");
                         incref(var_f);
                         push_value(var_f);
                         mw_List_2B__2E_find();
                         break;
                     default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-                
-}                break;
+                }
+                break;
             default:
                 WORD_ATOM(306, 9, "uncons");
                 mw_List_2B__2E_uncons();
@@ -11213,12 +11109,12 @@ static void mw_List_2B__2E_find (void){
                     mw_List_2E_find();
                 }
                 break;
-        
-}        decref(var_f);
+        }
+        decref(var_f);
     }
     WORD_EXIT(mw_List_2B__2E_find);
 }
-static void mw_List_2E_reverse_find (void){
+static void mw_List_2E_reverse_find (void) {
     WORD_ENTER(mw_List_2E_reverse_find, "List.reverse-find", "src/data/list.mth", 318, 5);
     WORD_ATOM(318, 5, "reverse");
     {
@@ -11233,7 +11129,7 @@ static void mw_List_2E_reverse_find (void){
     }
     WORD_EXIT(mw_List_2E_reverse_find);
 }
-static void mw_List_2E_any (void){
+static void mw_List_2E_any (void) {
     WORD_ENTER(mw_List_2E_any, "List.any", "src/data/list.mth", 326, 5);
     WORD_ATOM(326, 5, "find");
     {
@@ -11248,7 +11144,7 @@ static void mw_List_2E_any (void){
     }
     WORD_EXIT(mw_List_2E_any);
 }
-static void mw_List_2E_all (void){
+static void mw_List_2E_all (void) {
     WORD_ENTER(mw_List_2E_all, "List.all", "src/data/list.mth", 334, 5);
     WORD_ATOM(334, 5, "find");
     {
@@ -11267,7 +11163,7 @@ static void mw_List_2E_all (void){
     }
     WORD_EXIT(mw_List_2E_all);
 }
-static void mw_collect_while (void){
+static void mw_collect_while (void) {
     WORD_ENTER(mw_collect_while, "collect-while", "src/data/list.mth", 346, 5);
     WORD_ATOM(346, 5, "L0");
     {
@@ -11306,7 +11202,7 @@ static void mw_collect_while (void){
     }
     WORD_EXIT(mw_collect_while);
 }
-static void mw_Maybe_2E_none_3F_ (void){
+static void mw_Maybe_2E_none_3F_ (void) {
     WORD_ENTER(mw_Maybe_2E_none_3F_, "Maybe.none?", "src/data/maybe.mth", 8, 36);
     WORD_ATOM(8, 36, ">Bool");
     mw_Maybe_3E_Bool();
@@ -11314,33 +11210,33 @@ static void mw_Maybe_2E_none_3F_ (void){
     mw_Bool_2E_not();
     WORD_EXIT(mw_Maybe_2E_none_3F_);
 }
-static void mw_Maybe_2E_some_3F_ (void){
+static void mw_Maybe_2E_some_3F_ (void) {
     WORD_ENTER(mw_Maybe_2E_some_3F_, "Maybe.some?", "src/data/maybe.mth", 9, 36);
     WORD_ATOM(9, 36, ">Bool");
     mw_Maybe_3E_Bool();
     WORD_EXIT(mw_Maybe_2E_some_3F_);
 }
-static void mw_Maybe_3E_Bool (void){
+static void mw_Maybe_3E_Bool (void) {
     WORD_ENTER(mw_Maybe_3E_Bool, "Maybe>Bool", "src/data/maybe.mth", 11, 5);
     WORD_ATOM(11, 5, "NONE");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_NONE();
+            mp_NONE();
             WORD_ATOM(11, 13, "F");
             mw_F();
             break;
         case 1LL:
-            co_SOME();
+            mp_SOME();
             WORD_ATOM(12, 13, "drop");
             mw_prim_drop();
             WORD_ATOM(12, 18, "T");
             mw_T();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Maybe_3E_Bool);
+    }
+    WORD_EXIT(mw_Maybe_3E_Bool);
 }
-static void mw_Maybe_2E_if (void){
+static void mw_Maybe_2E_if (void) {
     WORD_ENTER(mw_Maybe_2E_if, "Maybe.if", "src/data/maybe.mth", 19, 5);
     WORD_ATOM(19, 5, "SOME");
     {
@@ -11349,7 +11245,7 @@ static void mw_Maybe_2E_if (void){
         WORD_ATOM(19, 5, "SOME");
         switch (get_top_data_tag()) {
             case 1LL:
-                co_SOME();
+                mp_SOME();
                 WORD_ATOM(19, 13, "drop");
                 mw_prim_drop();
                 WORD_ATOM(19, 18, "f");
@@ -11357,19 +11253,19 @@ static void mw_Maybe_2E_if (void){
                 run_value(var_f);
                 break;
             case 0LL:
-                co_NONE();
+                mp_NONE();
                 WORD_ATOM(20, 13, "g");
                 incref(var_g);
                 run_value(var_g);
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-        
-}        decref(var_g);
+        }
+        decref(var_g);
         decref(var_f);
     }
     WORD_EXIT(mw_Maybe_2E_if);
 }
-static void mw_Maybe_2E_if_some (void){
+static void mw_Maybe_2E_if_some (void) {
     WORD_ENTER(mw_Maybe_2E_if_some, "Maybe.if-some", "src/data/maybe.mth", 22, 5);
     WORD_ATOM(22, 5, "SOME");
     {
@@ -11378,25 +11274,25 @@ static void mw_Maybe_2E_if_some (void){
         WORD_ATOM(22, 5, "SOME");
         switch (get_top_data_tag()) {
             case 1LL:
-                co_SOME();
+                mp_SOME();
                 WORD_ATOM(22, 13, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 0LL:
-                co_NONE();
+                mp_NONE();
                 WORD_ATOM(23, 13, "g");
                 incref(var_g);
                 run_value(var_g);
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-        
-}        decref(var_g);
+        }
+        decref(var_g);
         decref(var_f);
     }
     WORD_EXIT(mw_Maybe_2E_if_some);
 }
-static void mw_Maybe_2E_else (void){
+static void mw_Maybe_2E_else (void) {
     WORD_ENTER(mw_Maybe_2E_else, "Maybe.else", "src/data/maybe.mth", 31, 5);
     WORD_ATOM(31, 5, "SOME");
     {
@@ -11404,23 +11300,23 @@ static void mw_Maybe_2E_else (void){
         WORD_ATOM(31, 5, "SOME");
         switch (get_top_data_tag()) {
             case 1LL:
-                co_SOME();
+                mp_SOME();
                 WORD_ATOM(31, 13, "drop");
                 mw_prim_drop();
                 break;
             case 0LL:
-                co_NONE();
+                mp_NONE();
                 WORD_ATOM(32, 13, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-        
-}        decref(var_f);
+        }
+        decref(var_f);
     }
     WORD_EXIT(mw_Maybe_2E_else);
 }
-static void mw_Maybe_2E_not (void){
+static void mw_Maybe_2E_not (void) {
     WORD_ENTER(mw_Maybe_2E_not, "Maybe.not", "src/data/maybe.mth", 34, 34);
     WORD_ATOM(34, 34, ">Bool");
     mw_Maybe_3E_Bool();
@@ -11428,7 +11324,7 @@ static void mw_Maybe_2E_not (void){
     mw_Bool_2E_not();
     WORD_EXIT(mw_Maybe_2E_not);
 }
-static void mw_Maybe_2E_and_some (void){
+static void mw_Maybe_2E_and_some (void) {
     WORD_ENTER(mw_Maybe_2E_and_some, "Maybe.and-some", "src/data/maybe.mth", 41, 5);
     WORD_ATOM(41, 5, "NONE");
     {
@@ -11436,28 +11332,28 @@ static void mw_Maybe_2E_and_some (void){
         WORD_ATOM(41, 5, "NONE");
         switch (get_top_data_tag()) {
             case 0LL:
-                co_NONE();
+                mp_NONE();
                 WORD_ATOM(41, 13, "F");
                 mw_F();
                 break;
             case 1LL:
-                co_SOME();
+                mp_SOME();
                 WORD_ATOM(42, 13, "p");
                 incref(var_p);
                 run_value(var_p);
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-        
-}        decref(var_p);
+        }
+        decref(var_p);
     }
     WORD_EXIT(mw_Maybe_2E_and_some);
 }
-static void mw_Maybe_2E_unwrap (void){
+static void mw_Maybe_2E_unwrap (void) {
     WORD_ENTER(mw_Maybe_2E_unwrap, "Maybe.unwrap", "src/data/maybe.mth", 45, 5);
     WORD_ATOM(45, 5, "NONE");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_NONE();
+            mp_NONE();
             WORD_ATOM(45, 13, "");
             {
                 static bool vready = false;
@@ -11473,15 +11369,15 @@ static void mw_Maybe_2E_unwrap (void){
             mw_prim_panic();
             break;
         case 1LL:
-            co_SOME();
+            mp_SOME();
             WORD_ATOM(46, 13, "id");
             mw_prim_id();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Maybe_2E_unwrap);
+    }
+    WORD_EXIT(mw_Maybe_2E_unwrap);
 }
-static void mw_Maybe_2E_unwrap_or (void){
+static void mw_Maybe_2E_unwrap_or (void) {
     WORD_ENTER(mw_Maybe_2E_unwrap_or, "Maybe.unwrap-or", "src/data/maybe.mth", 49, 5);
     WORD_ATOM(49, 5, "NONE");
     {
@@ -11489,23 +11385,23 @@ static void mw_Maybe_2E_unwrap_or (void){
         WORD_ATOM(49, 5, "NONE");
         switch (get_top_data_tag()) {
             case 0LL:
-                co_NONE();
+                mp_NONE();
                 WORD_ATOM(49, 13, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 1LL:
-                co_SOME();
+                mp_SOME();
                 WORD_ATOM(50, 13, "id");
                 mw_prim_id();
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-        
-}        decref(var_f);
+        }
+        decref(var_f);
     }
     WORD_EXIT(mw_Maybe_2E_unwrap_or);
 }
-static void mw_Maybe_2E_map (void){
+static void mw_Maybe_2E_map (void) {
     WORD_ENTER(mw_Maybe_2E_map, "Maybe.map", "src/data/maybe.mth", 53, 5);
     WORD_ATOM(53, 5, "NONE");
     {
@@ -11513,12 +11409,12 @@ static void mw_Maybe_2E_map (void){
         WORD_ATOM(53, 5, "NONE");
         switch (get_top_data_tag()) {
             case 0LL:
-                co_NONE();
+                mp_NONE();
                 WORD_ATOM(53, 13, "NONE");
                 mw_NONE();
                 break;
             case 1LL:
-                co_SOME();
+                mp_SOME();
                 WORD_ATOM(54, 13, "f");
                 incref(var_f);
                 run_value(var_f);
@@ -11526,12 +11422,12 @@ static void mw_Maybe_2E_map (void){
                 mw_SOME();
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-        
-}        decref(var_f);
+        }
+        decref(var_f);
     }
     WORD_EXIT(mw_Maybe_2E_map);
 }
-static void mw_Maybe_2E_bind (void){
+static void mw_Maybe_2E_bind (void) {
     WORD_ENTER(mw_Maybe_2E_bind, "Maybe.bind", "src/data/maybe.mth", 57, 5);
     WORD_ATOM(57, 5, "NONE");
     {
@@ -11539,23 +11435,23 @@ static void mw_Maybe_2E_bind (void){
         WORD_ATOM(57, 5, "NONE");
         switch (get_top_data_tag()) {
             case 0LL:
-                co_NONE();
+                mp_NONE();
                 WORD_ATOM(57, 13, "NONE");
                 mw_NONE();
                 break;
             case 1LL:
-                co_SOME();
+                mp_SOME();
                 WORD_ATOM(58, 13, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-        
-}        decref(var_f);
+        }
+        decref(var_f);
     }
     WORD_EXIT(mw_Maybe_2E_bind);
 }
-static void mw_Maybe_2E_for (void){
+static void mw_Maybe_2E_for (void) {
     WORD_ENTER(mw_Maybe_2E_for, "Maybe.for", "src/data/maybe.mth", 61, 5);
     WORD_ATOM(61, 5, "NONE");
     {
@@ -11563,23 +11459,23 @@ static void mw_Maybe_2E_for (void){
         WORD_ATOM(61, 5, "NONE");
         switch (get_top_data_tag()) {
             case 0LL:
-                co_NONE();
+                mp_NONE();
                 WORD_ATOM(61, 13, "id");
                 mw_prim_id();
                 break;
             case 1LL:
-                co_SOME();
+                mp_SOME();
                 WORD_ATOM(62, 13, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-        
-}        decref(var_f);
+        }
+        decref(var_f);
     }
     WORD_EXIT(mw_Maybe_2E_for);
 }
-static void mw_Maybe_2E_filter (void){
+static void mw_Maybe_2E_filter (void) {
     WORD_ENTER(mw_Maybe_2E_filter, "Maybe.filter", "src/data/maybe.mth", 65, 5);
     WORD_ATOM(65, 5, "NONE");
     {
@@ -11587,12 +11483,12 @@ static void mw_Maybe_2E_filter (void){
         WORD_ATOM(65, 5, "NONE");
         switch (get_top_data_tag()) {
             case 0LL:
-                co_NONE();
+                mp_NONE();
                 WORD_ATOM(65, 13, "NONE");
                 mw_NONE();
                 break;
             case 1LL:
-                co_SOME();
+                mp_SOME();
                 WORD_ATOM(66, 13, "f");
                 incref(var_f);
                 run_value(var_f);
@@ -11608,12 +11504,12 @@ static void mw_Maybe_2E_filter (void){
                 }
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-        
-}        decref(var_f);
+        }
+        decref(var_f);
     }
     WORD_EXIT(mw_Maybe_2E_filter);
 }
-static void mw_while_some (void){
+static void mw_while_some (void) {
     WORD_ENTER(mw_while_some, "while-some", "src/data/maybe.mth", 69, 5);
     WORD_ATOM(69, 5, "f");
     {
@@ -11645,65 +11541,65 @@ static void mw_while_some (void){
     }
     WORD_EXIT(mw_while_some);
 }
-static void mw_Bool_26__26_ (void){
+static void mw_Bool_26__26_ (void) {
     WORD_ENTER(mw_Bool_26__26_, "Bool&&", "src/prelude.mth", 41, 32);
     WORD_ATOM(41, 32, "T");
     switch (get_top_data_tag()) {
         case 1LL:
-            co_T();
+            mp_T();
             WORD_ATOM(41, 37, "id");
             mw_prim_id();
             break;
         case 0LL:
-            co_F();
+            mp_F();
             WORD_ATOM(41, 46, "drop");
             mw_prim_drop();
             WORD_ATOM(41, 51, "F");
             mw_F();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Bool_26__26_);
+    }
+    WORD_EXIT(mw_Bool_26__26_);
 }
-static void mw_Bool_7C__7C_ (void){
+static void mw_Bool_7C__7C_ (void) {
     WORD_ENTER(mw_Bool_7C__7C_, "Bool||", "src/prelude.mth", 42, 32);
     WORD_ATOM(42, 32, "T");
     switch (get_top_data_tag()) {
         case 1LL:
-            co_T();
+            mp_T();
             WORD_ATOM(42, 37, "drop");
             mw_prim_drop();
             WORD_ATOM(42, 42, "T");
             mw_T();
             break;
         case 0LL:
-            co_F();
+            mp_F();
             WORD_ATOM(42, 50, "id");
             mw_prim_id();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Bool_7C__7C_);
+    }
+    WORD_EXIT(mw_Bool_7C__7C_);
 }
-static void mw_Bool_2E_not (void){
+static void mw_Bool_2E_not (void) {
     WORD_ENTER(mw_Bool_2E_not, "Bool.not", "src/prelude.mth", 43, 29);
     WORD_ATOM(43, 29, "T");
     switch (get_top_data_tag()) {
         case 1LL:
-            co_T();
+            mp_T();
             WORD_ATOM(43, 34, "F");
             mw_F();
             break;
         case 0LL:
-            co_F();
+            mp_F();
             WORD_ATOM(43, 42, "T");
             mw_T();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Bool_2E_not);
+    }
+    WORD_EXIT(mw_Bool_2E_not);
 }
-static void mw_Bool_2E_or (void){
+static void mw_Bool_2E_or (void) {
     WORD_ENTER(mw_Bool_2E_or, "Bool.or", "src/prelude.mth", 44, 54);
     WORD_ATOM(44, 54, "if");
     {
@@ -11721,7 +11617,7 @@ static void mw_Bool_2E_or (void){
     }
     WORD_EXIT(mw_Bool_2E_or);
 }
-static void mw_Bool_2E_and (void){
+static void mw_Bool_2E_and (void) {
     WORD_ENTER(mw_Bool_2E_and, "Bool.and", "src/prelude.mth", 45, 54);
     WORD_ATOM(45, 54, "if");
     {
@@ -11739,7 +11635,7 @@ static void mw_Bool_2E_and (void){
     }
     WORD_EXIT(mw_Bool_2E_and);
 }
-static void mw_Bool_2E_then (void){
+static void mw_Bool_2E_then (void) {
     WORD_ENTER(mw_Bool_2E_then, "Bool.then", "src/prelude.mth", 51, 5);
     WORD_ATOM(51, 5, "T");
     {
@@ -11747,23 +11643,23 @@ static void mw_Bool_2E_then (void){
         WORD_ATOM(51, 5, "T");
         switch (get_top_data_tag()) {
             case 1LL:
-                co_T();
+                mp_T();
                 WORD_ATOM(51, 10, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 0LL:
-                co_F();
+                mp_F();
                 WORD_ATOM(52, 10, "id");
                 mw_prim_id();
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-        
-}        decref(var_f);
+        }
+        decref(var_f);
     }
     WORD_EXIT(mw_Bool_2E_then);
 }
-static void mw_Bool_2E_else (void){
+static void mw_Bool_2E_else (void) {
     WORD_ENTER(mw_Bool_2E_else, "Bool.else", "src/prelude.mth", 54, 5);
     WORD_ATOM(54, 5, "T");
     {
@@ -11771,23 +11667,23 @@ static void mw_Bool_2E_else (void){
         WORD_ATOM(54, 5, "T");
         switch (get_top_data_tag()) {
             case 1LL:
-                co_T();
+                mp_T();
                 WORD_ATOM(54, 10, "id");
                 mw_prim_id();
                 break;
             case 0LL:
-                co_F();
+                mp_F();
                 WORD_ATOM(55, 10, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-        
-}        decref(var_f);
+        }
+        decref(var_f);
     }
     WORD_EXIT(mw_Bool_2E_else);
 }
-static void mw_Ptr_2E_offset (void){
+static void mw_Ptr_2E_offset (void) {
     WORD_ENTER(mw_Ptr_2E_offset, "Ptr.offset", "src/prelude.mth", 68, 5);
     WORD_ATOM(68, 5, "dup");
     {
@@ -11810,7 +11706,7 @@ static void mw_Ptr_2E_offset (void){
     }
     WORD_EXIT(mw_Ptr_2E_offset);
 }
-static void mw_Int_3E_OS (void){
+static void mw_Int_3E_OS (void) {
     WORD_ENTER(mw_Int_3E_OS, "Int>OS", "src/prelude.mth", 100, 5);
     WORD_ATOM(100, 5, "dup");
     mw_prim_dup();
@@ -11860,7 +11756,7 @@ static void mw_Int_3E_OS (void){
     }
     WORD_EXIT(mw_Int_3E_OS);
 }
-static void mw_RUNNING_5F_OS (void){
+static void mw_RUNNING_5F_OS (void) {
     WORD_ENTER(mw_RUNNING_5F_OS, "RUNNING_OS", "src/prelude.mth", 111, 21);
     WORD_ATOM(111, 21, "prim-sys-os");
     mw_prim_sys_os();
@@ -11868,7 +11764,7 @@ static void mw_RUNNING_5F_OS (void){
     mw_Int_3E_OS();
     WORD_EXIT(mw_RUNNING_5F_OS);
 }
-static void mw_posix_open_21_ (void){
+static void mw_posix_open_21_ (void) {
     WORD_ENTER(mw_posix_open_21_, "posix-open!", "src/prelude.mth", 118, 5);
     WORD_ATOM(118, 5, "rotl");
     mw_rotl();
@@ -11889,7 +11785,7 @@ static void mw_posix_open_21_ (void){
     mw_prim_drop();
     WORD_EXIT(mw_posix_open_21_);
 }
-static void mw_rotr (void){
+static void mw_rotr (void) {
     WORD_ENTER(mw_rotr, "rotr", "src/prelude.mth", 125, 27);
     WORD_ATOM(125, 27, "swap");
     mw_prim_swap();
@@ -11902,7 +11798,7 @@ static void mw_rotr (void){
     }
     WORD_EXIT(mw_rotr);
 }
-static void mw_rotl (void){
+static void mw_rotl (void) {
     WORD_ENTER(mw_rotl, "rotl", "src/prelude.mth", 126, 27);
     WORD_ATOM(126, 27, "dip");
     {
@@ -11915,7 +11811,7 @@ static void mw_rotl (void){
     mw_prim_swap();
     WORD_EXIT(mw_rotl);
 }
-static void mw_over (void){
+static void mw_over (void) {
     WORD_ENTER(mw_over, "over", "src/prelude.mth", 131, 25);
     WORD_ATOM(131, 25, "dip");
     {
@@ -11928,7 +11824,7 @@ static void mw_over (void){
     mw_prim_swap();
     WORD_EXIT(mw_over);
 }
-static void mw_over2 (void){
+static void mw_over2 (void) {
     WORD_ENTER(mw_over2, "over2", "src/prelude.mth", 132, 34);
     WORD_ATOM(132, 34, "dip");
     {
@@ -11941,7 +11837,7 @@ static void mw_over2 (void){
     mw_prim_swap();
     WORD_EXIT(mw_over2);
 }
-static void mw_over3 (void){
+static void mw_over3 (void) {
     WORD_ENTER(mw_over3, "over3", "src/prelude.mth", 133, 40);
     WORD_ATOM(133, 40, "dip");
     {
@@ -11954,7 +11850,7 @@ static void mw_over3 (void){
     mw_prim_swap();
     WORD_EXIT(mw_over3);
 }
-static void mw_tuck (void){
+static void mw_tuck (void) {
     WORD_ENTER(mw_tuck, "tuck", "src/prelude.mth", 136, 25);
     WORD_ATOM(136, 25, "dup");
     mw_prim_dup();
@@ -11967,7 +11863,7 @@ static void mw_tuck (void){
     }
     WORD_EXIT(mw_tuck);
 }
-static void mw_nip (void){
+static void mw_nip (void) {
     WORD_ENTER(mw_nip, "nip", "src/prelude.mth", 138, 20);
     WORD_ATOM(138, 20, "dip");
     {
@@ -11978,7 +11874,7 @@ static void mw_nip (void){
     }
     WORD_EXIT(mw_nip);
 }
-static void mw_dup2 (void){
+static void mw_dup2 (void) {
     WORD_ENTER(mw_dup2, "dup2", "src/prelude.mth", 140, 34);
     WORD_ATOM(140, 34, "over");
     mw_over();
@@ -11986,7 +11882,7 @@ static void mw_dup2 (void){
     mw_over();
     WORD_EXIT(mw_dup2);
 }
-static void mw_dip_3F_ (void){
+static void mw_dip_3F_ (void) {
     WORD_ENTER(mw_dip_3F_, "dip?", "src/prelude.mth", 143, 49);
     WORD_ATOM(143, 49, "dip");
     {
@@ -12005,7 +11901,7 @@ static void mw_dip_3F_ (void){
     }
     WORD_EXIT(mw_dip_3F_);
 }
-static void mw_dip_27_ (void){
+static void mw_dip_27_ (void) {
     WORD_ENTER(mw_dip_27_, "dip'", "src/prelude.mth", 144, 47);
     WORD_ATOM(144, 47, "swap");
     {
@@ -12026,7 +11922,7 @@ static void mw_dip_27_ (void){
     }
     WORD_EXIT(mw_dip_27_);
 }
-static void mw_dip2 (void){
+static void mw_dip2 (void) {
     WORD_ENTER(mw_dip2, "dip2", "src/prelude.mth", 147, 5);
     WORD_ATOM(147, 5, "dip");
     {
@@ -12048,7 +11944,7 @@ static void mw_dip2 (void){
     }
     WORD_EXIT(mw_dip2);
 }
-static void mw_sip (void){
+static void mw_sip (void) {
     WORD_ENTER(mw_sip, "sip", "src/prelude.mth", 157, 5);
     WORD_ATOM(157, 5, "dup");
     {
@@ -12067,7 +11963,7 @@ static void mw_sip (void){
     }
     WORD_EXIT(mw_sip);
 }
-static void mw_both (void){
+static void mw_both (void) {
     WORD_ENTER(mw_both, "both", "src/prelude.mth", 161, 35);
     WORD_ATOM(161, 35, "dip");
     {
@@ -12087,7 +11983,7 @@ static void mw_both (void){
     }
     WORD_EXIT(mw_both);
 }
-static void mw_drop2 (void){
+static void mw_drop2 (void) {
     WORD_ENTER(mw_drop2, "drop2", "src/prelude.mth", 164, 20);
     WORD_ATOM(164, 20, "drop");
     mw_prim_drop();
@@ -12095,7 +11991,7 @@ static void mw_drop2 (void){
     mw_prim_drop();
     WORD_EXIT(mw_drop2);
 }
-static void mw_drop3 (void){
+static void mw_drop3 (void) {
     WORD_ENTER(mw_drop3, "drop3", "src/prelude.mth", 165, 22);
     WORD_ATOM(165, 22, "drop");
     mw_prim_drop();
@@ -12105,7 +12001,7 @@ static void mw_drop3 (void){
     mw_prim_drop();
     WORD_EXIT(mw_drop3);
 }
-static void mw_rot4r (void){
+static void mw_rot4r (void) {
     WORD_ENTER(mw_rot4r, "rot4r", "src/prelude.mth", 168, 32);
     WORD_ATOM(168, 32, "swap");
     mw_prim_swap();
@@ -12118,7 +12014,7 @@ static void mw_rot4r (void){
     }
     WORD_EXIT(mw_rot4r);
 }
-static void mw_rot4l (void){
+static void mw_rot4l (void) {
     WORD_ENTER(mw_rot4l, "rot4l", "src/prelude.mth", 169, 32);
     WORD_ATOM(169, 32, "dip");
     {
@@ -12131,7 +12027,7 @@ static void mw_rot4l (void){
     mw_prim_swap();
     WORD_EXIT(mw_rot4l);
 }
-static void mw_repeat (void){
+static void mw_repeat (void) {
     WORD_ENTER(mw_repeat, "repeat", "src/prelude.mth", 175, 5);
     WORD_ATOM(175, 5, "while");
     {
@@ -12160,7 +12056,7 @@ static void mw_repeat (void){
     }
     WORD_EXIT(mw_repeat);
 }
-static void mw_count (void){
+static void mw_count (void) {
     WORD_ENTER(mw_count, "count", "src/prelude.mth", 178, 5);
     WORD_ATOM(178, 5, "");
     {
@@ -12183,7 +12079,7 @@ static void mw_count (void){
     }
     WORD_EXIT(mw_count);
 }
-static void mw_countdown (void){
+static void mw_countdown (void) {
     WORD_ENTER(mw_countdown, "countdown", "src/prelude.mth", 180, 5);
     WORD_ATOM(180, 5, "dup");
     {
@@ -12208,65 +12104,65 @@ static void mw_countdown (void){
     }
     WORD_EXIT(mw_countdown);
 }
-static void mw_U8_5F_MAX (void){
+static void mw_U8_5F_MAX (void) {
     WORD_ENTER(mw_U8_5F_MAX, "U8_MAX", "src/prelude.mth", 185, 18);
     WORD_ATOM(185, 18, "");
     push_i64(255LL);
     WORD_EXIT(mw_U8_5F_MAX);
 }
-static void mw_U8_5F_MIN (void){
+static void mw_U8_5F_MIN (void) {
     WORD_ENTER(mw_U8_5F_MIN, "U8_MIN", "src/prelude.mth", 193, 18);
     WORD_ATOM(193, 18, "");
     push_i64(0LL);
     WORD_EXIT(mw_U8_5F_MIN);
 }
-static void mw_Comparison_2E_is_eq (void){
+static void mw_Comparison_2E_is_eq (void) {
     WORD_ENTER(mw_Comparison_2E_is_eq, "Comparison.is-eq", "src/prelude.mth", 202, 43);
     WORD_ATOM(202, 43, "LT");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_LT();
+            mp_LT();
             WORD_ATOM(202, 49, "F");
             mw_F();
             break;
         case 1LL:
-            co_EQ();
+            mp_EQ();
             WORD_ATOM(202, 58, "T");
             mw_T();
             break;
         case 2LL:
-            co_GT();
+            mp_GT();
             WORD_ATOM(202, 67, "F");
             mw_F();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Comparison_2E_is_eq);
+    }
+    WORD_EXIT(mw_Comparison_2E_is_eq);
 }
-static void mw_Comparison_2E_is_ne (void){
+static void mw_Comparison_2E_is_ne (void) {
     WORD_ENTER(mw_Comparison_2E_is_ne, "Comparison.is-ne", "src/prelude.mth", 207, 43);
     WORD_ATOM(207, 43, "LT");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_LT();
+            mp_LT();
             WORD_ATOM(207, 49, "T");
             mw_T();
             break;
         case 1LL:
-            co_EQ();
+            mp_EQ();
             WORD_ATOM(207, 58, "F");
             mw_F();
             break;
         case 2LL:
-            co_GT();
+            mp_GT();
             WORD_ATOM(207, 67, "T");
             mw_T();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Comparison_2E_is_ne);
+    }
+    WORD_EXIT(mw_Comparison_2E_is_ne);
 }
-static void mw_Int_3E_ (void){
+static void mw_Int_3E_ (void) {
     WORD_ENTER(mw_Int_3E_, "Int>", "src/prelude.mth", 211, 29);
     WORD_ATOM(211, 29, "swap");
     mw_prim_swap();
@@ -12274,7 +12170,7 @@ static void mw_Int_3E_ (void){
     mw_prim_int_lt();
     WORD_EXIT(mw_Int_3E_);
 }
-static void mw_Int_3E__3D_ (void){
+static void mw_Int_3E__3D_ (void) {
     WORD_ENTER(mw_Int_3E__3D_, "Int>=", "src/prelude.mth", 212, 29);
     WORD_ATOM(212, 29, "<");
     mw_prim_int_lt();
@@ -12282,7 +12178,7 @@ static void mw_Int_3E__3D_ (void){
     mw_Bool_2E_not();
     WORD_EXIT(mw_Int_3E__3D_);
 }
-static void mw_Int_3C__3D_ (void){
+static void mw_Int_3C__3D_ (void) {
     WORD_ENTER(mw_Int_3C__3D_, "Int<=", "src/prelude.mth", 213, 29);
     WORD_ATOM(213, 29, "swap");
     mw_prim_swap();
@@ -12292,7 +12188,7 @@ static void mw_Int_3C__3D_ (void){
     mw_Bool_2E_not();
     WORD_EXIT(mw_Int_3C__3D_);
 }
-static void mw_Int_2E_cmp (void){
+static void mw_Int_2E_cmp (void) {
     WORD_ENTER(mw_Int_2E_cmp, "Int.cmp", "src/prelude.mth", 215, 37);
     WORD_ATOM(215, 37, "dup2");
     mw_dup2();
@@ -12318,7 +12214,7 @@ static void mw_Int_2E_cmp (void){
     }
     WORD_EXIT(mw_Int_2E_cmp);
 }
-static void mw_Int_2E_in_range (void){
+static void mw_Int_2E_in_range (void) {
     WORD_ENTER(mw_Int_2E_in_range, "Int.in-range", "src/prelude.mth", 218, 40);
     WORD_ATOM(218, 40, "dip");
     {
@@ -12340,7 +12236,7 @@ static void mw_Int_2E_in_range (void){
     mw_Bool_26__26_();
     WORD_EXIT(mw_Int_2E_in_range);
 }
-static void mw_Str_2E_cmp (void){
+static void mw_Str_2E_cmp (void) {
     WORD_ENTER(mw_Str_2E_cmp, "Str.cmp", "src/prelude.mth", 220, 37);
     WORD_ATOM(220, 37, "prim-str-cmp");
     mw_prim_str_cmp();
@@ -12350,7 +12246,7 @@ static void mw_Str_2E_cmp (void){
     mw_Int_2E_cmp();
     WORD_EXIT(mw_Str_2E_cmp);
 }
-static void mw_Str_3D_ (void){
+static void mw_Str_3D_ (void) {
     WORD_ENTER(mw_Str_3D_, "Str=", "src/prelude.mth", 221, 29);
     WORD_ATOM(221, 29, ".cmp");
     mw_Str_2E_cmp();
@@ -12358,7 +12254,7 @@ static void mw_Str_3D_ (void){
     mw_Comparison_2E_is_eq();
     WORD_EXIT(mw_Str_3D_);
 }
-static void mw_Str_3C__3E_ (void){
+static void mw_Str_3C__3E_ (void) {
     WORD_ENTER(mw_Str_3C__3E_, "Str<>", "src/prelude.mth", 226, 29);
     WORD_ATOM(226, 29, ".cmp");
     mw_Str_2E_cmp();
@@ -12366,7 +12262,7 @@ static void mw_Str_3C__3E_ (void){
     mw_Comparison_2E_is_ne();
     WORD_EXIT(mw_Str_3C__3E_);
 }
-static void mw_prim_int_succ (void){
+static void mw_prim_int_succ (void) {
     WORD_ENTER(mw_prim_int_succ, "prim-int-succ", "src/prelude.mth", 230, 40);
     WORD_ATOM(230, 40, "");
     push_i64(1LL);
@@ -12374,7 +12270,7 @@ static void mw_prim_int_succ (void){
     mw_prim_int_add();
     WORD_EXIT(mw_prim_int_succ);
 }
-static void mw_prim_int_pred (void){
+static void mw_prim_int_pred (void) {
     WORD_ENTER(mw_prim_int_pred, "prim-int-pred", "src/prelude.mth", 231, 40);
     WORD_ATOM(231, 40, "");
     push_i64(1LL);
@@ -12382,7 +12278,7 @@ static void mw_prim_int_pred (void){
     mw_prim_int_sub();
     WORD_EXIT(mw_prim_int_pred);
 }
-static void mw_0_3D_ (void){
+static void mw_0_3D_ (void) {
     WORD_ENTER(mw_0_3D_, "0=", "src/prelude.mth", 239, 22);
     WORD_ATOM(239, 22, "");
     push_i64(0LL);
@@ -12390,7 +12286,7 @@ static void mw_0_3D_ (void){
     mw_prim_int_eq();
     WORD_EXIT(mw_0_3D_);
 }
-static void mw_0_3C_ (void){
+static void mw_0_3C_ (void) {
     WORD_ENTER(mw_0_3C_, "0<", "src/prelude.mth", 240, 22);
     WORD_ATOM(240, 22, "");
     push_i64(0LL);
@@ -12398,7 +12294,7 @@ static void mw_0_3C_ (void){
     mw_prim_int_lt();
     WORD_EXIT(mw_0_3C_);
 }
-static void mw_0_3E_ (void){
+static void mw_0_3E_ (void) {
     WORD_ENTER(mw_0_3E_, "0>", "src/prelude.mth", 241, 22);
     WORD_ATOM(241, 22, "");
     push_i64(0LL);
@@ -12406,7 +12302,7 @@ static void mw_0_3E_ (void){
     mw_Int_3E_();
     WORD_EXIT(mw_0_3E_);
 }
-static void mw_0_3E__3D_ (void){
+static void mw_0_3E__3D_ (void) {
     WORD_ENTER(mw_0_3E__3D_, "0>=", "src/prelude.mth", 242, 23);
     WORD_ATOM(242, 23, "");
     push_i64(0LL);
@@ -12414,7 +12310,7 @@ static void mw_0_3E__3D_ (void){
     mw_Int_3E__3D_();
     WORD_EXIT(mw_0_3E__3D_);
 }
-static void mw_Ptr_40__40_Ptr (void){
+static void mw_Ptr_40__40_Ptr (void) {
     WORD_ENTER(mw_Ptr_40__40_Ptr, "Ptr@@Ptr", "src/prelude.mth", 249, 34);
     WORD_ATOM(249, 34, "dip");
     {
@@ -12432,7 +12328,7 @@ static void mw_Ptr_40__40_Ptr (void){
     mw_Ptr_2E_offset();
     WORD_EXIT(mw_Ptr_40__40_Ptr);
 }
-static void mw_Ptr_40__40_I64 (void){
+static void mw_Ptr_40__40_I64 (void) {
     WORD_ENTER(mw_Ptr_40__40_I64, "Ptr@@I64", "src/prelude.mth", 259, 34);
     WORD_ATOM(259, 34, "dip");
     {
@@ -12450,7 +12346,7 @@ static void mw_Ptr_40__40_I64 (void){
     mw_Ptr_2E_offset();
     WORD_EXIT(mw_Ptr_40__40_I64);
 }
-static void mw_Ptr_21__21_U8 (void){
+static void mw_Ptr_21__21_U8 (void) {
     WORD_ENTER(mw_Ptr_21__21_U8, "Ptr!!U8", "src/prelude.mth", 261, 42);
     WORD_ATOM(261, 42, ".offset");
     push_u64(0);
@@ -12459,7 +12355,7 @@ static void mw_Ptr_21__21_U8 (void){
     mw_Ptr_2E_offset();
     WORD_EXIT(mw_Ptr_21__21_U8);
 }
-static void mw_Ptr_21__21_I64 (void){
+static void mw_Ptr_21__21_I64 (void) {
     WORD_ENTER(mw_Ptr_21__21_I64, "Ptr!!I64", "src/prelude.mth", 268, 34);
     WORD_ATOM(268, 34, "dip");
     {
@@ -12477,19 +12373,19 @@ static void mw_Ptr_21__21_I64 (void){
     mw_Ptr_2E_offset();
     WORD_EXIT(mw_Ptr_21__21_I64);
 }
-static void mw_U8_3E_Int (void){
+static void mw_U8_3E_Int (void) {
     WORD_ENTER(mw_U8_3E_Int, "U8>Int", "src/prelude.mth", 270, 26);
     WORD_ATOM(270, 26, "prim-unsafe-cast");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_U8_3E_Int);
 }
-static void mw_I64_3E_Int (void){
+static void mw_I64_3E_Int (void) {
     WORD_ENTER(mw_I64_3E_Int, "I64>Int", "src/prelude.mth", 280, 26);
     WORD_ATOM(280, 26, "prim-unsafe-cast");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_I64_3E_Int);
 }
-static void mw_Int_3E_U8_3F_ (void){
+static void mw_Int_3E_U8_3F_ (void) {
     WORD_ENTER(mw_Int_3E_U8_3F_, "Int>U8?", "src/prelude.mth", 295, 34);
     WORD_ATOM(295, 34, "dup");
     mw_prim_dup();
@@ -12513,7 +12409,7 @@ static void mw_Int_3E_U8_3F_ (void){
     }
     WORD_EXIT(mw_Int_3E_U8_3F_);
 }
-static void mw_Int_3E_U8 (void){
+static void mw_Int_3E_U8 (void) {
     WORD_ENTER(mw_Int_3E_U8, "Int>U8", "src/prelude.mth", 299, 26);
     WORD_ATOM(299, 26, "Int>U8?");
     mw_Int_3E_U8_3F_();
@@ -12524,13 +12420,13 @@ static void mw_Int_3E_U8 (void){
     mw_Maybe_2E_unwrap_or();
     WORD_EXIT(mw_Int_3E_U8);
 }
-static void mw_Int_3E_I64 (void){
+static void mw_Int_3E_I64 (void) {
     WORD_ENTER(mw_Int_3E_I64, "Int>I64", "src/prelude.mth", 311, 26);
     WORD_ATOM(311, 26, ">I64-unsafe");
     mw_Int_3E_I64_unsafe();
     WORD_EXIT(mw_Int_3E_I64);
 }
-static void mw_pack1 (void){
+static void mw_pack1 (void) {
     WORD_ENTER(mw_pack1, "pack1", "src/prelude.mth", 323, 22);
     WORD_ATOM(323, 22, "dip");
     {
@@ -12543,7 +12439,7 @@ static void mw_pack1 (void){
     mw_prim_pack_cons();
     WORD_EXIT(mw_pack1);
 }
-static void mw_pack2 (void){
+static void mw_pack2 (void) {
     WORD_ENTER(mw_pack2, "pack2", "src/prelude.mth", 324, 26);
     WORD_ATOM(324, 26, "dip");
     {
@@ -12556,7 +12452,7 @@ static void mw_pack2 (void){
     mw_prim_pack_cons();
     WORD_EXIT(mw_pack2);
 }
-static void mw_unpack1 (void){
+static void mw_unpack1 (void) {
     WORD_ENTER(mw_unpack1, "unpack1", "src/prelude.mth", 330, 24);
     WORD_ATOM(330, 24, "prim-pack-uncons");
     mw_prim_pack_uncons();
@@ -12564,7 +12460,7 @@ static void mw_unpack1 (void){
     mw_nip();
     WORD_EXIT(mw_unpack1);
 }
-static void mw_unpack2 (void){
+static void mw_unpack2 (void) {
     WORD_ENTER(mw_unpack2, "unpack2", "src/prelude.mth", 331, 28);
     WORD_ATOM(331, 28, "prim-pack-uncons");
     mw_prim_pack_uncons();
@@ -12577,7 +12473,7 @@ static void mw_unpack2 (void){
     }
     WORD_EXIT(mw_unpack2);
 }
-static void mw_modify (void){
+static void mw_modify (void) {
     WORD_ENTER(mw_modify, "modify", "src/prelude.mth", 339, 48);
     WORD_ATOM(339, 48, "dup");
     {
@@ -12600,7 +12496,7 @@ static void mw_modify (void){
     }
     WORD_EXIT(mw_modify);
 }
-static void mw_expect_21_ (void){
+static void mw_expect_21_ (void) {
     WORD_ENTER(mw_expect_21_, "expect!", "src/prelude.mth", 343, 5);
     WORD_ATOM(343, 5, "f");
     {
@@ -12625,7 +12521,7 @@ static void mw_expect_21_ (void){
     }
     WORD_EXIT(mw_expect_21_);
 }
-static void mw_assert_21_ (void){
+static void mw_assert_21_ (void) {
     WORD_ENTER(mw_assert_21_, "assert!", "src/prelude.mth", 345, 5);
     WORD_ATOM(345, 5, "expect!");
     {
@@ -12649,13 +12545,13 @@ static void mw_assert_21_ (void){
     }
     WORD_EXIT(mw_assert_21_);
 }
-static void mw_Byte_3E_Int (void){
+static void mw_Byte_3E_Int (void) {
     WORD_ENTER(mw_Byte_3E_Int, "Byte>Int", "src/data/byte.mth", 41, 28);
     WORD_ATOM(41, 28, "prim-unsafe-cast");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Byte_3E_Int);
 }
-static void mw_Int_3E_Byte (void){
+static void mw_Int_3E_Byte (void) {
     WORD_ENTER(mw_Int_3E_Byte, "Int>Byte", "src/data/byte.mth", 43, 5);
     WORD_ATOM(43, 5, "assert!");
     push_u64(0);
@@ -12669,7 +12565,7 @@ static void mw_Int_3E_Byte (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Int_3E_Byte);
 }
-static void mw_Byte_3E_U8 (void){
+static void mw_Byte_3E_U8 (void) {
     WORD_ENTER(mw_Byte_3E_U8, "Byte>U8", "src/data/byte.mth", 45, 26);
     WORD_ATOM(45, 26, ">Int");
     mw_Byte_3E_Int();
@@ -12677,7 +12573,7 @@ static void mw_Byte_3E_U8 (void){
     mw_Int_3E_U8();
     WORD_EXIT(mw_Byte_3E_U8);
 }
-static void mw_U8_3E_Byte (void){
+static void mw_U8_3E_Byte (void) {
     WORD_ENTER(mw_U8_3E_Byte, "U8>Byte", "src/data/byte.mth", 46, 26);
     WORD_ATOM(46, 26, ">Int");
     mw_U8_3E_Int();
@@ -12685,7 +12581,7 @@ static void mw_U8_3E_Byte (void){
     mw_Int_3E_Byte();
     WORD_EXIT(mw_U8_3E_Byte);
 }
-static void mw_Ptr_40_Byte (void){
+static void mw_Ptr_40_Byte (void) {
     WORD_ENTER(mw_Ptr_40_Byte, "Ptr@Byte", "src/data/byte.mth", 48, 28);
     WORD_ATOM(48, 28, "@U8");
     mw_prim_u8_get();
@@ -12693,7 +12589,7 @@ static void mw_Ptr_40_Byte (void){
     mw_U8_3E_Byte();
     WORD_EXIT(mw_Ptr_40_Byte);
 }
-static void mw_Byte_3D_ (void){
+static void mw_Byte_3D_ (void) {
     WORD_ENTER(mw_Byte_3D_, "Byte=", "src/data/byte.mth", 52, 32);
     WORD_ATOM(52, 32, "both");
     push_u64(0);
@@ -12704,7 +12600,7 @@ static void mw_Byte_3D_ (void){
     mw_prim_int_eq();
     WORD_EXIT(mw_Byte_3D_);
 }
-static void mw_Byte_3E_ (void){
+static void mw_Byte_3E_ (void) {
     WORD_ENTER(mw_Byte_3E_, "Byte>", "src/data/byte.mth", 54, 32);
     WORD_ATOM(54, 32, "both");
     push_u64(0);
@@ -12715,7 +12611,7 @@ static void mw_Byte_3E_ (void){
     mw_Int_3E_();
     WORD_EXIT(mw_Byte_3E_);
 }
-static void mw_Byte_2E_in_range (void){
+static void mw_Byte_2E_in_range (void) {
     WORD_ENTER(mw_Byte_2E_in_range, "Byte.in-range", "src/data/byte.mth", 58, 44);
     WORD_ATOM(58, 44, "dip");
     {
@@ -12733,7 +12629,7 @@ static void mw_Byte_2E_in_range (void){
     mw_Int_2E_in_range();
     WORD_EXIT(mw_Byte_2E_in_range);
 }
-static void mw_Byte_2E_is_upper (void){
+static void mw_Byte_2E_is_upper (void) {
     WORD_ENTER(mw_Byte_2E_is_upper, "Byte.is-upper", "src/data/byte.mth", 60, 34);
     WORD_ATOM(60, 34, "B'A'");
     mw_B_27_A_27_();
@@ -12743,7 +12639,7 @@ static void mw_Byte_2E_is_upper (void){
     mw_Byte_2E_in_range();
     WORD_EXIT(mw_Byte_2E_is_upper);
 }
-static void mw_Byte_2E_is_lower (void){
+static void mw_Byte_2E_is_lower (void) {
     WORD_ENTER(mw_Byte_2E_is_lower, "Byte.is-lower", "src/data/byte.mth", 61, 34);
     WORD_ATOM(61, 34, "B'a'");
     mw_B_27_a_27_();
@@ -12753,7 +12649,7 @@ static void mw_Byte_2E_is_lower (void){
     mw_Byte_2E_in_range();
     WORD_EXIT(mw_Byte_2E_is_lower);
 }
-static void mw_Byte_2E_is_digit (void){
+static void mw_Byte_2E_is_digit (void) {
     WORD_ENTER(mw_Byte_2E_is_digit, "Byte.is-digit", "src/data/byte.mth", 62, 34);
     WORD_ATOM(62, 34, "B'0'");
     mw_B_27_0_27_();
@@ -12763,7 +12659,7 @@ static void mw_Byte_2E_is_digit (void){
     mw_Byte_2E_in_range();
     WORD_EXIT(mw_Byte_2E_is_digit);
 }
-static void mw_Byte_2E_is_alpha (void){
+static void mw_Byte_2E_is_alpha (void) {
     WORD_ENTER(mw_Byte_2E_is_alpha, "Byte.is-alpha", "src/data/byte.mth", 63, 34);
     WORD_ATOM(63, 34, "dup");
     mw_prim_dup();
@@ -12781,7 +12677,7 @@ static void mw_Byte_2E_is_alpha (void){
     }
     WORD_EXIT(mw_Byte_2E_is_alpha);
 }
-static void mw_Byte_2E_is_alnum (void){
+static void mw_Byte_2E_is_alnum (void) {
     WORD_ENTER(mw_Byte_2E_is_alnum, "Byte.is-alnum", "src/data/byte.mth", 64, 34);
     WORD_ATOM(64, 34, "dup");
     mw_prim_dup();
@@ -12799,87 +12695,87 @@ static void mw_Byte_2E_is_alnum (void){
     }
     WORD_EXIT(mw_Byte_2E_is_alnum);
 }
-static void mw_Byte_2E_is_hexdigit (void){
+static void mw_Byte_2E_is_hexdigit (void) {
     WORD_ENTER(mw_Byte_2E_is_hexdigit, "Byte.is-hexdigit", "src/data/byte.mth", 67, 5);
     WORD_ATOM(67, 5, "B'0'");
     switch (get_top_data_tag()) {
         case 48LL:
-            co_B_27_0_27_();
+            mp_B_27_0_27_();
             WORD_ATOM(67, 13, "T");
             mw_T();
             break;
         case 49LL:
-            co_B_27_1_27_();
+            mp_B_27_1_27_();
             WORD_ATOM(67, 24, "T");
             mw_T();
             break;
         case 50LL:
-            co_B_27_2_27_();
+            mp_B_27_2_27_();
             WORD_ATOM(67, 35, "T");
             mw_T();
             break;
         case 51LL:
-            co_B_27_3_27_();
+            mp_B_27_3_27_();
             WORD_ATOM(67, 46, "T");
             mw_T();
             break;
         case 52LL:
-            co_B_27_4_27_();
+            mp_B_27_4_27_();
             WORD_ATOM(68, 13, "T");
             mw_T();
             break;
         case 53LL:
-            co_B_27_5_27_();
+            mp_B_27_5_27_();
             WORD_ATOM(68, 24, "T");
             mw_T();
             break;
         case 54LL:
-            co_B_27_6_27_();
+            mp_B_27_6_27_();
             WORD_ATOM(68, 35, "T");
             mw_T();
             break;
         case 55LL:
-            co_B_27_7_27_();
+            mp_B_27_7_27_();
             WORD_ATOM(68, 46, "T");
             mw_T();
             break;
         case 56LL:
-            co_B_27_8_27_();
+            mp_B_27_8_27_();
             WORD_ATOM(69, 13, "T");
             mw_T();
             break;
         case 57LL:
-            co_B_27_9_27_();
+            mp_B_27_9_27_();
             WORD_ATOM(69, 24, "T");
             mw_T();
             break;
         case 65LL:
-            co_B_27_A_27_();
+            mp_B_27_A_27_();
             WORD_ATOM(69, 35, "T");
             mw_T();
             break;
         case 66LL:
-            co_B_27_B_27_();
+            mp_B_27_B_27_();
             WORD_ATOM(69, 46, "T");
             mw_T();
             break;
         case 67LL:
-            co_B_27_C_27_();
+            mp_B_27_C_27_();
             WORD_ATOM(70, 13, "T");
             mw_T();
             break;
         case 68LL:
-            co_B_27_D_27_();
+            mp_B_27_D_27_();
             WORD_ATOM(70, 24, "T");
             mw_T();
             break;
         case 69LL:
-            co_B_27_E_27_();
+            mp_B_27_E_27_();
             WORD_ATOM(70, 35, "T");
             mw_T();
             break;
         case 70LL:
-            co_B_27_F_27_();
+            mp_B_27_F_27_();
             WORD_ATOM(70, 46, "T");
             mw_T();
             break;
@@ -12889,10 +12785,10 @@ static void mw_Byte_2E_is_hexdigit (void){
             WORD_ATOM(71, 15, "F");
             mw_F();
             break;
-    
-}    WORD_EXIT(mw_Byte_2E_is_hexdigit);
+    }
+    WORD_EXIT(mw_Byte_2E_is_hexdigit);
 }
-static void mw_Byte_2E_to_ascii_str (void){
+static void mw_Byte_2E_to_ascii_str (void) {
     WORD_ENTER(mw_Byte_2E_to_ascii_str, "Byte.to-ascii-str", "src/data/byte.mth", 75, 5);
     WORD_ATOM(75, 5, "dup");
     mw_prim_dup();
@@ -12926,22 +12822,22 @@ static void mw_Byte_2E_to_ascii_str (void){
     }
     WORD_EXIT(mw_Byte_2E_to_ascii_str);
 }
-static void mw_Byte_2E_is_string_end (void){
+static void mw_Byte_2E_is_string_end (void) {
     WORD_ENTER(mw_Byte_2E_is_string_end, "Byte.is-string-end", "src/data/byte.mth", 83, 5);
     WORD_ATOM(83, 5, "BQUOTE");
     switch (get_top_data_tag()) {
         case 34LL:
-            co_BQUOTE();
+            mp_BQUOTE();
             WORD_ATOM(83, 15, "T");
             mw_T();
             break;
         case 10LL:
-            co_BLF();
+            mp_BLF();
             WORD_ATOM(83, 25, "T");
             mw_T();
             break;
         case 0LL:
-            co_BNUL();
+            mp_BNUL();
             WORD_ATOM(83, 36, "T");
             mw_T();
             break;
@@ -12951,10 +12847,10 @@ static void mw_Byte_2E_is_string_end (void){
             WORD_ATOM(83, 49, "F");
             mw_F();
             break;
-    
-}    WORD_EXIT(mw_Byte_2E_is_string_end);
+    }
+    WORD_EXIT(mw_Byte_2E_is_string_end);
 }
-static void mw_Byte_2E_to_lower (void){
+static void mw_Byte_2E_to_lower (void) {
     WORD_ENTER(mw_Byte_2E_to_lower, "Byte.to-lower", "src/data/byte.mth", 86, 5);
     WORD_ATOM(86, 5, "dup");
     mw_prim_dup();
@@ -12976,7 +12872,7 @@ static void mw_Byte_2E_to_lower (void){
     }
     WORD_EXIT(mw_Byte_2E_to_lower);
 }
-static void mw_Byte_2E_to_hexdigits (void){
+static void mw_Byte_2E_to_hexdigits (void) {
     WORD_ENTER(mw_Byte_2E_to_hexdigits, "Byte.to-hexdigits", "src/data/byte.mth", 91, 5);
     WORD_ATOM(91, 5, ">Int");
     mw_Byte_3E_Int();
@@ -12998,7 +12894,7 @@ static void mw_Byte_2E_to_hexdigits (void){
     mw_one_hexdigit_byte();
     WORD_EXIT(mw_Byte_2E_to_hexdigits);
 }
-static void mw_one_hexdigit_byte (void){
+static void mw_one_hexdigit_byte (void) {
     WORD_ENTER(mw_one_hexdigit_byte, "one-hexdigit-byte", "src/data/byte.mth", 95, 5);
     WORD_ATOM(95, 5, "dup");
     mw_prim_dup();
@@ -13020,52 +12916,52 @@ static void mw_one_hexdigit_byte (void){
     mw_Int_3E_Byte();
     WORD_EXIT(mw_one_hexdigit_byte);
 }
-static void mw_Byte_2E_is_name_byte (void){
+static void mw_Byte_2E_is_name_byte (void) {
     WORD_ENTER(mw_Byte_2E_is_name_byte, "Byte.is-name-byte", "src/data/byte.mth", 98, 5);
     WORD_ATOM(98, 5, "BLPAREN");
     switch (get_top_data_tag()) {
         case 40LL:
-            co_BLPAREN();
+            mp_BLPAREN();
             WORD_ATOM(98, 16, "F");
             mw_F();
             break;
         case 41LL:
-            co_BRPAREN();
+            mp_BRPAREN();
             WORD_ATOM(99, 16, "F");
             mw_F();
             break;
         case 91LL:
-            co_BLSQUARE();
+            mp_BLSQUARE();
             WORD_ATOM(100, 17, "F");
             mw_F();
             break;
         case 93LL:
-            co_BRSQUARE();
+            mp_BRSQUARE();
             WORD_ATOM(101, 17, "F");
             mw_F();
             break;
         case 123LL:
-            co_BLCURLY();
+            mp_BLCURLY();
             WORD_ATOM(102, 16, "F");
             mw_F();
             break;
         case 125LL:
-            co_BRCURLY();
+            mp_BRCURLY();
             WORD_ATOM(103, 16, "F");
             mw_F();
             break;
         case 44LL:
-            co_BCOMMA();
+            mp_BCOMMA();
             WORD_ATOM(104, 15, "F");
             mw_F();
             break;
         case 34LL:
-            co_BQUOTE();
+            mp_BQUOTE();
             WORD_ATOM(105, 15, "F");
             mw_F();
             break;
         case 127LL:
-            co_BDEL();
+            mp_BDEL();
             WORD_ATOM(106, 13, "F");
             mw_F();
             break;
@@ -13075,20 +12971,20 @@ static void mw_Byte_2E_is_name_byte (void){
             WORD_ATOM(107, 17, ">");
             mw_Byte_3E_();
             break;
-    
-}    WORD_EXIT(mw_Byte_2E_is_name_byte);
+    }
+    WORD_EXIT(mw_Byte_2E_is_name_byte);
 }
-static void mw_Byte_2E_is_sign (void){
+static void mw_Byte_2E_is_sign (void) {
     WORD_ENTER(mw_Byte_2E_is_sign, "Byte.is-sign", "src/data/byte.mth", 110, 5);
     WORD_ATOM(110, 5, "B'-'");
     switch (get_top_data_tag()) {
         case 45LL:
-            co_B_27___27_();
+            mp_B_27___27_();
             WORD_ATOM(110, 13, "T");
             mw_T();
             break;
         case 43LL:
-            co_B_27__2B__27_();
+            mp_B_27__2B__27_();
             WORD_ATOM(111, 13, "T");
             mw_T();
             break;
@@ -13098,10 +12994,10 @@ static void mw_Byte_2E_is_sign (void){
             WORD_ATOM(112, 15, "F");
             mw_F();
             break;
-    
-}    WORD_EXIT(mw_Byte_2E_is_sign);
+    }
+    WORD_EXIT(mw_Byte_2E_is_sign);
 }
-static void mw_Str_2E_is_empty (void){
+static void mw_Str_2E_is_empty (void) {
     WORD_ENTER(mw_Str_2E_is_empty, "Str.is-empty", "src/data/str.mth", 9, 32);
     WORD_ATOM(9, 32, "num-bytes");
     mw_prim_str_num_bytes();
@@ -13109,13 +13005,13 @@ static void mw_Str_2E_is_empty (void){
     mw_0_3D_();
     WORD_EXIT(mw_Str_2E_is_empty);
 }
-static void mw_STR_5F_BUF_5F_SIZE (void){
+static void mw_STR_5F_BUF_5F_SIZE (void) {
     WORD_ENTER(mw_STR_5F_BUF_5F_SIZE, "STR_BUF_SIZE", "src/data/str.mth", 20, 24);
     WORD_ATOM(20, 24, "");
     push_i64(8192LL);
     WORD_EXIT(mw_STR_5F_BUF_5F_SIZE);
 }
-static void mw_build_str_21_ (void){
+static void mw_build_str_21_ (void) {
     WORD_ENTER(mw_build_str_21_, "build-str!", "src/data/str.mth", 25, 5);
     WORD_ATOM(25, 5, "str-buf-dup!");
     {
@@ -13140,7 +13036,7 @@ static void mw_build_str_21_ (void){
     }
     WORD_EXIT(mw_build_str_21_);
 }
-static void mw_str_copy_cstr (void){
+static void mw_str_copy_cstr (void) {
     WORD_ENTER(mw_str_copy_cstr, "str-copy-cstr", "src/data/str.mth", 33, 5);
     WORD_ATOM(33, 5, "dup");
     mw_prim_dup();
@@ -13150,7 +13046,7 @@ static void mw_str_copy_cstr (void){
     mw_prim_str_copy();
     WORD_EXIT(mw_str_copy_cstr);
 }
-static void mw_cstr_num_bytes (void){
+static void mw_cstr_num_bytes (void) {
     WORD_ENTER(mw_cstr_num_bytes, "cstr-num-bytes", "src/data/str.mth", 36, 5);
     WORD_ATOM(36, 5, "dup");
     mw_prim_dup();
@@ -13187,7 +13083,7 @@ static void mw_cstr_num_bytes (void){
     mw_nip();
     WORD_EXIT(mw_cstr_num_bytes);
 }
-static void mw_str_buf_dup_21_ (void){
+static void mw_str_buf_dup_21_ (void) {
     WORD_ENTER(mw_str_buf_dup_21_, "str-buf-dup!", "src/data/str.mth", 39, 5);
     WORD_ATOM(39, 5, "STR_BUF");
     mw_STR_5F_BUF();
@@ -13197,7 +13093,7 @@ static void mw_str_buf_dup_21_ (void){
     mw_prim_str_copy();
     WORD_EXIT(mw_str_buf_dup_21_);
 }
-static void mw_str_buf_length_3F_ (void){
+static void mw_str_buf_length_3F_ (void) {
     WORD_ENTER(mw_str_buf_length_3F_, "str-buf-length?", "src/data/str.mth", 42, 5);
     WORD_ATOM(42, 5, "STR_BUF_LEN");
     mw_STR_5F_BUF_5F_LEN();
@@ -13205,7 +13101,7 @@ static void mw_str_buf_length_3F_ (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_str_buf_length_3F_);
 }
-static void mw_str_buf_length_21_ (void){
+static void mw_str_buf_length_21_ (void) {
     WORD_ENTER(mw_str_buf_length_21_, "str-buf-length!", "src/data/str.mth", 45, 5);
     WORD_ATOM(45, 5, "dup");
     mw_prim_dup();
@@ -13226,7 +13122,7 @@ static void mw_str_buf_length_21_ (void){
     mw_str_buf_u8_21_();
     WORD_EXIT(mw_str_buf_length_21_);
 }
-static void mw_str_buf_u8_21_ (void){
+static void mw_str_buf_u8_21_ (void) {
     WORD_ENTER(mw_str_buf_u8_21_, "str-buf-u8!", "src/data/str.mth", 52, 5);
     WORD_ATOM(52, 5, "STR_BUF");
     mw_STR_5F_BUF();
@@ -13234,7 +13130,7 @@ static void mw_str_buf_u8_21_ (void){
     mw_Ptr_21__21_U8();
     WORD_EXIT(mw_str_buf_u8_21_);
 }
-static void mw_str_buf_byte_40_ (void){
+static void mw_str_buf_byte_40_ (void) {
     WORD_ENTER(mw_str_buf_byte_40_, "str-buf-byte@", "src/data/str.mth", 55, 5);
     WORD_ATOM(55, 5, "STR_BUF");
     mw_STR_5F_BUF();
@@ -13245,7 +13141,7 @@ static void mw_str_buf_byte_40_ (void){
     mw_Ptr_2E_offset();
     WORD_EXIT(mw_str_buf_byte_40_);
 }
-static void mw_str_buf_full_3F_ (void){
+static void mw_str_buf_full_3F_ (void) {
     WORD_ENTER(mw_str_buf_full_3F_, "str-buf-full?", "src/data/str.mth", 58, 26);
     WORD_ATOM(58, 26, "str-buf-length?");
     mw_str_buf_length_3F_();
@@ -13257,7 +13153,7 @@ static void mw_str_buf_full_3F_ (void){
     mw_Int_3E__3D_();
     WORD_EXIT(mw_str_buf_full_3F_);
 }
-static void mw_str_buf_clear_21_ (void){
+static void mw_str_buf_clear_21_ (void) {
     WORD_ENTER(mw_str_buf_clear_21_, "str-buf-clear!", "src/data/str.mth", 61, 5);
     WORD_ATOM(61, 5, "");
     push_i64(0LL);
@@ -13265,7 +13161,7 @@ static void mw_str_buf_clear_21_ (void){
     mw_str_buf_length_21_();
     WORD_EXIT(mw_str_buf_clear_21_);
 }
-static void mw_str_buf_push_u8_21_ (void){
+static void mw_str_buf_push_u8_21_ (void) {
     WORD_ENTER(mw_str_buf_push_u8_21_, "str-buf-push-u8!", "src/data/str.mth", 64, 5);
     WORD_ATOM(64, 5, "assert!");
     push_u64(0);
@@ -13287,7 +13183,7 @@ static void mw_str_buf_push_u8_21_ (void){
     mw_str_buf_length_21_();
     WORD_EXIT(mw_str_buf_push_u8_21_);
 }
-static void mw_str_buf_push_byte_21_ (void){
+static void mw_str_buf_push_byte_21_ (void) {
     WORD_ENTER(mw_str_buf_push_byte_21_, "str-buf-push-byte!", "src/data/str.mth", 69, 5);
     WORD_ATOM(69, 5, ">U8");
     mw_Byte_3E_U8();
@@ -13295,7 +13191,7 @@ static void mw_str_buf_push_byte_21_ (void){
     mw_str_buf_push_u8_21_();
     WORD_EXIT(mw_str_buf_push_byte_21_);
 }
-static void mw_str_buf_push_str_21_ (void){
+static void mw_str_buf_push_str_21_ (void) {
     WORD_ENTER(mw_str_buf_push_str_21_, "str-buf-push-str!", "src/data/str.mth", 74, 5);
     WORD_ATOM(74, 5, "with-str-data");
     push_u64(0);
@@ -13304,7 +13200,7 @@ static void mw_str_buf_push_str_21_ (void){
     mw_with_str_data();
     WORD_EXIT(mw_str_buf_push_str_21_);
 }
-static void mw_with_str_data (void){
+static void mw_with_str_data (void) {
     WORD_ENTER(mw_with_str_data, "with-str-data", "src/data/str.mth", 77, 5);
     WORD_ATOM(77, 5, "dup");
     {
@@ -13336,7 +13232,7 @@ static void mw_with_str_data (void){
     }
     WORD_EXIT(mw_with_str_data);
 }
-static void mw_str_buf_push_ptr_21_ (void){
+static void mw_str_buf_push_ptr_21_ (void) {
     WORD_ENTER(mw_str_buf_push_ptr_21_, "str-buf-push-ptr!", "src/data/str.mth", 80, 5);
     WORD_ATOM(80, 5, "tuck");
     mw_tuck();
@@ -13357,7 +13253,7 @@ static void mw_str_buf_push_ptr_21_ (void){
     mw_str_buf_length_21_();
     WORD_EXIT(mw_str_buf_push_ptr_21_);
 }
-static void mw_str_buf_21_ (void){
+static void mw_str_buf_21_ (void) {
     WORD_ENTER(mw_str_buf_21_, "str-buf!", "src/data/str.mth", 86, 5);
     WORD_ATOM(86, 5, "str-buf-clear!");
     mw_str_buf_clear_21_();
@@ -13365,7 +13261,7 @@ static void mw_str_buf_21_ (void){
     mw_str_buf_push_str_21_();
     WORD_EXIT(mw_str_buf_21_);
 }
-static void mw_str_bytes_for (void){
+static void mw_str_bytes_for (void) {
     WORD_ENTER(mw_str_bytes_for, "str-bytes-for", "src/data/str.mth", 96, 5);
     WORD_ATOM(96, 5, "with-str-data");
     {
@@ -13382,7 +13278,7 @@ static void mw_str_bytes_for (void){
     }
     WORD_EXIT(mw_str_bytes_for);
 }
-static void mw_Str_2E_first_byte (void){
+static void mw_Str_2E_first_byte (void) {
     WORD_ENTER(mw_Str_2E_first_byte, "Str.first-byte", "src/data/str.mth", 101, 5);
     WORD_ATOM(101, 5, "with-str-data");
     push_u64(0);
@@ -13391,14 +13287,14 @@ static void mw_Str_2E_first_byte (void){
     mw_with_str_data();
     WORD_EXIT(mw_Str_2E_first_byte);
 }
-static void mw_Path_3E_Str (void){
+static void mw_Path_3E_Str (void) {
     WORD_ENTER(mw_Path_3E_Str, "Path>Str", "src/data/path.mth", 7, 28);
     WORD_ATOM(7, 28, "Str>Path");
     WORD_ATOM(7, 40, "id");
     mw_prim_id();
     WORD_EXIT(mw_Path_3E_Str);
 }
-static void mw_Path_3D_ (void){
+static void mw_Path_3D_ (void) {
     WORD_ENTER(mw_Path_3D_, "Path=", "src/data/path.mth", 8, 31);
     WORD_ATOM(8, 31, "both");
     push_u64(0);
@@ -13409,7 +13305,7 @@ static void mw_Path_3D_ (void){
     mw_Str_3D_();
     WORD_EXIT(mw_Path_3D_);
 }
-static void mw_init_paths_21_ (void){
+static void mw_init_paths_21_ (void) {
     WORD_ENTER(mw_init_paths_21_, "init-paths!", "src/data/path.mth", 11, 5);
     WORD_ATOM(11, 5, "");
     {
@@ -13447,7 +13343,7 @@ static void mw_init_paths_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_init_paths_21_);
 }
-static void mw_Path_2E_is_empty (void){
+static void mw_Path_2E_is_empty (void) {
     WORD_ENTER(mw_Path_2E_is_empty, "Path.is-empty", "src/data/path.mth", 18, 34);
     WORD_ATOM(18, 34, ">Str");
     mw_Path_3E_Str();
@@ -13455,7 +13351,7 @@ static void mw_Path_2E_is_empty (void){
     mw_Str_2E_is_empty();
     WORD_EXIT(mw_Path_2E_is_empty);
 }
-static void mw_Path_2E_join_with (void){
+static void mw_Path_2E_join_with (void) {
     WORD_ENTER(mw_Path_2E_join_with, "Path.join-with", "src/data/path.mth", 20, 5);
     WORD_ATOM(20, 5, "over2");
     mw_over2();
@@ -13492,7 +13388,7 @@ static void mw_Path_2E_join_with (void){
     }
     WORD_EXIT(mw_Path_2E_join_with);
 }
-static void mw_Path_2E_join_unix (void){
+static void mw_Path_2E_join_unix (void) {
     WORD_ENTER(mw_Path_2E_join_unix, "Path.join-unix", "src/data/path.mth", 26, 40);
     WORD_ATOM(26, 40, "dip");
     {
@@ -13514,7 +13410,7 @@ static void mw_Path_2E_join_unix (void){
     mw_Path_2E_join_with();
     WORD_EXIT(mw_Path_2E_join_unix);
 }
-static void mw_Path_2E_to_source_path (void){
+static void mw_Path_2E_to_source_path (void) {
     WORD_ENTER(mw_Path_2E_to_source_path, "Path.to-source-path", "src/data/path.mth", 29, 40);
     WORD_ATOM(29, 40, "dip");
     {
@@ -13529,7 +13425,7 @@ static void mw_Path_2E_to_source_path (void){
     mw_Path_2E_join_unix();
     WORD_EXIT(mw_Path_2E_to_source_path);
 }
-static void mw_Path_2E_to_output_path (void){
+static void mw_Path_2E_to_output_path (void) {
     WORD_ENTER(mw_Path_2E_to_output_path, "Path.to-output-path", "src/data/path.mth", 32, 40);
     WORD_ATOM(32, 40, "dip");
     {
@@ -13544,7 +13440,7 @@ static void mw_Path_2E_to_output_path (void){
     mw_Path_2E_join_unix();
     WORD_EXIT(mw_Path_2E_to_output_path);
 }
-static void mw_Path_2E_trace_21_ (void){
+static void mw_Path_2E_trace_21_ (void) {
     WORD_ENTER(mw_Path_2E_trace_21_, "Path.trace!", "src/data/path.mth", 34, 27);
     WORD_ATOM(34, 27, ">Str");
     mw_Path_3E_Str();
@@ -13552,20 +13448,20 @@ static void mw_Path_2E_trace_21_ (void){
     mw_Str_2E_trace_21_();
     WORD_EXIT(mw_Path_2E_trace_21_);
 }
-static void mw_Int_3E_File (void){
+static void mw_Int_3E_File (void) {
     WORD_ENTER(mw_Int_3E_File, "Int>File", "src/platform/posix.mth", 7, 28);
     WORD_ATOM(7, 28, "FILE");
     mw_FILE();
     WORD_EXIT(mw_Int_3E_File);
 }
-static void mw_File_3E_Int (void){
+static void mw_File_3E_Int (void) {
     WORD_ENTER(mw_File_3E_Int, "File>Int", "src/platform/posix.mth", 8, 28);
     WORD_ATOM(8, 28, "FILE");
     WORD_ATOM(8, 36, "id");
     mw_prim_id();
     WORD_EXIT(mw_File_3E_Int);
 }
-static void mw_STDIN (void){
+static void mw_STDIN (void) {
     WORD_ENTER(mw_STDIN, "STDIN", "src/platform/posix.mth", 10, 18);
     WORD_ATOM(10, 18, "");
     push_i64(0LL);
@@ -13573,7 +13469,7 @@ static void mw_STDIN (void){
     mw_Int_3E_File();
     WORD_EXIT(mw_STDIN);
 }
-static void mw_STDERR (void){
+static void mw_STDERR (void) {
     WORD_ENTER(mw_STDERR, "STDERR", "src/platform/posix.mth", 12, 19);
     WORD_ATOM(12, 19, "");
     push_i64(2LL);
@@ -13581,7 +13477,7 @@ static void mw_STDERR (void){
     mw_Int_3E_File();
     WORD_EXIT(mw_STDERR);
 }
-static void mw_Str_2E_write_21_ (void){
+static void mw_Str_2E_write_21_ (void) {
     WORD_ENTER(mw_Str_2E_write_21_, "Str.write!", "src/platform/posix.mth", 15, 5);
     WORD_ATOM(15, 5, "with-str-data");
     push_u64(0);
@@ -13590,7 +13486,7 @@ static void mw_Str_2E_write_21_ (void){
     mw_with_str_data();
     WORD_EXIT(mw_Str_2E_write_21_);
 }
-static void mw_slice_write_21_ (void){
+static void mw_slice_write_21_ (void) {
     WORD_ENTER(mw_slice_write_21_, "slice-write!", "src/platform/posix.mth", 18, 5);
     WORD_ATOM(18, 5, "dip2");
     push_u64(0);
@@ -13626,7 +13522,7 @@ static void mw_slice_write_21_ (void){
     mw_drop2();
     WORD_EXIT(mw_slice_write_21_);
 }
-static void mw_Str_2E_trace_21_ (void){
+static void mw_Str_2E_trace_21_ (void) {
     WORD_ENTER(mw_Str_2E_trace_21_, "Str.trace!", "src/platform/posix.mth", 24, 25);
     WORD_ATOM(24, 25, "dip");
     {
@@ -13639,7 +13535,7 @@ static void mw_Str_2E_trace_21_ (void){
     mw_Str_2E_write_21_();
     WORD_EXIT(mw_Str_2E_trace_21_);
 }
-static void mw_Str_2E_trace_ln_21_ (void){
+static void mw_Str_2E_trace_ln_21_ (void) {
     WORD_ENTER(mw_Str_2E_trace_ln_21_, "Str.trace-ln!", "src/platform/posix.mth", 26, 28);
     WORD_ATOM(26, 28, "trace!");
     mw_Str_2E_trace_21_();
@@ -13647,7 +13543,7 @@ static void mw_Str_2E_trace_ln_21_ (void){
     mw_line_trace_21_();
     WORD_EXIT(mw_Str_2E_trace_ln_21_);
 }
-static void mw_line_trace_21_ (void){
+static void mw_line_trace_21_ (void) {
     WORD_ENTER(mw_line_trace_21_, "line-trace!", "src/platform/posix.mth", 28, 22);
     WORD_ATOM(28, 22, "");
     {
@@ -13664,7 +13560,7 @@ static void mw_line_trace_21_ (void){
     mw_Str_2E_trace_21_();
     WORD_EXIT(mw_line_trace_21_);
 }
-static void mw_Int_2E_trace_21_ (void){
+static void mw_Int_2E_trace_21_ (void) {
     WORD_ENTER(mw_Int_2E_trace_21_, "Int.trace!", "src/platform/posix.mth", 32, 25);
     WORD_ATOM(32, 25, "int-to-str");
     mw_prim_int_to_str();
@@ -13672,7 +13568,7 @@ static void mw_Int_2E_trace_21_ (void){
     mw_Str_2E_trace_21_();
     WORD_EXIT(mw_Int_2E_trace_21_);
 }
-static void mw_with_open_file_21_ (void){
+static void mw_with_open_file_21_ (void) {
     WORD_ENTER(mw_with_open_file_21_, "with-open-file!", "src/platform/posix.mth", 37, 5);
     WORD_ATOM(37, 5, "");
     {
@@ -13718,13 +13614,13 @@ static void mw_with_open_file_21_ (void){
     }
     WORD_EXIT(mw_with_open_file_21_);
 }
-static void mw_READ_5F_FILE_5F_BUF_5F_SIZE (void){
+static void mw_READ_5F_FILE_5F_BUF_5F_SIZE (void) {
     WORD_ENTER(mw_READ_5F_FILE_5F_BUF_5F_SIZE, "READ_FILE_BUF_SIZE", "src/platform/posix.mth", 39, 31);
     WORD_ATOM(39, 31, "");
     push_i64(4096LL);
     WORD_EXIT(mw_READ_5F_FILE_5F_BUF_5F_SIZE);
 }
-static void mw_read_file_21_ (void){
+static void mw_read_file_21_ (void) {
     WORD_ENTER(mw_read_file_21_, "read-file!", "src/platform/posix.mth", 42, 5);
     WORD_ATOM(42, 5, "File>Int");
     mw_File_3E_Int();
@@ -13796,7 +13692,7 @@ static void mw_read_file_21_ (void){
     }
     WORD_EXIT(mw_read_file_21_);
 }
-static void mw_open_file_21_ (void){
+static void mw_open_file_21_ (void) {
     WORD_ENTER(mw_open_file_21_, "open-file!", "src/platform/posix.mth", 51, 5);
     WORD_ATOM(51, 5, "");
     push_i64(0LL);
@@ -13816,7 +13712,7 @@ static void mw_open_file_21_ (void){
     mw_Int_3E_File();
     WORD_EXIT(mw_open_file_21_);
 }
-static void mw_create_file_21_ (void){
+static void mw_create_file_21_ (void) {
     WORD_ENTER(mw_create_file_21_, "create-file!", "src/platform/posix.mth", 56, 5);
     WORD_ATOM(56, 5, "O_WRONLY|O_CREAT|O_TRUNC");
     mw_O_5F_WRONLY_7C_O_5F_CREAT_7C_O_5F_TRUNC();
@@ -13836,29 +13732,29 @@ static void mw_create_file_21_ (void){
     mw_Int_3E_File();
     WORD_EXIT(mw_create_file_21_);
 }
-static void mw_O_5F_WRONLY_7C_O_5F_CREAT_7C_O_5F_TRUNC (void){
+static void mw_O_5F_WRONLY_7C_O_5F_CREAT_7C_O_5F_TRUNC (void) {
     WORD_ENTER(mw_O_5F_WRONLY_7C_O_5F_CREAT_7C_O_5F_TRUNC, "O_WRONLY|O_CREAT|O_TRUNC", "src/platform/posix.mth", 67, 5);
     WORD_ATOM(67, 5, "RUNNING_OS");
     mw_RUNNING_5F_OS();
     WORD_ATOM(67, 16, "match");
     switch (get_top_data_tag()) {
         case 3LL:
-            co_OS_5F_MACOS();
+            mp_OS_5F_MACOS();
             WORD_ATOM(68, 21, "");
             push_i64(1537LL);
             break;
         case 2LL:
-            co_OS_5F_LINUX();
+            mp_OS_5F_LINUX();
             WORD_ATOM(69, 21, "");
             push_i64(577LL);
             break;
         case 1LL:
-            co_OS_5F_WINDOWS();
+            mp_OS_5F_WINDOWS();
             WORD_ATOM(70, 23, "");
             push_i64(769LL);
             break;
         case 0LL:
-            co_OS_5F_UNKNOWN();
+            mp_OS_5F_UNKNOWN();
             WORD_ATOM(71, 23, "");
             {
                 static bool vready = false;
@@ -13874,10 +13770,10 @@ static void mw_O_5F_WRONLY_7C_O_5F_CREAT_7C_O_5F_TRUNC (void){
             mw_prim_panic();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_O_5F_WRONLY_7C_O_5F_CREAT_7C_O_5F_TRUNC);
+    }
+    WORD_EXIT(mw_O_5F_WRONLY_7C_O_5F_CREAT_7C_O_5F_TRUNC);
 }
-static void mw_close_file_21_ (void){
+static void mw_close_file_21_ (void) {
     WORD_ENTER(mw_close_file_21_, "close-file!", "src/platform/posix.mth", 75, 5);
     WORD_ATOM(75, 5, "File>Int");
     mw_File_3E_Int();
@@ -13895,13 +13791,13 @@ static void mw_close_file_21_ (void){
     mw_prim_drop();
     WORD_EXIT(mw_close_file_21_);
 }
-static void mw_ready (void){
+static void mw_ready (void) {
     WORD_ENTER(mw_ready, "ready", "src/data/lazy.mth", 11, 5);
     WORD_ATOM(11, 5, "LAZY_READY");
     mw_LAZY_5F_READY();
     WORD_EXIT(mw_ready);
 }
-static void mw_ready2 (void){
+static void mw_ready2 (void) {
     WORD_ENTER(mw_ready2, "ready2", "src/data/lazy.mth", 13, 5);
     WORD_ATOM(13, 5, "pack2");
     mw_pack2();
@@ -13909,13 +13805,13 @@ static void mw_ready2 (void){
     mw_LAZY_5F_READY();
     WORD_EXIT(mw_ready2);
 }
-static void mw_delay (void){
+static void mw_delay (void) {
     WORD_ENTER(mw_delay, "delay", "src/data/lazy.mth", 15, 35);
     WORD_ATOM(15, 35, "LAZY_DELAY");
     mw_LAZY_5F_DELAY();
     WORD_EXIT(mw_delay);
 }
-static void mw_force_21_ (void){
+static void mw_force_21_ (void) {
     WORD_ENTER(mw_force_21_, "force!", "src/data/lazy.mth", 25, 5);
     WORD_ATOM(25, 5, "dup");
     mw_prim_dup();
@@ -13924,12 +13820,12 @@ static void mw_force_21_ (void){
     WORD_ATOM(25, 11, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_LAZY_5F_READY();
+            mp_LAZY_5F_READY();
             WORD_ATOM(26, 23, "nip");
             mw_nip();
             break;
         case 1LL:
-            co_LAZY_5F_DELAY();
+            mp_LAZY_5F_DELAY();
             WORD_ATOM(28, 13, "rotl");
             mw_rotl();
             WORD_ATOM(28, 18, "LAZY_WAIT");
@@ -13953,7 +13849,7 @@ static void mw_force_21_ (void){
             mw_prim_mut_set();
             break;
         case 2LL:
-            co_LAZY_5F_WAIT();
+            mp_LAZY_5F_WAIT();
             WORD_ATOM(31, 13, "");
             {
                 static bool vready = false;
@@ -13969,10 +13865,10 @@ static void mw_force_21_ (void){
             mw_prim_panic();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_force_21_);
+    }
+    WORD_EXIT(mw_force_21_);
 }
-static void mw_force_or_21_ (void){
+static void mw_force_or_21_ (void) {
     WORD_ENTER(mw_force_or_21_, "force-or!", "src/data/lazy.mth", 34, 5);
     WORD_ATOM(34, 5, "dup");
     {
@@ -13984,7 +13880,7 @@ static void mw_force_or_21_ (void){
         WORD_ATOM(34, 11, "match");
         switch (get_top_data_tag()) {
             case 2LL:
-                co_LAZY_5F_WAIT();
+                mp_LAZY_5F_WAIT();
                 WORD_ATOM(35, 22, "drop");
                 mw_prim_drop();
                 WORD_ATOM(35, 27, "f");
@@ -13997,18 +13893,18 @@ static void mw_force_or_21_ (void){
                 WORD_ATOM(36, 19, "force!");
                 mw_force_21_();
                 break;
-        
-}        decref(var_f);
+        }
+        decref(var_f);
     }
     WORD_EXIT(mw_force_or_21_);
 }
-static void mw_Var_2E_id (void){
+static void mw_Var_2E_id (void) {
     WORD_ENTER(mw_Var_2E_id, "Var.id", "src/mirth/data/var.mth", 13, 7);
     WORD_ATOM(13, 7, "Var");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Var_2E_id);
 }
-static void mw_Var_2E_alloc_21_ (void){
+static void mw_Var_2E_alloc_21_ (void) {
     WORD_ENTER(mw_Var_2E_alloc_21_, "Var.alloc!", "src/mirth/data/var.mth", 13, 7);
     WORD_ATOM(13, 7, "Var");
     mw_Var_2E_NUM();
@@ -14032,7 +13928,7 @@ static void mw_Var_2E_alloc_21_ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Var_2E_alloc_21_);
 }
-static void mw_Var_2E_name (void){
+static void mw_Var_2E_name (void) {
     WORD_ENTER(mw_Var_2E_name, "Var.name", "src/mirth/data/var.mth", 18, 28);
     WORD_ATOM(18, 28, "~name");
     mw_Var_7E_name();
@@ -14040,7 +13936,7 @@ static void mw_Var_2E_name (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Var_2E_name);
 }
-static void mw_Var_2E_type (void){
+static void mw_Var_2E_type (void) {
     WORD_ENTER(mw_Var_2E_type, "Var.type", "src/mirth/data/var.mth", 19, 28);
     WORD_ATOM(19, 28, "~type");
     mw_Var_7E_type();
@@ -14048,7 +13944,7 @@ static void mw_Var_2E_type (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Var_2E_type);
 }
-static void mw_Var_2E_auto_run_3F_ (void){
+static void mw_Var_2E_auto_run_3F_ (void) {
     WORD_ENTER(mw_Var_2E_auto_run_3F_, "Var.auto-run?", "src/mirth/data/var.mth", 20, 33);
     WORD_ATOM(20, 33, "~auto-run?");
     mw_Var_7E_auto_run_3F_();
@@ -14056,7 +13952,7 @@ static void mw_Var_2E_auto_run_3F_ (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Var_2E_auto_run_3F_);
 }
-static void mw_Var_3D_ (void){
+static void mw_Var_3D_ (void) {
     WORD_ENTER(mw_Var_3D_, "Var=", "src/mirth/data/var.mth", 22, 28);
     WORD_ATOM(22, 28, "both");
     push_u64(0);
@@ -14067,7 +13963,7 @@ static void mw_Var_3D_ (void){
     mw_prim_int_eq();
     WORD_EXIT(mw_Var_3D_);
 }
-static void mw_Var_2E_trace_21_ (void){
+static void mw_Var_2E_trace_21_ (void) {
     WORD_ENTER(mw_Var_2E_trace_21_, "Var.trace!", "src/mirth/data/var.mth", 23, 25);
     WORD_ATOM(23, 25, "name");
     mw_Var_2E_name();
@@ -14075,7 +13971,7 @@ static void mw_Var_2E_trace_21_ (void){
     mw_Name_2E_trace_21_();
     WORD_EXIT(mw_Var_2E_trace_21_);
 }
-static void mw_Var_2E_is_stack_3F_ (void){
+static void mw_Var_2E_is_stack_3F_ (void) {
     WORD_ENTER(mw_Var_2E_is_stack_3F_, "Var.is-stack?", "src/mirth/data/var.mth", 25, 33);
     WORD_ATOM(25, 33, "type");
     mw_Var_2E_type();
@@ -14088,7 +13984,7 @@ static void mw_Var_2E_is_stack_3F_ (void){
     mw_Maybe_2E_and_some();
     WORD_EXIT(mw_Var_2E_is_stack_3F_);
 }
-static void mw_Var_2E_is_physical_3F_ (void){
+static void mw_Var_2E_is_physical_3F_ (void) {
     WORD_ENTER(mw_Var_2E_is_physical_3F_, "Var.is-physical?", "src/mirth/data/var.mth", 27, 36);
     WORD_ATOM(27, 36, "type");
     mw_Var_2E_type();
@@ -14096,7 +13992,7 @@ static void mw_Var_2E_is_physical_3F_ (void){
     mw_Type_2E_is_physical_3F_();
     WORD_EXIT(mw_Var_2E_is_physical_3F_);
 }
-static void mw_Var_2E_new_21_ (void){
+static void mw_Var_2E_new_21_ (void) {
     WORD_ENTER(mw_Var_2E_new_21_, "Var.new!", "src/mirth/data/var.mth", 30, 5);
     WORD_ATOM(30, 5, "Var.alloc!");
     mw_Var_2E_alloc_21_();
@@ -14122,7 +14018,7 @@ static void mw_Var_2E_new_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_Var_2E_new_21_);
 }
-static void mw_Var_2E_new_auto_run_21_ (void){
+static void mw_Var_2E_new_auto_run_21_ (void) {
     WORD_ENTER(mw_Var_2E_new_auto_run_21_, "Var.new-auto-run!", "src/mirth/data/var.mth", 36, 5);
     WORD_ATOM(36, 5, "Var.new!");
     mw_Var_2E_new_21_();
@@ -14136,20 +14032,20 @@ static void mw_Var_2E_new_auto_run_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_Var_2E_new_auto_run_21_);
 }
-static void mw_List_3E_Ctx (void){
+static void mw_List_3E_Ctx (void) {
     WORD_ENTER(mw_List_3E_Ctx, "List>Ctx", "src/mirth/data/ctx.mth", 16, 33);
     WORD_ATOM(16, 33, "CTX");
     mw_CTX();
     WORD_EXIT(mw_List_3E_Ctx);
 }
-static void mw_Ctx_3E_List (void){
+static void mw_Ctx_3E_List (void) {
     WORD_ENTER(mw_Ctx_3E_List, "Ctx>List", "src/mirth/data/ctx.mth", 17, 33);
     WORD_ATOM(17, 33, "CTX");
     WORD_ATOM(17, 40, "id");
     mw_prim_id();
     WORD_EXIT(mw_Ctx_3E_List);
 }
-static void mw_CTX0 (void){
+static void mw_CTX0 (void) {
     WORD_ENTER(mw_CTX0, "CTX0", "src/mirth/data/ctx.mth", 19, 16);
     WORD_ATOM(19, 16, "L0");
     mw_L0();
@@ -14157,7 +14053,7 @@ static void mw_CTX0 (void){
     mw_CTX();
     WORD_EXIT(mw_CTX0);
 }
-static void mw_CTX1 (void){
+static void mw_CTX1 (void) {
     WORD_ENTER(mw_CTX1, "CTX1", "src/mirth/data/ctx.mth", 20, 23);
     WORD_ATOM(20, 23, "L1");
     mw_L1();
@@ -14165,7 +14061,7 @@ static void mw_CTX1 (void){
     mw_CTX();
     WORD_EXIT(mw_CTX1);
 }
-static void mw_CTX2 (void){
+static void mw_CTX2 (void) {
     WORD_ENTER(mw_CTX2, "CTX2", "src/mirth/data/ctx.mth", 21, 27);
     WORD_ATOM(21, 27, "L2");
     mw_L2();
@@ -14173,7 +14069,7 @@ static void mw_CTX2 (void){
     mw_CTX();
     WORD_EXIT(mw_CTX2);
 }
-static void mw_CTX3 (void){
+static void mw_CTX3 (void) {
     WORD_ENTER(mw_CTX3, "CTX3", "src/mirth/data/ctx.mth", 22, 31);
     WORD_ATOM(22, 31, "L3");
     mw_L3();
@@ -14181,7 +14077,7 @@ static void mw_CTX3 (void){
     mw_CTX();
     WORD_EXIT(mw_CTX3);
 }
-static void mw_Ctx_2E_new (void){
+static void mw_Ctx_2E_new (void) {
     WORD_ENTER(mw_Ctx_2E_new, "Ctx.new", "src/mirth/data/ctx.mth", 25, 30);
     WORD_ATOM(25, 30, "dip");
     {
@@ -14196,13 +14092,13 @@ static void mw_Ctx_2E_new (void){
     mw_List_3E_Ctx();
     WORD_EXIT(mw_Ctx_2E_new);
 }
-static void mw_Ctx_2E_vars (void){
+static void mw_Ctx_2E_vars (void) {
     WORD_ENTER(mw_Ctx_2E_vars, "Ctx.vars", "src/mirth/data/ctx.mth", 27, 33);
     WORD_ATOM(27, 33, ">List");
     mw_Ctx_3E_List();
     WORD_EXIT(mw_Ctx_2E_vars);
 }
-static void mw_Ctx_2E_physical_vars (void){
+static void mw_Ctx_2E_physical_vars (void) {
     WORD_ENTER(mw_Ctx_2E_physical_vars, "Ctx.physical-vars", "src/mirth/data/ctx.mth", 28, 42);
     WORD_ATOM(28, 42, "vars");
     mw_Ctx_2E_vars();
@@ -14213,7 +14109,7 @@ static void mw_Ctx_2E_physical_vars (void){
     mw_List_2E_filter();
     WORD_EXIT(mw_Ctx_2E_physical_vars);
 }
-static void mw_Ctx_2E_lookup (void){
+static void mw_Ctx_2E_lookup (void) {
     WORD_ENTER(mw_Ctx_2E_lookup, "Ctx.lookup", "src/mirth/data/ctx.mth", 30, 41);
     WORD_ATOM(30, 41, ">List");
     mw_Ctx_3E_List();
@@ -14226,13 +14122,13 @@ static void mw_Ctx_2E_lookup (void){
     mw_nip();
     WORD_EXIT(mw_Ctx_2E_lookup);
 }
-static void mw_Data_2E_id (void){
+static void mw_Data_2E_id (void) {
     WORD_ENTER(mw_Data_2E_id, "Data.id", "src/mirth/data/data.mth", 13, 7);
     WORD_ATOM(13, 7, "Data");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Data_2E_id);
 }
-static void mw_Data_2E_alloc_21_ (void){
+static void mw_Data_2E_alloc_21_ (void) {
     WORD_ENTER(mw_Data_2E_alloc_21_, "Data.alloc!", "src/mirth/data/data.mth", 13, 7);
     WORD_ATOM(13, 7, "Data");
     mw_Data_2E_NUM();
@@ -14256,7 +14152,7 @@ static void mw_Data_2E_alloc_21_ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Data_2E_alloc_21_);
 }
-static void mw_Data_2E_head_3F_ (void){
+static void mw_Data_2E_head_3F_ (void) {
     WORD_ENTER(mw_Data_2E_head_3F_, "Data.head?", "src/mirth/data/data.mth", 19, 39);
     WORD_ATOM(19, 39, "~head?");
     mw_Data_7E_head_3F_();
@@ -14264,7 +14160,7 @@ static void mw_Data_2E_head_3F_ (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Data_2E_head_3F_);
 }
-static void mw_Data_2E_name (void){
+static void mw_Data_2E_name (void) {
     WORD_ENTER(mw_Data_2E_name, "Data.name", "src/mirth/data/data.mth", 20, 30);
     WORD_ATOM(20, 30, "~name");
     mw_Data_7E_name();
@@ -14272,7 +14168,7 @@ static void mw_Data_2E_name (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Data_2E_name);
 }
-static void mw_Data_2E_arity (void){
+static void mw_Data_2E_arity (void) {
     WORD_ENTER(mw_Data_2E_arity, "Data.arity", "src/mirth/data/data.mth", 21, 30);
     WORD_ATOM(21, 30, "~arity");
     mw_Data_7E_arity();
@@ -14280,7 +14176,7 @@ static void mw_Data_2E_arity (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Data_2E_arity);
 }
-static void mw_Data_2E_tags (void){
+static void mw_Data_2E_tags (void) {
     WORD_ENTER(mw_Data_2E_tags, "Data.tags", "src/mirth/data/data.mth", 22, 35);
     WORD_ATOM(22, 35, "~tags");
     mw_Data_7E_tags();
@@ -14288,7 +14184,7 @@ static void mw_Data_2E_tags (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Data_2E_tags);
 }
-static void mw_TYPE_5F_BOOL (void){
+static void mw_TYPE_5F_BOOL (void) {
     WORD_ENTER(mw_TYPE_5F_BOOL, "TYPE_BOOL", "src/mirth/data/data.mth", 27, 22);
     WORD_ATOM(27, 22, "DATA_BOOL");
     mw_DATA_5F_BOOL();
@@ -14298,7 +14194,7 @@ static void mw_TYPE_5F_BOOL (void){
     mw_TData();
     WORD_EXIT(mw_TYPE_5F_BOOL);
 }
-static void mw_TYPE_5F_U64 (void){
+static void mw_TYPE_5F_U64 (void) {
     WORD_ENTER(mw_TYPE_5F_U64, "TYPE_U64", "src/mirth/data/data.mth", 37, 21);
     WORD_ATOM(37, 21, "DATA_U64");
     mw_DATA_5F_U64();
@@ -14308,7 +14204,7 @@ static void mw_TYPE_5F_U64 (void){
     mw_TData();
     WORD_EXIT(mw_TYPE_5F_U64);
 }
-static void mw_TYPE_5F_U32 (void){
+static void mw_TYPE_5F_U32 (void) {
     WORD_ENTER(mw_TYPE_5F_U32, "TYPE_U32", "src/mirth/data/data.mth", 38, 21);
     WORD_ATOM(38, 21, "DATA_U32");
     mw_DATA_5F_U32();
@@ -14318,7 +14214,7 @@ static void mw_TYPE_5F_U32 (void){
     mw_TData();
     WORD_EXIT(mw_TYPE_5F_U32);
 }
-static void mw_TYPE_5F_U16 (void){
+static void mw_TYPE_5F_U16 (void) {
     WORD_ENTER(mw_TYPE_5F_U16, "TYPE_U16", "src/mirth/data/data.mth", 39, 21);
     WORD_ATOM(39, 21, "DATA_U16");
     mw_DATA_5F_U16();
@@ -14328,7 +14224,7 @@ static void mw_TYPE_5F_U16 (void){
     mw_TData();
     WORD_EXIT(mw_TYPE_5F_U16);
 }
-static void mw_TYPE_5F_U8 (void){
+static void mw_TYPE_5F_U8 (void) {
     WORD_ENTER(mw_TYPE_5F_U8, "TYPE_U8", "src/mirth/data/data.mth", 40, 20);
     WORD_ATOM(40, 20, "DATA_U8");
     mw_DATA_5F_U8();
@@ -14338,7 +14234,7 @@ static void mw_TYPE_5F_U8 (void){
     mw_TData();
     WORD_EXIT(mw_TYPE_5F_U8);
 }
-static void mw_TYPE_5F_I64 (void){
+static void mw_TYPE_5F_I64 (void) {
     WORD_ENTER(mw_TYPE_5F_I64, "TYPE_I64", "src/mirth/data/data.mth", 41, 21);
     WORD_ATOM(41, 21, "DATA_I64");
     mw_DATA_5F_I64();
@@ -14348,7 +14244,7 @@ static void mw_TYPE_5F_I64 (void){
     mw_TData();
     WORD_EXIT(mw_TYPE_5F_I64);
 }
-static void mw_TYPE_5F_I32 (void){
+static void mw_TYPE_5F_I32 (void) {
     WORD_ENTER(mw_TYPE_5F_I32, "TYPE_I32", "src/mirth/data/data.mth", 42, 21);
     WORD_ATOM(42, 21, "DATA_I32");
     mw_DATA_5F_I32();
@@ -14358,7 +14254,7 @@ static void mw_TYPE_5F_I32 (void){
     mw_TData();
     WORD_EXIT(mw_TYPE_5F_I32);
 }
-static void mw_TYPE_5F_I16 (void){
+static void mw_TYPE_5F_I16 (void) {
     WORD_ENTER(mw_TYPE_5F_I16, "TYPE_I16", "src/mirth/data/data.mth", 43, 21);
     WORD_ATOM(43, 21, "DATA_I16");
     mw_DATA_5F_I16();
@@ -14368,7 +14264,7 @@ static void mw_TYPE_5F_I16 (void){
     mw_TData();
     WORD_EXIT(mw_TYPE_5F_I16);
 }
-static void mw_TYPE_5F_I8 (void){
+static void mw_TYPE_5F_I8 (void) {
     WORD_ENTER(mw_TYPE_5F_I8, "TYPE_I8", "src/mirth/data/data.mth", 44, 20);
     WORD_ATOM(44, 20, "DATA_I8");
     mw_DATA_5F_I8();
@@ -14378,7 +14274,7 @@ static void mw_TYPE_5F_I8 (void){
     mw_TData();
     WORD_EXIT(mw_TYPE_5F_I8);
 }
-static void mw_make_data_21_ (void){
+static void mw_make_data_21_ (void) {
     WORD_ENTER(mw_make_data_21_, "make-data!", "src/mirth/data/data.mth", 47, 5);
     WORD_ATOM(47, 5, "dip");
     {
@@ -14464,7 +14360,7 @@ static void mw_make_data_21_ (void){
     mw_prim_drop();
     WORD_EXIT(mw_make_data_21_);
 }
-static void mw_make_tag_21_ (void){
+static void mw_make_tag_21_ (void) {
     WORD_ENTER(mw_make_tag_21_, "make-tag!", "src/mirth/data/data.mth", 65, 5);
     WORD_ATOM(65, 5, "@");
     mw_prim_mut_get();
@@ -14528,7 +14424,7 @@ static void mw_make_tag_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_make_tag_21_);
 }
-static void mw_init_data_21_ (void){
+static void mw_init_data_21_ (void) {
     WORD_ENTER(mw_init_data_21_, "init-data!", "src/mirth/data/data.mth", 75, 5);
     WORD_ATOM(75, 5, "");
     {
@@ -14911,7 +14807,7 @@ static void mw_init_data_21_ (void){
     mw_make_tag_21_();
     WORD_EXIT(mw_init_data_21_);
 }
-static void mw_Data_3D_ (void){
+static void mw_Data_3D_ (void) {
     WORD_ENTER(mw_Data_3D_, "Data=", "src/mirth/data/data.mth", 92, 31);
     WORD_ATOM(92, 31, "both");
     push_u64(0);
@@ -14922,7 +14818,7 @@ static void mw_Data_3D_ (void){
     mw_prim_int_eq();
     WORD_EXIT(mw_Data_3D_);
 }
-static void mw_Data_2E_num_tags (void){
+static void mw_Data_2E_num_tags (void) {
     WORD_ENTER(mw_Data_2E_num_tags, "Data.num-tags", "src/mirth/data/data.mth", 93, 33);
     WORD_ATOM(93, 33, "tags");
     mw_Data_2E_tags();
@@ -14930,7 +14826,7 @@ static void mw_Data_2E_num_tags (void){
     mw_List_2E_len();
     WORD_EXIT(mw_Data_2E_num_tags);
 }
-static void mw_Data_2E_add_tag_21_ (void){
+static void mw_Data_2E_add_tag_21_ (void) {
     WORD_ENTER(mw_Data_2E_add_tag_21_, "Data.add-tag!", "src/mirth/data/data.mth", 97, 5);
     WORD_ATOM(97, 5, "dup2");
     mw_dup2();
@@ -14961,7 +14857,7 @@ static void mw_Data_2E_add_tag_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_Data_2E_add_tag_21_);
 }
-static void mw_Data_2E_is_transparent_3F_ (void){
+static void mw_Data_2E_is_transparent_3F_ (void) {
     WORD_ENTER(mw_Data_2E_is_transparent_3F_, "Data.is-transparent?", "src/mirth/data/data.mth", 104, 5);
     WORD_ATOM(104, 5, "dup");
     mw_prim_dup();
@@ -14979,7 +14875,7 @@ static void mw_Data_2E_is_transparent_3F_ (void){
         WORD_ATOM(106, 14, "match");
         switch (get_top_data_tag()) {
             case 1LL:
-                co_L1();
+                mp_L1();
                 WORD_ATOM(107, 19, "dup");
                 mw_prim_dup();
                 WORD_ATOM(107, 23, "num-type-inputs");
@@ -15005,11 +14901,11 @@ static void mw_Data_2E_is_transparent_3F_ (void){
                 WORD_ATOM(108, 23, "F");
                 mw_F();
                 break;
-        
-}    }
+        }
+    }
     WORD_EXIT(mw_Data_2E_is_transparent_3F_);
 }
-static void mw_Data_2E_is_resource_3F_ (void){
+static void mw_Data_2E_is_resource_3F_ (void) {
     WORD_ENTER(mw_Data_2E_is_resource_3F_, "Data.is-resource?", "src/mirth/data/data.mth", 113, 5);
     WORD_ATOM(113, 5, "name");
     mw_Data_2E_name();
@@ -15017,13 +14913,13 @@ static void mw_Data_2E_is_resource_3F_ (void){
     mw_Name_2E_could_be_resource_con();
     WORD_EXIT(mw_Data_2E_is_resource_3F_);
 }
-static void mw_Tag_2E_id (void){
+static void mw_Tag_2E_id (void) {
     WORD_ENTER(mw_Tag_2E_id, "Tag.id", "src/mirth/data/data.mth", 119, 7);
     WORD_ATOM(119, 7, "Tag");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Tag_2E_id);
 }
-static void mw_Tag_2E_for (void){
+static void mw_Tag_2E_for (void) {
     WORD_ENTER(mw_Tag_2E_for, "Tag.for", "src/mirth/data/data.mth", 119, 7);
     WORD_ATOM(119, 7, "Tag");
     {
@@ -15070,7 +14966,7 @@ static void mw_Tag_2E_for (void){
     }
     WORD_EXIT(mw_Tag_2E_for);
 }
-static void mw_Tag_2E_alloc_21_ (void){
+static void mw_Tag_2E_alloc_21_ (void) {
     WORD_ENTER(mw_Tag_2E_alloc_21_, "Tag.alloc!", "src/mirth/data/data.mth", 119, 7);
     WORD_ATOM(119, 7, "Tag");
     mw_Tag_2E_NUM();
@@ -15094,7 +14990,7 @@ static void mw_Tag_2E_alloc_21_ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Tag_2E_alloc_21_);
 }
-static void mw_Tag_2E_data (void){
+static void mw_Tag_2E_data (void) {
     WORD_ENTER(mw_Tag_2E_data, "Tag.data", "src/mirth/data/data.mth", 128, 28);
     WORD_ATOM(128, 28, "~data");
     mw_Tag_7E_data();
@@ -15102,7 +14998,7 @@ static void mw_Tag_2E_data (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Tag_2E_data);
 }
-static void mw_Tag_2E_name (void){
+static void mw_Tag_2E_name (void) {
     WORD_ENTER(mw_Tag_2E_name, "Tag.name", "src/mirth/data/data.mth", 129, 28);
     WORD_ATOM(129, 28, "~name");
     mw_Tag_7E_name();
@@ -15110,7 +15006,7 @@ static void mw_Tag_2E_name (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Tag_2E_name);
 }
-static void mw_Tag_2E_value (void){
+static void mw_Tag_2E_value (void) {
     WORD_ENTER(mw_Tag_2E_value, "Tag.value", "src/mirth/data/data.mth", 130, 28);
     WORD_ATOM(130, 28, "~value");
     mw_Tag_7E_value();
@@ -15118,7 +15014,7 @@ static void mw_Tag_2E_value (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Tag_2E_value);
 }
-static void mw_Tag_2E_num_type_inputs (void){
+static void mw_Tag_2E_num_type_inputs (void) {
     WORD_ENTER(mw_Tag_2E_num_type_inputs, "Tag.num-type-inputs", "src/mirth/data/data.mth", 131, 38);
     WORD_ATOM(131, 38, "~num-type-inputs");
     mw_Tag_7E_num_type_inputs();
@@ -15126,7 +15022,7 @@ static void mw_Tag_2E_num_type_inputs (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Tag_2E_num_type_inputs);
 }
-static void mw_Tag_2E_num_resource_inputs (void){
+static void mw_Tag_2E_num_resource_inputs (void) {
     WORD_ENTER(mw_Tag_2E_num_resource_inputs, "Tag.num-resource-inputs", "src/mirth/data/data.mth", 132, 42);
     WORD_ATOM(132, 42, "~num-resource-inputs");
     mw_Tag_7E_num_resource_inputs();
@@ -15134,7 +15030,7 @@ static void mw_Tag_2E_num_resource_inputs (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Tag_2E_num_resource_inputs);
 }
-static void mw_Tag_2E_sig_3F_ (void){
+static void mw_Tag_2E_sig_3F_ (void) {
     WORD_ENTER(mw_Tag_2E_sig_3F_, "Tag.sig?", "src/mirth/data/data.mth", 133, 36);
     WORD_ATOM(133, 36, "~sig?");
     mw_Tag_7E_sig_3F_();
@@ -15142,7 +15038,7 @@ static void mw_Tag_2E_sig_3F_ (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Tag_2E_sig_3F_);
 }
-static void mw_Tag_2E_ctx_type (void){
+static void mw_Tag_2E_ctx_type (void) {
     WORD_ENTER(mw_Tag_2E_ctx_type, "Tag.ctx-type", "src/mirth/data/data.mth", 134, 41);
     WORD_ATOM(134, 41, "~ctx-type");
     mw_Tag_7E_ctx_type();
@@ -15152,7 +15048,7 @@ static void mw_Tag_2E_ctx_type (void){
     mw_unpack2();
     WORD_EXIT(mw_Tag_2E_ctx_type);
 }
-static void mw_Tag_2E_type (void){
+static void mw_Tag_2E_type (void) {
     WORD_ENTER(mw_Tag_2E_type, "Tag.type", "src/mirth/data/data.mth", 136, 33);
     WORD_ATOM(136, 33, "ctx-type");
     mw_Tag_2E_ctx_type();
@@ -15160,7 +15056,7 @@ static void mw_Tag_2E_type (void){
     mw_nip();
     WORD_EXIT(mw_Tag_2E_type);
 }
-static void mw_Tag_2E_num_type_inputs_from_sig (void){
+static void mw_Tag_2E_num_type_inputs_from_sig (void) {
     WORD_ENTER(mw_Tag_2E_num_type_inputs_from_sig, "Tag.num-type-inputs-from-sig", "src/mirth/data/data.mth", 139, 5);
     WORD_ATOM(139, 5, "dup");
     mw_prim_dup();
@@ -15176,7 +15072,7 @@ static void mw_Tag_2E_num_type_inputs_from_sig (void){
     mw_Maybe_2E_if_some();
     WORD_EXIT(mw_Tag_2E_num_type_inputs_from_sig);
 }
-static void mw_Tag_2E_num_resource_inputs_from_sig (void){
+static void mw_Tag_2E_num_resource_inputs_from_sig (void) {
     WORD_ENTER(mw_Tag_2E_num_resource_inputs_from_sig, "Tag.num-resource-inputs-from-sig", "src/mirth/data/data.mth", 146, 5);
     WORD_ATOM(146, 5, "sig?");
     mw_Tag_2E_sig_3F_();
@@ -15190,7 +15086,7 @@ static void mw_Tag_2E_num_resource_inputs_from_sig (void){
     mw_Maybe_2E_if_some();
     WORD_EXIT(mw_Tag_2E_num_resource_inputs_from_sig);
 }
-static void mw_Tag_2E_is_transparent_3F_ (void){
+static void mw_Tag_2E_is_transparent_3F_ (void) {
     WORD_ENTER(mw_Tag_2E_is_transparent_3F_, "Tag.is-transparent?", "src/mirth/data/data.mth", 154, 5);
     WORD_ATOM(154, 5, ".data");
     mw_Tag_2E_data();
@@ -15198,7 +15094,7 @@ static void mw_Tag_2E_is_transparent_3F_ (void){
     mw_Data_2E_is_transparent_3F_();
     WORD_EXIT(mw_Tag_2E_is_transparent_3F_);
 }
-static void mw_Tag_2E_outputs_resource_3F_ (void){
+static void mw_Tag_2E_outputs_resource_3F_ (void) {
     WORD_ENTER(mw_Tag_2E_outputs_resource_3F_, "Tag.outputs-resource?", "src/mirth/data/data.mth", 157, 5);
     WORD_ATOM(157, 5, ".data");
     mw_Tag_2E_data();
@@ -15206,7 +15102,7 @@ static void mw_Tag_2E_outputs_resource_3F_ (void){
     mw_Data_2E_is_resource_3F_();
     WORD_EXIT(mw_Tag_2E_outputs_resource_3F_);
 }
-static void mw_Tag_3D_ (void){
+static void mw_Tag_3D_ (void) {
     WORD_ENTER(mw_Tag_3D_, "Tag=", "src/mirth/data/data.mth", 159, 28);
     WORD_ATOM(159, 28, "both");
     push_u64(0);
@@ -15217,7 +15113,7 @@ static void mw_Tag_3D_ (void){
     mw_prim_int_eq();
     WORD_EXIT(mw_Tag_3D_);
 }
-static void mw_Match_2E_alloc_21_ (void){
+static void mw_Match_2E_alloc_21_ (void) {
     WORD_ENTER(mw_Match_2E_alloc_21_, "Match.alloc!", "src/mirth/data/match.mth", 14, 7);
     WORD_ATOM(14, 7, "Match");
     mw_Match_2E_NUM();
@@ -15241,7 +15137,7 @@ static void mw_Match_2E_alloc_21_ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Match_2E_alloc_21_);
 }
-static void mw_Match_2E_ctx (void){
+static void mw_Match_2E_ctx (void) {
     WORD_ENTER(mw_Match_2E_ctx, "Match.ctx", "src/mirth/data/match.mth", 21, 30);
     WORD_ATOM(21, 30, "~ctx");
     mw_Match_7E_ctx();
@@ -15249,7 +15145,7 @@ static void mw_Match_2E_ctx (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Match_2E_ctx);
 }
-static void mw_Match_2E_dom (void){
+static void mw_Match_2E_dom (void) {
     WORD_ENTER(mw_Match_2E_dom, "Match.dom", "src/mirth/data/match.mth", 22, 36);
     WORD_ATOM(22, 36, "~dom");
     mw_Match_7E_dom();
@@ -15257,7 +15153,7 @@ static void mw_Match_2E_dom (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Match_2E_dom);
 }
-static void mw_Match_2E_cod (void){
+static void mw_Match_2E_cod (void) {
     WORD_ENTER(mw_Match_2E_cod, "Match.cod", "src/mirth/data/match.mth", 23, 36);
     WORD_ATOM(23, 36, "~cod");
     mw_Match_7E_cod();
@@ -15265,7 +15161,7 @@ static void mw_Match_2E_cod (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Match_2E_cod);
 }
-static void mw_Match_2E_token (void){
+static void mw_Match_2E_token (void) {
     WORD_ENTER(mw_Match_2E_token, "Match.token", "src/mirth/data/match.mth", 24, 34);
     WORD_ATOM(24, 34, "~token");
     mw_Match_7E_token();
@@ -15273,7 +15169,7 @@ static void mw_Match_2E_token (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Match_2E_token);
 }
-static void mw_Match_2E_body (void){
+static void mw_Match_2E_body (void) {
     WORD_ENTER(mw_Match_2E_body, "Match.body", "src/mirth/data/match.mth", 25, 33);
     WORD_ATOM(25, 33, "~body");
     mw_Match_7E_body();
@@ -15281,7 +15177,7 @@ static void mw_Match_2E_body (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Match_2E_body);
 }
-static void mw_Match_2E_cases (void){
+static void mw_Match_2E_cases (void) {
     WORD_ENTER(mw_Match_2E_cases, "Match.cases", "src/mirth/data/match.mth", 26, 39);
     WORD_ATOM(26, 39, "~cases");
     mw_Match_7E_cases();
@@ -15289,7 +15185,7 @@ static void mw_Match_2E_cases (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Match_2E_cases);
 }
-static void mw_Case_2E_alloc_21_ (void){
+static void mw_Case_2E_alloc_21_ (void) {
     WORD_ENTER(mw_Case_2E_alloc_21_, "Case.alloc!", "src/mirth/data/match.mth", 28, 7);
     WORD_ATOM(28, 7, "Case");
     mw_Case_2E_NUM();
@@ -15313,7 +15209,7 @@ static void mw_Case_2E_alloc_21_ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Case_2E_alloc_21_);
 }
-static void mw_Case_2E_match (void){
+static void mw_Case_2E_match (void) {
     WORD_ENTER(mw_Case_2E_match, "Case.match", "src/mirth/data/match.mth", 35, 32);
     WORD_ATOM(35, 32, "~match");
     mw_Case_7E_match();
@@ -15321,7 +15217,7 @@ static void mw_Case_2E_match (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Case_2E_match);
 }
-static void mw_Case_2E_token (void){
+static void mw_Case_2E_token (void) {
     WORD_ENTER(mw_Case_2E_token, "Case.token", "src/mirth/data/match.mth", 36, 32);
     WORD_ATOM(36, 32, "~token");
     mw_Case_7E_token();
@@ -15329,7 +15225,7 @@ static void mw_Case_2E_token (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Case_2E_token);
 }
-static void mw_Case_2E_pattern (void){
+static void mw_Case_2E_pattern (void) {
     WORD_ENTER(mw_Case_2E_pattern, "Case.pattern", "src/mirth/data/match.mth", 37, 36);
     WORD_ATOM(37, 36, "~pattern");
     mw_Case_7E_pattern();
@@ -15337,7 +15233,7 @@ static void mw_Case_2E_pattern (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Case_2E_pattern);
 }
-static void mw_Case_2E_mid (void){
+static void mw_Case_2E_mid (void) {
     WORD_ENTER(mw_Case_2E_mid, "Case.mid", "src/mirth/data/match.mth", 39, 34);
     WORD_ATOM(39, 34, "~mid");
     mw_Case_7E_mid();
@@ -15345,7 +15241,7 @@ static void mw_Case_2E_mid (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Case_2E_mid);
 }
-static void mw_Case_2E_body (void){
+static void mw_Case_2E_body (void) {
     WORD_ENTER(mw_Case_2E_body, "Case.body", "src/mirth/data/match.mth", 40, 31);
     WORD_ATOM(40, 31, "~body");
     mw_Case_7E_body();
@@ -15353,7 +15249,7 @@ static void mw_Case_2E_body (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Case_2E_body);
 }
-static void mw_Match_2E_is_exhaustive_3F_ (void){
+static void mw_Match_2E_is_exhaustive_3F_ (void) {
     WORD_ENTER(mw_Match_2E_is_exhaustive_3F_, "Match.is-exhaustive?", "src/mirth/data/match.mth", 43, 5);
     WORD_ATOM(43, 5, "dup");
     mw_prim_dup();
@@ -15368,7 +15264,7 @@ static void mw_Match_2E_is_exhaustive_3F_ (void){
     mw_nip();
     WORD_EXIT(mw_Match_2E_is_exhaustive_3F_);
 }
-static void mw_Match_2E_has_default_case_3F_ (void){
+static void mw_Match_2E_has_default_case_3F_ (void) {
     WORD_ENTER(mw_Match_2E_has_default_case_3F_, "Match.has-default-case?", "src/mirth/data/match.mth", 56, 5);
     WORD_ATOM(56, 5, "cases");
     mw_Match_2E_cases();
@@ -15379,7 +15275,7 @@ static void mw_Match_2E_has_default_case_3F_ (void){
     mw_List_2E_any();
     WORD_EXIT(mw_Match_2E_has_default_case_3F_);
 }
-static void mw_Match_2E_scrutinee_data_3F_ (void){
+static void mw_Match_2E_scrutinee_data_3F_ (void) {
     WORD_ENTER(mw_Match_2E_scrutinee_data_3F_, "Match.scrutinee-data?", "src/mirth/data/match.mth", 61, 5);
     WORD_ATOM(61, 5, "cases");
     mw_Match_2E_cases();
@@ -15412,43 +15308,43 @@ static void mw_Match_2E_scrutinee_data_3F_ (void){
     mw_Maybe_2E_if_some();
     WORD_EXIT(mw_Match_2E_scrutinee_data_3F_);
 }
-static void mw_Match_2E_is_transparent_3F_ (void){
+static void mw_Match_2E_is_transparent_3F_ (void) {
     WORD_ENTER(mw_Match_2E_is_transparent_3F_, "Match.is-transparent?", "src/mirth/data/match.mth", 71, 5);
     WORD_ATOM(71, 5, "cases");
     mw_Match_2E_cases();
     WORD_ATOM(71, 11, "match");
     switch (get_top_data_tag()) {
         case 1LL:
-            co_L1();
+            mp_L1();
             WORD_ATOM(72, 15, "pattern");
             mw_Case_2E_pattern();
             WORD_ATOM(72, 23, "match");
             switch (get_top_data_tag()) {
                 case 1LL:
-                    co_PATTERN_5F_TAG();
+                    mp_PATTERN_5F_TAG();
                     WORD_ATOM(73, 28, ".data");
                     mw_Tag_2E_data();
                     WORD_ATOM(73, 34, "is-transparent?");
                     mw_Data_2E_is_transparent_3F_();
                     break;
                 case 0LL:
-                    co_PATTERN_5F_UNDERSCORE();
+                    mp_PATTERN_5F_UNDERSCORE();
                     WORD_ATOM(74, 35, "T");
                     mw_T();
                     break;
                 default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-            
-}            break;
+            }
+            break;
         default:
             WORD_ATOM(76, 14, "drop");
             mw_prim_drop();
             WORD_ATOM(76, 19, "F");
             mw_F();
             break;
-    
-}    WORD_EXIT(mw_Match_2E_is_transparent_3F_);
+    }
+    WORD_EXIT(mw_Match_2E_is_transparent_3F_);
 }
-static void mw_Match_2E_add_case_21_ (void){
+static void mw_Match_2E_add_case_21_ (void) {
     WORD_ENTER(mw_Match_2E_add_case_21_, "Match.add-case!", "src/mirth/data/match.mth", 80, 5);
     WORD_ATOM(80, 5, "dup2");
     mw_dup2();
@@ -15486,7 +15382,7 @@ static void mw_Match_2E_add_case_21_ (void){
     }
     WORD_EXIT(mw_Match_2E_add_case_21_);
 }
-static void mw_Match_2E_case_redundant_3F_ (void){
+static void mw_Match_2E_case_redundant_3F_ (void) {
     WORD_ENTER(mw_Match_2E_case_redundant_3F_, "Match.case-redundant?", "src/mirth/data/match.mth", 86, 5);
     WORD_ATOM(86, 5, "cases");
     mw_Match_2E_cases();
@@ -15499,7 +15395,7 @@ static void mw_Match_2E_case_redundant_3F_ (void){
     mw_nip();
     WORD_EXIT(mw_Match_2E_case_redundant_3F_);
 }
-static void mw_Case_2E_covers_3F_ (void){
+static void mw_Case_2E_covers_3F_ (void) {
     WORD_ENTER(mw_Case_2E_covers_3F_, "Case.covers?", "src/mirth/data/match.mth", 93, 38);
     WORD_ATOM(93, 38, "both");
     push_u64(0);
@@ -15510,7 +15406,7 @@ static void mw_Case_2E_covers_3F_ (void){
     mw_Pattern_2E_covers_3F_();
     WORD_EXIT(mw_Case_2E_covers_3F_);
 }
-static void mw_Case_2E_is_default_case_3F_ (void){
+static void mw_Case_2E_is_default_case_3F_ (void) {
     WORD_ENTER(mw_Case_2E_is_default_case_3F_, "Case.is-default-case?", "src/mirth/data/match.mth", 96, 42);
     WORD_ATOM(96, 42, "pattern");
     mw_Case_2E_pattern();
@@ -15518,12 +15414,12 @@ static void mw_Case_2E_is_default_case_3F_ (void){
     mw_Pattern_2E_underscore_3F_();
     WORD_EXIT(mw_Case_2E_is_default_case_3F_);
 }
-static void mw_Pattern_2E_underscore_3F_ (void){
+static void mw_Pattern_2E_underscore_3F_ (void) {
     WORD_ENTER(mw_Pattern_2E_underscore_3F_, "Pattern.underscore?", "src/mirth/data/match.mth", 106, 43);
     WORD_ATOM(106, 43, "PATTERN_UNDERSCORE");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_PATTERN_5F_UNDERSCORE();
+            mp_PATTERN_5F_UNDERSCORE();
             WORD_ATOM(106, 65, "T");
             mw_T();
             break;
@@ -15533,15 +15429,15 @@ static void mw_Pattern_2E_underscore_3F_ (void){
             WORD_ATOM(106, 78, "F");
             mw_F();
             break;
-    
-}    WORD_EXIT(mw_Pattern_2E_underscore_3F_);
+    }
+    WORD_EXIT(mw_Pattern_2E_underscore_3F_);
 }
-static void mw_Pattern_2E_tag_3F_ (void){
+static void mw_Pattern_2E_tag_3F_ (void) {
     WORD_ENTER(mw_Pattern_2E_tag_3F_, "Pattern.tag?", "src/mirth/data/match.mth", 107, 42);
     WORD_ATOM(107, 42, "PATTERN_TAG");
     switch (get_top_data_tag()) {
         case 1LL:
-            co_PATTERN_5F_TAG();
+            mp_PATTERN_5F_TAG();
             WORD_ATOM(107, 57, "SOME");
             mw_SOME();
             break;
@@ -15551,10 +15447,10 @@ static void mw_Pattern_2E_tag_3F_ (void){
             WORD_ATOM(107, 73, "NONE");
             mw_NONE();
             break;
-    
-}    WORD_EXIT(mw_Pattern_2E_tag_3F_);
+    }
+    WORD_EXIT(mw_Pattern_2E_tag_3F_);
 }
-static void mw_Pattern_2E_tag_3D_ (void){
+static void mw_Pattern_2E_tag_3D_ (void) {
     WORD_ENTER(mw_Pattern_2E_tag_3D_, "Pattern.tag=", "src/mirth/data/match.mth", 108, 40);
     WORD_ATOM(108, 40, "tag?");
     mw_Pattern_2E_tag_3F_();
@@ -15568,29 +15464,29 @@ static void mw_Pattern_2E_tag_3D_ (void){
     mw_Maybe_2E_if_some();
     WORD_EXIT(mw_Pattern_2E_tag_3D_);
 }
-static void mw_Pattern_2E_covers_3F_ (void){
+static void mw_Pattern_2E_covers_3F_ (void) {
     WORD_ENTER(mw_Pattern_2E_covers_3F_, "Pattern.covers?", "src/mirth/data/match.mth", 116, 5);
     WORD_ATOM(116, 5, "PATTERN_UNDERSCORE");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_PATTERN_5F_UNDERSCORE();
+            mp_PATTERN_5F_UNDERSCORE();
             WORD_ATOM(116, 27, "drop");
             mw_prim_drop();
             WORD_ATOM(116, 32, "T");
             mw_T();
             break;
         case 1LL:
-            co_PATTERN_5F_TAG();
+            mp_PATTERN_5F_TAG();
             WORD_ATOM(117, 20, "swap");
             mw_prim_swap();
             WORD_ATOM(117, 25, "tag=");
             mw_Pattern_2E_tag_3D_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Pattern_2E_covers_3F_);
+    }
+    WORD_EXIT(mw_Pattern_2E_covers_3F_);
 }
-static void mw_External_2E_for (void){
+static void mw_External_2E_for (void) {
     WORD_ENTER(mw_External_2E_for, "External.for", "src/mirth/data/external.mth", 8, 7);
     WORD_ATOM(8, 7, "External");
     {
@@ -15637,7 +15533,7 @@ static void mw_External_2E_for (void){
     }
     WORD_EXIT(mw_External_2E_for);
 }
-static void mw_External_2E_alloc_21_ (void){
+static void mw_External_2E_alloc_21_ (void) {
     WORD_ENTER(mw_External_2E_alloc_21_, "External.alloc!", "src/mirth/data/external.mth", 8, 7);
     WORD_ATOM(8, 7, "External");
     mw_External_2E_NUM();
@@ -15661,7 +15557,7 @@ static void mw_External_2E_alloc_21_ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_External_2E_alloc_21_);
 }
-static void mw_External_2E_name (void){
+static void mw_External_2E_name (void) {
     WORD_ENTER(mw_External_2E_name, "External.name", "src/mirth/data/external.mth", 13, 38);
     WORD_ATOM(13, 38, "~name");
     mw_External_7E_name();
@@ -15669,7 +15565,7 @@ static void mw_External_2E_name (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_External_2E_name);
 }
-static void mw_External_2E_sig (void){
+static void mw_External_2E_sig (void) {
     WORD_ENTER(mw_External_2E_sig, "External.sig", "src/mirth/data/external.mth", 14, 38);
     WORD_ATOM(14, 38, "~sig");
     mw_External_7E_sig();
@@ -15677,7 +15573,7 @@ static void mw_External_2E_sig (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_External_2E_sig);
 }
-static void mw_External_2E_ctx_type (void){
+static void mw_External_2E_ctx_type (void) {
     WORD_ENTER(mw_External_2E_ctx_type, "External.ctx-type", "src/mirth/data/external.mth", 15, 51);
     WORD_ATOM(15, 51, "~ctx-type");
     mw_External_7E_ctx_type();
@@ -15687,7 +15583,7 @@ static void mw_External_2E_ctx_type (void){
     mw_unpack2();
     WORD_EXIT(mw_External_2E_ctx_type);
 }
-static void mw_External_2E_type (void){
+static void mw_External_2E_type (void) {
     WORD_ENTER(mw_External_2E_type, "External.type", "src/mirth/data/external.mth", 17, 43);
     WORD_ATOM(17, 43, "ctx-type");
     mw_External_2E_ctx_type();
@@ -15695,7 +15591,7 @@ static void mw_External_2E_type (void){
     mw_nip();
     WORD_EXIT(mw_External_2E_type);
 }
-static void mw_Word_2E_for (void){
+static void mw_Word_2E_for (void) {
     WORD_ENTER(mw_Word_2E_for, "Word.for", "src/mirth/data/word.mth", 11, 7);
     WORD_ATOM(11, 7, "Word");
     {
@@ -15742,7 +15638,7 @@ static void mw_Word_2E_for (void){
     }
     WORD_EXIT(mw_Word_2E_for);
 }
-static void mw_Word_2E_alloc_21_ (void){
+static void mw_Word_2E_alloc_21_ (void) {
     WORD_ENTER(mw_Word_2E_alloc_21_, "Word.alloc!", "src/mirth/data/word.mth", 11, 7);
     WORD_ATOM(11, 7, "Word");
     mw_Word_2E_NUM();
@@ -15766,7 +15662,7 @@ static void mw_Word_2E_alloc_21_ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Word_2E_alloc_21_);
 }
-static void mw_Word_2E_name (void){
+static void mw_Word_2E_name (void) {
     WORD_ENTER(mw_Word_2E_name, "Word.name", "src/mirth/data/word.mth", 20, 30);
     WORD_ATOM(20, 30, "~name");
     mw_Word_7E_name();
@@ -15774,7 +15670,7 @@ static void mw_Word_2E_name (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Word_2E_name);
 }
-static void mw_Word_2E_head (void){
+static void mw_Word_2E_head (void) {
     WORD_ENTER(mw_Word_2E_head, "Word.head", "src/mirth/data/word.mth", 21, 31);
     WORD_ATOM(21, 31, "~head");
     mw_Word_7E_head();
@@ -15782,7 +15678,7 @@ static void mw_Word_2E_head (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Word_2E_head);
 }
-static void mw_Word_2E_sig (void){
+static void mw_Word_2E_sig (void) {
     WORD_ENTER(mw_Word_2E_sig, "Word.sig", "src/mirth/data/word.mth", 22, 37);
     WORD_ATOM(22, 37, "~sig");
     mw_Word_7E_sig();
@@ -15790,7 +15686,7 @@ static void mw_Word_2E_sig (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Word_2E_sig);
 }
-static void mw_Word_2E_body (void){
+static void mw_Word_2E_body (void) {
     WORD_ENTER(mw_Word_2E_body, "Word.body", "src/mirth/data/word.mth", 23, 31);
     WORD_ATOM(23, 31, "~body");
     mw_Word_7E_body();
@@ -15798,7 +15694,7 @@ static void mw_Word_2E_body (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Word_2E_body);
 }
-static void mw_Word_2E_params (void){
+static void mw_Word_2E_params (void) {
     WORD_ENTER(mw_Word_2E_params, "Word.params", "src/mirth/data/word.mth", 24, 39);
     WORD_ATOM(24, 39, "~params");
     mw_Word_7E_params();
@@ -15806,7 +15702,7 @@ static void mw_Word_2E_params (void){
     mw_force_21_();
     WORD_EXIT(mw_Word_2E_params);
 }
-static void mw_Word_2E_arrow (void){
+static void mw_Word_2E_arrow (void) {
     WORD_ENTER(mw_Word_2E_arrow, "Word.arrow", "src/mirth/data/word.mth", 25, 32);
     WORD_ATOM(25, 32, "~arrow");
     mw_Word_7E_arrow();
@@ -15814,7 +15710,7 @@ static void mw_Word_2E_arrow (void){
     mw_force_21_();
     WORD_EXIT(mw_Word_2E_arrow);
 }
-static void mw_Word_2E_ctx_type (void){
+static void mw_Word_2E_ctx_type (void) {
     WORD_ENTER(mw_Word_2E_ctx_type, "Word.ctx-type", "src/mirth/data/word.mth", 28, 5);
     WORD_ATOM(28, 5, "dup");
     mw_prim_dup();
@@ -15831,7 +15727,7 @@ static void mw_Word_2E_ctx_type (void){
     mw_unpack2();
     WORD_EXIT(mw_Word_2E_ctx_type);
 }
-static void mw_Word_2E_type (void){
+static void mw_Word_2E_type (void) {
     WORD_ENTER(mw_Word_2E_type, "Word.type", "src/mirth/data/word.mth", 32, 35);
     WORD_ATOM(32, 35, "ctx-type");
     mw_Word_2E_ctx_type();
@@ -15839,7 +15735,7 @@ static void mw_Word_2E_type (void){
     mw_nip();
     WORD_EXIT(mw_Word_2E_type);
 }
-static void mw_Word_2E_new_21_ (void){
+static void mw_Word_2E_new_21_ (void) {
     WORD_ENTER(mw_Word_2E_new_21_, "Word.new!", "src/mirth/data/word.mth", 35, 5);
     WORD_ATOM(35, 5, "Word.alloc!");
     mw_Word_2E_alloc_21_();
@@ -15883,7 +15779,7 @@ static void mw_Word_2E_new_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_Word_2E_new_21_);
 }
-static void mw_Buffer_2E_for (void){
+static void mw_Buffer_2E_for (void) {
     WORD_ENTER(mw_Buffer_2E_for, "Buffer.for", "src/mirth/data/buffer.mth", 8, 7);
     WORD_ATOM(8, 7, "Buffer");
     {
@@ -15930,7 +15826,7 @@ static void mw_Buffer_2E_for (void){
     }
     WORD_EXIT(mw_Buffer_2E_for);
 }
-static void mw_Buffer_2E_alloc_21_ (void){
+static void mw_Buffer_2E_alloc_21_ (void) {
     WORD_ENTER(mw_Buffer_2E_alloc_21_, "Buffer.alloc!", "src/mirth/data/buffer.mth", 8, 7);
     WORD_ATOM(8, 7, "Buffer");
     mw_Buffer_2E_NUM();
@@ -15954,7 +15850,7 @@ static void mw_Buffer_2E_alloc_21_ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Buffer_2E_alloc_21_);
 }
-static void mw_Buffer_2E_head (void){
+static void mw_Buffer_2E_head (void) {
     WORD_ENTER(mw_Buffer_2E_head, "Buffer.head", "src/mirth/data/buffer.mth", 13, 35);
     WORD_ATOM(13, 35, "~head");
     mw_Buffer_7E_head();
@@ -15962,7 +15858,7 @@ static void mw_Buffer_2E_head (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Buffer_2E_head);
 }
-static void mw_Buffer_2E_size (void){
+static void mw_Buffer_2E_size (void) {
     WORD_ENTER(mw_Buffer_2E_size, "Buffer.size", "src/mirth/data/buffer.mth", 14, 34);
     WORD_ATOM(14, 34, "~size");
     mw_Buffer_7E_size();
@@ -15970,7 +15866,7 @@ static void mw_Buffer_2E_size (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Buffer_2E_size);
 }
-static void mw_Buffer_2E_name (void){
+static void mw_Buffer_2E_name (void) {
     WORD_ENTER(mw_Buffer_2E_name, "Buffer.name", "src/mirth/data/buffer.mth", 15, 34);
     WORD_ATOM(15, 34, "~name");
     mw_Buffer_7E_name();
@@ -15978,7 +15874,7 @@ static void mw_Buffer_2E_name (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Buffer_2E_name);
 }
-static void mw_Buffer_2E_new_21_ (void){
+static void mw_Buffer_2E_new_21_ (void) {
     WORD_ENTER(mw_Buffer_2E_new_21_, "Buffer.new!", "src/mirth/data/buffer.mth", 18, 5);
     WORD_ATOM(18, 5, "Buffer.alloc!");
     mw_Buffer_2E_alloc_21_();
@@ -16012,7 +15908,7 @@ static void mw_Buffer_2E_new_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_Buffer_2E_new_21_);
 }
-static void mw_Variable_2E_for (void){
+static void mw_Variable_2E_for (void) {
     WORD_ENTER(mw_Variable_2E_for, "Variable.for", "src/mirth/data/variable.mth", 8, 7);
     WORD_ATOM(8, 7, "Variable");
     {
@@ -16059,7 +15955,7 @@ static void mw_Variable_2E_for (void){
     }
     WORD_EXIT(mw_Variable_2E_for);
 }
-static void mw_Variable_2E_alloc_21_ (void){
+static void mw_Variable_2E_alloc_21_ (void) {
     WORD_ENTER(mw_Variable_2E_alloc_21_, "Variable.alloc!", "src/mirth/data/variable.mth", 8, 7);
     WORD_ATOM(8, 7, "Variable");
     mw_Variable_2E_NUM();
@@ -16083,7 +15979,7 @@ static void mw_Variable_2E_alloc_21_ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Variable_2E_alloc_21_);
 }
-static void mw_Variable_2E_head (void){
+static void mw_Variable_2E_head (void) {
     WORD_ENTER(mw_Variable_2E_head, "Variable.head", "src/mirth/data/variable.mth", 13, 39);
     WORD_ATOM(13, 39, "~head");
     mw_Variable_7E_head();
@@ -16091,7 +15987,7 @@ static void mw_Variable_2E_head (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Variable_2E_head);
 }
-static void mw_Variable_2E_name (void){
+static void mw_Variable_2E_name (void) {
     WORD_ENTER(mw_Variable_2E_name, "Variable.name", "src/mirth/data/variable.mth", 14, 38);
     WORD_ATOM(14, 38, "~name");
     mw_Variable_7E_name();
@@ -16099,7 +15995,7 @@ static void mw_Variable_2E_name (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Variable_2E_name);
 }
-static void mw_Variable_2E_type (void){
+static void mw_Variable_2E_type (void) {
     WORD_ENTER(mw_Variable_2E_type, "Variable.type", "src/mirth/data/variable.mth", 15, 38);
     WORD_ATOM(15, 38, "~type");
     mw_Variable_7E_type();
@@ -16107,7 +16003,7 @@ static void mw_Variable_2E_type (void){
     mw_force_21_();
     WORD_EXIT(mw_Variable_2E_type);
 }
-static void mw_Variable_2E_new_21_ (void){
+static void mw_Variable_2E_new_21_ (void) {
     WORD_ENTER(mw_Variable_2E_new_21_, "Variable.new!", "src/mirth/data/variable.mth", 18, 5);
     WORD_ATOM(18, 5, "Variable.alloc!");
     mw_Variable_2E_alloc_21_();
@@ -16143,7 +16039,7 @@ static void mw_Variable_2E_new_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_Variable_2E_new_21_);
 }
-static void mw_Constant_2E_alloc_21_ (void){
+static void mw_Constant_2E_alloc_21_ (void) {
     WORD_ENTER(mw_Constant_2E_alloc_21_, "Constant.alloc!", "src/mirth/data/constant.mth", 7, 7);
     WORD_ATOM(7, 7, "Constant");
     mw_Constant_2E_NUM();
@@ -16167,7 +16063,7 @@ static void mw_Constant_2E_alloc_21_ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Constant_2E_alloc_21_);
 }
-static void mw_Constant_2E_head (void){
+static void mw_Constant_2E_head (void) {
     WORD_ENTER(mw_Constant_2E_head, "Constant.head", "src/mirth/data/constant.mth", 12, 39);
     WORD_ATOM(12, 39, "~head");
     mw_Constant_7E_head();
@@ -16175,7 +16071,7 @@ static void mw_Constant_2E_head (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Constant_2E_head);
 }
-static void mw_Constant_2E_value (void){
+static void mw_Constant_2E_value (void) {
     WORD_ENTER(mw_Constant_2E_value, "Constant.value", "src/mirth/data/constant.mth", 14, 40);
     WORD_ATOM(14, 40, "~value");
     mw_Constant_7E_value();
@@ -16183,7 +16079,7 @@ static void mw_Constant_2E_value (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Constant_2E_value);
 }
-static void mw_Constant_2E_new_21_ (void){
+static void mw_Constant_2E_new_21_ (void) {
     WORD_ENTER(mw_Constant_2E_new_21_, "Constant.new!", "src/mirth/data/constant.mth", 17, 5);
     WORD_ATOM(17, 5, "Constant.alloc!");
     mw_Constant_2E_alloc_21_();
@@ -16217,13 +16113,13 @@ static void mw_Constant_2E_new_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_Constant_2E_new_21_);
 }
-static void mw_Table_2E_id (void){
+static void mw_Table_2E_id (void) {
     WORD_ENTER(mw_Table_2E_id, "Table.id", "src/mirth/data/table.mth", 10, 7);
     WORD_ATOM(10, 7, "Table");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Table_2E_id);
 }
-static void mw_Table_2E_alloc_21_ (void){
+static void mw_Table_2E_alloc_21_ (void) {
     WORD_ENTER(mw_Table_2E_alloc_21_, "Table.alloc!", "src/mirth/data/table.mth", 10, 7);
     WORD_ATOM(10, 7, "Table");
     mw_Table_2E_NUM();
@@ -16247,7 +16143,7 @@ static void mw_Table_2E_alloc_21_ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Table_2E_alloc_21_);
 }
-static void mw_Table_2E_head (void){
+static void mw_Table_2E_head (void) {
     WORD_ENTER(mw_Table_2E_head, "Table.head", "src/mirth/data/table.mth", 16, 33);
     WORD_ATOM(16, 33, "~head");
     mw_Table_7E_head();
@@ -16255,7 +16151,7 @@ static void mw_Table_2E_head (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Table_2E_head);
 }
-static void mw_Table_2E_name (void){
+static void mw_Table_2E_name (void) {
     WORD_ENTER(mw_Table_2E_name, "Table.name", "src/mirth/data/table.mth", 17, 32);
     WORD_ATOM(17, 32, "~name");
     mw_Table_7E_name();
@@ -16263,7 +16159,7 @@ static void mw_Table_2E_name (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Table_2E_name);
 }
-static void mw_Table_2E_num_buffer (void){
+static void mw_Table_2E_num_buffer (void) {
     WORD_ENTER(mw_Table_2E_num_buffer, "Table.num-buffer", "src/mirth/data/table.mth", 18, 40);
     WORD_ATOM(18, 40, "~num-buffer");
     mw_Table_7E_num_buffer();
@@ -16271,7 +16167,7 @@ static void mw_Table_2E_num_buffer (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Table_2E_num_buffer);
 }
-static void mw_Table_3D_ (void){
+static void mw_Table_3D_ (void) {
     WORD_ENTER(mw_Table_3D_, "Table=", "src/mirth/data/table.mth", 20, 34);
     WORD_ATOM(20, 34, "both");
     push_u64(0);
@@ -16282,7 +16178,7 @@ static void mw_Table_3D_ (void){
     mw_prim_int_eq();
     WORD_EXIT(mw_Table_3D_);
 }
-static void mw_Field_2E_for (void){
+static void mw_Field_2E_for (void) {
     WORD_ENTER(mw_Field_2E_for, "Field.for", "src/mirth/data/table.mth", 22, 7);
     WORD_ATOM(22, 7, "Field");
     {
@@ -16329,7 +16225,7 @@ static void mw_Field_2E_for (void){
     }
     WORD_EXIT(mw_Field_2E_for);
 }
-static void mw_Field_2E_alloc_21_ (void){
+static void mw_Field_2E_alloc_21_ (void) {
     WORD_ENTER(mw_Field_2E_alloc_21_, "Field.alloc!", "src/mirth/data/table.mth", 22, 7);
     WORD_ATOM(22, 7, "Field");
     mw_Field_2E_NUM();
@@ -16353,7 +16249,7 @@ static void mw_Field_2E_alloc_21_ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Field_2E_alloc_21_);
 }
-static void mw_Field_2E_head (void){
+static void mw_Field_2E_head (void) {
     WORD_ENTER(mw_Field_2E_head, "Field.head", "src/mirth/data/table.mth", 28, 33);
     WORD_ATOM(28, 33, "~head");
     mw_Field_7E_head();
@@ -16361,7 +16257,7 @@ static void mw_Field_2E_head (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Field_2E_head);
 }
-static void mw_Field_2E_name (void){
+static void mw_Field_2E_name (void) {
     WORD_ENTER(mw_Field_2E_name, "Field.name", "src/mirth/data/table.mth", 29, 32);
     WORD_ATOM(29, 32, "~name");
     mw_Field_7E_name();
@@ -16369,7 +16265,7 @@ static void mw_Field_2E_name (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Field_2E_name);
 }
-static void mw_Field_2E_index_type (void){
+static void mw_Field_2E_index_type (void) {
     WORD_ENTER(mw_Field_2E_index_type, "Field.index-type", "src/mirth/data/table.mth", 30, 38);
     WORD_ATOM(30, 38, "~index-type");
     mw_Field_7E_index_type();
@@ -16377,7 +16273,7 @@ static void mw_Field_2E_index_type (void){
     mw_force_21_();
     WORD_EXIT(mw_Field_2E_index_type);
 }
-static void mw_Field_2E_value_type (void){
+static void mw_Field_2E_value_type (void) {
     WORD_ENTER(mw_Field_2E_value_type, "Field.value-type", "src/mirth/data/table.mth", 31, 38);
     WORD_ATOM(31, 38, "~value-type");
     mw_Field_7E_value_type();
@@ -16385,7 +16281,7 @@ static void mw_Field_2E_value_type (void){
     mw_force_21_();
     WORD_EXIT(mw_Field_2E_value_type);
 }
-static void mw_Field_2E_dom (void){
+static void mw_Field_2E_dom (void) {
     WORD_ENTER(mw_Field_2E_dom, "Field.dom", "src/mirth/data/table.mth", 33, 36);
     WORD_ATOM(33, 36, "index-type");
     mw_Field_2E_index_type();
@@ -16393,7 +16289,7 @@ static void mw_Field_2E_dom (void){
     mw_T1();
     WORD_EXIT(mw_Field_2E_dom);
 }
-static void mw_Field_2E_cod (void){
+static void mw_Field_2E_cod (void) {
     WORD_ENTER(mw_Field_2E_cod, "Field.cod", "src/mirth/data/table.mth", 34, 36);
     WORD_ATOM(34, 36, "value-type");
     mw_Field_2E_value_type();
@@ -16403,7 +16299,7 @@ static void mw_Field_2E_cod (void){
     mw_T1();
     WORD_EXIT(mw_Field_2E_cod);
 }
-static void mw_Field_2E_type (void){
+static void mw_Field_2E_type (void) {
     WORD_ENTER(mw_Field_2E_type, "Field.type", "src/mirth/data/table.mth", 35, 37);
     WORD_ATOM(35, 37, "sip");
     push_u64(0);
@@ -16416,7 +16312,7 @@ static void mw_Field_2E_type (void){
     mw_T__3E_();
     WORD_EXIT(mw_Field_2E_type);
 }
-static void mw_Stack_2E_push_21_ (void){
+static void mw_Stack_2E_push_21_ (void) {
     WORD_ENTER(mw_Stack_2E_push_21_, "Stack.push!", "src/data/stack.mth", 10, 5);
     WORD_ATOM(10, 5, "modify");
     push_u64(0);
@@ -16425,7 +16321,7 @@ static void mw_Stack_2E_push_21_ (void){
     mw_modify();
     WORD_EXIT(mw_Stack_2E_push_21_);
 }
-static void mw_Stack_2E_pop_21_ (void){
+static void mw_Stack_2E_pop_21_ (void) {
     WORD_ENTER(mw_Stack_2E_pop_21_, "Stack.pop!", "src/data/stack.mth", 12, 5);
     WORD_ATOM(12, 5, "modify");
     push_u64(0);
@@ -16434,19 +16330,19 @@ static void mw_Stack_2E_pop_21_ (void){
     mw_modify();
     WORD_EXIT(mw_Stack_2E_pop_21_);
 }
-static void mw_Stack_2E_uncons (void){
+static void mw_Stack_2E_uncons (void) {
     WORD_ENTER(mw_Stack_2E_uncons, "Stack.uncons", "src/data/stack.mth", 14, 5);
     WORD_ATOM(14, 5, "STACK_NIL");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_STACK_5F_NIL();
+            mp_STACK_5F_NIL();
             WORD_ATOM(14, 18, "NONE");
             mw_NONE();
             WORD_ATOM(14, 23, "STACK_NIL");
             mw_STACK_5F_NIL();
             break;
         case 1LL:
-            co_STACK_5F_CONS();
+            mp_STACK_5F_CONS();
             WORD_ATOM(15, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -16456,10 +16352,10 @@ static void mw_Stack_2E_uncons (void){
             }
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Stack_2E_uncons);
+    }
+    WORD_EXIT(mw_Stack_2E_uncons);
 }
-static void mw_Stack_2E_reset_21_ (void){
+static void mw_Stack_2E_reset_21_ (void) {
     WORD_ENTER(mw_Stack_2E_reset_21_, "Stack.reset!", "src/data/stack.mth", 17, 5);
     WORD_ATOM(17, 5, "STACK_NIL");
     mw_STACK_5F_NIL();
@@ -16469,13 +16365,13 @@ static void mw_Stack_2E_reset_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_Stack_2E_reset_21_);
 }
-static void mw_INPUT_5F_BUFFER_5F_SIZE (void){
+static void mw_INPUT_5F_BUFFER_5F_SIZE (void) {
     WORD_ENTER(mw_INPUT_5F_BUFFER_5F_SIZE, "INPUT_BUFFER_SIZE", "src/mirth/input.mth", 16, 30);
     WORD_ATOM(16, 30, "");
     push_i64(8192LL);
     WORD_EXIT(mw_INPUT_5F_BUFFER_5F_SIZE);
 }
-static void mw_input_start_21_ (void){
+static void mw_input_start_21_ (void) {
     WORD_ENTER(mw_input_start_21_, "input-start!", "src/mirth/input.mth", 19, 5);
     WORD_ATOM(19, 5, "input-handle");
     mw_input_handle();
@@ -16503,7 +16399,7 @@ static void mw_input_start_21_ (void){
     mw_input_fill_buffer_21_();
     WORD_EXIT(mw_input_start_21_);
 }
-static void mw_input_end_21_ (void){
+static void mw_input_end_21_ (void) {
     WORD_ENTER(mw_input_end_21_, "input-end!", "src/mirth/input.mth", 26, 5);
     WORD_ATOM(26, 5, "input-isopen");
     mw_input_isopen();
@@ -16547,7 +16443,7 @@ static void mw_input_end_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_input_end_21_);
 }
-static void mw_input_done_3F_ (void){
+static void mw_input_done_3F_ (void) {
     WORD_ENTER(mw_input_done_3F_, "input-done?", "src/mirth/input.mth", 36, 5);
     WORD_ATOM(36, 5, "input-isopen");
     mw_input_isopen();
@@ -16557,7 +16453,7 @@ static void mw_input_done_3F_ (void){
     mw_Bool_2E_not();
     WORD_EXIT(mw_input_done_3F_);
 }
-static void mw_input_fill_buffer_21_ (void){
+static void mw_input_fill_buffer_21_ (void) {
     WORD_ENTER(mw_input_fill_buffer_21_, "input-fill-buffer!", "src/mirth/input.mth", 39, 5);
     WORD_ATOM(39, 5, "assert!");
     push_u64(0);
@@ -16611,7 +16507,7 @@ static void mw_input_fill_buffer_21_ (void){
     }
     WORD_EXIT(mw_input_fill_buffer_21_);
 }
-static void mw_input_peek (void){
+static void mw_input_peek (void) {
     WORD_ENTER(mw_input_peek, "input-peek", "src/mirth/input.mth", 55, 5);
     WORD_ATOM(55, 5, "input-isopen");
     mw_input_isopen();
@@ -16647,7 +16543,7 @@ static void mw_input_peek (void){
     }
     WORD_EXIT(mw_input_peek);
 }
-static void mw_input_move_21_ (void){
+static void mw_input_move_21_ (void) {
     WORD_ENTER(mw_input_move_21_, "input-move!", "src/mirth/input.mth", 63, 5);
     WORD_ATOM(63, 5, "input-isopen");
     mw_input_isopen();
@@ -16684,7 +16580,7 @@ static void mw_input_move_21_ (void){
     }
     WORD_EXIT(mw_input_move_21_);
 }
-static void mw_input_prepare_for_more_21_ (void){
+static void mw_input_prepare_for_more_21_ (void) {
     WORD_ENTER(mw_input_prepare_for_more_21_, "input-prepare-for-more!", "src/mirth/input.mth", 71, 5);
     WORD_ATOM(71, 5, "input-offset");
     mw_input_offset();
@@ -16706,7 +16602,7 @@ static void mw_input_prepare_for_more_21_ (void){
     }
     WORD_EXIT(mw_input_prepare_for_more_21_);
 }
-static void mw_run_lexer_21_ (void){
+static void mw_run_lexer_21_ (void) {
     WORD_ENTER(mw_run_lexer_21_, "run-lexer!", "src/mirth/lexer.mth", 26, 5);
     WORD_ATOM(26, 5, "Module.new!");
     mw_Module_2E_new_21_();
@@ -16769,14 +16665,14 @@ static void mw_run_lexer_21_ (void){
     WORD_ATOM(41, 22, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_NONE();
+            mp_NONE();
             WORD_ATOM(42, 17, "TOKEN_NONE");
             mw_TOKEN_5F_NONE();
             WORD_ATOM(42, 28, "lexer-emit!");
             mw_lexer_emit_21_();
             break;
         case 1LL:
-            co_SOME();
+            mp_SOME();
             WORD_ATOM(43, 17, "");
             {
                 static bool vready = false;
@@ -16792,8 +16688,8 @@ static void mw_run_lexer_21_ (void){
             mw_emit_fatal_error_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_ATOM(46, 5, "Token.alloc-none!");
+    }
+    WORD_ATOM(46, 5, "Token.alloc-none!");
     mw_Token_2E_alloc_none_21_();
     WORD_ATOM(46, 23, "lexer-module");
     mw_lexer_module();
@@ -16819,13 +16715,13 @@ static void mw_run_lexer_21_ (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_run_lexer_21_);
 }
-static void mw_lexer_done_3F_ (void){
+static void mw_lexer_done_3F_ (void) {
     WORD_ENTER(mw_lexer_done_3F_, "lexer-done?", "src/mirth/lexer.mth", 52, 24);
     WORD_ATOM(52, 24, "input-done?");
     mw_input_done_3F_();
     WORD_EXIT(mw_lexer_done_3F_);
 }
-static void mw_lexer_make_21_ (void){
+static void mw_lexer_make_21_ (void) {
     WORD_ENTER(mw_lexer_make_21_, "lexer-make!", "src/mirth/lexer.mth", 57, 5);
     WORD_ATOM(57, 5, "Token.alloc!");
     mw_Token_2E_alloc_21_();
@@ -16867,7 +16763,7 @@ static void mw_lexer_make_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_lexer_make_21_);
 }
-static void mw_lexer_emit_21_ (void){
+static void mw_lexer_emit_21_ (void) {
     WORD_ENTER(mw_lexer_emit_21_, "lexer-emit!", "src/mirth/lexer.mth", 64, 33);
     WORD_ATOM(64, 33, "lexer-make!");
     mw_lexer_make_21_();
@@ -16875,48 +16771,48 @@ static void mw_lexer_emit_21_ (void){
     mw_prim_drop();
     WORD_EXIT(mw_lexer_emit_21_);
 }
-static void mw_lexer_next_21_ (void){
+static void mw_lexer_next_21_ (void) {
     WORD_ENTER(mw_lexer_next_21_, "lexer-next!", "src/mirth/lexer.mth", 67, 22);
     WORD_ATOM(67, 22, "lexer-peek");
     mw_lexer_peek();
     WORD_ATOM(67, 33, "match");
     switch (get_top_data_tag()) {
         case 10LL:
-            co_BLF();
+            mp_BLF();
             WORD_ATOM(68, 12, "lexer-newline!");
             mw_lexer_newline_21_();
             WORD_ATOM(68, 27, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 32LL:
-            co_BSPACE();
+            mp_BSPACE();
             WORD_ATOM(69, 15, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 9LL:
-            co_BHT();
+            mp_BHT();
             WORD_ATOM(70, 12, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 11LL:
-            co_BVT();
+            mp_BVT();
             WORD_ATOM(71, 12, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 13LL:
-            co_BCR();
+            mp_BCR();
             WORD_ATOM(72, 12, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 35LL:
-            co_BHASH();
+            mp_BHASH();
             WORD_ATOM(73, 14, "lexer-skip-comment!");
             mw_lexer_skip_comment_21_();
             WORD_ATOM(73, 34, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 44LL:
-            co_BCOMMA();
+            mp_BCOMMA();
             WORD_ATOM(74, 15, "TOKEN_COMMA");
             mw_TOKEN_5F_COMMA();
             WORD_ATOM(74, 27, "lexer-emit!");
@@ -16925,49 +16821,49 @@ static void mw_lexer_next_21_ (void){
             mw_lexer_move_21_();
             break;
         case 40LL:
-            co_BLPAREN();
+            mp_BLPAREN();
             WORD_ATOM(75, 16, "lexer-emit-lparen!");
             mw_lexer_emit_lparen_21_();
             WORD_ATOM(75, 35, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 41LL:
-            co_BRPAREN();
+            mp_BRPAREN();
             WORD_ATOM(76, 16, "lexer-emit-rparen!");
             mw_lexer_emit_rparen_21_();
             WORD_ATOM(76, 35, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 91LL:
-            co_BLSQUARE();
+            mp_BLSQUARE();
             WORD_ATOM(77, 17, "lexer-emit-lsquare!");
             mw_lexer_emit_lsquare_21_();
             WORD_ATOM(77, 37, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 93LL:
-            co_BRSQUARE();
+            mp_BRSQUARE();
             WORD_ATOM(78, 17, "lexer-emit-rsquare!");
             mw_lexer_emit_rsquare_21_();
             WORD_ATOM(78, 37, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 123LL:
-            co_BLCURLY();
+            mp_BLCURLY();
             WORD_ATOM(79, 16, "lexer-emit-lcurly!");
             mw_lexer_emit_lcurly_21_();
             WORD_ATOM(79, 35, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 125LL:
-            co_BRCURLY();
+            mp_BRCURLY();
             WORD_ATOM(80, 16, "lexer-emit-rcurly!");
             mw_lexer_emit_rcurly_21_();
             WORD_ATOM(80, 35, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 34LL:
-            co_BQUOTE();
+            mp_BQUOTE();
             WORD_ATOM(81, 15, "lexer-emit-string!");
             mw_lexer_emit_string_21_();
             WORD_ATOM(81, 34, "lexer-move!");
@@ -16996,10 +16892,10 @@ static void mw_lexer_next_21_ (void){
                 mw_lexer_emit_fatal_error_21_();
             }
             break;
-    
-}    WORD_EXIT(mw_lexer_next_21_);
+    }
+    WORD_EXIT(mw_lexer_next_21_);
 }
-static void mw_lexer_newline_21_ (void){
+static void mw_lexer_newline_21_ (void) {
     WORD_ENTER(mw_lexer_newline_21_, "lexer-newline!", "src/mirth/lexer.mth", 88, 5);
     WORD_ATOM(88, 5, "lexer-row");
     mw_lexer_row();
@@ -17018,7 +16914,7 @@ static void mw_lexer_newline_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_lexer_newline_21_);
 }
-static void mw_lexer_emit_lparen_21_ (void){
+static void mw_lexer_emit_lparen_21_ (void) {
     WORD_ENTER(mw_lexer_emit_lparen_21_, "lexer-emit-lparen!", "src/mirth/lexer.mth", 92, 5);
     WORD_ATOM(92, 5, "TOKEN_LPAREN_OPEN");
     mw_TOKEN_5F_LPAREN_5F_OPEN();
@@ -17030,7 +16926,7 @@ static void mw_lexer_emit_lparen_21_ (void){
     mw_Stack_2E_push_21_();
     WORD_EXIT(mw_lexer_emit_lparen_21_);
 }
-static void mw_lexer_emit_rparen_21_ (void){
+static void mw_lexer_emit_rparen_21_ (void) {
     WORD_ENTER(mw_lexer_emit_rparen_21_, "lexer-emit-rparen!", "src/mirth/lexer.mth", 95, 5);
     WORD_ATOM(95, 5, "lexer-stack");
     mw_lexer_stack();
@@ -17039,7 +16935,7 @@ static void mw_lexer_emit_rparen_21_ (void){
     WORD_ATOM(95, 22, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_NONE();
+            mp_NONE();
             WORD_ATOM(96, 17, "");
             {
                 static bool vready = false;
@@ -17055,7 +16951,7 @@ static void mw_lexer_emit_rparen_21_ (void){
             mw_lexer_emit_fatal_error_21_();
             break;
         case 1LL:
-            co_SOME();
+            mp_SOME();
             WORD_ATOM(97, 17, "dup");
             mw_prim_dup();
             WORD_ATOM(97, 21, "lparen-open?");
@@ -17093,10 +16989,10 @@ static void mw_lexer_emit_rparen_21_ (void){
             }
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_lexer_emit_rparen_21_);
+    }
+    WORD_EXIT(mw_lexer_emit_rparen_21_);
 }
-static void mw_lexer_emit_lsquare_21_ (void){
+static void mw_lexer_emit_lsquare_21_ (void) {
     WORD_ENTER(mw_lexer_emit_lsquare_21_, "lexer-emit-lsquare!", "src/mirth/lexer.mth", 105, 5);
     WORD_ATOM(105, 5, "TOKEN_LSQUARE_OPEN");
     mw_TOKEN_5F_LSQUARE_5F_OPEN();
@@ -17108,7 +17004,7 @@ static void mw_lexer_emit_lsquare_21_ (void){
     mw_Stack_2E_push_21_();
     WORD_EXIT(mw_lexer_emit_lsquare_21_);
 }
-static void mw_lexer_emit_rsquare_21_ (void){
+static void mw_lexer_emit_rsquare_21_ (void) {
     WORD_ENTER(mw_lexer_emit_rsquare_21_, "lexer-emit-rsquare!", "src/mirth/lexer.mth", 108, 5);
     WORD_ATOM(108, 5, "lexer-stack");
     mw_lexer_stack();
@@ -17117,7 +17013,7 @@ static void mw_lexer_emit_rsquare_21_ (void){
     WORD_ATOM(108, 22, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_NONE();
+            mp_NONE();
             WORD_ATOM(109, 17, "");
             {
                 static bool vready = false;
@@ -17133,7 +17029,7 @@ static void mw_lexer_emit_rsquare_21_ (void){
             mw_lexer_emit_fatal_error_21_();
             break;
         case 1LL:
-            co_SOME();
+            mp_SOME();
             WORD_ATOM(110, 17, "dup");
             mw_prim_dup();
             WORD_ATOM(110, 21, "lsquare-open?");
@@ -17171,10 +17067,10 @@ static void mw_lexer_emit_rsquare_21_ (void){
             }
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_lexer_emit_rsquare_21_);
+    }
+    WORD_EXIT(mw_lexer_emit_rsquare_21_);
 }
-static void mw_lexer_emit_lcurly_21_ (void){
+static void mw_lexer_emit_lcurly_21_ (void) {
     WORD_ENTER(mw_lexer_emit_lcurly_21_, "lexer-emit-lcurly!", "src/mirth/lexer.mth", 118, 5);
     WORD_ATOM(118, 5, "TOKEN_LCURLY_OPEN");
     mw_TOKEN_5F_LCURLY_5F_OPEN();
@@ -17186,7 +17082,7 @@ static void mw_lexer_emit_lcurly_21_ (void){
     mw_Stack_2E_push_21_();
     WORD_EXIT(mw_lexer_emit_lcurly_21_);
 }
-static void mw_lexer_emit_rcurly_21_ (void){
+static void mw_lexer_emit_rcurly_21_ (void) {
     WORD_ENTER(mw_lexer_emit_rcurly_21_, "lexer-emit-rcurly!", "src/mirth/lexer.mth", 121, 5);
     WORD_ATOM(121, 5, "lexer-stack");
     mw_lexer_stack();
@@ -17195,7 +17091,7 @@ static void mw_lexer_emit_rcurly_21_ (void){
     WORD_ATOM(121, 22, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_NONE();
+            mp_NONE();
             WORD_ATOM(122, 17, "");
             {
                 static bool vready = false;
@@ -17211,7 +17107,7 @@ static void mw_lexer_emit_rcurly_21_ (void){
             mw_lexer_emit_fatal_error_21_();
             break;
         case 1LL:
-            co_SOME();
+            mp_SOME();
             WORD_ATOM(123, 17, "dup");
             mw_prim_dup();
             WORD_ATOM(123, 21, "lcurly-open?");
@@ -17249,10 +17145,10 @@ static void mw_lexer_emit_rcurly_21_ (void){
             }
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_lexer_emit_rcurly_21_);
+    }
+    WORD_EXIT(mw_lexer_emit_rcurly_21_);
 }
-static void mw_lexer_emit_name_21_ (void){
+static void mw_lexer_emit_name_21_ (void) {
     WORD_ENTER(mw_lexer_emit_name_21_, "lexer-emit-name!", "src/mirth/lexer.mth", 131, 5);
     WORD_ATOM(131, 5, "str-buf-clear!");
     mw_str_buf_clear_21_();
@@ -17338,7 +17234,7 @@ static void mw_lexer_emit_name_21_ (void){
     }
     WORD_EXIT(mw_lexer_emit_name_21_);
 }
-static void mw_str_buf_is_doc_start_3F_ (void){
+static void mw_str_buf_is_doc_start_3F_ (void) {
     WORD_ENTER(mw_str_buf_is_doc_start_3F_, "str-buf-is-doc-start?", "src/mirth/lexer.mth", 161, 5);
     WORD_ATOM(161, 5, "str-buf-length?");
     mw_str_buf_length_3F_();
@@ -17382,7 +17278,7 @@ static void mw_str_buf_is_doc_start_3F_ (void){
     }
     WORD_EXIT(mw_str_buf_is_doc_start_3F_);
 }
-static void mw_str_buf_is_int_3F_ (void){
+static void mw_str_buf_is_int_3F_ (void) {
     WORD_ENTER(mw_str_buf_is_int_3F_, "str-buf-is-int?", "src/mirth/lexer.mth", 182, 5);
     WORD_ATOM(182, 5, "str-buf-is-dec-int?");
     mw_str_buf_is_dec_int_3F_();
@@ -17396,7 +17292,7 @@ static void mw_str_buf_is_int_3F_ (void){
     }
     WORD_EXIT(mw_str_buf_is_int_3F_);
 }
-static void mw_str_buf_is_dec_int_3F_ (void){
+static void mw_str_buf_is_dec_int_3F_ (void) {
     WORD_ENTER(mw_str_buf_is_dec_int_3F_, "str-buf-is-dec-int?", "src/mirth/lexer.mth", 185, 5);
     WORD_ATOM(185, 5, "");
     push_i64(0LL);
@@ -17455,7 +17351,7 @@ static void mw_str_buf_is_dec_int_3F_ (void){
     }
     WORD_EXIT(mw_str_buf_is_dec_int_3F_);
 }
-static void mw_str_buf_is_hex_int_3F_ (void){
+static void mw_str_buf_is_hex_int_3F_ (void) {
     WORD_ENTER(mw_str_buf_is_hex_int_3F_, "str-buf-is-hex-int?", "src/mirth/lexer.mth", 192, 5);
     WORD_ATOM(192, 5, "");
     push_i64(0LL);
@@ -17550,7 +17446,7 @@ static void mw_str_buf_is_hex_int_3F_ (void){
     }
     WORD_EXIT(mw_str_buf_is_hex_int_3F_);
 }
-static void mw_str_buf_int_3F_ (void){
+static void mw_str_buf_int_3F_ (void) {
     WORD_ENTER(mw_str_buf_int_3F_, "str-buf-int?", "src/mirth/lexer.mth", 215, 5);
     WORD_ATOM(215, 5, "str-buf-is-dec-int?");
     mw_str_buf_is_dec_int_3F_();
@@ -17564,7 +17460,7 @@ static void mw_str_buf_int_3F_ (void){
     }
     WORD_EXIT(mw_str_buf_int_3F_);
 }
-static void mw_str_buf_int_sign (void){
+static void mw_str_buf_int_sign (void) {
     WORD_ENTER(mw_str_buf_int_sign, "str-buf-int-sign", "src/mirth/lexer.mth", 228, 5);
     WORD_ATOM(228, 5, "");
     push_i64(0LL);
@@ -17573,7 +17469,7 @@ static void mw_str_buf_int_sign (void){
     WORD_ATOM(228, 21, "match");
     switch (get_top_data_tag()) {
         case 45LL:
-            co_B_27___27_();
+            mp_B_27___27_();
             WORD_ATOM(229, 17, "");
             push_i64(-1LL);
             WORD_ATOM(229, 20, "");
@@ -17582,7 +17478,7 @@ static void mw_str_buf_int_sign (void){
             push_i64(1LL);
             break;
         case 43LL:
-            co_B_27__2B__27_();
+            mp_B_27__2B__27_();
             WORD_ATOM(230, 17, "");
             push_i64(1LL);
             WORD_ATOM(230, 20, "");
@@ -17600,10 +17496,10 @@ static void mw_str_buf_int_sign (void){
             WORD_ATOM(231, 24, "");
             push_i64(0LL);
             break;
-    
-}    WORD_EXIT(mw_str_buf_int_sign);
+    }
+    WORD_EXIT(mw_str_buf_int_sign);
 }
-static void mw_str_buf_dec_int_3F_ (void){
+static void mw_str_buf_dec_int_3F_ (void) {
     WORD_ENTER(mw_str_buf_dec_int_3F_, "str-buf-dec-int?", "src/mirth/lexer.mth", 235, 5);
     WORD_ATOM(235, 5, "str-buf-int-sign");
     mw_str_buf_int_sign();
@@ -17630,7 +17526,7 @@ static void mw_str_buf_dec_int_3F_ (void){
     mw_prim_int_mul();
     WORD_EXIT(mw_str_buf_dec_int_3F_);
 }
-static void mw_str_buf_hex_int_3F_ (void){
+static void mw_str_buf_hex_int_3F_ (void) {
     WORD_ENTER(mw_str_buf_hex_int_3F_, "str-buf-hex-int?", "src/mirth/lexer.mth", 245, 5);
     WORD_ATOM(245, 5, "str-buf-int-sign");
     mw_str_buf_int_sign();
@@ -17661,7 +17557,7 @@ static void mw_str_buf_hex_int_3F_ (void){
     mw_prim_int_mul();
     WORD_EXIT(mw_str_buf_hex_int_3F_);
 }
-static void mw_hexdigit_value (void){
+static void mw_hexdigit_value (void) {
     WORD_ENTER(mw_hexdigit_value, "hexdigit-value", "src/mirth/lexer.mth", 255, 5);
     WORD_ATOM(255, 5, "dup");
     mw_prim_dup();
@@ -17685,7 +17581,7 @@ static void mw_hexdigit_value (void){
     }
     WORD_EXIT(mw_hexdigit_value);
 }
-static void mw_lexer_emit_string_21_ (void){
+static void mw_lexer_emit_string_21_ (void) {
     WORD_ENTER(mw_lexer_emit_string_21_, "lexer-emit-string!", "src/mirth/lexer.mth", 261, 5);
     WORD_ATOM(261, 5, "str-buf-clear!");
     mw_str_buf_clear_21_();
@@ -17727,12 +17623,12 @@ static void mw_lexer_emit_string_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_lexer_emit_string_21_);
 }
-static void mw_lexer_push_string_byte_21_ (void){
+static void mw_lexer_push_string_byte_21_ (void) {
     WORD_ENTER(mw_lexer_push_string_byte_21_, "lexer-push-string-byte!", "src/mirth/lexer.mth", 276, 5);
     WORD_ATOM(276, 5, "B'\\'");
     switch (get_top_data_tag()) {
         case 92LL:
-            co_B_27__5C__27_();
+            mp_B_27__5C__27_();
             WORD_ATOM(276, 13, "lexer-move!");
             mw_lexer_move_21_();
             WORD_ATOM(276, 25, "lexer-peek");
@@ -17744,48 +17640,48 @@ static void mw_lexer_push_string_byte_21_ (void){
             WORD_ATOM(277, 10, "str-buf-push-byte!");
             mw_str_buf_push_byte_21_();
             break;
-    
-}    WORD_EXIT(mw_lexer_push_string_byte_21_);
+    }
+    WORD_EXIT(mw_lexer_push_string_byte_21_);
 }
-static void mw_lexer_push_string_escape_byte_21_ (void){
+static void mw_lexer_push_string_escape_byte_21_ (void) {
     WORD_ENTER(mw_lexer_push_string_escape_byte_21_, "lexer-push-string-escape-byte!", "src/mirth/lexer.mth", 280, 5);
     WORD_ATOM(280, 5, "BLF");
     switch (get_top_data_tag()) {
         case 10LL:
-            co_BLF();
+            mp_BLF();
             WORD_ATOM(280, 12, "id");
             mw_prim_id();
             break;
         case 110LL:
-            co_B_27_n_27_();
+            mp_B_27_n_27_();
             WORD_ATOM(281, 13, "BLF");
             mw_BLF();
             WORD_ATOM(281, 17, "str-buf-push-byte!");
             mw_str_buf_push_byte_21_();
             break;
         case 114LL:
-            co_B_27_r_27_();
+            mp_B_27_r_27_();
             WORD_ATOM(282, 13, "BCR");
             mw_BCR();
             WORD_ATOM(282, 17, "str-buf-push-byte!");
             mw_str_buf_push_byte_21_();
             break;
         case 116LL:
-            co_B_27_t_27_();
+            mp_B_27_t_27_();
             WORD_ATOM(283, 13, "BHT");
             mw_BHT();
             WORD_ATOM(283, 17, "str-buf-push-byte!");
             mw_str_buf_push_byte_21_();
             break;
         case 92LL:
-            co_B_27__5C__27_();
+            mp_B_27__5C__27_();
             WORD_ATOM(284, 13, "B'\\'");
             mw_B_27__5C__27_();
             WORD_ATOM(284, 18, "str-buf-push-byte!");
             mw_str_buf_push_byte_21_();
             break;
         case 34LL:
-            co_BQUOTE();
+            mp_BQUOTE();
             WORD_ATOM(285, 15, "BQUOTE");
             mw_BQUOTE();
             WORD_ATOM(285, 22, "str-buf-push-byte!");
@@ -17808,10 +17704,10 @@ static void mw_lexer_push_string_escape_byte_21_ (void){
             WORD_ATOM(287, 42, "lexer-emit-warning!");
             mw_lexer_emit_warning_21_();
             break;
-    
-}    WORD_EXIT(mw_lexer_push_string_escape_byte_21_);
+    }
+    WORD_EXIT(mw_lexer_push_string_escape_byte_21_);
 }
-static void mw_lexer_skip_comment_21_ (void){
+static void mw_lexer_skip_comment_21_ (void) {
     WORD_ENTER(mw_lexer_skip_comment_21_, "lexer-skip-comment!", "src/mirth/lexer.mth", 290, 5);
     WORD_ATOM(290, 5, "while");
     while(1) {
@@ -17843,7 +17739,7 @@ static void mw_lexer_skip_comment_21_ (void){
     mw_prim_drop();
     WORD_EXIT(mw_lexer_skip_comment_21_);
 }
-static void mw_lexer_skip_doc_21_ (void){
+static void mw_lexer_skip_doc_21_ (void) {
     WORD_ENTER(mw_lexer_skip_doc_21_, "lexer-skip-doc!", "src/mirth/lexer.mth", 293, 26);
     WORD_ATOM(293, 26, "while");
     while(1) {
@@ -17857,7 +17753,7 @@ static void mw_lexer_skip_doc_21_ (void){
     }
     WORD_EXIT(mw_lexer_skip_doc_21_);
 }
-static void mw_lexer_comment_end_3F_ (void){
+static void mw_lexer_comment_end_3F_ (void) {
     WORD_ENTER(mw_lexer_comment_end_3F_, "lexer-comment-end?", "src/mirth/lexer.mth", 296, 5);
     WORD_ATOM(296, 5, "lexer-done?");
     mw_lexer_done_3F_();
@@ -17879,13 +17775,13 @@ static void mw_lexer_comment_end_3F_ (void){
     }
     WORD_EXIT(mw_lexer_comment_end_3F_);
 }
-static void mw_lexer_peek (void){
+static void mw_lexer_peek (void) {
     WORD_ENTER(mw_lexer_peek, "lexer-peek", "src/mirth/lexer.mth", 301, 23);
     WORD_ATOM(301, 23, "input-peek");
     mw_input_peek();
     WORD_EXIT(mw_lexer_peek);
 }
-static void mw_lexer_move_21_ (void){
+static void mw_lexer_move_21_ (void) {
     WORD_ENTER(mw_lexer_move_21_, "lexer-move!", "src/mirth/lexer.mth", 302, 22);
     WORD_ATOM(302, 22, "input-move!");
     mw_input_move_21_();
@@ -17898,7 +17794,7 @@ static void mw_lexer_move_21_ (void){
     mw_modify();
     WORD_EXIT(mw_lexer_move_21_);
 }
-static void mw_lexer_location (void){
+static void mw_lexer_location (void) {
     WORD_ENTER(mw_lexer_location, "lexer-location", "src/mirth/lexer.mth", 306, 5);
     WORD_ATOM(306, 5, "lexer-module");
     mw_lexer_module();
@@ -17916,7 +17812,7 @@ static void mw_lexer_location (void){
     mw_LOCATION();
     WORD_EXIT(mw_lexer_location);
 }
-static void mw_lexer_emit_warning_21_ (void){
+static void mw_lexer_emit_warning_21_ (void) {
     WORD_ENTER(mw_lexer_emit_warning_21_, "lexer-emit-warning!", "src/mirth/lexer.mth", 308, 34);
     WORD_ATOM(308, 34, "dip");
     {
@@ -17929,7 +17825,7 @@ static void mw_lexer_emit_warning_21_ (void){
     mw_emit_warning_at_21_();
     WORD_EXIT(mw_lexer_emit_warning_21_);
 }
-static void mw_lexer_emit_fatal_error_21_ (void){
+static void mw_lexer_emit_fatal_error_21_ (void) {
     WORD_ENTER(mw_lexer_emit_fatal_error_21_, "lexer-emit-fatal-error!", "src/mirth/lexer.mth", 310, 44);
     WORD_ATOM(310, 44, "dip");
     {
@@ -17942,7 +17838,7 @@ static void mw_lexer_emit_fatal_error_21_ (void){
     mw_emit_fatal_error_at_21_();
     WORD_EXIT(mw_lexer_emit_fatal_error_21_);
 }
-static void mw_reset_needs_21_ (void){
+static void mw_reset_needs_21_ (void) {
     WORD_ENTER(mw_reset_needs_21_, "reset-needs!", "src/mirth/codegen.mth", 43, 5);
     WORD_ATOM(43, 5, "Block.for");
     push_u64(0);
@@ -17960,7 +17856,7 @@ static void mw_reset_needs_21_ (void){
     mw_Stack_2E_reset_21_();
     WORD_EXIT(mw_reset_needs_21_);
 }
-static void mw_for_needed_words (void){
+static void mw_for_needed_words (void) {
     WORD_ENTER(mw_for_needed_words, "for-needed-words", "src/mirth/codegen.mth", 47, 5);
     WORD_ATOM(47, 5, "Word.for");
     {
@@ -17977,7 +17873,7 @@ static void mw_for_needed_words (void){
     }
     WORD_EXIT(mw_for_needed_words);
 }
-static void mw_for_needed_blocks (void){
+static void mw_for_needed_blocks (void) {
     WORD_ENTER(mw_for_needed_blocks, "for-needed-blocks", "src/mirth/codegen.mth", 49, 5);
     WORD_ATOM(49, 5, "Block.for");
     {
@@ -17994,7 +17890,7 @@ static void mw_for_needed_blocks (void){
     }
     WORD_EXIT(mw_for_needed_blocks);
 }
-static void mw_need_block (void){
+static void mw_need_block (void) {
     WORD_ENTER(mw_need_block, "need-block", "src/mirth/codegen.mth", 52, 5);
     WORD_ATOM(52, 5, "dup");
     mw_prim_dup();
@@ -18024,7 +17920,7 @@ static void mw_need_block (void){
     }
     WORD_EXIT(mw_need_block);
 }
-static void mw_need_word (void){
+static void mw_need_word (void) {
     WORD_ENTER(mw_need_word, "need-word", "src/mirth/codegen.mth", 58, 5);
     WORD_ATOM(58, 5, "dup");
     mw_prim_dup();
@@ -18054,7 +17950,7 @@ static void mw_need_word (void){
     }
     WORD_EXIT(mw_need_word);
 }
-static void mw_determine_arrow_needs_21_ (void){
+static void mw_determine_arrow_needs_21_ (void) {
     WORD_ENTER(mw_determine_arrow_needs_21_, "determine-arrow-needs!", "src/mirth/codegen.mth", 65, 5);
     WORD_ATOM(65, 5, "need-arrow-run");
     mw_need_arrow_run();
@@ -18062,7 +17958,7 @@ static void mw_determine_arrow_needs_21_ (void){
     mw_determine_transitive_needs_21_();
     WORD_EXIT(mw_determine_arrow_needs_21_);
 }
-static void mw_determine_transitive_needs_21_ (void){
+static void mw_determine_transitive_needs_21_ (void) {
     WORD_ENTER(mw_determine_transitive_needs_21_, "determine-transitive-needs!", "src/mirth/codegen.mth", 67, 5);
     WORD_ATOM(67, 5, "while-some");
     push_u64(0);
@@ -18074,7 +17970,7 @@ static void mw_determine_transitive_needs_21_ (void){
     mw_while_some();
     WORD_EXIT(mw_determine_transitive_needs_21_);
 }
-static void mw_need_arrow_run (void){
+static void mw_need_arrow_run (void) {
     WORD_ENTER(mw_need_arrow_run, "need-arrow-run", "src/mirth/codegen.mth", 72, 31);
     WORD_ATOM(72, 31, "atoms");
     mw_Arrow_2E_atoms();
@@ -18085,7 +17981,7 @@ static void mw_need_arrow_run (void){
     mw_List_2E_for();
     WORD_EXIT(mw_need_arrow_run);
 }
-static void mw_need_atom_run (void){
+static void mw_need_atom_run (void) {
     WORD_ENTER(mw_need_atom_run, "need-atom-run", "src/mirth/codegen.mth", 74, 5);
     WORD_ATOM(74, 5, "sip");
     push_u64(0);
@@ -18097,103 +17993,103 @@ static void mw_need_atom_run (void){
     WORD_ATOM(74, 18, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_OP_5F_NONE();
+            mp_OP_5F_NONE();
             WORD_ATOM(75, 20, "drop");
             mw_prim_drop();
             break;
         case 8LL:
-            co_OP_5F_INT();
+            mp_OP_5F_INT();
             WORD_ATOM(76, 19, "drop2");
             mw_drop2();
             break;
         case 9LL:
-            co_OP_5F_STR();
+            mp_OP_5F_STR();
             WORD_ATOM(77, 19, "drop2");
             mw_drop2();
             break;
         case 6LL:
-            co_OP_5F_CONSTANT();
+            mp_OP_5F_CONSTANT();
             WORD_ATOM(78, 24, "drop2");
             mw_drop2();
             break;
         case 2LL:
-            co_OP_5F_WORD();
+            mp_OP_5F_WORD();
             WORD_ATOM(79, 20, "need-word");
             mw_need_word();
             WORD_ATOM(79, 30, "need-args-push");
             mw_need_args_push();
             break;
         case 3LL:
-            co_OP_5F_EXTERNAL();
+            mp_OP_5F_EXTERNAL();
             WORD_ATOM(80, 24, "drop");
             mw_prim_drop();
             WORD_ATOM(80, 29, "need-args-push");
             mw_need_args_push();
             break;
         case 4LL:
-            co_OP_5F_BUFFER();
+            mp_OP_5F_BUFFER();
             WORD_ATOM(81, 22, "drop");
             mw_prim_drop();
             WORD_ATOM(81, 27, "need-args-push");
             mw_need_args_push();
             break;
         case 5LL:
-            co_OP_5F_VARIABLE();
+            mp_OP_5F_VARIABLE();
             WORD_ATOM(82, 24, "drop");
             mw_prim_drop();
             WORD_ATOM(82, 29, "need-args-push");
             mw_need_args_push();
             break;
         case 7LL:
-            co_OP_5F_FIELD();
+            mp_OP_5F_FIELD();
             WORD_ATOM(83, 21, "drop");
             mw_prim_drop();
             WORD_ATOM(83, 26, "need-args-push");
             mw_need_args_push();
             break;
         case 10LL:
-            co_OP_5F_TAG();
+            mp_OP_5F_TAG();
             WORD_ATOM(84, 19, "drop");
             mw_prim_drop();
             WORD_ATOM(84, 24, "need-args-push");
             mw_need_args_push();
             break;
         case 1LL:
-            co_OP_5F_PRIM();
+            mp_OP_5F_PRIM();
             WORD_ATOM(85, 20, "need-prim");
             mw_need_prim();
             break;
         case 11LL:
-            co_OP_5F_MATCH();
+            mp_OP_5F_MATCH();
             WORD_ATOM(86, 21, "nip");
             mw_nip();
             WORD_ATOM(86, 25, "need-match");
             mw_need_match();
             break;
         case 12LL:
-            co_OP_5F_LAMBDA();
+            mp_OP_5F_LAMBDA();
             WORD_ATOM(87, 22, "nip");
             mw_nip();
             WORD_ATOM(87, 26, "need-lambda");
             mw_need_lambda();
             break;
         case 13LL:
-            co_OP_5F_VAR();
+            mp_OP_5F_VAR();
             WORD_ATOM(88, 19, "drop2");
             mw_drop2();
             break;
         case 14LL:
-            co_OP_5F_BLOCK();
+            mp_OP_5F_BLOCK();
             WORD_ATOM(89, 21, "nip");
             mw_nip();
             WORD_ATOM(89, 25, "need-block-push");
             mw_need_block_push();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_need_atom_run);
+    }
+    WORD_EXIT(mw_need_atom_run);
 }
-static void mw_need_args_push (void){
+static void mw_need_args_push (void) {
     WORD_ENTER(mw_need_args_push, "need-args-push", "src/mirth/codegen.mth", 91, 35);
     WORD_ATOM(91, 35, "for");
     push_u64(0);
@@ -18202,30 +18098,30 @@ static void mw_need_args_push (void){
     mw_List_2E_for();
     WORD_EXIT(mw_need_args_push);
 }
-static void mw_need_arg_push (void){
+static void mw_need_arg_push (void) {
     WORD_ENTER(mw_need_arg_push, "need-arg-push", "src/mirth/codegen.mth", 92, 28);
     WORD_ATOM(92, 28, "ARG_BLOCK");
     WORD_ATOM(92, 41, "need-block-push");
     mw_need_block_push();
     WORD_EXIT(mw_need_arg_push);
 }
-static void mw_need_arg_run (void){
+static void mw_need_arg_run (void) {
     WORD_ENTER(mw_need_arg_run, "need-arg-run", "src/mirth/codegen.mth", 93, 27);
     WORD_ATOM(93, 27, "ARG_BLOCK");
     WORD_ATOM(93, 40, "need-block-run");
     mw_need_block_run();
     WORD_EXIT(mw_need_arg_run);
 }
-static void mw_need_prim (void){
+static void mw_need_prim (void) {
     WORD_ENTER(mw_need_prim, "need-prim", "src/mirth/codegen.mth", 96, 5);
     WORD_ATOM(96, 5, "PRIM_CORE_DIP");
     switch (get_top_data_tag()) {
         case 4LL:
-            co_PRIM_5F_CORE_5F_DIP();
+            mp_PRIM_5F_CORE_5F_DIP();
             WORD_ATOM(97, 9, "match");
             switch (get_top_data_tag()) {
                 case 1LL:
-                    co_L1();
+                    mp_L1();
                     WORD_ATOM(98, 19, "need-arg-run");
                     mw_need_arg_run();
                     break;
@@ -18233,14 +18129,14 @@ static void mw_need_prim (void){
                     WORD_ATOM(99, 18, "need-args-push");
                     mw_need_args_push();
                     break;
-            
-}            break;
+            }
+            break;
         case 13LL:
-            co_PRIM_5F_CORE_5F_RDIP();
+            mp_PRIM_5F_CORE_5F_RDIP();
             WORD_ATOM(102, 9, "match");
             switch (get_top_data_tag()) {
                 case 1LL:
-                    co_L1();
+                    mp_L1();
                     WORD_ATOM(103, 19, "need-arg-run");
                     mw_need_arg_run();
                     break;
@@ -18248,14 +18144,14 @@ static void mw_need_prim (void){
                     WORD_ATOM(104, 18, "need-args-push");
                     mw_need_args_push();
                     break;
-            
-}            break;
+            }
+            break;
         case 5LL:
-            co_PRIM_5F_CORE_5F_IF();
+            mp_PRIM_5F_CORE_5F_IF();
             WORD_ATOM(107, 9, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
-                    co_L2();
+                    mp_L2();
                     WORD_ATOM(108, 19, "dip");
                     {
                         VAL d6 = pop_value();
@@ -18270,14 +18166,14 @@ static void mw_need_prim (void){
                     WORD_ATOM(109, 18, "need-args-push");
                     mw_need_args_push();
                     break;
-            
-}            break;
+            }
+            break;
         case 6LL:
-            co_PRIM_5F_CORE_5F_WHILE();
+            mp_PRIM_5F_CORE_5F_WHILE();
             WORD_ATOM(112, 9, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
-                    co_L2();
+                    mp_L2();
                     WORD_ATOM(113, 19, "dip");
                     {
                         VAL d6 = pop_value();
@@ -18292,18 +18188,18 @@ static void mw_need_prim (void){
                     WORD_ATOM(114, 18, "need-args-push");
                     mw_need_args_push();
                     break;
-            
-}            break;
+            }
+            break;
         default:
             WORD_ATOM(116, 10, "drop");
             mw_prim_drop();
             WORD_ATOM(116, 15, "need-args-push");
             mw_need_args_push();
             break;
-    
-}    WORD_EXIT(mw_need_prim);
+    }
+    WORD_EXIT(mw_need_prim);
 }
-static void mw_need_match (void){
+static void mw_need_match (void) {
     WORD_ENTER(mw_need_match, "need-match", "src/mirth/codegen.mth", 118, 27);
     WORD_ATOM(118, 27, "cases");
     mw_Match_2E_cases();
@@ -18314,7 +18210,7 @@ static void mw_need_match (void){
     mw_List_2E_for();
     WORD_EXIT(mw_need_match);
 }
-static void mw_need_lambda (void){
+static void mw_need_lambda (void) {
     WORD_ENTER(mw_need_lambda, "need-lambda", "src/mirth/codegen.mth", 119, 29);
     WORD_ATOM(119, 29, "body");
     mw_Lambda_2E_body();
@@ -18322,7 +18218,7 @@ static void mw_need_lambda (void){
     mw_need_arrow_run();
     WORD_EXIT(mw_need_lambda);
 }
-static void mw_need_block_push (void){
+static void mw_need_block_push (void) {
     WORD_ENTER(mw_need_block_push, "need-block-push", "src/mirth/codegen.mth", 122, 5);
     WORD_ATOM(122, 5, "dup");
     mw_prim_dup();
@@ -18331,20 +18227,20 @@ static void mw_need_block_push (void){
     WORD_ATOM(122, 26, "match");
     switch (get_top_data_tag()) {
         case 1LL:
-            co_SOME();
+            mp_SOME();
             WORD_ATOM(123, 17, "drop2");
             mw_drop2();
             break;
         case 0LL:
-            co_NONE();
+            mp_NONE();
             WORD_ATOM(124, 17, "need-block");
             mw_need_block();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_need_block_push);
+    }
+    WORD_EXIT(mw_need_block_push);
 }
-static void mw_need_block_run (void){
+static void mw_need_block_run (void) {
     WORD_ENTER(mw_need_block_run, "need-block-run", "src/mirth/codegen.mth", 126, 31);
     WORD_ATOM(126, 31, "arrow");
     mw_Block_2E_arrow();
@@ -18352,20 +18248,20 @@ static void mw_need_block_run (void){
     mw_need_arrow_run();
     WORD_EXIT(mw_need_block_run);
 }
-static void mw__2B_C99_2F_MKC99 (void){
+static void mw__2B_C99_2F_MKC99 (void) {
     WORD_ENTER(mw__2B_C99_2F_MKC99, "+C99/MKC99", "src/mirth/codegen.mth", 133, 39);
     WORD_ATOM(133, 39, "MKC99");
     switch (get_top_resource_data_tag()) {
         case 0LL:
-            co_MKC99();
+            mp_MKC99();
             WORD_ATOM(133, 48, "id");
             mw_prim_id();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw__2B_C99_2F_MKC99);
+    }
+    WORD_EXIT(mw__2B_C99_2F_MKC99);
 }
-static void mw__2B_C99_2E_depth_40_ (void){
+static void mw__2B_C99_2E_depth_40_ (void) {
     WORD_ENTER(mw__2B_C99_2E_depth_40_, "+C99.depth@", "src/mirth/codegen.mth", 135, 36);
     WORD_ATOM(135, 36, "/MKC99");
     mw__2B_C99_2F_MKC99();
@@ -18380,7 +18276,7 @@ static void mw__2B_C99_2E_depth_40_ (void){
     }
     WORD_EXIT(mw__2B_C99_2E_depth_40_);
 }
-static void mw__2B_C99_2E_depth_21_ (void){
+static void mw__2B_C99_2E_depth_21_ (void) {
     WORD_ENTER(mw__2B_C99_2E_depth_21_, "+C99.depth!", "src/mirth/codegen.mth", 136, 36);
     WORD_ATOM(136, 36, "dip");
     {
@@ -18397,175 +18293,60 @@ static void mw__2B_C99_2E_depth_21_ (void){
     mw_MKC99();
     WORD_EXIT(mw__2B_C99_2E_depth_21_);
 }
-static void mw_Str_2B_C99_2E_ (void){
-    WORD_ENTER(mw_Str_2B_C99_2E_, "Str+C99.", "src/mirth/codegen.mth", 138, 5);
-    WORD_ATOM(138, 5, "dip");
+static void mw_Str_2B_C99_2E_put (void) {
+    WORD_ENTER(mw_Str_2B_C99_2E_put, "Str+C99.put", "src/mirth/codegen.mth", 139, 5);
+    WORD_ATOM(139, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(138, 9, "/MKC99");
+        WORD_ATOM(139, 9, "/MKC99");
         mw__2B_C99_2F_MKC99();
         push_value(d2);
     }
-    WORD_ATOM(138, 17, "cat");
+    WORD_ATOM(139, 17, "cat");
     mw_prim_str_cat();
-    WORD_ATOM(139, 5, "dup");
+    WORD_ATOM(140, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(139, 9, "num-bytes");
+    WORD_ATOM(140, 9, "num-bytes");
     mw_prim_str_num_bytes();
-    WORD_ATOM(139, 19, "dip");
+    WORD_ATOM(140, 19, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(139, 23, "MKC99");
+        WORD_ATOM(140, 23, "MKC99");
         mw_MKC99();
         push_value(d2);
     }
-    WORD_ATOM(140, 5, "");
+    WORD_ATOM(141, 5, "");
     push_i64(512LL);
-    WORD_ATOM(140, 9, ">");
+    WORD_ATOM(141, 9, ">");
     mw_Int_3E_();
-    WORD_ATOM(140, 11, "then");
+    WORD_ATOM(141, 11, "then");
     push_u64(0);
-    push_fnptr(&mb_Str_2B_C99_2E__3);
+    push_fnptr(&mb_Str_2B_C99_2E_put_3);
     mw_prim_pack_cons();
     mw_Bool_2E_then();
-    WORD_EXIT(mw_Str_2B_C99_2E_);
+    WORD_EXIT(mw_Str_2B_C99_2E_put);
 }
-static void mw_Int_2B_C99_2E_n (void){
-    WORD_ENTER(mw_Int_2B_C99_2E_n, "Int+C99.n", "src/mirth/codegen.mth", 142, 34);
-    WORD_ATOM(142, 34, "int-to-str");
+static void mw_Int_2B_C99_2E_put (void) {
+    WORD_ENTER(mw_Int_2B_C99_2E_put, "Int+C99.put", "src/mirth/codegen.mth", 142, 36);
+    WORD_ATOM(142, 36, "int-to-str");
     mw_prim_int_to_str();
-    WORD_ATOM(142, 45, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_EXIT(mw_Int_2B_C99_2E_n);
+    WORD_ATOM(142, 47, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_EXIT(mw_Int_2B_C99_2E_put);
 }
-static void mw_Byte_2B_C99_2E_b (void){
-    WORD_ENTER(mw_Byte_2B_C99_2E_b, "Byte+C99.b", "src/mirth/codegen.mth", 143, 36);
-    WORD_ATOM(143, 36, "to-ascii-str");
+static void mw_Byte_2B_C99_2E_put (void) {
+    WORD_ENTER(mw_Byte_2B_C99_2E_put, "Byte+C99.put", "src/mirth/codegen.mth", 143, 38);
+    WORD_ATOM(143, 38, "to-ascii-str");
     mw_Byte_2E_to_ascii_str();
-    WORD_ATOM(143, 49, "unwrap");
+    WORD_ATOM(143, 51, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(143, 56, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_EXIT(mw_Byte_2B_C99_2E_b);
+    WORD_ATOM(143, 58, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_EXIT(mw_Byte_2B_C99_2E_put);
 }
-static void mw_codegen_start_21_ (void){
-    WORD_ENTER(mw_codegen_start_21_, "codegen-start!", "src/mirth/codegen.mth", 146, 5);
-    WORD_ATOM(146, 5, ">Str");
-    mw_Path_3E_Str();
-    WORD_ATOM(146, 10, "create-file!");
-    mw_create_file_21_();
-    WORD_ATOM(146, 23, "");
-    push_i64(0LL);
-    WORD_ATOM(146, 25, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr("", 0);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(146, 28, "MKC99");
-    mw_MKC99();
-    WORD_EXIT(mw_codegen_start_21_);
-}
-static void mw_codegen_flush_21_ (void){
-    WORD_ENTER(mw_codegen_flush_21_, "codegen-flush!", "src/mirth/codegen.mth", 149, 5);
-    WORD_ATOM(149, 5, "/MKC99");
-    mw__2B_C99_2F_MKC99();
-    WORD_ATOM(149, 12, "dip");
-    {
-        VAL d2 = pop_value();
-        WORD_ATOM(149, 16, "over");
-        mw_over();
-        push_value(d2);
-    }
-    WORD_ATOM(149, 22, "write!");
-    mw_Str_2E_write_21_();
-    WORD_ATOM(149, 29, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr("", 0);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(149, 32, "MKC99");
-    mw_MKC99();
-    WORD_EXIT(mw_codegen_flush_21_);
-}
-static void mw_codegen_end_21_ (void){
-    WORD_ENTER(mw_codegen_end_21_, "codegen-end!", "src/mirth/codegen.mth", 152, 5);
-    WORD_ATOM(152, 5, "codegen-flush!");
-    mw_codegen_flush_21_();
-    WORD_ATOM(153, 5, "/MKC99");
-    mw__2B_C99_2F_MKC99();
-    WORD_ATOM(153, 12, "drop2");
-    mw_drop2();
-    WORD_ATOM(153, 18, "close-file!");
-    mw_close_file_21_();
-    WORD_EXIT(mw_codegen_end_21_);
-}
-static void mw_run_output_c99_21_ (void){
-    WORD_ENTER(mw_run_output_c99_21_, "run-output-c99!", "src/mirth/codegen.mth", 156, 5);
-    WORD_ATOM(156, 5, "num-errors");
-    mw_num_errors();
-    WORD_ATOM(156, 16, "@");
-    mw_prim_mut_get();
-    WORD_ATOM(156, 18, "0>");
-    mw_0_3E_();
-    WORD_ATOM(156, 21, "if");
-    if (pop_u64()) {
-        WORD_ATOM(157, 9, "drop2");
-        mw_drop2();
-    } else {
-        WORD_ATOM(159, 9, "reset-needs!");
-        mw_reset_needs_21_();
-        WORD_ATOM(160, 9, "over");
-        mw_over();
-        WORD_ATOM(160, 14, "determine-arrow-needs!");
-        mw_determine_arrow_needs_21_();
-        WORD_ATOM(162, 9, "to-output-path");
-        mw_Path_2E_to_output_path();
-        WORD_ATOM(163, 9, "codegen-start!");
-        mw_codegen_start_21_();
-        WORD_ATOM(164, 9, "c99-header!");
-        mw_c99_header_21_();
-        WORD_ATOM(165, 9, "c99-tags!");
-        mw_c99_tags_21_();
-        WORD_ATOM(166, 9, "c99-buffers!");
-        mw_c99_buffers_21_();
-        WORD_ATOM(167, 9, "c99-variables!");
-        mw_c99_variables_21_();
-        WORD_ATOM(168, 9, "c99-externals!");
-        mw_c99_externals_21_();
-        WORD_ATOM(169, 9, "c99-word-sigs!");
-        mw_c99_word_sigs_21_();
-        WORD_ATOM(170, 9, "c99-block-sigs!");
-        mw_c99_block_sigs_21_();
-        WORD_ATOM(171, 9, "c99-field-sigs!");
-        mw_c99_field_sigs_21_();
-        WORD_ATOM(172, 9, "c99-main!");
-        mw_c99_main_21_();
-        WORD_ATOM(173, 9, "c99-field-defs!");
-        mw_c99_field_defs_21_();
-        WORD_ATOM(174, 9, "c99-word-defs!");
-        mw_c99_word_defs_21_();
-        WORD_ATOM(175, 9, "c99-block-defs!");
-        mw_c99_block_defs_21_();
-        WORD_ATOM(176, 9, "codegen-end!");
-        mw_codegen_end_21_();
-    }
-    WORD_EXIT(mw_run_output_c99_21_);
-}
-static void mw__2B_C99_2E_lf (void){
-    WORD_ENTER(mw__2B_C99_2E_lf, "+C99.lf", "src/mirth/codegen.mth", 179, 28);
-    WORD_ATOM(179, 28, "");
+static void mw__2B_C99_2E_line (void) {
+    WORD_ENTER(mw__2B_C99_2E_line, "+C99.line", "src/mirth/codegen.mth", 144, 30);
+    WORD_ATOM(144, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18576,54 +18357,156 @@ static void mw__2B_C99_2E_lf (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(179, 33, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_EXIT(mw__2B_C99_2E_lf);
+    WORD_ATOM(144, 35, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_EXIT(mw__2B_C99_2E_line);
 }
-static void mw_Str_2B_C99_3B_ (void){
-    WORD_ENTER(mw_Str_2B_C99_3B_, "Str+C99;", "src/mirth/codegen.mth", 180, 33);
-    WORD_ATOM(180, 33, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(180, 35, ".lf");
-    mw__2B_C99_2E_lf();
-    WORD_EXIT(mw_Str_2B_C99_3B_);
-}
-static void mw_Str_2B_C99_3B__3B_ (void){
-    WORD_ENTER(mw_Str_2B_C99_3B__3B_, "Str+C99;;", "src/mirth/codegen.mth", 181, 34);
-    WORD_ATOM(181, 34, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(181, 36, ".lf");
-    mw__2B_C99_2E_lf();
-    WORD_ATOM(181, 40, ".lf");
-    mw__2B_C99_2E_lf();
-    WORD_EXIT(mw_Str_2B_C99_3B__3B_);
-}
-static void mw_Name_2B_C99_2E_name (void){
-    WORD_ENTER(mw_Name_2B_C99_2E_name, "Name+C99.name", "src/mirth/codegen.mth", 182, 39);
-    WORD_ATOM(182, 39, "mangled");
-    mw_Name_2E_mangled();
-    WORD_ATOM(182, 47, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_EXIT(mw_Name_2B_C99_2E_name);
-}
-static void mw_Name_2B_C99_2E_w (void){
-    WORD_ENTER(mw_Name_2B_C99_2E_w, "Name+C99.w", "src/mirth/codegen.mth", 183, 36);
-    WORD_ATOM(183, 36, "");
+static void mw_codegen_start_21_ (void) {
+    WORD_ENTER(mw_codegen_start_21_, "codegen-start!", "src/mirth/codegen.mth", 147, 5);
+    WORD_ATOM(147, 5, ">Str");
+    mw_Path_3E_Str();
+    WORD_ATOM(147, 10, "create-file!");
+    mw_create_file_21_();
+    WORD_ATOM(147, 23, "");
+    push_i64(0LL);
+    WORD_ATOM(147, 25, "");
     {
         static bool vready = false;
         static VAL v;
         if (! vready) {
-            v = mkstr("static void mw_", 15);
+            v = mkstr("", 0);
             vready = true;
         }
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(183, 54, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(183, 56, ".name");
-    mw_Name_2B_C99_2E_name();
-    WORD_ATOM(183, 62, "");
+    WORD_ATOM(147, 28, "MKC99");
+    mw_MKC99();
+    WORD_EXIT(mw_codegen_start_21_);
+}
+static void mw_codegen_flush_21_ (void) {
+    WORD_ENTER(mw_codegen_flush_21_, "codegen-flush!", "src/mirth/codegen.mth", 150, 5);
+    WORD_ATOM(150, 5, "/MKC99");
+    mw__2B_C99_2F_MKC99();
+    WORD_ATOM(150, 12, "dip");
+    {
+        VAL d2 = pop_value();
+        WORD_ATOM(150, 16, "over");
+        mw_over();
+        push_value(d2);
+    }
+    WORD_ATOM(150, 22, "write!");
+    mw_Str_2E_write_21_();
+    WORD_ATOM(150, 29, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("", 0);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(150, 32, "MKC99");
+    mw_MKC99();
+    WORD_EXIT(mw_codegen_flush_21_);
+}
+static void mw_codegen_end_21_ (void) {
+    WORD_ENTER(mw_codegen_end_21_, "codegen-end!", "src/mirth/codegen.mth", 153, 5);
+    WORD_ATOM(153, 5, "codegen-flush!");
+    mw_codegen_flush_21_();
+    WORD_ATOM(154, 5, "/MKC99");
+    mw__2B_C99_2F_MKC99();
+    WORD_ATOM(154, 12, "drop2");
+    mw_drop2();
+    WORD_ATOM(154, 18, "close-file!");
+    mw_close_file_21_();
+    WORD_EXIT(mw_codegen_end_21_);
+}
+static void mw_run_output_c99_21_ (void) {
+    WORD_ENTER(mw_run_output_c99_21_, "run-output-c99!", "src/mirth/codegen.mth", 157, 5);
+    WORD_ATOM(157, 5, "num-errors");
+    mw_num_errors();
+    WORD_ATOM(157, 16, "@");
+    mw_prim_mut_get();
+    WORD_ATOM(157, 18, "0>");
+    mw_0_3E_();
+    WORD_ATOM(157, 21, "if");
+    if (pop_u64()) {
+        WORD_ATOM(158, 9, "drop2");
+        mw_drop2();
+    } else {
+        WORD_ATOM(160, 9, "reset-needs!");
+        mw_reset_needs_21_();
+        WORD_ATOM(161, 9, "over");
+        mw_over();
+        WORD_ATOM(161, 14, "determine-arrow-needs!");
+        mw_determine_arrow_needs_21_();
+        WORD_ATOM(163, 9, "to-output-path");
+        mw_Path_2E_to_output_path();
+        WORD_ATOM(164, 9, "codegen-start!");
+        mw_codegen_start_21_();
+        WORD_ATOM(165, 9, "c99-header!");
+        mw_c99_header_21_();
+        WORD_ATOM(166, 9, "c99-tags!");
+        mw_c99_tags_21_();
+        WORD_ATOM(167, 9, "c99-buffers!");
+        mw_c99_buffers_21_();
+        WORD_ATOM(168, 9, "c99-variables!");
+        mw_c99_variables_21_();
+        WORD_ATOM(169, 9, "c99-externals!");
+        mw_c99_externals_21_();
+        WORD_ATOM(170, 9, "c99-word-sigs!");
+        mw_c99_word_sigs_21_();
+        WORD_ATOM(171, 9, "c99-block-sigs!");
+        mw_c99_block_sigs_21_();
+        WORD_ATOM(172, 9, "c99-field-sigs!");
+        mw_c99_field_sigs_21_();
+        WORD_ATOM(173, 9, "c99-main!");
+        mw_c99_main_21_();
+        WORD_ATOM(174, 9, "c99-field-defs!");
+        mw_c99_field_defs_21_();
+        WORD_ATOM(175, 9, "c99-word-defs!");
+        mw_c99_word_defs_21_();
+        WORD_ATOM(176, 9, "c99-block-defs!");
+        mw_c99_block_defs_21_();
+        WORD_ATOM(177, 9, "codegen-end!");
+        mw_codegen_end_21_();
+    }
+    WORD_EXIT(mw_run_output_c99_21_);
+}
+static void mw_Name_2B_C99_2E_put (void) {
+    WORD_ENTER(mw_Name_2B_C99_2E_put, "Name+C99.put", "src/mirth/codegen.mth", 180, 38);
+    WORD_ATOM(180, 38, "mangled");
+    mw_Name_2E_mangled();
+    WORD_ATOM(180, 46, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_EXIT(mw_Name_2B_C99_2E_put);
+}
+static void mw_Name_2B_C99_2E_sig (void) {
+    WORD_ENTER(mw_Name_2B_C99_2E_sig, "Name+C99.sig", "src/mirth/codegen.mth", 181, 42);
+    WORD_ATOM(181, 42, "dip");
+    {
+        VAL d2 = pop_value();
+        WORD_ATOM(181, 46, "");
+        {
+            static bool vready = false;
+            static VAL v;
+            if (! vready) {
+                v = mkstr("static void mw_", 15);
+                vready = true;
+            }
+            push_value(v);
+            incref(v);
+        }
+        push_value(d2);
+    }
+    WORD_ATOM(181, 65, "mangled");
+    mw_Name_2E_mangled();
+    WORD_ATOM(181, 73, "cat");
+    mw_prim_str_cat();
+    WORD_ATOM(181, 77, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18634,11 +18517,48 @@ static void mw_Name_2B_C99_2E_w (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(183, 72, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_EXIT(mw_Name_2B_C99_2E_w);
+    WORD_ATOM(181, 87, "cat");
+    mw_prim_str_cat();
+    WORD_EXIT(mw_Name_2B_C99_2E_sig);
 }
-static void mw_c99_header_21_ (void){
+static void mw_Name_2B_C99_2E_cosig (void) {
+    WORD_ENTER(mw_Name_2B_C99_2E_cosig, "Name+C99.cosig", "src/mirth/codegen.mth", 182, 44);
+    WORD_ATOM(182, 44, "dip");
+    {
+        VAL d2 = pop_value();
+        WORD_ATOM(182, 48, "");
+        {
+            static bool vready = false;
+            static VAL v;
+            if (! vready) {
+                v = mkstr("static void mp_", 15);
+                vready = true;
+            }
+            push_value(v);
+            incref(v);
+        }
+        push_value(d2);
+    }
+    WORD_ATOM(182, 67, "mangled");
+    mw_Name_2E_mangled();
+    WORD_ATOM(182, 75, "cat");
+    mw_prim_str_cat();
+    WORD_ATOM(182, 79, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr(" (void)", 7);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(182, 89, "cat");
+    mw_prim_str_cat();
+    WORD_EXIT(mw_Name_2B_C99_2E_cosig);
+}
+static void mw_c99_header_21_ (void) {
     WORD_ENTER(mw_c99_header_21_, "c99-header!", "src/mirth/codegen.mth", 188, 32);
     WORD_ATOM(188, 32, "c99-header-str");
     {
@@ -19847,32 +19767,34 @@ static uint8_t b[] = {                47,42,32,77,73,82,84,72,32,72,69,65,68,69,
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(188, 47, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(188, 49, ".lf");
-    mw__2B_C99_2E_lf();
+    WORD_ATOM(188, 47, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(188, 51, "line");
+    mw__2B_C99_2E_line();
     WORD_EXIT(mw_c99_header_21_);
 }
-static void mw_c99_buffers_21_ (void){
+static void mw_c99_buffers_21_ (void) {
     WORD_ENTER(mw_c99_buffers_21_, "c99-buffers!", "src/mirth/codegen.mth", 190, 33);
     WORD_ATOM(190, 33, "Buffer.for");
     push_u64(0);
     push_fnptr(&mb_c99_buffers_21__1);
     mw_prim_pack_cons();
     mw_Buffer_2E_for();
-    WORD_ATOM(190, 57, ".lf");
-    mw__2B_C99_2E_lf();
+    WORD_ATOM(190, 57, "line");
+    mw__2B_C99_2E_line();
     WORD_EXIT(mw_c99_buffers_21_);
 }
-static void mw_c99_buffer_21_ (void){
+static void mw_c99_buffer_21_ (void) {
     WORD_ENTER(mw_c99_buffer_21_, "c99-buffer!", "src/mirth/codegen.mth", 192, 5);
     WORD_ATOM(192, 5, "dup");
     mw_prim_dup();
     WORD_ATOM(192, 9, "name");
     mw_Buffer_2E_name();
-    WORD_ATOM(192, 14, ".w");
-    mw_Name_2B_C99_2E_w();
-    WORD_ATOM(192, 17, "");
+    WORD_ATOM(192, 14, "sig");
+    mw_Name_2B_C99_2E_sig();
+    WORD_ATOM(192, 18, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(192, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -19883,8 +19805,10 @@ static void mw_c99_buffer_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(192, 22, ";");
-    mw_Str_2B_C99_3B_();
+    WORD_ATOM(192, 27, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(192, 31, "line");
+    mw__2B_C99_2E_line();
     WORD_ATOM(193, 5, "");
     {
         static bool vready = false;
@@ -19896,15 +19820,15 @@ static void mw_c99_buffer_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(193, 29, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(193, 31, "dup");
+    WORD_ATOM(193, 29, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(193, 33, "dup");
     mw_prim_dup();
-    WORD_ATOM(193, 35, "size");
+    WORD_ATOM(193, 37, "size");
     mw_Buffer_2E_size();
-    WORD_ATOM(193, 40, ".n");
-    mw_Int_2B_C99_2E_n();
-    WORD_ATOM(193, 43, "");
+    WORD_ATOM(193, 42, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(193, 46, "");
     {
         static bool vready = false;
         static VAL v;
@@ -19915,8 +19839,10 @@ static void mw_c99_buffer_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(193, 54, ";");
-    mw_Str_2B_C99_3B_();
+    WORD_ATOM(193, 57, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(193, 61, "line");
+    mw__2B_C99_2E_line();
     WORD_ATOM(194, 5, "");
     {
         static bool vready = false;
@@ -19928,8 +19854,10 @@ static void mw_c99_buffer_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(194, 25, ";");
-    mw_Str_2B_C99_3B_();
+    WORD_ATOM(194, 25, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(194, 29, "line");
+    mw__2B_C99_2E_line();
     WORD_ATOM(195, 5, "");
     {
         static bool vready = false;
@@ -19941,55 +19869,48 @@ static void mw_c99_buffer_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(195, 9, ";");
-    mw_Str_2B_C99_3B_();
+    WORD_ATOM(195, 9, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(195, 13, "line");
+    mw__2B_C99_2E_line();
     WORD_ATOM(196, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_buffer_21_);
 }
-static void mw_c99_variables_21_ (void){
+static void mw_c99_variables_21_ (void) {
     WORD_ENTER(mw_c99_variables_21_, "c99-variables!", "src/mirth/codegen.mth", 198, 35);
     WORD_ATOM(198, 35, "Variable.for");
     push_u64(0);
     push_fnptr(&mb_c99_variables_21__1);
     mw_prim_pack_cons();
     mw_Variable_2E_for();
-    WORD_ATOM(198, 63, ".lf");
-    mw__2B_C99_2E_lf();
+    WORD_ATOM(198, 63, "line");
+    mw__2B_C99_2E_line();
     WORD_EXIT(mw_c99_variables_21_);
 }
-static void mw_c99_variable_21_ (void){
+static void mw_c99_variable_21_ (void) {
     WORD_ENTER(mw_c99_variable_21_, "c99-variable!", "src/mirth/codegen.mth", 200, 5);
-    WORD_ATOM(200, 5, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr("void mw_", 8);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(200, 16, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(200, 18, "name");
+    WORD_ATOM(200, 5, "name");
     mw_Variable_2E_name();
-    WORD_ATOM(200, 23, ".name");
-    mw_Name_2B_C99_2E_name();
-    WORD_ATOM(200, 29, "");
+    WORD_ATOM(200, 10, "sig");
+    mw_Name_2B_C99_2E_sig();
+    WORD_ATOM(200, 14, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(200, 18, "");
     {
         static bool vready = false;
         static VAL v;
         if (! vready) {
-            v = mkstr("() {", 4);
+            v = mkstr(" {", 2);
             vready = true;
         }
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(200, 36, ";");
-    mw_Str_2B_C99_3B_();
+    WORD_ATOM(200, 23, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(200, 27, "line");
+    mw__2B_C99_2E_line();
     WORD_ATOM(201, 5, "");
     {
         static bool vready = false;
@@ -20001,8 +19922,10 @@ static void mw_c99_variable_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(201, 31, ";");
-    mw_Str_2B_C99_3B_();
+    WORD_ATOM(201, 31, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(201, 35, "line");
+    mw__2B_C99_2E_line();
     WORD_ATOM(202, 5, "");
     {
         static bool vready = false;
@@ -20014,8 +19937,10 @@ static void mw_c99_variable_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(202, 25, ";");
-    mw_Str_2B_C99_3B_();
+    WORD_ATOM(202, 25, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(202, 29, "line");
+    mw__2B_C99_2E_line();
     WORD_ATOM(203, 5, "");
     {
         static bool vready = false;
@@ -20027,30 +19952,34 @@ static void mw_c99_variable_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(203, 9, ";");
-    mw_Str_2B_C99_3B_();
+    WORD_ATOM(203, 9, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(203, 13, "line");
+    mw__2B_C99_2E_line();
     WORD_EXIT(mw_c99_variable_21_);
 }
-static void mw_c99_tags_21_ (void){
+static void mw_c99_tags_21_ (void) {
     WORD_ENTER(mw_c99_tags_21_, "c99-tags!", "src/mirth/codegen.mth", 205, 30);
     WORD_ATOM(205, 30, "Tag.for");
     push_u64(0);
     push_fnptr(&mb_c99_tags_21__1);
     mw_prim_pack_cons();
     mw_Tag_2E_for();
-    WORD_ATOM(205, 48, ".lf");
-    mw__2B_C99_2E_lf();
+    WORD_ATOM(205, 48, "line");
+    mw__2B_C99_2E_line();
     WORD_EXIT(mw_c99_tags_21_);
 }
-static void mw_c99_tag_21_ (void){
+static void mw_c99_tag_21_ (void) {
     WORD_ENTER(mw_c99_tag_21_, "c99-tag!", "src/mirth/codegen.mth", 207, 5);
     WORD_ATOM(207, 5, "dup");
     mw_prim_dup();
     WORD_ATOM(207, 9, "name");
     mw_Tag_2E_name();
-    WORD_ATOM(207, 14, ".w");
-    mw_Name_2B_C99_2E_w();
-    WORD_ATOM(207, 17, "");
+    WORD_ATOM(207, 14, "sig");
+    mw_Name_2B_C99_2E_sig();
+    WORD_ATOM(207, 18, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(207, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20061,8 +19990,10 @@ static void mw_c99_tag_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(207, 22, ";");
-    mw_Str_2B_C99_3B_();
+    WORD_ATOM(207, 27, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(207, 31, "line");
+    mw__2B_C99_2E_line();
     WORD_ATOM(208, 5, "dup");
     mw_prim_dup();
     WORD_ATOM(208, 9, "is-transparent?");
@@ -20083,15 +20014,15 @@ static void mw_c99_tag_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(210, 32, ".");
-        mw_Str_2B_C99_2E_();
-        WORD_ATOM(210, 34, "dup");
+        WORD_ATOM(210, 32, "put");
+        mw_Str_2B_C99_2E_put();
+        WORD_ATOM(210, 36, "dup");
         mw_prim_dup();
-        WORD_ATOM(210, 38, "value");
+        WORD_ATOM(210, 40, "value");
         mw_Tag_2E_value();
-        WORD_ATOM(210, 44, ".n");
-        mw_Int_2B_C99_2E_n();
-        WORD_ATOM(210, 47, "");
+        WORD_ATOM(210, 46, "put");
+        mw_Int_2B_C99_2E_put();
+        WORD_ATOM(210, 50, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20102,8 +20033,10 @@ static void mw_c99_tag_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(210, 54, ";");
-        mw_Str_2B_C99_3B_();
+        WORD_ATOM(210, 57, "put");
+        mw_Str_2B_C99_2E_put();
+        WORD_ATOM(210, 61, "line");
+        mw__2B_C99_2E_line();
         WORD_ATOM(211, 9, "");
         {
             static bool vready = false;
@@ -20115,8 +20048,8 @@ static void mw_c99_tag_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(211, 27, ".");
-        mw_Str_2B_C99_2E_();
+        WORD_ATOM(211, 27, "put");
+        mw_Str_2B_C99_2E_put();
         WORD_ATOM(212, 9, "dup");
         mw_prim_dup();
         WORD_ATOM(212, 13, "num-type-inputs");
@@ -20146,8 +20079,10 @@ static void mw_c99_tag_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(220, 17, ";");
-        mw_Str_2B_C99_3B_();
+        WORD_ATOM(220, 17, "put");
+        mw_Str_2B_C99_2E_put();
+        WORD_ATOM(220, 21, "line");
+        mw__2B_C99_2E_line();
         WORD_ATOM(221, 9, "dup");
         mw_prim_dup();
         WORD_ATOM(221, 13, "outputs-resource?");
@@ -20165,8 +20100,6 @@ static void mw_c99_tag_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(222, 39, ";");
-            mw_Str_2B_C99_3B_();
         } else {
             WORD_ATOM(223, 13, "");
             {
@@ -20179,9 +20112,11 @@ static void mw_c99_tag_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(223, 36, ";");
-            mw_Str_2B_C99_3B_();
         }
+        WORD_ATOM(224, 11, "put");
+        mw_Str_2B_C99_2E_put();
+        WORD_ATOM(224, 15, "line");
+        mw__2B_C99_2E_line();
     }
     WORD_ATOM(226, 5, "");
     {
@@ -20194,40 +20129,33 @@ static void mw_c99_tag_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(226, 9, ";");
-    mw_Str_2B_C99_3B_();
-    WORD_ATOM(228, 5, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr("void co_", 8);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(228, 16, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(228, 18, "dup");
+    WORD_ATOM(226, 9, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(226, 13, "line");
+    mw__2B_C99_2E_line();
+    WORD_ATOM(228, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(228, 22, "name");
+    WORD_ATOM(228, 9, "name");
     mw_Tag_2E_name();
-    WORD_ATOM(228, 27, ".name");
-    mw_Name_2B_C99_2E_name();
-    WORD_ATOM(228, 33, "");
+    WORD_ATOM(228, 14, "cosig");
+    mw_Name_2B_C99_2E_cosig();
+    WORD_ATOM(228, 20, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(228, 24, "");
     {
         static bool vready = false;
         static VAL v;
         if (! vready) {
-            v = mkstr("() {", 4);
+            v = mkstr(" {", 2);
             vready = true;
         }
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(228, 40, ";");
-    mw_Str_2B_C99_3B_();
+    WORD_ATOM(228, 29, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(228, 33, "line");
+    mw__2B_C99_2E_line();
     WORD_ATOM(229, 5, "dup");
     mw_prim_dup();
     WORD_ATOM(229, 9, "is-transparent?");
@@ -20254,8 +20182,6 @@ static void mw_c99_tag_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(232, 45, ";");
-            mw_Str_2B_C99_3B_();
         } else {
             WORD_ATOM(233, 13, "");
             {
@@ -20268,9 +20194,11 @@ static void mw_c99_tag_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(233, 42, ";");
-            mw_Str_2B_C99_3B_();
         }
+        WORD_ATOM(234, 11, "put");
+        mw_Str_2B_C99_2E_put();
+        WORD_ATOM(234, 15, "line");
+        mw__2B_C99_2E_line();
         WORD_ATOM(235, 9, "");
         {
             static bool vready = false;
@@ -20282,8 +20210,10 @@ static void mw_c99_tag_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(235, 24, ";");
-        mw_Str_2B_C99_3B_();
+        WORD_ATOM(235, 24, "put");
+        mw_Str_2B_C99_2E_put();
+        WORD_ATOM(235, 28, "line");
+        mw__2B_C99_2E_line();
         WORD_ATOM(236, 9, "");
         {
             static bool vready = false;
@@ -20313,9 +20243,9 @@ static void mw_c99_tag_21_ (void){
         push_fnptr(&mb_c99_tag_21__12);
         mw_prim_pack_cons();
         mw_repeat();
-        WORD_ATOM(247, 9, ".");
-        mw_Str_2B_C99_2E_();
-        WORD_ATOM(247, 11, "");
+        WORD_ATOM(247, 9, "put");
+        mw_Str_2B_C99_2E_put();
+        WORD_ATOM(247, 13, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20326,8 +20256,10 @@ static void mw_c99_tag_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(247, 19, ";");
-        mw_Str_2B_C99_3B_();
+        WORD_ATOM(247, 21, "put");
+        mw_Str_2B_C99_2E_put();
+        WORD_ATOM(247, 25, "line");
+        mw__2B_C99_2E_line();
     }
     WORD_ATOM(249, 5, "");
     {
@@ -20340,24 +20272,26 @@ static void mw_c99_tag_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(249, 9, ";");
-    mw_Str_2B_C99_3B_();
+    WORD_ATOM(249, 9, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(249, 13, "line");
+    mw__2B_C99_2E_line();
     WORD_ATOM(251, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_tag_21_);
 }
-static void mw_c99_externals_21_ (void){
+static void mw_c99_externals_21_ (void) {
     WORD_ENTER(mw_c99_externals_21_, "c99-externals!", "src/mirth/codegen.mth", 254, 5);
     WORD_ATOM(254, 5, "External.for");
     push_u64(0);
     push_fnptr(&mb_c99_externals_21__1);
     mw_prim_pack_cons();
     mw_External_2E_for();
-    WORD_ATOM(254, 33, ".lf");
-    mw__2B_C99_2E_lf();
+    WORD_ATOM(254, 33, "line");
+    mw__2B_C99_2E_line();
     WORD_EXIT(mw_c99_externals_21_);
 }
-static void mw_c99_external_21_ (void){
+static void mw_c99_external_21_ (void) {
     WORD_ENTER(mw_c99_external_21_, "c99-external!", "src/mirth/codegen.mth", 257, 5);
     WORD_ATOM(257, 5, "dup");
     mw_prim_dup();
@@ -20406,8 +20340,6 @@ static void mw_c99_external_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(262, 24, ".");
-            mw_Str_2B_C99_2E_();
         } else {
             WORD_ATOM(263, 13, "");
             {
@@ -20420,9 +20352,9 @@ static void mw_c99_external_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(263, 21, ".");
-            mw_Str_2B_C99_2E_();
         }
+        WORD_ATOM(264, 11, "put");
+        mw_Str_2B_C99_2E_put();
     }
     WORD_ATOM(267, 5, "dip2");
     push_u64(0);
@@ -20440,8 +20372,8 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(269, 10, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(269, 10, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_ATOM(270, 5, "over");
     mw_over();
     WORD_ATOM(270, 10, "dup");
@@ -20461,19 +20393,19 @@ static void mw_c99_external_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(270, 30, ".");
-        mw_Str_2B_C99_2E_();
-        WORD_ATOM(270, 32, "1-");
+        WORD_ATOM(270, 30, "put");
+        mw_Str_2B_C99_2E_put();
+        WORD_ATOM(270, 34, "1-");
         mw_prim_int_pred();
-        WORD_ATOM(270, 35, "repeat");
+        WORD_ATOM(270, 37, "repeat");
         push_u64(0);
         push_fnptr(&mb_c99_external_21__7);
         mw_prim_pack_cons();
         mw_repeat();
     } else {
-        WORD_ATOM(270, 58, "drop");
+        WORD_ATOM(270, 62, "drop");
         mw_prim_drop();
-        WORD_ATOM(270, 63, "");
+        WORD_ATOM(270, 67, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20484,8 +20416,8 @@ static void mw_c99_external_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(270, 70, ".");
-        mw_Str_2B_C99_2E_();
+        WORD_ATOM(270, 74, "put");
+        mw_Str_2B_C99_2E_put();
     }
     WORD_ATOM(271, 5, "");
     {
@@ -20498,39 +20430,30 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(271, 10, ";");
-    mw_Str_2B_C99_3B_();
-    WORD_ATOM(273, 5, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr("static void mw_", 15);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(273, 23, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(273, 25, "dip2");
+    WORD_ATOM(271, 10, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(271, 14, "line");
+    mw__2B_C99_2E_line();
+    WORD_ATOM(273, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_c99_external_21__9);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(273, 46, "");
+    WORD_ATOM(273, 28, "");
     {
         static bool vready = false;
         static VAL v;
         if (! vready) {
-            v = mkstr(" (void) {", 9);
+            v = mkstr(" {", 2);
             vready = true;
         }
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(273, 58, ";");
-    mw_Str_2B_C99_3B_();
+    WORD_ATOM(273, 33, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(273, 37, "line");
+    mw__2B_C99_2E_line();
     WORD_ATOM(274, 5, "over");
     mw_over();
     WORD_ATOM(274, 10, "countdown");
@@ -20568,8 +20491,8 @@ static void mw_c99_external_21_ (void){
             incref(v);
         }
     }
-    WORD_ATOM(275, 40, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(275, 40, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_ATOM(276, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_c99_external_21__13);
@@ -20586,8 +20509,8 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(277, 9, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(277, 9, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_ATOM(278, 5, "dip");
     {
         VAL d2 = pop_value();
@@ -20608,7 +20531,7 @@ static void mw_c99_external_21_ (void){
             push_fnptr(&mb_c99_external_21__16);
             mw_prim_pack_cons();
             mw_count();
-            WORD_ATOM(279, 43, "");
+            WORD_ATOM(279, 48, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20619,10 +20542,10 @@ static void mw_c99_external_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(279, 47, ".");
-            mw_Str_2B_C99_2E_();
-            WORD_ATOM(279, 49, ".n");
-            mw_Int_2B_C99_2E_n();
+            WORD_ATOM(279, 52, "put");
+            mw_Str_2B_C99_2E_put();
+            WORD_ATOM(279, 56, "put");
+            mw_Int_2B_C99_2E_put();
         } else {
             WORD_ATOM(280, 9, "id");
             mw_prim_id();
@@ -20640,8 +20563,8 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(282, 9, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(282, 9, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_ATOM(283, 5, "dup");
     mw_prim_dup();
     WORD_ATOM(283, 9, "0>");
@@ -20672,8 +20595,10 @@ static void mw_c99_external_21_ (void){
             incref(v);
         }
     }
-    WORD_ATOM(283, 26, ";");
-    mw_Str_2B_C99_3B_();
+    WORD_ATOM(283, 26, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(283, 30, "line");
+    mw__2B_C99_2E_line();
     WORD_ATOM(284, 5, "");
     {
         static bool vready = false;
@@ -20685,13 +20610,15 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(284, 9, ";");
-    mw_Str_2B_C99_3B_();
+    WORD_ATOM(284, 9, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(284, 13, "line");
+    mw__2B_C99_2E_line();
     WORD_ATOM(285, 5, "drop3");
     mw_drop3();
     WORD_EXIT(mw_c99_external_21_);
 }
-static void mw_c99_nest (void){
+static void mw_c99_nest (void) {
     WORD_ENTER(mw_c99_nest, "c99-nest", "src/mirth/codegen.mth", 288, 5);
     WORD_ATOM(288, 5, "depth@");
     {
@@ -20715,7 +20642,7 @@ static void mw_c99_nest (void){
     }
     WORD_EXIT(mw_c99_nest);
 }
-static void mw_c99_indent (void){
+static void mw_c99_indent (void) {
     WORD_ENTER(mw_c99_indent, "c99-indent", "src/mirth/codegen.mth", 292, 31);
     WORD_ATOM(292, 31, "depth@");
     mw__2B_C99_2E_depth_40_();
@@ -20726,7 +20653,7 @@ static void mw_c99_indent (void){
     mw_repeat();
     WORD_EXIT(mw_c99_indent);
 }
-static void mw_c99_line (void){
+static void mw_c99_line (void) {
     WORD_ENTER(mw_c99_line, "c99-line", "src/mirth/codegen.mth", 293, 59);
     WORD_ATOM(293, 59, "c99-indent");
     {
@@ -20736,13 +20663,13 @@ static void mw_c99_line (void){
         WORD_ATOM(293, 70, "f");
         incref(var_f);
         run_value(var_f);
-        WORD_ATOM(293, 72, ".lf");
-        mw__2B_C99_2E_lf();
+        WORD_ATOM(293, 72, "line");
+        mw__2B_C99_2E_line();
         decref(var_f);
     }
     WORD_EXIT(mw_c99_line);
 }
-static void mw_c99_call_21_ (void){
+static void mw_c99_call_21_ (void) {
     WORD_ENTER(mw_c99_call_21_, "c99-call!", "src/mirth/codegen.mth", 296, 5);
     WORD_ATOM(296, 5, "dip");
     {
@@ -20758,7 +20685,7 @@ static void mw_c99_call_21_ (void){
     mw_c99_line();
     WORD_EXIT(mw_c99_call_21_);
 }
-static void mw_c99_arrow_21_ (void){
+static void mw_c99_arrow_21_ (void) {
     WORD_ENTER(mw_c99_arrow_21_, "c99-arrow!", "src/mirth/codegen.mth", 299, 37);
     WORD_ATOM(299, 37, "atoms");
     mw_Arrow_2E_atoms();
@@ -20769,7 +20696,7 @@ static void mw_c99_arrow_21_ (void){
     mw_List_2E_for();
     WORD_EXIT(mw_c99_arrow_21_);
 }
-static void mw_c99_atom_21_ (void){
+static void mw_c99_atom_21_ (void) {
     WORD_ENTER(mw_c99_atom_21_, "c99-atom!", "src/mirth/codegen.mth", 301, 5);
     WORD_ATOM(301, 5, "c99-line");
     push_u64(0);
@@ -20787,116 +20714,116 @@ static void mw_c99_atom_21_ (void){
     mw_c99_args_op_21_();
     WORD_EXIT(mw_c99_atom_21_);
 }
-static void mw_c99_args_op_21_ (void){
+static void mw_c99_args_op_21_ (void) {
     WORD_ENTER(mw_c99_args_op_21_, "c99-args-op!", "src/mirth/codegen.mth", 310, 5);
     WORD_ATOM(310, 5, "OP_NONE");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_OP_5F_NONE();
+            mp_OP_5F_NONE();
             WORD_ATOM(310, 20, "drop");
             mw_prim_drop();
             break;
         case 8LL:
-            co_OP_5F_INT();
+            mp_OP_5F_INT();
             WORD_ATOM(311, 20, "nip");
             mw_nip();
             WORD_ATOM(311, 24, "c99-int!");
             mw_c99_int_21_();
             break;
         case 9LL:
-            co_OP_5F_STR();
+            mp_OP_5F_STR();
             WORD_ATOM(312, 20, "nip");
             mw_nip();
             WORD_ATOM(312, 24, "c99-str!");
             mw_c99_str_21_();
             break;
         case 6LL:
-            co_OP_5F_CONSTANT();
+            mp_OP_5F_CONSTANT();
             WORD_ATOM(313, 20, "nip");
             mw_nip();
             WORD_ATOM(313, 24, "c99-constant!");
             mw_c99_constant_21_();
             break;
         case 2LL:
-            co_OP_5F_WORD();
+            mp_OP_5F_WORD();
             WORD_ATOM(314, 20, "name");
             mw_Word_2E_name();
             WORD_ATOM(314, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 3LL:
-            co_OP_5F_EXTERNAL();
+            mp_OP_5F_EXTERNAL();
             WORD_ATOM(315, 20, "name");
             mw_External_2E_name();
             WORD_ATOM(315, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 4LL:
-            co_OP_5F_BUFFER();
+            mp_OP_5F_BUFFER();
             WORD_ATOM(316, 20, "name");
             mw_Buffer_2E_name();
             WORD_ATOM(316, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 5LL:
-            co_OP_5F_VARIABLE();
+            mp_OP_5F_VARIABLE();
             WORD_ATOM(317, 20, "name");
             mw_Variable_2E_name();
             WORD_ATOM(317, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 7LL:
-            co_OP_5F_FIELD();
+            mp_OP_5F_FIELD();
             WORD_ATOM(318, 20, "name");
             mw_Field_2E_name();
             WORD_ATOM(318, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 10LL:
-            co_OP_5F_TAG();
+            mp_OP_5F_TAG();
             WORD_ATOM(319, 20, "name");
             mw_Tag_2E_name();
             WORD_ATOM(319, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 1LL:
-            co_OP_5F_PRIM();
+            mp_OP_5F_PRIM();
             WORD_ATOM(320, 20, "c99-prim!");
             mw_c99_prim_21_();
             break;
         case 11LL:
-            co_OP_5F_MATCH();
+            mp_OP_5F_MATCH();
             WORD_ATOM(321, 20, "nip");
             mw_nip();
             WORD_ATOM(321, 24, "c99-match!");
             mw_c99_match_21_();
             break;
         case 12LL:
-            co_OP_5F_LAMBDA();
+            mp_OP_5F_LAMBDA();
             WORD_ATOM(322, 20, "nip");
             mw_nip();
             WORD_ATOM(322, 24, "c99-lambda!");
             mw_c99_lambda_21_();
             break;
         case 13LL:
-            co_OP_5F_VAR();
+            mp_OP_5F_VAR();
             WORD_ATOM(323, 20, "nip");
             mw_nip();
             WORD_ATOM(323, 24, "c99-var!");
             mw_c99_var_21_();
             break;
         case 14LL:
-            co_OP_5F_BLOCK();
+            mp_OP_5F_BLOCK();
             WORD_ATOM(324, 20, "nip");
             mw_nip();
             WORD_ATOM(324, 24, "c99-block-push!");
             mw_c99_block_push_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_c99_args_op_21_);
+    }
+    WORD_EXIT(mw_c99_args_op_21_);
 }
-static void mw_c99_int_21_ (void){
+static void mw_c99_int_21_ (void) {
     WORD_ENTER(mw_c99_int_21_, "c99-int!", "src/mirth/codegen.mth", 327, 5);
     WORD_ATOM(327, 5, "c99-line");
     push_u64(0);
@@ -20905,7 +20832,7 @@ static void mw_c99_int_21_ (void){
     mw_c99_line();
     WORD_EXIT(mw_c99_int_21_);
 }
-static void mw_c99_str_21_ (void){
+static void mw_c99_str_21_ (void) {
     WORD_ENTER(mw_c99_str_21_, "c99-str!", "src/mirth/codegen.mth", 330, 5);
     WORD_ATOM(330, 5, "c99-line");
     push_u64(0);
@@ -20926,9 +20853,9 @@ static void mw_c99_str_21_ (void){
     mw_prim_drop();
     WORD_EXIT(mw_c99_str_21_);
 }
-static void mw__2E_str (void){
-    WORD_ENTER(mw__2E_str, ".str", "src/mirth/codegen.mth", 357, 29);
-    WORD_ATOM(357, 29, "");
+static void mw__2B_C99_2E_put_cstr (void) {
+    WORD_ENTER(mw__2B_C99_2E_put_cstr, "+C99.put-cstr", "src/mirth/codegen.mth", 358, 5);
+    WORD_ATOM(358, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20939,14 +20866,14 @@ static void mw__2E_str (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(357, 34, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(357, 36, "str-bytes-for");
+    WORD_ATOM(358, 10, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(358, 14, "str-bytes-for");
     push_u64(0);
-    push_fnptr(&mb__2E_str_1);
+    push_fnptr(&mb__2B_C99_2E_put_cstr_1);
     mw_prim_pack_cons();
     mw_str_bytes_for();
-    WORD_ATOM(357, 68, "");
+    WORD_ATOM(358, 46, "");
     {
         static bool vready = false;
         static VAL v;
@@ -20957,17 +20884,17 @@ static void mw__2E_str (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(357, 73, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_EXIT(mw__2E_str);
+    WORD_ATOM(358, 51, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_EXIT(mw__2B_C99_2E_put_cstr);
 }
-static void mw_c99_string_byte_21_ (void){
-    WORD_ENTER(mw_c99_string_byte_21_, "c99-string-byte!", "src/mirth/codegen.mth", 360, 5);
-    WORD_ATOM(360, 5, "B'\\'");
+static void mw_c99_string_byte_21_ (void) {
+    WORD_ENTER(mw_c99_string_byte_21_, "c99-string-byte!", "src/mirth/codegen.mth", 361, 5);
+    WORD_ATOM(361, 5, "B'\\'");
     switch (get_top_data_tag()) {
         case 92LL:
-            co_B_27__5C__27_();
-            WORD_ATOM(360, 13, "");
+            mp_B_27__5C__27_();
+            WORD_ATOM(361, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20978,12 +20905,12 @@ static void mw_c99_string_byte_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(360, 20, ".");
-            mw_Str_2B_C99_2E_();
+            WORD_ATOM(361, 20, "put");
+            mw_Str_2B_C99_2E_put();
             break;
         case 34LL:
-            co_BQUOTE();
-            WORD_ATOM(361, 15, "");
+            mp_BQUOTE();
+            WORD_ATOM(362, 15, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20994,12 +20921,12 @@ static void mw_c99_string_byte_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(361, 22, ".");
-            mw_Str_2B_C99_2E_();
+            WORD_ATOM(362, 22, "put");
+            mw_Str_2B_C99_2E_put();
             break;
         case 9LL:
-            co_BHT();
-            WORD_ATOM(362, 12, "");
+            mp_BHT();
+            WORD_ATOM(363, 12, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -21010,12 +20937,12 @@ static void mw_c99_string_byte_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(362, 18, ".");
-            mw_Str_2B_C99_2E_();
+            WORD_ATOM(363, 18, "put");
+            mw_Str_2B_C99_2E_put();
             break;
         case 10LL:
-            co_BLF();
-            WORD_ATOM(363, 12, "");
+            mp_BLF();
+            WORD_ATOM(364, 12, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -21026,12 +20953,12 @@ static void mw_c99_string_byte_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(363, 18, ".");
-            mw_Str_2B_C99_2E_();
+            WORD_ATOM(364, 18, "put");
+            mw_Str_2B_C99_2E_put();
             break;
         case 13LL:
-            co_BCR();
-            WORD_ATOM(364, 12, "");
+            mp_BCR();
+            WORD_ATOM(365, 12, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -21042,24 +20969,24 @@ static void mw_c99_string_byte_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(364, 18, ".");
-            mw_Str_2B_C99_2E_();
+            WORD_ATOM(365, 18, "put");
+            mw_Str_2B_C99_2E_put();
             break;
         default:
-            WORD_ATOM(366, 9, "dup");
+            WORD_ATOM(367, 9, "dup");
             mw_prim_dup();
-            WORD_ATOM(366, 13, "BSPACE");
+            WORD_ATOM(367, 13, "BSPACE");
             mw_BSPACE();
-            WORD_ATOM(366, 20, "B'~'");
+            WORD_ATOM(367, 20, "B'~'");
             mw_B_27__7E__27_();
-            WORD_ATOM(366, 25, "in-range");
+            WORD_ATOM(367, 25, "in-range");
             mw_Byte_2E_in_range();
-            WORD_ATOM(366, 34, "if");
+            WORD_ATOM(367, 34, "if");
             if (pop_u64()) {
-                WORD_ATOM(367, 13, ".b");
-                mw_Byte_2B_C99_2E_b();
+                WORD_ATOM(368, 13, "put");
+                mw_Byte_2B_C99_2E_put();
             } else {
-                WORD_ATOM(368, 13, "");
+                WORD_ATOM(369, 13, "");
                 {
                     static bool vready = false;
                     static VAL v;
@@ -21070,238 +20997,238 @@ static void mw_c99_string_byte_21_ (void){
                     push_value(v);
                     incref(v);
                 }
-                WORD_ATOM(368, 19, ".");
-                mw_Str_2B_C99_2E_();
-                WORD_ATOM(368, 21, "to-hexdigits");
+                WORD_ATOM(369, 19, "put");
+                mw_Str_2B_C99_2E_put();
+                WORD_ATOM(369, 23, "to-hexdigits");
                 mw_Byte_2E_to_hexdigits();
-                WORD_ATOM(368, 34, "dip");
+                WORD_ATOM(369, 36, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(368, 38, ".b");
-                    mw_Byte_2B_C99_2E_b();
+                    WORD_ATOM(369, 40, "put");
+                    mw_Byte_2B_C99_2E_put();
                     push_value(d5);
                 }
-                WORD_ATOM(368, 42, ".b");
-                mw_Byte_2B_C99_2E_b();
+                WORD_ATOM(369, 45, "put");
+                mw_Byte_2B_C99_2E_put();
             }
             break;
-    
-}    WORD_EXIT(mw_c99_string_byte_21_);
+    }
+    WORD_EXIT(mw_c99_string_byte_21_);
 }
-static void mw_c99_constant_21_ (void){
-    WORD_ENTER(mw_c99_constant_21_, "c99-constant!", "src/mirth/codegen.mth", 373, 5);
-    WORD_ATOM(373, 5, "value");
+static void mw_c99_constant_21_ (void) {
+    WORD_ENTER(mw_c99_constant_21_, "c99-constant!", "src/mirth/codegen.mth", 374, 5);
+    WORD_ATOM(374, 5, "value");
     mw_Constant_2E_value();
-    WORD_ATOM(373, 11, "c99-value!");
+    WORD_ATOM(374, 11, "c99-value!");
     mw_c99_value_21_();
     WORD_EXIT(mw_c99_constant_21_);
 }
-static void mw_c99_value_21_ (void){
-    WORD_ENTER(mw_c99_value_21_, "c99-value!", "src/mirth/codegen.mth", 376, 5);
-    WORD_ATOM(376, 5, "VALUE_INT");
+static void mw_c99_value_21_ (void) {
+    WORD_ENTER(mw_c99_value_21_, "c99-value!", "src/mirth/codegen.mth", 377, 5);
+    WORD_ATOM(377, 5, "VALUE_INT");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_VALUE_5F_INT();
-            WORD_ATOM(376, 18, "c99-int!");
+            mp_VALUE_5F_INT();
+            WORD_ATOM(377, 18, "c99-int!");
             mw_c99_int_21_();
             break;
         case 1LL:
-            co_VALUE_5F_STR();
-            WORD_ATOM(377, 18, "c99-str!");
+            mp_VALUE_5F_STR();
+            WORD_ATOM(378, 18, "c99-str!");
             mw_c99_str_21_();
             break;
         case 2LL:
-            co_VALUE_5F_BLOCK();
-            WORD_ATOM(378, 20, "c99-block-push!");
+            mp_VALUE_5F_BLOCK();
+            WORD_ATOM(379, 20, "c99-block-push!");
             mw_c99_block_push_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_c99_value_21_);
+    }
+    WORD_EXIT(mw_c99_value_21_);
 }
-static void mw_c99_prim_21_ (void){
-    WORD_ENTER(mw_c99_prim_21_, "c99-prim!", "src/mirth/codegen.mth", 381, 5);
-    WORD_ATOM(381, 5, "PRIM_CORE_DIP");
+static void mw_c99_prim_21_ (void) {
+    WORD_ENTER(mw_c99_prim_21_, "c99-prim!", "src/mirth/codegen.mth", 382, 5);
+    WORD_ATOM(382, 5, "PRIM_CORE_DIP");
     switch (get_top_data_tag()) {
         case 4LL:
-            co_PRIM_5F_CORE_5F_DIP();
-            WORD_ATOM(382, 9, "match");
+            mp_PRIM_5F_CORE_5F_DIP();
+            WORD_ATOM(383, 9, "match");
             switch (get_top_data_tag()) {
                 case 1LL:
-                    co_L1();
-                    WORD_ATOM(384, 17, "c99-line");
+                    mp_L1();
+                    WORD_ATOM(385, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__3);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(385, 17, "c99-nest");
+                    WORD_ATOM(386, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__4);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(390, 17, "c99-line");
+                    WORD_ATOM(391, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__7);
                     mw_prim_pack_cons();
                     mw_c99_line();
                     break;
                 default:
-                    WORD_ATOM(392, 17, "PRIM_CORE_DIP");
+                    WORD_ATOM(393, 17, "PRIM_CORE_DIP");
                     mw_PRIM_5F_CORE_5F_DIP();
-                    WORD_ATOM(392, 31, "c99-prim-default!");
+                    WORD_ATOM(393, 31, "c99-prim-default!");
                     mw_c99_prim_default_21_();
                     break;
-            
-}            break;
+            }
+            break;
         case 13LL:
-            co_PRIM_5F_CORE_5F_RDIP();
-            WORD_ATOM(396, 9, "match");
+            mp_PRIM_5F_CORE_5F_RDIP();
+            WORD_ATOM(397, 9, "match");
             switch (get_top_data_tag()) {
                 case 1LL:
-                    co_L1();
-                    WORD_ATOM(398, 17, "c99-line");
+                    mp_L1();
+                    WORD_ATOM(399, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__11);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(399, 17, "c99-nest");
+                    WORD_ATOM(400, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__12);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(404, 17, "c99-line");
+                    WORD_ATOM(405, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__15);
                     mw_prim_pack_cons();
                     mw_c99_line();
                     break;
                 default:
-                    WORD_ATOM(406, 17, "PRIM_CORE_RDIP");
+                    WORD_ATOM(407, 17, "PRIM_CORE_RDIP");
                     mw_PRIM_5F_CORE_5F_RDIP();
-                    WORD_ATOM(406, 32, "c99-prim-default!");
+                    WORD_ATOM(407, 32, "c99-prim-default!");
                     mw_c99_prim_default_21_();
                     break;
-            
-}            break;
+            }
+            break;
         case 5LL:
-            co_PRIM_5F_CORE_5F_IF();
-            WORD_ATOM(410, 9, "match");
+            mp_PRIM_5F_CORE_5F_IF();
+            WORD_ATOM(411, 9, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
-                    co_L2();
-                    WORD_ATOM(412, 17, "c99-line");
+                    mp_L2();
+                    WORD_ATOM(413, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__19);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(413, 17, "c99-nest");
+                    WORD_ATOM(414, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__20);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(414, 17, "c99-line");
+                    WORD_ATOM(415, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__21);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(415, 17, "c99-nest");
+                    WORD_ATOM(416, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__22);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(416, 17, "c99-line");
+                    WORD_ATOM(417, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__23);
                     mw_prim_pack_cons();
                     mw_c99_line();
                     break;
                 default:
-                    WORD_ATOM(418, 17, "PRIM_CORE_IF");
+                    WORD_ATOM(419, 17, "PRIM_CORE_IF");
                     mw_PRIM_5F_CORE_5F_IF();
-                    WORD_ATOM(418, 30, "c99-prim-default!");
+                    WORD_ATOM(419, 30, "c99-prim-default!");
                     mw_c99_prim_default_21_();
                     break;
-            
-}            break;
+            }
+            break;
         case 6LL:
-            co_PRIM_5F_CORE_5F_WHILE();
-            WORD_ATOM(422, 9, "match");
+            mp_PRIM_5F_CORE_5F_WHILE();
+            WORD_ATOM(423, 9, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
-                    co_L2();
-                    WORD_ATOM(424, 17, "c99-line");
+                    mp_L2();
+                    WORD_ATOM(425, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__27);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(425, 17, "c99-nest");
+                    WORD_ATOM(426, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__28);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(430, 17, "c99-line");
+                    WORD_ATOM(431, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__30);
                     mw_prim_pack_cons();
                     mw_c99_line();
                     break;
                 default:
-                    WORD_ATOM(433, 17, "PRIM_CORE_WHILE");
+                    WORD_ATOM(434, 17, "PRIM_CORE_WHILE");
                     mw_PRIM_5F_CORE_5F_WHILE();
-                    WORD_ATOM(433, 33, "c99-prim-default!");
+                    WORD_ATOM(434, 33, "c99-prim-default!");
                     mw_c99_prim_default_21_();
                     break;
-            
-}            break;
+            }
+            break;
         default:
-            WORD_ATOM(436, 10, "c99-prim-default!");
+            WORD_ATOM(437, 10, "c99-prim-default!");
             mw_c99_prim_default_21_();
             break;
-    
-}    WORD_EXIT(mw_c99_prim_21_);
+    }
+    WORD_EXIT(mw_c99_prim_21_);
 }
-static void mw_c99_prim_default_21_ (void){
-    WORD_ENTER(mw_c99_prim_default_21_, "c99-prim-default!", "src/mirth/codegen.mth", 439, 5);
-    WORD_ATOM(439, 5, "name");
+static void mw_c99_prim_default_21_ (void) {
+    WORD_ENTER(mw_c99_prim_default_21_, "c99-prim-default!", "src/mirth/codegen.mth", 440, 5);
+    WORD_ATOM(440, 5, "name");
     mw_Prim_2E_name();
-    WORD_ATOM(439, 10, "c99-call!");
+    WORD_ATOM(440, 10, "c99-call!");
     mw_c99_call_21_();
     WORD_EXIT(mw_c99_prim_default_21_);
 }
-static void mw_c99_args_push_21_ (void){
-    WORD_ENTER(mw_c99_args_push_21_, "c99-args-push!", "src/mirth/codegen.mth", 442, 5);
-    WORD_ATOM(442, 5, "for");
+static void mw_c99_args_push_21_ (void) {
+    WORD_ENTER(mw_c99_args_push_21_, "c99-args-push!", "src/mirth/codegen.mth", 443, 5);
+    WORD_ATOM(443, 5, "for");
     push_u64(0);
     push_fnptr(&mb_c99_args_push_21__1);
     mw_prim_pack_cons();
     mw_List_2E_for();
     WORD_EXIT(mw_c99_args_push_21_);
 }
-static void mw_c99_arg_push_21_ (void){
-    WORD_ENTER(mw_c99_arg_push_21_, "c99-arg-push!", "src/mirth/codegen.mth", 445, 5);
-    WORD_ATOM(445, 5, "ARG_BLOCK");
-    WORD_ATOM(445, 18, "c99-block-push!");
+static void mw_c99_arg_push_21_ (void) {
+    WORD_ENTER(mw_c99_arg_push_21_, "c99-arg-push!", "src/mirth/codegen.mth", 446, 5);
+    WORD_ATOM(446, 5, "ARG_BLOCK");
+    WORD_ATOM(446, 18, "c99-block-push!");
     mw_c99_block_push_21_();
     WORD_EXIT(mw_c99_arg_push_21_);
 }
-static void mw_c99_arg_run_21_ (void){
-    WORD_ENTER(mw_c99_arg_run_21_, "c99-arg-run!", "src/mirth/codegen.mth", 448, 5);
-    WORD_ATOM(448, 5, "ARG_BLOCK");
-    WORD_ATOM(448, 18, "c99-block-run!");
+static void mw_c99_arg_run_21_ (void) {
+    WORD_ENTER(mw_c99_arg_run_21_, "c99-arg-run!", "src/mirth/codegen.mth", 449, 5);
+    WORD_ATOM(449, 5, "ARG_BLOCK");
+    WORD_ATOM(449, 18, "c99-block-run!");
     mw_c99_block_run_21_();
     WORD_EXIT(mw_c99_arg_run_21_);
 }
-static void mw_c99_block_run_21_ (void){
-    WORD_ENTER(mw_c99_block_run_21_, "c99-block-run!", "src/mirth/codegen.mth", 451, 5);
-    WORD_ATOM(451, 5, "arrow");
+static void mw_c99_block_run_21_ (void) {
+    WORD_ENTER(mw_c99_block_run_21_, "c99-block-run!", "src/mirth/codegen.mth", 452, 5);
+    WORD_ATOM(452, 5, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(451, 11, "c99-arrow!");
+    WORD_ATOM(452, 11, "c99-arrow!");
     mw_c99_arrow_21_();
     WORD_EXIT(mw_c99_block_run_21_);
 }
-static void mw_Var_2B_C99_2E_var (void){
-    WORD_ENTER(mw_Var_2B_C99_2E_var, "Var+C99.var", "src/mirth/codegen.mth", 453, 36);
-    WORD_ATOM(453, 36, "");
+static void mw_Var_2B_C99_2E_put (void) {
+    WORD_ENTER(mw_Var_2B_C99_2E_put, "Var+C99.put", "src/mirth/codegen.mth", 454, 36);
+    WORD_ATOM(454, 36, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21312,388 +21239,386 @@ static void mw_Var_2B_C99_2E_var (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(453, 43, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(453, 45, "name");
+    WORD_ATOM(454, 43, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(454, 47, "name");
     mw_Var_2E_name();
-    WORD_ATOM(453, 50, ".name");
-    mw_Name_2B_C99_2E_name();
-    WORD_EXIT(mw_Var_2B_C99_2E_var);
+    WORD_ATOM(454, 52, "put");
+    mw_Name_2B_C99_2E_put();
+    WORD_EXIT(mw_Var_2B_C99_2E_put);
 }
-static void mw_Param_2B_C99_2E_param (void){
-    WORD_ENTER(mw_Param_2B_C99_2E_param, "Param+C99.param", "src/mirth/codegen.mth", 454, 42);
-    WORD_ATOM(454, 42, ">Var");
+static void mw_Param_2B_C99_2E_put (void) {
+    WORD_ENTER(mw_Param_2B_C99_2E_put, "Param+C99.put", "src/mirth/codegen.mth", 455, 40);
+    WORD_ATOM(455, 40, ">Var");
     mw_Param_3E_Var();
-    WORD_ATOM(454, 47, ".var");
-    mw_Var_2B_C99_2E_var();
-    WORD_EXIT(mw_Param_2B_C99_2E_param);
+    WORD_ATOM(455, 45, "put");
+    mw_Var_2B_C99_2E_put();
+    WORD_EXIT(mw_Param_2B_C99_2E_put);
 }
-static void mw_c99_pack_ctx_21_ (void){
-    WORD_ENTER(mw_c99_pack_ctx_21_, "c99-pack-ctx!", "src/mirth/codegen.mth", 457, 5);
-    WORD_ATOM(457, 5, "c99-line");
+static void mw_c99_pack_ctx_21_ (void) {
+    WORD_ENTER(mw_c99_pack_ctx_21_, "c99-pack-ctx!", "src/mirth/codegen.mth", 458, 5);
+    WORD_ATOM(458, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_pack_ctx_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(458, 5, "physical-vars");
+    WORD_ATOM(459, 5, "physical-vars");
     mw_Ctx_2E_physical_vars();
-    WORD_ATOM(458, 19, "for");
+    WORD_ATOM(459, 19, "for");
     push_u64(0);
     push_fnptr(&mb_c99_pack_ctx_21__2);
     mw_prim_pack_cons();
     mw_List_2E_for();
     WORD_EXIT(mw_c99_pack_ctx_21_);
 }
-static void mw_c99_unpack_ctx_21_ (void){
-    WORD_ENTER(mw_c99_unpack_ctx_21_, "c99-unpack-ctx!", "src/mirth/codegen.mth", 464, 5);
-    WORD_ATOM(464, 5, "physical-vars");
+static void mw_c99_unpack_ctx_21_ (void) {
+    WORD_ENTER(mw_c99_unpack_ctx_21_, "c99-unpack-ctx!", "src/mirth/codegen.mth", 465, 5);
+    WORD_ATOM(465, 5, "physical-vars");
     mw_Ctx_2E_physical_vars();
-    WORD_ATOM(464, 19, "reverse-for");
+    WORD_ATOM(465, 19, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_c99_unpack_ctx_21__1);
     mw_prim_pack_cons();
     mw_List_2E_reverse_for();
-    WORD_ATOM(468, 5, "c99-line");
+    WORD_ATOM(469, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_unpack_ctx_21__4);
     mw_prim_pack_cons();
     mw_c99_line();
     WORD_EXIT(mw_c99_unpack_ctx_21_);
 }
-static void mw_c99_decref_ctx_21_ (void){
-    WORD_ENTER(mw_c99_decref_ctx_21_, "c99-decref-ctx!", "src/mirth/codegen.mth", 471, 5);
-    WORD_ATOM(471, 5, "physical-vars");
+static void mw_c99_decref_ctx_21_ (void) {
+    WORD_ENTER(mw_c99_decref_ctx_21_, "c99-decref-ctx!", "src/mirth/codegen.mth", 472, 5);
+    WORD_ATOM(472, 5, "physical-vars");
     mw_Ctx_2E_physical_vars();
-    WORD_ATOM(471, 19, "reverse-for");
+    WORD_ATOM(472, 19, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_c99_decref_ctx_21__1);
     mw_prim_pack_cons();
     mw_List_2E_reverse_for();
     WORD_EXIT(mw_c99_decref_ctx_21_);
 }
-static void mw_c99_block_push_21_ (void){
-    WORD_ENTER(mw_c99_block_push_21_, "c99-block-push!", "src/mirth/codegen.mth", 476, 5);
-    WORD_ATOM(476, 5, "dup");
+static void mw_c99_block_push_21_ (void) {
+    WORD_ENTER(mw_c99_block_push_21_, "c99-block-push!", "src/mirth/codegen.mth", 477, 5);
+    WORD_ATOM(477, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(476, 9, "block-to-run-var");
+    WORD_ATOM(477, 9, "block-to-run-var");
     mw_block_to_run_var();
-    WORD_ATOM(476, 26, "match");
+    WORD_ATOM(477, 26, "match");
     switch (get_top_data_tag()) {
         case 1LL:
-            co_SOME();
-            WORD_ATOM(477, 17, "nip");
+            mp_SOME();
+            WORD_ATOM(478, 17, "nip");
             mw_nip();
-            WORD_ATOM(477, 21, "c99-var-push!");
+            WORD_ATOM(478, 21, "c99-var-push!");
             mw_c99_var_push_21_();
             break;
         case 0LL:
-            co_NONE();
-            WORD_ATOM(479, 13, "dup");
+            mp_NONE();
+            WORD_ATOM(480, 13, "dup");
             mw_prim_dup();
-            WORD_ATOM(479, 17, "ctx");
+            WORD_ATOM(480, 17, "ctx");
             mw_Block_2E_ctx();
-            WORD_ATOM(479, 21, "c99-pack-ctx!");
+            WORD_ATOM(480, 21, "c99-pack-ctx!");
             mw_c99_pack_ctx_21_();
-            WORD_ATOM(480, 13, "c99-line");
+            WORD_ATOM(481, 13, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_block_push_21__3);
             mw_prim_pack_cons();
             mw_c99_line();
-            WORD_ATOM(481, 13, "c99-line");
+            WORD_ATOM(482, 13, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_block_push_21__4);
             mw_prim_pack_cons();
             mw_c99_line();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_c99_block_push_21_);
+    }
+    WORD_EXIT(mw_c99_block_push_21_);
 }
-static void mw_c99_var_21_ (void){
-    WORD_ENTER(mw_c99_var_21_, "c99-var!", "src/mirth/codegen.mth", 485, 5);
-    WORD_ATOM(485, 5, "dup");
+static void mw_c99_var_21_ (void) {
+    WORD_ENTER(mw_c99_var_21_, "c99-var!", "src/mirth/codegen.mth", 486, 5);
+    WORD_ATOM(486, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(485, 9, "auto-run?");
+    WORD_ATOM(486, 9, "auto-run?");
     mw_Var_2E_auto_run_3F_();
-    WORD_ATOM(485, 19, "if");
+    WORD_ATOM(486, 19, "if");
     if (pop_u64()) {
-        WORD_ATOM(485, 22, "c99-var-run!");
+        WORD_ATOM(486, 22, "c99-var-run!");
         mw_c99_var_run_21_();
     } else {
-        WORD_ATOM(485, 36, "c99-var-push!");
+        WORD_ATOM(486, 36, "c99-var-push!");
         mw_c99_var_push_21_();
     }
     WORD_EXIT(mw_c99_var_21_);
 }
-static void mw_c99_var_run_21_ (void){
-    WORD_ENTER(mw_c99_var_run_21_, "c99-var-run!", "src/mirth/codegen.mth", 488, 5);
-    WORD_ATOM(488, 5, "c99-line");
+static void mw_c99_var_run_21_ (void) {
+    WORD_ENTER(mw_c99_var_run_21_, "c99-var-run!", "src/mirth/codegen.mth", 489, 5);
+    WORD_ATOM(489, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_var_run_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(489, 5, "c99-line");
+    WORD_ATOM(490, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_var_run_21__2);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(490, 5, "drop");
+    WORD_ATOM(491, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_var_run_21_);
 }
-static void mw_c99_var_push_21_ (void){
-    WORD_ENTER(mw_c99_var_push_21_, "c99-var-push!", "src/mirth/codegen.mth", 493, 5);
-    WORD_ATOM(493, 5, "c99-line");
+static void mw_c99_var_push_21_ (void) {
+    WORD_ENTER(mw_c99_var_push_21_, "c99-var-push!", "src/mirth/codegen.mth", 494, 5);
+    WORD_ATOM(494, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_var_push_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(494, 5, "c99-line");
+    WORD_ATOM(495, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_var_push_21__2);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(495, 5, "drop");
+    WORD_ATOM(496, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_var_push_21_);
 }
-static void mw_c99_lambda_21_ (void){
-    WORD_ENTER(mw_c99_lambda_21_, "c99-lambda!", "src/mirth/codegen.mth", 498, 5);
-    WORD_ATOM(498, 5, "c99-line");
+static void mw_c99_lambda_21_ (void) {
+    WORD_ENTER(mw_c99_lambda_21_, "c99-lambda!", "src/mirth/codegen.mth", 499, 5);
+    WORD_ATOM(499, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(499, 5, "c99-nest");
+    WORD_ATOM(500, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(508, 5, "c99-line");
+    WORD_ATOM(509, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__7);
     mw_prim_pack_cons();
     mw_c99_line();
     WORD_EXIT(mw_c99_lambda_21_);
 }
-static void mw_c99_match_21_ (void){
-    WORD_ENTER(mw_c99_match_21_, "c99-match!", "src/mirth/codegen.mth", 511, 5);
-    WORD_ATOM(511, 5, "dup");
+static void mw_c99_match_21_ (void) {
+    WORD_ENTER(mw_c99_match_21_, "c99-match!", "src/mirth/codegen.mth", 512, 5);
+    WORD_ATOM(512, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(511, 9, "is-transparent?");
+    WORD_ATOM(512, 9, "is-transparent?");
     mw_Match_2E_is_transparent_3F_();
-    WORD_ATOM(511, 25, "if");
+    WORD_ATOM(512, 25, "if");
     if (pop_u64()) {
-        WORD_ATOM(512, 9, "cases");
+        WORD_ATOM(513, 9, "cases");
         mw_Match_2E_cases();
-        WORD_ATOM(512, 15, "first");
+        WORD_ATOM(513, 15, "first");
         mw_List_2E_first();
-        WORD_ATOM(512, 21, "unwrap");
+        WORD_ATOM(513, 21, "unwrap");
         mw_Maybe_2E_unwrap();
-        WORD_ATOM(512, 28, "body");
+        WORD_ATOM(513, 28, "body");
         mw_Case_2E_body();
-        WORD_ATOM(512, 33, "c99-arrow!");
+        WORD_ATOM(513, 33, "c99-arrow!");
         mw_c99_arrow_21_();
     } else {
-        WORD_ATOM(514, 9, "dup");
+        WORD_ATOM(515, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(514, 13, "scrutinee-data?");
+        WORD_ATOM(515, 13, "scrutinee-data?");
         mw_Match_2E_scrutinee_data_3F_();
-        WORD_ATOM(515, 9, "unwrap-or");
+        WORD_ATOM(516, 9, "unwrap-or");
         push_u64(0);
         push_fnptr(&mb_c99_match_21__3);
         mw_prim_pack_cons();
         mw_Maybe_2E_unwrap_or();
-        WORD_ATOM(516, 9, "is-resource?");
+        WORD_ATOM(517, 9, "is-resource?");
         mw_Data_2E_is_resource_3F_();
-        WORD_ATOM(516, 22, "if");
+        WORD_ATOM(517, 22, "if");
         if (pop_u64()) {
-            WORD_ATOM(517, 13, "c99-line");
+            WORD_ATOM(518, 13, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_match_21__5);
             mw_prim_pack_cons();
             mw_c99_line();
         } else {
-            WORD_ATOM(518, 13, "c99-line");
+            WORD_ATOM(519, 13, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_match_21__7);
             mw_prim_pack_cons();
             mw_c99_line();
         }
-        WORD_ATOM(520, 9, "c99-nest");
+        WORD_ATOM(521, 9, "c99-nest");
         push_u64(0);
         push_fnptr(&mb_c99_match_21__8);
         mw_prim_pack_cons();
         mw_c99_nest();
-        WORD_ATOM(526, 9, "c99-line");
+        WORD_ATOM(527, 9, "c99-line");
         push_u64(0);
         push_fnptr(&mb_c99_match_21__12);
         mw_prim_pack_cons();
         mw_c99_line();
-        WORD_ATOM(526, 22, ".");
-        mw_Str_2B_C99_2E_();
     }
     WORD_EXIT(mw_c99_match_21_);
 }
-static void mw_c99_case_21_ (void){
-    WORD_ENTER(mw_c99_case_21_, "c99-case!", "src/mirth/codegen.mth", 530, 5);
-    WORD_ATOM(530, 5, "dup");
+static void mw_c99_case_21_ (void) {
+    WORD_ENTER(mw_c99_case_21_, "c99-case!", "src/mirth/codegen.mth", 531, 5);
+    WORD_ATOM(531, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(530, 9, "pattern");
+    WORD_ATOM(531, 9, "pattern");
     mw_Case_2E_pattern();
-    WORD_ATOM(530, 17, "c99-pattern!");
+    WORD_ATOM(531, 17, "c99-pattern!");
     mw_c99_pattern_21_();
-    WORD_ATOM(531, 5, "c99-nest");
+    WORD_ATOM(532, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_case_21__1);
     mw_prim_pack_cons();
     mw_c99_nest();
     WORD_EXIT(mw_c99_case_21_);
 }
-static void mw_c99_pattern_21_ (void){
-    WORD_ENTER(mw_c99_pattern_21_, "c99-pattern!", "src/mirth/codegen.mth", 537, 5);
-    WORD_ATOM(537, 5, "PATTERN_UNDERSCORE");
+static void mw_c99_pattern_21_ (void) {
+    WORD_ENTER(mw_c99_pattern_21_, "c99-pattern!", "src/mirth/codegen.mth", 538, 5);
+    WORD_ATOM(538, 5, "PATTERN_UNDERSCORE");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_PATTERN_5F_UNDERSCORE();
-            WORD_ATOM(538, 9, "c99-line");
+            mp_PATTERN_5F_UNDERSCORE();
+            WORD_ATOM(539, 9, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_pattern_21__2);
             mw_prim_pack_cons();
             mw_c99_line();
             break;
         case 1LL:
-            co_PATTERN_5F_TAG();
-            WORD_ATOM(541, 9, "c99-line");
+            mp_PATTERN_5F_TAG();
+            WORD_ATOM(542, 9, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_pattern_21__4);
             mw_prim_pack_cons();
             mw_c99_line();
-            WORD_ATOM(542, 9, "c99-nest");
+            WORD_ATOM(543, 9, "c99-nest");
             push_u64(0);
             push_fnptr(&mb_c99_pattern_21__5);
             mw_prim_pack_cons();
             mw_c99_nest();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_c99_pattern_21_);
+    }
+    WORD_EXIT(mw_c99_pattern_21_);
 }
-static void mw_c99_word_sigs_21_ (void){
-    WORD_ENTER(mw_c99_word_sigs_21_, "c99-word-sigs!", "src/mirth/codegen.mth", 547, 35);
-    WORD_ATOM(547, 35, "for-needed-words");
+static void mw_c99_word_sigs_21_ (void) {
+    WORD_ENTER(mw_c99_word_sigs_21_, "c99-word-sigs!", "src/mirth/codegen.mth", 548, 35);
+    WORD_ATOM(548, 35, "for-needed-words");
     push_u64(0);
     push_fnptr(&mb_c99_word_sigs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_words();
-    WORD_ATOM(547, 67, ".lf");
-    mw__2B_C99_2E_lf();
+    WORD_ATOM(548, 67, "line");
+    mw__2B_C99_2E_line();
     WORD_EXIT(mw_c99_word_sigs_21_);
 }
-static void mw_c99_word_sig_21_ (void){
-    WORD_ENTER(mw_c99_word_sig_21_, "c99-word-sig!", "src/mirth/codegen.mth", 549, 5);
-    WORD_ATOM(549, 5, "c99-line");
+static void mw_c99_word_sig_21_ (void) {
+    WORD_ENTER(mw_c99_word_sig_21_, "c99-word-sig!", "src/mirth/codegen.mth", 550, 5);
+    WORD_ATOM(550, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_sig_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
     WORD_EXIT(mw_c99_word_sig_21_);
 }
-static void mw_c99_block_sigs_21_ (void){
-    WORD_ENTER(mw_c99_block_sigs_21_, "c99-block-sigs!", "src/mirth/codegen.mth", 551, 36);
-    WORD_ATOM(551, 36, "for-needed-blocks");
+static void mw_c99_block_sigs_21_ (void) {
+    WORD_ENTER(mw_c99_block_sigs_21_, "c99-block-sigs!", "src/mirth/codegen.mth", 552, 36);
+    WORD_ATOM(552, 36, "for-needed-blocks");
     push_u64(0);
     push_fnptr(&mb_c99_block_sigs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_blocks();
-    WORD_ATOM(551, 70, ".lf");
-    mw__2B_C99_2E_lf();
+    WORD_ATOM(552, 70, "line");
+    mw__2B_C99_2E_line();
     WORD_EXIT(mw_c99_block_sigs_21_);
 }
-static void mw_c99_block_sig_21_ (void){
-    WORD_ENTER(mw_c99_block_sig_21_, "c99-block-sig!", "src/mirth/codegen.mth", 553, 5);
-    WORD_ATOM(553, 5, "c99-line");
+static void mw_c99_block_sig_21_ (void) {
+    WORD_ENTER(mw_c99_block_sig_21_, "c99-block-sig!", "src/mirth/codegen.mth", 554, 5);
+    WORD_ATOM(554, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_sig_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
     WORD_EXIT(mw_c99_block_sig_21_);
 }
-static void mw_c99_field_sigs_21_ (void){
-    WORD_ENTER(mw_c99_field_sigs_21_, "c99-field-sigs!", "src/mirth/codegen.mth", 555, 36);
-    WORD_ATOM(555, 36, "Field.for");
+static void mw_c99_field_sigs_21_ (void) {
+    WORD_ENTER(mw_c99_field_sigs_21_, "c99-field-sigs!", "src/mirth/codegen.mth", 556, 36);
+    WORD_ATOM(556, 36, "Field.for");
     push_u64(0);
     push_fnptr(&mb_c99_field_sigs_21__1);
     mw_prim_pack_cons();
     mw_Field_2E_for();
-    WORD_ATOM(555, 62, ".lf");
-    mw__2B_C99_2E_lf();
+    WORD_ATOM(556, 62, "line");
+    mw__2B_C99_2E_line();
     WORD_EXIT(mw_c99_field_sigs_21_);
 }
-static void mw_c99_field_sig_21_ (void){
-    WORD_ENTER(mw_c99_field_sig_21_, "c99-field-sig!", "src/mirth/codegen.mth", 557, 5);
-    WORD_ATOM(557, 5, "c99-line");
+static void mw_c99_field_sig_21_ (void) {
+    WORD_ENTER(mw_c99_field_sig_21_, "c99-field-sig!", "src/mirth/codegen.mth", 558, 5);
+    WORD_ATOM(558, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_field_sig_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
     WORD_EXIT(mw_c99_field_sig_21_);
 }
-static void mw_c99_block_enter_21_ (void){
-    WORD_ENTER(mw_c99_block_enter_21_, "c99-block-enter!", "src/mirth/codegen.mth", 560, 5);
-    WORD_ATOM(560, 5, "c99-line");
+static void mw_c99_block_enter_21_ (void) {
+    WORD_ENTER(mw_c99_block_enter_21_, "c99-block-enter!", "src/mirth/codegen.mth", 561, 5);
+    WORD_ATOM(561, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_enter_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(569, 5, "drop");
+    WORD_ATOM(570, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_block_enter_21_);
 }
-static void mw_c99_block_exit_21_ (void){
-    WORD_ENTER(mw_c99_block_exit_21_, "c99-block-exit!", "src/mirth/codegen.mth", 572, 5);
-    WORD_ATOM(572, 5, "c99-line");
+static void mw_c99_block_exit_21_ (void) {
+    WORD_ENTER(mw_c99_block_exit_21_, "c99-block-exit!", "src/mirth/codegen.mth", 573, 5);
+    WORD_ATOM(573, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_exit_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
     WORD_EXIT(mw_c99_block_exit_21_);
 }
-static void mw_c99_block_defs_21_ (void){
-    WORD_ENTER(mw_c99_block_defs_21_, "c99-block-defs!", "src/mirth/codegen.mth", 574, 36);
-    WORD_ATOM(574, 36, "for-needed-blocks");
+static void mw_c99_block_defs_21_ (void) {
+    WORD_ENTER(mw_c99_block_defs_21_, "c99-block-defs!", "src/mirth/codegen.mth", 575, 36);
+    WORD_ATOM(575, 36, "for-needed-blocks");
     push_u64(0);
     push_fnptr(&mb_c99_block_defs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_blocks();
-    WORD_ATOM(574, 70, ".lf");
-    mw__2B_C99_2E_lf();
+    WORD_ATOM(575, 70, "line");
+    mw__2B_C99_2E_line();
     WORD_EXIT(mw_c99_block_defs_21_);
 }
-static void mw_c99_block_def_21_ (void){
-    WORD_ENTER(mw_c99_block_def_21_, "c99-block-def!", "src/mirth/codegen.mth", 576, 5);
-    WORD_ATOM(576, 5, "c99-line");
+static void mw_c99_block_def_21_ (void) {
+    WORD_ENTER(mw_c99_block_def_21_, "c99-block-def!", "src/mirth/codegen.mth", 577, 5);
+    WORD_ATOM(577, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_def_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(577, 5, "c99-nest");
+    WORD_ATOM(578, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_block_def_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(585, 5, "c99-line");
+    WORD_ATOM(586, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_def_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(585, 21, ".lf");
-    mw__2B_C99_2E_lf();
+    WORD_ATOM(586, 23, "line");
+    mw__2B_C99_2E_line();
     WORD_EXIT(mw_c99_block_def_21_);
 }
-static void mw_Block_2B_C99_2E_block (void){
-    WORD_ENTER(mw_Block_2B_C99_2E_block, "Block+C99.block", "src/mirth/codegen.mth", 588, 5);
-    WORD_ATOM(588, 5, "");
+static void mw_Block_2B_C99_2E_put (void) {
+    WORD_ENTER(mw_Block_2B_C99_2E_put, "Block+C99.put", "src/mirth/codegen.mth", 589, 5);
+    WORD_ATOM(589, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21704,34 +21629,34 @@ static void mw_Block_2B_C99_2E_block (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(588, 11, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(589, 5, "dup");
+    WORD_ATOM(589, 11, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(590, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(589, 9, "arrow");
+    WORD_ATOM(590, 9, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(589, 15, "dup");
+    WORD_ATOM(590, 15, "dup");
     mw_prim_dup();
-    WORD_ATOM(589, 19, "home");
+    WORD_ATOM(590, 19, "home");
     mw_Arrow_2E_home();
-    WORD_ATOM(589, 24, "match");
+    WORD_ATOM(590, 24, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_NONE();
-            WORD_ATOM(590, 17, "drop");
+            mp_NONE();
+            WORD_ATOM(591, 17, "drop");
             mw_prim_drop();
-            WORD_ATOM(590, 22, "Block.id");
+            WORD_ATOM(591, 22, "Block.id");
             mw_Block_2E_id();
-            WORD_ATOM(590, 31, ".n");
-            mw_Int_2B_C99_2E_n();
+            WORD_ATOM(591, 31, "put");
+            mw_Int_2B_C99_2E_put();
             break;
         case 1LL:
-            co_SOME();
-            WORD_ATOM(592, 13, "name");
+            mp_SOME();
+            WORD_ATOM(593, 13, "name");
             mw_Word_2E_name();
-            WORD_ATOM(592, 18, ".name");
-            mw_Name_2B_C99_2E_name();
-            WORD_ATOM(592, 24, "");
+            WORD_ATOM(593, 18, "put");
+            mw_Name_2B_C99_2E_put();
+            WORD_ATOM(593, 22, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -21742,87 +21667,87 @@ static void mw_Block_2B_C99_2E_block (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(592, 28, ".");
-            mw_Str_2B_C99_2E_();
-            WORD_ATOM(593, 13, "homeidx");
+            WORD_ATOM(593, 26, "put");
+            mw_Str_2B_C99_2E_put();
+            WORD_ATOM(594, 13, "homeidx");
             mw_Arrow_2E_homeidx();
-            WORD_ATOM(593, 21, ".n");
-            mw_Int_2B_C99_2E_n();
-            WORD_ATOM(593, 24, "drop");
+            WORD_ATOM(594, 21, "put");
+            mw_Int_2B_C99_2E_put();
+            WORD_ATOM(594, 25, "drop");
             mw_prim_drop();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Block_2B_C99_2E_block);
+    }
+    WORD_EXIT(mw_Block_2B_C99_2E_put);
 }
-static void mw_c99_word_enter_21_ (void){
-    WORD_ENTER(mw_c99_word_enter_21_, "c99-word-enter!", "src/mirth/codegen.mth", 597, 5);
-    WORD_ATOM(597, 5, "c99-line");
+static void mw_c99_word_enter_21_ (void) {
+    WORD_ENTER(mw_c99_word_enter_21_, "c99-word-enter!", "src/mirth/codegen.mth", 598, 5);
+    WORD_ATOM(598, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_enter_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(603, 5, "drop");
+    WORD_ATOM(604, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_word_enter_21_);
 }
-static void mw_c99_word_exit_21_ (void){
-    WORD_ENTER(mw_c99_word_exit_21_, "c99-word-exit!", "src/mirth/codegen.mth", 606, 5);
-    WORD_ATOM(606, 5, "c99-line");
+static void mw_c99_word_exit_21_ (void) {
+    WORD_ENTER(mw_c99_word_exit_21_, "c99-word-exit!", "src/mirth/codegen.mth", 607, 5);
+    WORD_ATOM(607, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_exit_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(608, 5, "drop");
+    WORD_ATOM(609, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_word_exit_21_);
 }
-static void mw_c99_word_defs_21_ (void){
-    WORD_ENTER(mw_c99_word_defs_21_, "c99-word-defs!", "src/mirth/codegen.mth", 610, 35);
-    WORD_ATOM(610, 35, "for-needed-words");
+static void mw_c99_word_defs_21_ (void) {
+    WORD_ENTER(mw_c99_word_defs_21_, "c99-word-defs!", "src/mirth/codegen.mth", 611, 35);
+    WORD_ATOM(611, 35, "for-needed-words");
     push_u64(0);
     push_fnptr(&mb_c99_word_defs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_words();
-    WORD_ATOM(610, 67, ".lf");
-    mw__2B_C99_2E_lf();
+    WORD_ATOM(611, 67, "line");
+    mw__2B_C99_2E_line();
     WORD_EXIT(mw_c99_word_defs_21_);
 }
-static void mw_c99_word_def_21_ (void){
-    WORD_ENTER(mw_c99_word_def_21_, "c99-word-def!", "src/mirth/codegen.mth", 612, 5);
-    WORD_ATOM(612, 5, "c99-line");
+static void mw_c99_word_def_21_ (void) {
+    WORD_ENTER(mw_c99_word_def_21_, "c99-word-def!", "src/mirth/codegen.mth", 613, 5);
+    WORD_ATOM(613, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_def_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(613, 5, "c99-nest");
+    WORD_ATOM(614, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_word_def_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(618, 5, "c99-line");
+    WORD_ATOM(619, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_def_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(619, 5, "drop");
+    WORD_ATOM(620, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_word_def_21_);
 }
-static void mw_c99_field_defs_21_ (void){
-    WORD_ENTER(mw_c99_field_defs_21_, "c99-field-defs!", "src/mirth/codegen.mth", 621, 36);
-    WORD_ATOM(621, 36, "Field.for");
+static void mw_c99_field_defs_21_ (void) {
+    WORD_ENTER(mw_c99_field_defs_21_, "c99-field-defs!", "src/mirth/codegen.mth", 622, 36);
+    WORD_ATOM(622, 36, "Field.for");
     push_u64(0);
     push_fnptr(&mb_c99_field_defs_21__1);
     mw_prim_pack_cons();
     mw_Field_2E_for();
-    WORD_ATOM(621, 62, ".lf");
-    mw__2B_C99_2E_lf();
+    WORD_ATOM(622, 62, "line");
+    mw__2B_C99_2E_line();
     WORD_EXIT(mw_c99_field_defs_21_);
 }
-static void mw_c99_field_def_21_ (void){
-    WORD_ENTER(mw_c99_field_def_21_, "c99-field-def!", "src/mirth/codegen.mth", 623, 5);
-    WORD_ATOM(623, 5, "");
+static void mw_c99_field_def_21_ (void) {
+    WORD_ENTER(mw_c99_field_def_21_, "c99-field-def!", "src/mirth/codegen.mth", 624, 5);
+    WORD_ATOM(624, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21833,15 +21758,15 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(623, 29, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(623, 31, "dup");
+    WORD_ATOM(624, 29, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(624, 33, "dup");
     mw_prim_dup();
-    WORD_ATOM(623, 35, "name");
+    WORD_ATOM(624, 37, "name");
     mw_Field_2E_name();
-    WORD_ATOM(623, 40, ".name");
-    mw_Name_2B_C99_2E_name();
-    WORD_ATOM(623, 46, "");
+    WORD_ATOM(624, 42, "put");
+    mw_Name_2B_C99_2E_put();
+    WORD_ATOM(624, 46, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21852,9 +21777,11 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(623, 62, ";");
-    mw_Str_2B_C99_3B_();
-    WORD_ATOM(624, 5, "");
+    WORD_ATOM(624, 62, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(624, 66, "line");
+    mw__2B_C99_2E_line();
+    WORD_ATOM(625, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21865,9 +21792,11 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(624, 37, ";");
-    mw_Str_2B_C99_3B_();
-    WORD_ATOM(625, 5, "");
+    WORD_ATOM(625, 38, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(625, 42, "line");
+    mw__2B_C99_2E_line();
+    WORD_ATOM(626, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21878,13 +21807,13 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(625, 23, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(625, 25, "TABLE_MAX_SIZE");
+    WORD_ATOM(626, 23, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(626, 27, "TABLE_MAX_SIZE");
     mw_TABLE_5F_MAX_5F_SIZE();
-    WORD_ATOM(625, 40, ".n");
-    mw_Int_2B_C99_2E_n();
-    WORD_ATOM(625, 43, "");
+    WORD_ATOM(626, 42, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(626, 46, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21895,9 +21824,11 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(625, 47, ";");
-    mw_Str_2B_C99_3B_();
-    WORD_ATOM(626, 5, "");
+    WORD_ATOM(626, 50, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(626, 54, "line");
+    mw__2B_C99_2E_line();
+    WORD_ATOM(627, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21908,9 +21839,11 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(626, 50, ";");
-    mw_Str_2B_C99_3B_();
-    WORD_ATOM(627, 5, "");
+    WORD_ATOM(627, 50, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(627, 54, "line");
+    mw__2B_C99_2E_line();
+    WORD_ATOM(628, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21921,9 +21854,11 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(627, 70, ";");
-    mw_Str_2B_C99_3B_();
-    WORD_ATOM(628, 5, "");
+    WORD_ATOM(628, 70, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(628, 74, "line");
+    mw__2B_C99_2E_line();
+    WORD_ATOM(629, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21934,9 +21869,11 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(628, 23, ";");
-    mw_Str_2B_C99_3B_();
-    WORD_ATOM(629, 5, "");
+    WORD_ATOM(629, 23, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(629, 27, "line");
+    mw__2B_C99_2E_line();
+    WORD_ATOM(630, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21947,15 +21884,21 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(629, 9, ";;");
-    mw_Str_2B_C99_3B__3B_();
-    WORD_ATOM(632, 5, "dup");
+    WORD_ATOM(630, 9, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(630, 13, "line");
+    mw__2B_C99_2E_line();
+    WORD_ATOM(630, 18, "line");
+    mw__2B_C99_2E_line();
+    WORD_ATOM(634, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(632, 9, "name");
+    WORD_ATOM(634, 9, "name");
     mw_Field_2E_name();
-    WORD_ATOM(632, 14, ".w");
-    mw_Name_2B_C99_2E_w();
-    WORD_ATOM(632, 17, "");
+    WORD_ATOM(634, 14, "sig");
+    mw_Name_2B_C99_2E_sig();
+    WORD_ATOM(634, 18, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(634, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21966,9 +21909,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(632, 21, ";");
-    mw_Str_2B_C99_3B_();
-    WORD_ATOM(633, 5, "");
+    WORD_ATOM(634, 26, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(635, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21979,9 +21922,11 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(633, 45, ";");
-    mw_Str_2B_C99_3B_();
-    WORD_ATOM(634, 5, "");
+    WORD_ATOM(635, 45, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(635, 49, "line");
+    mw__2B_C99_2E_line();
+    WORD_ATOM(636, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -21992,15 +21937,15 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(634, 30, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(634, 32, "dup");
+    WORD_ATOM(636, 30, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(636, 34, "dup");
     mw_prim_dup();
-    WORD_ATOM(634, 36, "name");
+    WORD_ATOM(636, 38, "name");
     mw_Field_2E_name();
-    WORD_ATOM(634, 41, ".name");
-    mw_Name_2B_C99_2E_name();
-    WORD_ATOM(634, 47, "");
+    WORD_ATOM(636, 43, "put");
+    mw_Name_2B_C99_2E_put();
+    WORD_ATOM(636, 47, "");
     {
         static bool vready = false;
         static VAL v;
@@ -22011,9 +21956,11 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(634, 58, ";");
-    mw_Str_2B_C99_3B_();
-    WORD_ATOM(635, 5, "");
+    WORD_ATOM(636, 58, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(636, 62, "line");
+    mw__2B_C99_2E_line();
+    WORD_ATOM(637, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -22024,9 +21971,11 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(635, 24, ";");
-    mw_Str_2B_C99_3B_();
-    WORD_ATOM(636, 5, "");
+    WORD_ATOM(637, 24, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(637, 28, "line");
+    mw__2B_C99_2E_line();
+    WORD_ATOM(638, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -22037,32 +21986,36 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(636, 9, ";;");
-    mw_Str_2B_C99_3B__3B_();
-    WORD_ATOM(638, 5, "drop");
+    WORD_ATOM(638, 9, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(638, 13, "line");
+    mw__2B_C99_2E_line();
+    WORD_ATOM(638, 18, "line");
+    mw__2B_C99_2E_line();
+    WORD_ATOM(639, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_field_def_21_);
 }
-static void mw_c99_main_21_ (void){
-    WORD_ENTER(mw_c99_main_21_, "c99-main!", "src/mirth/codegen.mth", 641, 5);
-    WORD_ATOM(641, 5, "c99-line");
+static void mw_c99_main_21_ (void) {
+    WORD_ENTER(mw_c99_main_21_, "c99-main!", "src/mirth/codegen.mth", 642, 5);
+    WORD_ATOM(642, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(642, 5, "c99-nest");
+    WORD_ATOM(643, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(655, 5, "c99-line");
+    WORD_ATOM(656, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__8);
     mw_prim_pack_cons();
     mw_c99_line();
     WORD_EXIT(mw_c99_main_21_);
 }
-static void mw_type_elab_default (void){
+static void mw_type_elab_default (void) {
     WORD_ENTER(mw_type_elab_default, "type-elab-default", "src/mirth/elab.mth", 40, 34);
     WORD_ATOM(40, 34, "F");
     mw_F();
@@ -22072,7 +22025,7 @@ static void mw_type_elab_default (void){
     mw_TYPE_5F_ELAB();
     WORD_EXIT(mw_type_elab_default);
 }
-static void mw_type_elab_stack_assertion (void){
+static void mw_type_elab_stack_assertion (void) {
     WORD_ENTER(mw_type_elab_stack_assertion, "type-elab-stack-assertion", "src/mirth/elab.mth", 41, 49);
     WORD_ATOM(41, 49, "dip");
     {
@@ -22085,33 +22038,33 @@ static void mw_type_elab_stack_assertion (void){
     mw_TYPE_5F_ELAB();
     WORD_EXIT(mw_type_elab_stack_assertion);
 }
-static void mw_type_elab_holes_allowed (void){
+static void mw_type_elab_holes_allowed (void) {
     WORD_ENTER(mw_type_elab_holes_allowed, "type-elab-holes-allowed", "src/mirth/elab.mth", 42, 48);
     WORD_ATOM(42, 48, "TYPE_ELAB");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_TYPE_5F_ELAB();
+            mp_TYPE_5F_ELAB();
             WORD_ATOM(42, 61, "drop");
             mw_prim_drop();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_type_elab_holes_allowed);
+    }
+    WORD_EXIT(mw_type_elab_holes_allowed);
 }
-static void mw_type_elab_ctx (void){
+static void mw_type_elab_ctx (void) {
     WORD_ENTER(mw_type_elab_ctx, "type-elab-ctx", "src/mirth/elab.mth", 43, 37);
     WORD_ATOM(43, 37, "TYPE_ELAB");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_TYPE_5F_ELAB();
+            mp_TYPE_5F_ELAB();
             WORD_ATOM(43, 50, "nip");
             mw_nip();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_type_elab_ctx);
+    }
+    WORD_EXIT(mw_type_elab_ctx);
 }
-static void mw_type_elab_ctx_3F_ (void){
+static void mw_type_elab_ctx_3F_ (void) {
     WORD_ENTER(mw_type_elab_ctx_3F_, "type-elab-ctx?", "src/mirth/elab.mth", 44, 47);
     WORD_ATOM(44, 47, "dup");
     mw_prim_dup();
@@ -22119,14 +22072,14 @@ static void mw_type_elab_ctx_3F_ (void){
     mw_type_elab_ctx();
     WORD_EXIT(mw_type_elab_ctx_3F_);
 }
-static void mw_type_elab_ctx_replace (void){
+static void mw_type_elab_ctx_replace (void) {
     WORD_ENTER(mw_type_elab_ctx_replace, "type-elab-ctx-replace", "src/mirth/elab.mth", 46, 5);
     WORD_ATOM(46, 5, "swap");
     mw_prim_swap();
     WORD_ATOM(46, 10, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_TYPE_5F_ELAB();
+            mp_TYPE_5F_ELAB();
             WORD_ATOM(46, 29, "drop");
             mw_prim_drop();
             WORD_ATOM(46, 34, "swap");
@@ -22135,10 +22088,10 @@ static void mw_type_elab_ctx_replace (void){
             mw_TYPE_5F_ELAB();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_type_elab_ctx_replace);
+    }
+    WORD_EXIT(mw_type_elab_ctx_replace);
 }
-static void mw_elab_type_sig_21_ (void){
+static void mw_elab_type_sig_21_ (void) {
     WORD_ENTER(mw_elab_type_sig_21_, "elab-type-sig!", "src/mirth/elab.mth", 49, 5);
     WORD_ATOM(49, 5, "dup");
     mw_prim_dup();
@@ -22227,7 +22180,7 @@ static void mw_elab_type_sig_21_ (void){
     }
     WORD_EXIT(mw_elab_type_sig_21_);
 }
-static void mw_elab_type_sig_params_21_ (void){
+static void mw_elab_type_sig_params_21_ (void) {
     WORD_ENTER(mw_elab_type_sig_params_21_, "elab-type-sig-params!", "src/mirth/elab.mth", 59, 5);
     WORD_ATOM(59, 5, "dup");
     mw_prim_dup();
@@ -22243,7 +22196,7 @@ static void mw_elab_type_sig_params_21_ (void){
     mw_Maybe_2E_if();
     WORD_EXIT(mw_elab_type_sig_params_21_);
 }
-static void mw_elab_type_stack_21_ (void){
+static void mw_elab_type_stack_21_ (void) {
     WORD_ENTER(mw_elab_type_stack_21_, "elab-type-stack!", "src/mirth/elab.mth", 69, 5);
     WORD_ATOM(69, 5, "dup");
     mw_prim_dup();
@@ -22273,7 +22226,7 @@ static void mw_elab_type_stack_21_ (void){
     mw_elab_type_stack_rest_21_();
     WORD_EXIT(mw_elab_type_stack_21_);
 }
-static void mw_elab_type_stack_rest_21_ (void){
+static void mw_elab_type_stack_rest_21_ (void) {
     WORD_ENTER(mw_elab_type_stack_rest_21_, "elab-type-stack-rest!", "src/mirth/elab.mth", 76, 5);
     WORD_ATOM(76, 5, "while");
     while(1) {
@@ -22307,7 +22260,7 @@ static void mw_elab_type_stack_rest_21_ (void){
     }
     WORD_EXIT(mw_elab_type_stack_rest_21_);
 }
-static void mw_elab_type_arg_21_ (void){
+static void mw_elab_type_arg_21_ (void) {
     WORD_ENTER(mw_elab_type_arg_21_, "elab-type-arg!", "src/mirth/elab.mth", 82, 5);
     WORD_ATOM(82, 5, "elab-type-atom!");
     mw_elab_type_atom_21_();
@@ -22316,12 +22269,12 @@ static void mw_elab_type_arg_21_ (void){
     WORD_ATOM(83, 10, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_LEFT();
+            mp_LEFT();
             WORD_ATOM(84, 17, "swap");
             mw_prim_swap();
             break;
         case 1LL:
-            co_RIGHT();
+            mp_RIGHT();
             WORD_ATOM(85, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(85, 23, "");
@@ -22339,8 +22292,8 @@ static void mw_elab_type_arg_21_ (void){
             mw_emit_fatal_error_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_ATOM(87, 5, "dup");
+    }
+    WORD_ATOM(87, 5, "dup");
     mw_prim_dup();
     WORD_ATOM(87, 9, "arg-end?");
     mw_Token_2E_arg_end_3F_();
@@ -22365,7 +22318,7 @@ static void mw_elab_type_arg_21_ (void){
     }
     WORD_EXIT(mw_elab_type_arg_21_);
 }
-static void mw_elab_type_atom_21_ (void){
+static void mw_elab_type_atom_21_ (void) {
     WORD_ENTER(mw_elab_type_atom_21_, "elab-type-atom!", "src/mirth/elab.mth", 94, 5);
     WORD_ATOM(94, 5, "dup");
     mw_prim_dup();
@@ -22489,7 +22442,7 @@ static void mw_elab_type_atom_21_ (void){
     }
     WORD_EXIT(mw_elab_type_atom_21_);
 }
-static void mw_elab_stack_var_21_ (void){
+static void mw_elab_stack_var_21_ (void) {
     WORD_ENTER(mw_elab_stack_var_21_, "elab-stack-var!", "src/mirth/elab.mth", 120, 5);
     WORD_ATOM(120, 5, "TYPE_STACK");
     mw_TYPE_5F_STACK();
@@ -22497,7 +22450,7 @@ static void mw_elab_stack_var_21_ (void){
     mw_elab_implicit_var_21_();
     WORD_EXIT(mw_elab_stack_var_21_);
 }
-static void mw_elab_type_var_21_ (void){
+static void mw_elab_type_var_21_ (void) {
     WORD_ENTER(mw_elab_type_var_21_, "elab-type-var!", "src/mirth/elab.mth", 123, 5);
     WORD_ATOM(123, 5, "TYPE_TYPE");
     mw_TYPE_5F_TYPE();
@@ -22505,7 +22458,7 @@ static void mw_elab_type_var_21_ (void){
     mw_elab_implicit_var_21_();
     WORD_EXIT(mw_elab_type_var_21_);
 }
-static void mw_elab_resource_var_21_ (void){
+static void mw_elab_resource_var_21_ (void) {
     WORD_ENTER(mw_elab_resource_var_21_, "elab-resource-var!", "src/mirth/elab.mth", 126, 5);
     WORD_ATOM(126, 5, "TYPE_RESOURCE");
     mw_TYPE_5F_RESOURCE();
@@ -22513,7 +22466,7 @@ static void mw_elab_resource_var_21_ (void){
     mw_elab_implicit_var_21_();
     WORD_EXIT(mw_elab_resource_var_21_);
 }
-static void mw_elab_implicit_var_21_ (void){
+static void mw_elab_implicit_var_21_ (void) {
     WORD_ENTER(mw_elab_implicit_var_21_, "elab-implicit-var!", "src/mirth/elab.mth", 129, 5);
     WORD_ATOM(129, 5, "dip2");
     push_u64(0);
@@ -22532,7 +22485,7 @@ static void mw_elab_implicit_var_21_ (void){
     WORD_ATOM(131, 10, "match");
     switch (get_top_data_tag()) {
         case 1LL:
-            co_SOME();
+            mp_SOME();
             WORD_ATOM(133, 13, "rotr");
             mw_rotr();
             WORD_ATOM(133, 18, "dip2");
@@ -22546,7 +22499,7 @@ static void mw_elab_implicit_var_21_ (void){
             mw_nip();
             break;
         case 0LL:
-            co_NONE();
+            mp_NONE();
             WORD_ATOM(136, 13, "dip");
             {
                 VAL d4 = pop_value();
@@ -22563,8 +22516,8 @@ static void mw_elab_implicit_var_21_ (void){
             }
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_ATOM(141, 5, "next");
+    }
+    WORD_ATOM(141, 5, "next");
     mw_Token_2E_next();
     WORD_ATOM(142, 5, "dip2");
     push_u64(0);
@@ -22573,7 +22526,7 @@ static void mw_elab_implicit_var_21_ (void){
     mw_dip2();
     WORD_EXIT(mw_elab_implicit_var_21_);
 }
-static void mw_elab_type_con_21_ (void){
+static void mw_elab_type_con_21_ (void) {
     WORD_ENTER(mw_elab_type_con_21_, "elab-type-con!", "src/mirth/elab.mth", 145, 5);
     WORD_ATOM(145, 5, "dup");
     mw_prim_dup();
@@ -22624,7 +22577,7 @@ static void mw_elab_type_con_21_ (void){
         WORD_ATOM(149, 31, "match");
         switch (get_top_data_tag()) {
             case 3LL:
-                co_DEF_5F_TYPE();
+                mp_DEF_5F_TYPE();
                 WORD_ATOM(151, 17, "over");
                 mw_over();
                 WORD_ATOM(151, 22, "num-args");
@@ -22662,7 +22615,7 @@ static void mw_elab_type_con_21_ (void){
                 }
                 break;
             case 0LL:
-                co_DEF_5F_NONE();
+                mp_DEF_5F_NONE();
                 WORD_ATOM(160, 17, "dup");
                 mw_prim_dup();
                 WORD_ATOM(160, 21, "");
@@ -22702,15 +22655,15 @@ static void mw_elab_type_con_21_ (void){
                 WORD_ATOM(162, 52, "TYPE_ERROR");
                 mw_TYPE_5F_ERROR();
                 break;
-        
-}        WORD_ATOM(164, 9, "swap");
+        }
+        WORD_ATOM(164, 9, "swap");
         mw_prim_swap();
         WORD_ATOM(164, 14, "next");
         mw_Token_2E_next();
     }
     WORD_EXIT(mw_elab_type_con_21_);
 }
-static void mw_elab_resource_con_21_ (void){
+static void mw_elab_resource_con_21_ (void) {
     WORD_ENTER(mw_elab_resource_con_21_, "elab-resource-con!", "src/mirth/elab.mth", 168, 5);
     WORD_ATOM(168, 5, "elab-type-con!");
     mw_elab_type_con_21_();
@@ -22723,7 +22676,7 @@ static void mw_elab_resource_con_21_ (void){
     }
     WORD_EXIT(mw_elab_resource_con_21_);
 }
-static void mw_elab_type_args_21_ (void){
+static void mw_elab_type_args_21_ (void) {
     WORD_ENTER(mw_elab_type_args_21_, "elab-type-args!", "src/mirth/elab.mth", 171, 5);
     WORD_ATOM(171, 5, "over");
     mw_over();
@@ -22789,7 +22742,7 @@ static void mw_elab_type_args_21_ (void){
     }
     WORD_EXIT(mw_elab_type_args_21_);
 }
-static void mw_elab_type_hole_21_ (void){
+static void mw_elab_type_hole_21_ (void) {
     WORD_ENTER(mw_elab_type_hole_21_, "elab-type-hole!", "src/mirth/elab.mth", 183, 5);
     WORD_ATOM(183, 5, "over");
     mw_over();
@@ -22830,7 +22783,7 @@ static void mw_elab_type_hole_21_ (void){
     }
     WORD_EXIT(mw_elab_type_hole_21_);
 }
-static void mw_elab_type_dont_care_21_ (void){
+static void mw_elab_type_dont_care_21_ (void) {
     WORD_ENTER(mw_elab_type_dont_care_21_, "elab-type-dont-care!", "src/mirth/elab.mth", 191, 5);
     WORD_ATOM(191, 5, "over");
     mw_over();
@@ -22865,7 +22818,7 @@ static void mw_elab_type_dont_care_21_ (void){
     }
     WORD_EXIT(mw_elab_type_dont_care_21_);
 }
-static void mw_elab_type_quote_21_ (void){
+static void mw_elab_type_quote_21_ (void) {
     WORD_ENTER(mw_elab_type_quote_21_, "elab-type-quote!", "src/mirth/elab.mth", 199, 5);
     WORD_ATOM(199, 5, "args-1");
     mw_Token_2E_args_1();
@@ -22899,7 +22852,7 @@ static void mw_elab_type_quote_21_ (void){
     mw_Token_2E_next();
     WORD_EXIT(mw_elab_type_quote_21_);
 }
-static void mw_elab_type_unify_21_ (void){
+static void mw_elab_type_unify_21_ (void) {
     WORD_ENTER(mw_elab_type_unify_21_, "elab-type-unify!", "src/mirth/elab.mth", 205, 5);
     WORD_ATOM(205, 5, "sip");
     push_u64(0);
@@ -22908,7 +22861,7 @@ static void mw_elab_type_unify_21_ (void){
     mw_sip();
     WORD_EXIT(mw_elab_type_unify_21_);
 }
-static void mw_elab_stack_type_unify_21_ (void){
+static void mw_elab_stack_type_unify_21_ (void) {
     WORD_ENTER(mw_elab_stack_type_unify_21_, "elab-stack-type-unify!", "src/mirth/elab.mth", 207, 5);
     WORD_ATOM(207, 5, "sip");
     push_u64(0);
@@ -22917,7 +22870,7 @@ static void mw_elab_stack_type_unify_21_ (void){
     mw_sip();
     WORD_EXIT(mw_elab_stack_type_unify_21_);
 }
-static void mw_elab_simple_type_arg_21_ (void){
+static void mw_elab_simple_type_arg_21_ (void) {
     WORD_ENTER(mw_elab_simple_type_arg_21_, "elab-simple-type-arg!", "src/mirth/elab.mth", 210, 5);
     WORD_ATOM(210, 5, "dip");
     {
@@ -22934,7 +22887,7 @@ static void mw_elab_simple_type_arg_21_ (void){
     mw_nip();
     WORD_EXIT(mw_elab_simple_type_arg_21_);
 }
-static void mw_ab_ctx (void){
+static void mw_ab_ctx (void) {
     WORD_ENTER(mw_ab_ctx, "ab-ctx", "src/mirth/elab.mth", 220, 23);
     WORD_ATOM(220, 23, "ab-arrow");
     mw_ab_arrow();
@@ -22944,7 +22897,7 @@ static void mw_ab_ctx (void){
     mw_Arrow_7E_ctx();
     WORD_EXIT(mw_ab_ctx);
 }
-static void mw_ab_token (void){
+static void mw_ab_token (void) {
     WORD_ENTER(mw_ab_token, "ab-token", "src/mirth/elab.mth", 221, 27);
     WORD_ATOM(221, 27, "ab-arrow");
     mw_ab_arrow();
@@ -22954,7 +22907,7 @@ static void mw_ab_token (void){
     mw_Arrow_7E_token_end();
     WORD_EXIT(mw_ab_token);
 }
-static void mw_ab_type (void){
+static void mw_ab_type (void) {
     WORD_ENTER(mw_ab_type, "ab-type", "src/mirth/elab.mth", 222, 30);
     WORD_ATOM(222, 30, "ab-arrow");
     mw_ab_arrow();
@@ -22964,7 +22917,7 @@ static void mw_ab_type (void){
     mw_Arrow_7E_cod();
     WORD_EXIT(mw_ab_type);
 }
-static void mw_init_elab_21_ (void){
+static void mw_init_elab_21_ (void) {
     WORD_ENTER(mw_init_elab_21_, "init-elab!", "src/mirth/elab.mth", 225, 5);
     WORD_ATOM(225, 5, "Arrow.nil");
     mw_Arrow_2E_nil();
@@ -22974,7 +22927,7 @@ static void mw_init_elab_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_init_elab_21_);
 }
-static void mw_ab_save_21_ (void){
+static void mw_ab_save_21_ (void) {
     WORD_ENTER(mw_ab_save_21_, "ab-save!", "src/mirth/elab.mth", 228, 5);
     WORD_ATOM(228, 5, "ab-arrow");
     {
@@ -22999,7 +22952,7 @@ static void mw_ab_save_21_ (void){
     }
     WORD_EXIT(mw_ab_save_21_);
 }
-static void mw_ab_build_21_ (void){
+static void mw_ab_build_21_ (void) {
     WORD_ENTER(mw_ab_build_21_, "ab-build!", "src/mirth/elab.mth", 231, 5);
     WORD_ATOM(231, 5, "ab-save!");
     {
@@ -23016,7 +22969,7 @@ static void mw_ab_build_21_ (void){
     }
     WORD_EXIT(mw_ab_build_21_);
 }
-static void mw_ab_build_hom_21_ (void){
+static void mw_ab_build_hom_21_ (void) {
     WORD_ENTER(mw_ab_build_hom_21_, "ab-build-hom!", "src/mirth/elab.mth", 249, 5);
     WORD_ATOM(249, 5, "dip");
     {
@@ -23042,7 +22995,7 @@ static void mw_ab_build_hom_21_ (void){
     }
     WORD_EXIT(mw_ab_build_hom_21_);
 }
-static void mw_ab_build_word_arrow_21_ (void){
+static void mw_ab_build_word_arrow_21_ (void) {
     WORD_ENTER(mw_ab_build_word_arrow_21_, "ab-build-word-arrow!", "src/mirth/elab.mth", 252, 5);
     WORD_ATOM(252, 5, "dup");
     {
@@ -23085,7 +23038,7 @@ static void mw_ab_build_word_arrow_21_ (void){
     }
     WORD_EXIT(mw_ab_build_word_arrow_21_);
 }
-static void mw_ab_build_word_21_ (void){
+static void mw_ab_build_word_21_ (void) {
     WORD_ENTER(mw_ab_build_word_21_, "ab-build-word!", "src/mirth/elab.mth", 257, 5);
     WORD_ATOM(257, 5, "sip");
     {
@@ -23108,7 +23061,7 @@ static void mw_ab_build_word_21_ (void){
     }
     WORD_EXIT(mw_ab_build_word_21_);
 }
-static void mw_ab_unify_type_21_ (void){
+static void mw_ab_unify_type_21_ (void) {
     WORD_ENTER(mw_ab_unify_type_21_, "ab-unify-type!", "src/mirth/elab.mth", 261, 5);
     WORD_ATOM(261, 5, "dip");
     {
@@ -23135,7 +23088,7 @@ static void mw_ab_unify_type_21_ (void){
     mw_prim_drop();
     WORD_EXIT(mw_ab_unify_type_21_);
 }
-static void mw_ab_atom_21_ (void){
+static void mw_ab_atom_21_ (void) {
     WORD_ENTER(mw_ab_atom_21_, "ab-atom!", "src/mirth/elab.mth", 264, 5);
     WORD_ATOM(264, 5, "dup");
     mw_prim_dup();
@@ -23176,7 +23129,7 @@ static void mw_ab_atom_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_ab_atom_21_);
 }
-static void mw_ab_optimized_snoc_21_ (void){
+static void mw_ab_optimized_snoc_21_ (void) {
     WORD_ENTER(mw_ab_optimized_snoc_21_, "ab-optimized-snoc!", "src/mirth/elab.mth", 275, 5);
     WORD_ATOM(275, 5, "while");
     while(1) {
@@ -23202,7 +23155,7 @@ static void mw_ab_optimized_snoc_21_ (void){
     mw_snoc();
     WORD_EXIT(mw_ab_optimized_snoc_21_);
 }
-static void mw_atom_accepts_args_3F_ (void){
+static void mw_atom_accepts_args_3F_ (void) {
     WORD_ENTER(mw_atom_accepts_args_3F_, "atom-accepts-args?", "src/mirth/elab.mth", 280, 5);
     WORD_ATOM(280, 5, "dup");
     mw_prim_dup();
@@ -23211,7 +23164,7 @@ static void mw_atom_accepts_args_3F_ (void){
     WORD_ATOM(280, 12, "match");
     switch (get_top_data_tag()) {
         case 2LL:
-            co_OP_5F_WORD();
+            mp_OP_5F_WORD();
             WORD_ATOM(281, 20, "dip");
             {
                 VAL d4 = pop_value();
@@ -23231,11 +23184,11 @@ static void mw_atom_accepts_args_3F_ (void){
             mw_prim_int_lt();
             break;
         case 1LL:
-            co_OP_5F_PRIM();
+            mp_OP_5F_PRIM();
             WORD_ATOM(283, 13, "match");
             switch (get_top_data_tag()) {
                 case 4LL:
-                    co_PRIM_5F_CORE_5F_DIP();
+                    mp_PRIM_5F_CORE_5F_DIP();
                     WORD_ATOM(284, 34, "dup");
                     mw_prim_dup();
                     WORD_ATOM(284, 38, "args");
@@ -23248,7 +23201,7 @@ static void mw_atom_accepts_args_3F_ (void){
                     mw_prim_int_lt();
                     break;
                 case 13LL:
-                    co_PRIM_5F_CORE_5F_RDIP();
+                    mp_PRIM_5F_CORE_5F_RDIP();
                     WORD_ATOM(285, 35, "dup");
                     mw_prim_dup();
                     WORD_ATOM(285, 39, "args");
@@ -23261,7 +23214,7 @@ static void mw_atom_accepts_args_3F_ (void){
                     mw_prim_int_lt();
                     break;
                 case 5LL:
-                    co_PRIM_5F_CORE_5F_IF();
+                    mp_PRIM_5F_CORE_5F_IF();
                     WORD_ATOM(286, 33, "dup");
                     mw_prim_dup();
                     WORD_ATOM(286, 37, "args");
@@ -23274,7 +23227,7 @@ static void mw_atom_accepts_args_3F_ (void){
                     mw_prim_int_lt();
                     break;
                 case 6LL:
-                    co_PRIM_5F_CORE_5F_WHILE();
+                    mp_PRIM_5F_CORE_5F_WHILE();
                     WORD_ATOM(287, 36, "dup");
                     mw_prim_dup();
                     WORD_ATOM(287, 40, "args");
@@ -23292,18 +23245,18 @@ static void mw_atom_accepts_args_3F_ (void){
                     WORD_ATOM(288, 27, "F");
                     mw_F();
                     break;
-            
-}            break;
+            }
+            break;
         default:
             WORD_ATOM(290, 14, "drop");
             mw_prim_drop();
             WORD_ATOM(290, 19, "F");
             mw_F();
             break;
-    
-}    WORD_EXIT(mw_atom_accepts_args_3F_);
+    }
+    WORD_EXIT(mw_atom_accepts_args_3F_);
 }
-static void mw_atoms_has_last_block_3F_ (void){
+static void mw_atoms_has_last_block_3F_ (void) {
     WORD_ENTER(mw_atoms_has_last_block_3F_, "atoms-has-last-block?", "src/mirth/elab.mth", 294, 5);
     WORD_ATOM(294, 5, "dup");
     mw_prim_dup();
@@ -23312,18 +23265,18 @@ static void mw_atoms_has_last_block_3F_ (void){
     WORD_ATOM(294, 14, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_NONE();
+            mp_NONE();
             WORD_ATOM(295, 17, "F");
             mw_F();
             break;
         case 1LL:
-            co_SOME();
+            mp_SOME();
             WORD_ATOM(297, 13, "op");
             mw_Atom_2E_op();
             WORD_ATOM(297, 16, "match");
             switch (get_top_data_tag()) {
                 case 14LL:
-                    co_OP_5F_BLOCK();
+                    mp_OP_5F_BLOCK();
                     WORD_ATOM(298, 29, "drop");
                     mw_prim_drop();
                     WORD_ATOM(298, 34, "T");
@@ -23335,25 +23288,25 @@ static void mw_atoms_has_last_block_3F_ (void){
                     WORD_ATOM(299, 27, "F");
                     mw_F();
                     break;
-            
-}            break;
+            }
+            break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_atoms_has_last_block_3F_);
+    }
+    WORD_EXIT(mw_atoms_has_last_block_3F_);
 }
-static void mw_atoms_turn_last_block_to_arg (void){
+static void mw_atoms_turn_last_block_to_arg (void) {
     WORD_ENTER(mw_atoms_turn_last_block_to_arg, "atoms-turn-last-block-to-arg", "src/mirth/elab.mth", 304, 5);
     WORD_ATOM(304, 5, ">List+");
     mw_List_3E_List_2B_();
     WORD_ATOM(304, 12, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_NONE();
+            mp_NONE();
             WORD_ATOM(305, 17, "L0");
             mw_L0();
             break;
         case 1LL:
-            co_SOME();
+            mp_SOME();
             WORD_ATOM(307, 13, "unsnoc");
             mw_List_2B__2E_unsnoc();
             WORD_ATOM(307, 20, "dup");
@@ -23363,7 +23316,7 @@ static void mw_atoms_turn_last_block_to_arg (void){
             WORD_ATOM(307, 27, "match");
             switch (get_top_data_tag()) {
                 case 14LL:
-                    co_OP_5F_BLOCK();
+                    mp_OP_5F_BLOCK();
                     WORD_ATOM(310, 21, "dip");
                     {
                         VAL d6 = pop_value();
@@ -23394,13 +23347,13 @@ static void mw_atoms_turn_last_block_to_arg (void){
                     WORD_ATOM(314, 27, "snoc");
                     mw_snoc();
                     break;
-            
-}            break;
+            }
+            break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_atoms_turn_last_block_to_arg);
+    }
+    WORD_EXIT(mw_atoms_turn_last_block_to_arg);
 }
-static void mw_block_to_run_var (void){
+static void mw_block_to_run_var (void) {
     WORD_ENTER(mw_block_to_run_var, "block-to-run-var", "src/mirth/elab.mth", 319, 5);
     WORD_ATOM(319, 5, "arrow");
     mw_Block_2E_arrow();
@@ -23408,14 +23361,14 @@ static void mw_block_to_run_var (void){
     mw_arrow_to_run_var();
     WORD_EXIT(mw_block_to_run_var);
 }
-static void mw_arrow_to_run_var (void){
+static void mw_arrow_to_run_var (void) {
     WORD_ENTER(mw_arrow_to_run_var, "arrow-to-run-var", "src/mirth/elab.mth", 322, 5);
     WORD_ATOM(322, 5, "atoms");
     mw_Arrow_2E_atoms();
     WORD_ATOM(322, 11, "match");
     switch (get_top_data_tag()) {
         case 1LL:
-            co_L1();
+            mp_L1();
             WORD_ATOM(323, 15, "atom-to-run-var");
             mw_atom_to_run_var();
             break;
@@ -23425,17 +23378,17 @@ static void mw_arrow_to_run_var (void){
             WORD_ATOM(324, 19, "NONE");
             mw_NONE();
             break;
-    
-}    WORD_EXIT(mw_arrow_to_run_var);
+    }
+    WORD_EXIT(mw_arrow_to_run_var);
 }
-static void mw_atom_to_run_var (void){
+static void mw_atom_to_run_var (void) {
     WORD_ENTER(mw_atom_to_run_var, "atom-to-run-var", "src/mirth/elab.mth", 328, 5);
     WORD_ATOM(328, 5, "op");
     mw_Atom_2E_op();
     WORD_ATOM(328, 8, "match");
     switch (get_top_data_tag()) {
         case 13LL:
-            co_OP_5F_VAR();
+            mp_OP_5F_VAR();
             WORD_ATOM(329, 19, "dup");
             mw_prim_dup();
             WORD_ATOM(329, 23, "auto-run?");
@@ -23457,10 +23410,10 @@ static void mw_atom_to_run_var (void){
             WORD_ATOM(330, 19, "NONE");
             mw_NONE();
             break;
-    
-}    WORD_EXIT(mw_atom_to_run_var);
+    }
+    WORD_EXIT(mw_atom_to_run_var);
 }
-static void mw_ab_op_21_ (void){
+static void mw_ab_op_21_ (void) {
     WORD_ENTER(mw_ab_op_21_, "ab-op!", "src/mirth/elab.mth", 334, 5);
     WORD_ATOM(334, 5, "Atom.alloc!");
     mw_Atom_2E_alloc_21_();
@@ -23536,12 +23489,12 @@ static void mw_ab_op_21_ (void){
     mw_ab_atom_21_();
     WORD_EXIT(mw_ab_op_21_);
 }
-static void mw_ab_expand_opsig_21_ (void){
+static void mw_ab_expand_opsig_21_ (void) {
     WORD_ENTER(mw_ab_expand_opsig_21_, "ab-expand-opsig!", "src/mirth/elab.mth", 346, 5);
     WORD_ATOM(346, 5, "OPSIG_ID");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_OPSIG_5F_ID();
+            mp_OPSIG_5F_ID();
             WORD_ATOM(346, 17, "ab-type");
             mw_ab_type();
             WORD_ATOM(346, 25, "@");
@@ -23550,7 +23503,7 @@ static void mw_ab_expand_opsig_21_ (void){
             mw_prim_dup();
             break;
         case 1LL:
-            co_OPSIG_5F_PUSH();
+            mp_OPSIG_5F_PUSH();
             WORD_ATOM(347, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -23566,7 +23519,7 @@ static void mw_ab_expand_opsig_21_ (void){
             mw_STCons();
             break;
         case 2LL:
-            co_OPSIG_5F_APPLY();
+            mp_OPSIG_5F_APPLY();
             WORD_ATOM(349, 9, "dip");
             {
                 VAL d4 = pop_value();
@@ -23593,10 +23546,10 @@ static void mw_ab_expand_opsig_21_ (void){
             }
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_ab_expand_opsig_21_);
+    }
+    WORD_EXIT(mw_ab_expand_opsig_21_);
 }
-static void mw_ab_int_21_ (void){
+static void mw_ab_int_21_ (void) {
     WORD_ENTER(mw_ab_int_21_, "ab-int!", "src/mirth/elab.mth", 352, 22);
     WORD_ATOM(352, 22, "OP_INT");
     mw_OP_5F_INT();
@@ -23604,7 +23557,7 @@ static void mw_ab_int_21_ (void){
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_int_21_);
 }
-static void mw_ab_str_21_ (void){
+static void mw_ab_str_21_ (void) {
     WORD_ENTER(mw_ab_str_21_, "ab-str!", "src/mirth/elab.mth", 353, 22);
     WORD_ATOM(353, 22, "OP_STR");
     mw_OP_5F_STR();
@@ -23612,7 +23565,7 @@ static void mw_ab_str_21_ (void){
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_str_21_);
 }
-static void mw_ab_buffer_21_ (void){
+static void mw_ab_buffer_21_ (void) {
     WORD_ENTER(mw_ab_buffer_21_, "ab-buffer!", "src/mirth/elab.mth", 354, 28);
     WORD_ATOM(354, 28, "OP_BUFFER");
     mw_OP_5F_BUFFER();
@@ -23620,7 +23573,7 @@ static void mw_ab_buffer_21_ (void){
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_buffer_21_);
 }
-static void mw_ab_variable_21_ (void){
+static void mw_ab_variable_21_ (void) {
     WORD_ENTER(mw_ab_variable_21_, "ab-variable!", "src/mirth/elab.mth", 355, 32);
     WORD_ATOM(355, 32, "OP_VARIABLE");
     mw_OP_5F_VARIABLE();
@@ -23628,7 +23581,7 @@ static void mw_ab_variable_21_ (void){
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_variable_21_);
 }
-static void mw_ab_constant_21_ (void){
+static void mw_ab_constant_21_ (void) {
     WORD_ENTER(mw_ab_constant_21_, "ab-constant!", "src/mirth/elab.mth", 356, 32);
     WORD_ATOM(356, 32, "OP_CONSTANT");
     mw_OP_5F_CONSTANT();
@@ -23636,7 +23589,7 @@ static void mw_ab_constant_21_ (void){
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_constant_21_);
 }
-static void mw_ab_field_21_ (void){
+static void mw_ab_field_21_ (void) {
     WORD_ENTER(mw_ab_field_21_, "ab-field!", "src/mirth/elab.mth", 357, 26);
     WORD_ATOM(357, 26, "OP_FIELD");
     mw_OP_5F_FIELD();
@@ -23644,7 +23597,7 @@ static void mw_ab_field_21_ (void){
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_field_21_);
 }
-static void mw_ab_var_21_ (void){
+static void mw_ab_var_21_ (void) {
     WORD_ENTER(mw_ab_var_21_, "ab-var!", "src/mirth/elab.mth", 358, 22);
     WORD_ATOM(358, 22, "OP_VAR");
     mw_OP_5F_VAR();
@@ -23652,7 +23605,7 @@ static void mw_ab_var_21_ (void){
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_var_21_);
 }
-static void mw_ab_tag_21_ (void){
+static void mw_ab_tag_21_ (void) {
     WORD_ENTER(mw_ab_tag_21_, "ab-tag!", "src/mirth/elab.mth", 359, 22);
     WORD_ATOM(359, 22, "OP_TAG");
     mw_OP_5F_TAG();
@@ -23660,7 +23613,7 @@ static void mw_ab_tag_21_ (void){
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_tag_21_);
 }
-static void mw_ab_prim_21_ (void){
+static void mw_ab_prim_21_ (void) {
     WORD_ENTER(mw_ab_prim_21_, "ab-prim!", "src/mirth/elab.mth", 361, 5);
     WORD_ATOM(361, 5, "dup");
     mw_prim_dup();
@@ -23695,7 +23648,7 @@ static void mw_ab_prim_21_ (void){
     }
     WORD_EXIT(mw_ab_prim_21_);
 }
-static void mw_ab_word_21_ (void){
+static void mw_ab_word_21_ (void) {
     WORD_ENTER(mw_ab_word_21_, "ab-word!", "src/mirth/elab.mth", 365, 24);
     WORD_ATOM(365, 24, "OP_WORD");
     mw_OP_5F_WORD();
@@ -23703,7 +23656,7 @@ static void mw_ab_word_21_ (void){
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_word_21_);
 }
-static void mw_ab_external_21_ (void){
+static void mw_ab_external_21_ (void) {
     WORD_ENTER(mw_ab_external_21_, "ab-external!", "src/mirth/elab.mth", 366, 32);
     WORD_ATOM(366, 32, "OP_EXTERNAL");
     mw_OP_5F_EXTERNAL();
@@ -23711,7 +23664,7 @@ static void mw_ab_external_21_ (void){
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_external_21_);
 }
-static void mw_ab_block_at_21_ (void){
+static void mw_ab_block_at_21_ (void) {
     WORD_ENTER(mw_ab_block_at_21_, "ab-block-at!", "src/mirth/elab.mth", 369, 5);
     WORD_ATOM(369, 5, "ab-ctx");
     {
@@ -23740,7 +23693,7 @@ static void mw_ab_block_at_21_ (void){
     }
     WORD_EXIT(mw_ab_block_at_21_);
 }
-static void mw_ab_block_21_ (void){
+static void mw_ab_block_21_ (void) {
     WORD_ENTER(mw_ab_block_21_, "ab-block!", "src/mirth/elab.mth", 373, 5);
     WORD_ATOM(373, 5, "ab-token");
     {
@@ -23757,7 +23710,7 @@ static void mw_ab_block_21_ (void){
     }
     WORD_EXIT(mw_ab_block_21_);
 }
-static void mw_ab_dip_21_ (void){
+static void mw_ab_dip_21_ (void) {
     WORD_ENTER(mw_ab_dip_21_, "ab-dip!", "src/mirth/elab.mth", 376, 5);
     WORD_ATOM(376, 5, "ab-block!");
     {
@@ -23774,7 +23727,7 @@ static void mw_ab_dip_21_ (void){
     }
     WORD_EXIT(mw_ab_dip_21_);
 }
-static void mw_ab_if_21_ (void){
+static void mw_ab_if_21_ (void) {
     WORD_ENTER(mw_ab_if_21_, "ab-if!", "src/mirth/elab.mth", 379, 5);
     WORD_ATOM(379, 5, "ab-block!");
     {
@@ -23797,7 +23750,7 @@ static void mw_ab_if_21_ (void){
     }
     WORD_EXIT(mw_ab_if_21_);
 }
-static void mw_ab_while_21_ (void){
+static void mw_ab_while_21_ (void) {
     WORD_ENTER(mw_ab_while_21_, "ab-while!", "src/mirth/elab.mth", 382, 5);
     WORD_ATOM(382, 5, "ab-block!");
     {
@@ -23820,7 +23773,7 @@ static void mw_ab_while_21_ (void){
     }
     WORD_EXIT(mw_ab_while_21_);
 }
-static void mw_ab_lambda_21_ (void){
+static void mw_ab_lambda_21_ (void) {
     WORD_ENTER(mw_ab_lambda_21_, "ab-lambda!", "src/mirth/elab.mth", 385, 5);
     WORD_ATOM(385, 5, "Lambda.alloc!");
     {
@@ -23932,7 +23885,7 @@ static void mw_ab_lambda_21_ (void){
     }
     WORD_EXIT(mw_ab_lambda_21_);
 }
-static void mw_elab_op_fresh_sig_21_ (void){
+static void mw_elab_op_fresh_sig_21_ (void) {
     WORD_ENTER(mw_elab_op_fresh_sig_21_, "elab-op-fresh-sig!", "src/mirth/elab.mth", 416, 5);
     WORD_ATOM(416, 5, "Subst.nil");
     mw_Subst_2E_nil();
@@ -23941,12 +23894,12 @@ static void mw_elab_op_fresh_sig_21_ (void){
     WORD_ATOM(416, 20, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_OP_5F_NONE();
+            mp_OP_5F_NONE();
             WORD_ATOM(417, 20, "OPSIG_ID");
             mw_OPSIG_5F_ID();
             break;
         case 8LL:
-            co_OP_5F_INT();
+            mp_OP_5F_INT();
             WORD_ATOM(418, 19, "VALUE_INT");
             mw_VALUE_5F_INT();
             WORD_ATOM(418, 29, "TValue");
@@ -23955,7 +23908,7 @@ static void mw_elab_op_fresh_sig_21_ (void){
             mw_OPSIG_5F_PUSH();
             break;
         case 9LL:
-            co_OP_5F_STR();
+            mp_OP_5F_STR();
             WORD_ATOM(419, 19, "VALUE_STR");
             mw_VALUE_5F_STR();
             WORD_ATOM(419, 29, "TValue");
@@ -23964,7 +23917,7 @@ static void mw_elab_op_fresh_sig_21_ (void){
             mw_OPSIG_5F_PUSH();
             break;
         case 4LL:
-            co_OP_5F_BUFFER();
+            mp_OP_5F_BUFFER();
             WORD_ATOM(420, 22, "drop");
             mw_prim_drop();
             WORD_ATOM(420, 27, "TYPE_PTR");
@@ -23973,7 +23926,7 @@ static void mw_elab_op_fresh_sig_21_ (void){
             mw_OPSIG_5F_PUSH();
             break;
         case 5LL:
-            co_OP_5F_VARIABLE();
+            mp_OP_5F_VARIABLE();
             WORD_ATOM(421, 24, "type");
             mw_Variable_2E_type();
             WORD_ATOM(421, 29, "TMut");
@@ -23982,7 +23935,7 @@ static void mw_elab_op_fresh_sig_21_ (void){
             mw_OPSIG_5F_PUSH();
             break;
         case 6LL:
-            co_OP_5F_CONSTANT();
+            mp_OP_5F_CONSTANT();
             WORD_ATOM(422, 24, "value");
             mw_Constant_2E_value();
             WORD_ATOM(422, 30, "TValue");
@@ -23991,7 +23944,7 @@ static void mw_elab_op_fresh_sig_21_ (void){
             mw_OPSIG_5F_PUSH();
             break;
         case 10LL:
-            co_OP_5F_TAG();
+            mp_OP_5F_TAG();
             WORD_ATOM(423, 19, "type");
             mw_Tag_2E_type();
             WORD_ATOM(423, 24, "freshen-sig");
@@ -24000,7 +23953,7 @@ static void mw_elab_op_fresh_sig_21_ (void){
             mw_OPSIG_5F_APPLY();
             break;
         case 2LL:
-            co_OP_5F_WORD();
+            mp_OP_5F_WORD();
             WORD_ATOM(424, 20, "type");
             mw_Word_2E_type();
             WORD_ATOM(424, 25, "freshen-sig");
@@ -24009,7 +23962,7 @@ static void mw_elab_op_fresh_sig_21_ (void){
             mw_OPSIG_5F_APPLY();
             break;
         case 1LL:
-            co_OP_5F_PRIM();
+            mp_OP_5F_PRIM();
             WORD_ATOM(425, 20, "type");
             mw_Prim_2E_type();
             WORD_ATOM(425, 25, "freshen-sig");
@@ -24018,7 +23971,7 @@ static void mw_elab_op_fresh_sig_21_ (void){
             mw_OPSIG_5F_APPLY();
             break;
         case 3LL:
-            co_OP_5F_EXTERNAL();
+            mp_OP_5F_EXTERNAL();
             WORD_ATOM(426, 24, "type");
             mw_External_2E_type();
             WORD_ATOM(426, 29, "freshen-sig");
@@ -24027,7 +23980,7 @@ static void mw_elab_op_fresh_sig_21_ (void){
             mw_OPSIG_5F_APPLY();
             break;
         case 7LL:
-            co_OP_5F_FIELD();
+            mp_OP_5F_FIELD();
             WORD_ATOM(427, 21, "type");
             mw_Field_2E_type();
             WORD_ATOM(427, 26, "freshen-sig");
@@ -24036,30 +23989,30 @@ static void mw_elab_op_fresh_sig_21_ (void){
             mw_OPSIG_5F_APPLY();
             break;
         case 14LL:
-            co_OP_5F_BLOCK();
+            mp_OP_5F_BLOCK();
             WORD_ATOM(428, 21, "elab-block-sig!");
             mw_elab_block_sig_21_();
             break;
         case 13LL:
-            co_OP_5F_VAR();
+            mp_OP_5F_VAR();
             WORD_ATOM(429, 19, "elab-var-sig!");
             mw_elab_var_sig_21_();
             break;
         case 11LL:
-            co_OP_5F_MATCH();
+            mp_OP_5F_MATCH();
             WORD_ATOM(430, 21, "elab-match-sig!");
             mw_elab_match_sig_21_();
             break;
         case 12LL:
-            co_OP_5F_LAMBDA();
+            mp_OP_5F_LAMBDA();
             WORD_ATOM(431, 22, "elab-lambda-sig!");
             mw_elab_lambda_sig_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_elab_op_fresh_sig_21_);
+    }
+    WORD_EXIT(mw_elab_op_fresh_sig_21_);
 }
-static void mw_elab_block_sig_21_ (void){
+static void mw_elab_block_sig_21_ (void) {
     WORD_ENTER(mw_elab_block_sig_21_, "elab-block-sig!", "src/mirth/elab.mth", 435, 5);
     WORD_ATOM(435, 5, "VALUE_BLOCK");
     mw_VALUE_5F_BLOCK();
@@ -24069,7 +24022,7 @@ static void mw_elab_block_sig_21_ (void){
     mw_OPSIG_5F_PUSH();
     WORD_EXIT(mw_elab_block_sig_21_);
 }
-static void mw_elab_match_sig_21_ (void){
+static void mw_elab_match_sig_21_ (void) {
     WORD_ENTER(mw_elab_match_sig_21_, "elab-match-sig!", "src/mirth/elab.mth", 438, 5);
     WORD_ATOM(438, 5, "sip");
     push_u64(0);
@@ -24084,7 +24037,7 @@ static void mw_elab_match_sig_21_ (void){
     mw_OPSIG_5F_APPLY();
     WORD_EXIT(mw_elab_match_sig_21_);
 }
-static void mw_elab_lambda_sig_21_ (void){
+static void mw_elab_lambda_sig_21_ (void) {
     WORD_ENTER(mw_elab_lambda_sig_21_, "elab-lambda-sig!", "src/mirth/elab.mth", 441, 5);
     WORD_ATOM(441, 5, "sip");
     push_u64(0);
@@ -24099,7 +24052,7 @@ static void mw_elab_lambda_sig_21_ (void){
     mw_OPSIG_5F_APPLY();
     WORD_EXIT(mw_elab_lambda_sig_21_);
 }
-static void mw_elab_var_sig_21_ (void){
+static void mw_elab_var_sig_21_ (void) {
     WORD_ENTER(mw_elab_var_sig_21_, "elab-var-sig!", "src/mirth/elab.mth", 444, 5);
     WORD_ATOM(444, 5, "dup");
     mw_prim_dup();
@@ -24125,7 +24078,7 @@ static void mw_elab_var_sig_21_ (void){
     }
     WORD_EXIT(mw_elab_var_sig_21_);
 }
-static void mw_elab_word_ctx_type_weak_21_ (void){
+static void mw_elab_word_ctx_type_weak_21_ (void) {
     WORD_ENTER(mw_elab_word_ctx_type_weak_21_, "elab-word-ctx-type-weak!", "src/mirth/elab.mth", 450, 5);
     WORD_ATOM(450, 5, "dup");
     mw_prim_dup();
@@ -24134,7 +24087,7 @@ static void mw_elab_word_ctx_type_weak_21_ (void){
     WORD_ATOM(450, 13, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_NONE();
+            mp_NONE();
             WORD_ATOM(451, 17, "~ctx-type");
             mw_Word_7E_ctx_type();
             WORD_ATOM(451, 27, "@");
@@ -24142,7 +24095,7 @@ static void mw_elab_word_ctx_type_weak_21_ (void){
             WORD_ATOM(451, 29, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    co_LAZY_5F_READY();
+                    mp_LAZY_5F_READY();
                     WORD_ATOM(452, 27, "unpack2");
                     mw_unpack2();
                     break;
@@ -24162,20 +24115,20 @@ static void mw_elab_word_ctx_type_weak_21_ (void){
                     WORD_ATOM(453, 68, "T->");
                     mw_T__3E_();
                     break;
-            
-}            break;
+            }
+            break;
         case 1LL:
-            co_SOME();
+            mp_SOME();
             WORD_ATOM(455, 17, "drop");
             mw_prim_drop();
             WORD_ATOM(455, 22, "ctx-type");
             mw_Word_2E_ctx_type();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_elab_word_ctx_type_weak_21_);
+    }
+    WORD_EXIT(mw_elab_word_ctx_type_weak_21_);
 }
-static void mw_elab_arrow_21_ (void){
+static void mw_elab_arrow_21_ (void) {
     WORD_ENTER(mw_elab_arrow_21_, "elab-arrow!", "src/mirth/elab.mth", 459, 5);
     WORD_ATOM(459, 5, "dip");
     {
@@ -24188,7 +24141,7 @@ static void mw_elab_arrow_21_ (void){
     mw_elab_arrow_hom_21_();
     WORD_EXIT(mw_elab_arrow_21_);
 }
-static void mw_elab_arrow_hom_21_ (void){
+static void mw_elab_arrow_hom_21_ (void) {
     WORD_ENTER(mw_elab_arrow_hom_21_, "elab-arrow-hom!", "src/mirth/elab.mth", 462, 5);
     WORD_ATOM(462, 5, "swap");
     mw_prim_swap();
@@ -24215,7 +24168,7 @@ static void mw_elab_arrow_hom_21_ (void){
     mw_drop2();
     WORD_EXIT(mw_elab_arrow_hom_21_);
 }
-static void mw_elab_arrow_fwd_21_ (void){
+static void mw_elab_arrow_fwd_21_ (void) {
     WORD_ENTER(mw_elab_arrow_fwd_21_, "elab-arrow-fwd!", "src/mirth/elab.mth", 470, 5);
     WORD_ATOM(470, 5, "ab-build!");
     push_u64(0);
@@ -24224,7 +24177,7 @@ static void mw_elab_arrow_fwd_21_ (void){
     mw_ab_build_21_();
     WORD_EXIT(mw_elab_arrow_fwd_21_);
 }
-static void mw_elab_atoms_21_ (void){
+static void mw_elab_atoms_21_ (void) {
     WORD_ENTER(mw_elab_atoms_21_, "elab-atoms!", "src/mirth/elab.mth", 473, 5);
     WORD_ATOM(473, 5, "while");
     while(1) {
@@ -24245,7 +24198,7 @@ static void mw_elab_atoms_21_ (void){
     }
     WORD_EXIT(mw_elab_atoms_21_);
 }
-static void mw_elab_atoms_done_3F_ (void){
+static void mw_elab_atoms_done_3F_ (void) {
     WORD_ENTER(mw_elab_atoms_done_3F_, "elab-atoms-done?", "src/mirth/elab.mth", 479, 5);
     WORD_ATOM(479, 5, "ab-token");
     mw_ab_token();
@@ -24255,7 +24208,7 @@ static void mw_elab_atoms_done_3F_ (void){
     mw_Token_2E_run_end_3F_();
     WORD_EXIT(mw_elab_atoms_done_3F_);
 }
-static void mw_elab_atom_21_ (void){
+static void mw_elab_atom_21_ (void) {
     WORD_ENTER(mw_elab_atom_21_, "elab-atom!", "src/mirth/elab.mth", 482, 5);
     WORD_ATOM(482, 5, "ab-token");
     mw_ab_token();
@@ -24266,29 +24219,29 @@ static void mw_elab_atom_21_ (void){
     WORD_ATOM(482, 22, "match");
     switch (get_top_data_tag()) {
         case 13LL:
-            co_TOKEN_5F_NAME();
+            mp_TOKEN_5F_NAME();
             WORD_ATOM(483, 23, "elab-atom-name!");
             mw_elab_atom_name_21_();
             break;
         case 11LL:
-            co_TOKEN_5F_INT();
+            mp_TOKEN_5F_INT();
             WORD_ATOM(484, 22, "ab-int!");
             mw_ab_int_21_();
             break;
         case 12LL:
-            co_TOKEN_5F_STR();
+            mp_TOKEN_5F_STR();
             WORD_ATOM(485, 22, "ab-str!");
             mw_ab_str_21_();
             break;
         case 6LL:
-            co_TOKEN_5F_LSQUARE();
+            mp_TOKEN_5F_LSQUARE();
             WORD_ATOM(486, 26, "drop");
             mw_prim_drop();
             WORD_ATOM(486, 31, "elab-atom-block!");
             mw_elab_atom_block_21_();
             break;
         case 9LL:
-            co_TOKEN_5F_LCURLY();
+            mp_TOKEN_5F_LCURLY();
             WORD_ATOM(487, 25, "drop");
             mw_prim_drop();
             WORD_ATOM(487, 30, "elab-atom-assert!");
@@ -24313,10 +24266,10 @@ static void mw_elab_atom_21_ (void){
             WORD_ATOM(488, 58, "emit-fatal-error!");
             mw_emit_fatal_error_21_();
             break;
-    
-}    WORD_EXIT(mw_elab_atom_21_);
+    }
+    WORD_EXIT(mw_elab_atom_21_);
 }
-static void mw_elab_atom_block_21_ (void){
+static void mw_elab_atom_block_21_ (void) {
     WORD_ENTER(mw_elab_atom_block_21_, "elab-atom-block!", "src/mirth/elab.mth", 492, 5);
     WORD_ATOM(492, 5, "ab-token");
     mw_ab_token();
@@ -24328,7 +24281,7 @@ static void mw_elab_atom_block_21_ (void){
     mw_elab_block_at_21_();
     WORD_EXIT(mw_elab_atom_block_21_);
 }
-static void mw_elab_block_at_21_ (void){
+static void mw_elab_block_at_21_ (void) {
     WORD_ENTER(mw_elab_block_at_21_, "elab-block-at!", "src/mirth/elab.mth", 495, 5);
     WORD_ATOM(495, 5, "ab-ctx");
     mw_ab_ctx();
@@ -24344,7 +24297,7 @@ static void mw_elab_block_at_21_ (void){
     mw_ab_op_21_();
     WORD_EXIT(mw_elab_block_at_21_);
 }
-static void mw_elab_args_21_ (void){
+static void mw_elab_args_21_ (void) {
     WORD_ENTER(mw_elab_args_21_, "elab-args!", "src/mirth/elab.mth", 498, 5);
     WORD_ATOM(498, 5, "ab-token");
     mw_ab_token();
@@ -24359,7 +24312,7 @@ static void mw_elab_args_21_ (void){
     mw_List_2E_for();
     WORD_EXIT(mw_elab_args_21_);
 }
-static void mw_elab_no_args_21_ (void){
+static void mw_elab_no_args_21_ (void) {
     WORD_ENTER(mw_elab_no_args_21_, "elab-no-args!", "src/mirth/elab.mth", 501, 5);
     WORD_ATOM(501, 5, "ab-token");
     mw_ab_token();
@@ -24369,7 +24322,7 @@ static void mw_elab_no_args_21_ (void){
     mw_Token_2E_args_0();
     WORD_EXIT(mw_elab_no_args_21_);
 }
-static void mw_elab_atom_name_21_ (void){
+static void mw_elab_atom_name_21_ (void) {
     WORD_ENTER(mw_elab_atom_name_21_, "elab-atom-name!", "src/mirth/elab.mth", 504, 5);
     WORD_ATOM(504, 5, "dup");
     mw_prim_dup();
@@ -24382,7 +24335,7 @@ static void mw_elab_atom_name_21_ (void){
     WORD_ATOM(504, 25, "match");
     switch (get_top_data_tag()) {
         case 1LL:
-            co_SOME();
+            mp_SOME();
             WORD_ATOM(505, 17, "nip");
             mw_nip();
             WORD_ATOM(505, 21, "elab-args!");
@@ -24391,7 +24344,7 @@ static void mw_elab_atom_name_21_ (void){
             mw_ab_var_21_();
             break;
         case 0LL:
-            co_NONE();
+            mp_NONE();
             WORD_ATOM(507, 13, "elab-relativize-name!");
             mw_elab_relativize_name_21_();
             WORD_ATOM(508, 13, "elab-check-name-visible!");
@@ -24400,10 +24353,10 @@ static void mw_elab_atom_name_21_ (void){
             mw_elab_atom_name_global_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_elab_atom_name_21_);
+    }
+    WORD_EXIT(mw_elab_atom_name_21_);
 }
-static void mw_elab_needs_dot (void){
+static void mw_elab_needs_dot (void) {
     WORD_ENTER(mw_elab_needs_dot, "elab-needs-dot", "src/mirth/elab.mth", 514, 5);
     WORD_ATOM(514, 5, "first-byte");
     mw_Str_2E_first_byte();
@@ -24417,7 +24370,7 @@ static void mw_elab_needs_dot (void){
     mw_Maybe_2E_if_some();
     WORD_EXIT(mw_elab_needs_dot);
 }
-static void mw_elab_combine_prefix (void){
+static void mw_elab_combine_prefix (void) {
     WORD_ENTER(mw_elab_combine_prefix, "elab-combine-prefix", "src/mirth/elab.mth", 517, 5);
     WORD_ATOM(517, 5, "over");
     mw_over();
@@ -24434,7 +24387,7 @@ static void mw_elab_combine_prefix (void){
     mw_prim_str_cat();
     WORD_EXIT(mw_elab_combine_prefix);
 }
-static void mw_elab_combine_prefixes (void){
+static void mw_elab_combine_prefixes (void) {
     WORD_ENTER(mw_elab_combine_prefixes, "elab-combine-prefixes", "src/mirth/elab.mth", 520, 5);
     WORD_ATOM(520, 5, "if-some");
     push_u64(0);
@@ -24446,7 +24399,7 @@ static void mw_elab_combine_prefixes (void){
     mw_Maybe_2E_if_some();
     WORD_EXIT(mw_elab_combine_prefixes);
 }
-static void mw_elab_word_search (void){
+static void mw_elab_word_search (void) {
     WORD_ENTER(mw_elab_word_search, "elab-word-search", "src/mirth/elab.mth", 526, 5);
     WORD_ATOM(526, 5, "Name.search");
     mw_Name_2E_search();
@@ -24457,7 +24410,7 @@ static void mw_elab_word_search (void){
     mw_Maybe_2E_filter();
     WORD_EXIT(mw_elab_word_search);
 }
-static void mw_elab_name_candidates (void){
+static void mw_elab_name_candidates (void) {
     WORD_ENTER(mw_elab_name_candidates, "elab-name-candidates", "src/mirth/elab.mth", 529, 5);
     WORD_ATOM(529, 5, ">Str");
     mw_Name_3E_Str();
@@ -24496,7 +24449,7 @@ static void mw_elab_name_candidates (void){
     mw_List_2B__2E_filter_some();
     WORD_EXIT(mw_elab_name_candidates);
 }
-static void mw_elab_relativize_name_21_ (void){
+static void mw_elab_relativize_name_21_ (void) {
     WORD_ENTER(mw_elab_relativize_name_21_, "elab-relativize-name!", "src/mirth/elab.mth", 535, 5);
     WORD_ATOM(535, 5, "dup");
     mw_prim_dup();
@@ -24514,7 +24467,7 @@ static void mw_elab_relativize_name_21_ (void){
     mw_Maybe_2E_if_some();
     WORD_EXIT(mw_elab_relativize_name_21_);
 }
-static void mw_elab_check_name_visible_21_ (void){
+static void mw_elab_check_name_visible_21_ (void) {
     WORD_ENTER(mw_elab_check_name_visible_21_, "elab-check-name-visible!", "src/mirth/elab.mth", 538, 5);
     WORD_ATOM(538, 5, "dup");
     mw_prim_dup();
@@ -24529,7 +24482,7 @@ static void mw_elab_check_name_visible_21_ (void){
     mw_Maybe_2E_for();
     WORD_EXIT(mw_elab_check_name_visible_21_);
 }
-static void mw_elab_module_is_visible (void){
+static void mw_elab_module_is_visible (void) {
     WORD_ENTER(mw_elab_module_is_visible, "elab-module-is-visible", "src/mirth/elab.mth", 545, 5);
     WORD_ATOM(545, 5, "ab-token");
     mw_ab_token();
@@ -24541,7 +24494,7 @@ static void mw_elab_module_is_visible (void){
     mw_Module_2E_visible();
     WORD_EXIT(mw_elab_module_is_visible);
 }
-static void mw_elab_atom_name_global_21_ (void){
+static void mw_elab_atom_name_global_21_ (void) {
     WORD_ENTER(mw_elab_atom_name_global_21_, "elab-atom-name-global!", "src/mirth/elab.mth", 548, 5);
     WORD_ATOM(548, 5, "dup");
     mw_prim_dup();
@@ -24550,7 +24503,7 @@ static void mw_elab_atom_name_global_21_ (void){
     WORD_ATOM(548, 14, "match");
     switch (get_top_data_tag()) {
         case 1LL:
-            co_DEF_5F_ALIAS();
+            mp_DEF_5F_ALIAS();
             WORD_ATOM(549, 22, "nip");
             mw_nip();
             WORD_ATOM(549, 26, "target");
@@ -24559,7 +24512,7 @@ static void mw_elab_atom_name_global_21_ (void){
             mw_elab_atom_name_global_21_();
             break;
         case 7LL:
-            co_DEF_5F_BUFFER();
+            mp_DEF_5F_BUFFER();
             WORD_ATOM(550, 23, "nip");
             mw_nip();
             WORD_ATOM(550, 27, "elab-no-args!");
@@ -24568,7 +24521,7 @@ static void mw_elab_atom_name_global_21_ (void){
             mw_ab_buffer_21_();
             break;
         case 8LL:
-            co_DEF_5F_VARIABLE();
+            mp_DEF_5F_VARIABLE();
             WORD_ATOM(551, 25, "nip");
             mw_nip();
             WORD_ATOM(551, 29, "elab-no-args!");
@@ -24577,7 +24530,7 @@ static void mw_elab_atom_name_global_21_ (void){
             mw_ab_variable_21_();
             break;
         case 9LL:
-            co_DEF_5F_CONSTANT();
+            mp_DEF_5F_CONSTANT();
             WORD_ATOM(552, 25, "nip");
             mw_nip();
             WORD_ATOM(552, 29, "elab-no-args!");
@@ -24586,7 +24539,7 @@ static void mw_elab_atom_name_global_21_ (void){
             mw_ab_constant_21_();
             break;
         case 10LL:
-            co_DEF_5F_EXTERNAL();
+            mp_DEF_5F_EXTERNAL();
             WORD_ATOM(553, 25, "nip");
             mw_nip();
             WORD_ATOM(553, 29, "elab-no-args!");
@@ -24595,7 +24548,7 @@ static void mw_elab_atom_name_global_21_ (void){
             mw_ab_external_21_();
             break;
         case 11LL:
-            co_DEF_5F_FIELD();
+            mp_DEF_5F_FIELD();
             WORD_ATOM(554, 22, "nip");
             mw_nip();
             WORD_ATOM(554, 26, "elab-no-args!");
@@ -24604,7 +24557,7 @@ static void mw_elab_atom_name_global_21_ (void){
             mw_ab_field_21_();
             break;
         case 6LL:
-            co_DEF_5F_WORD();
+            mp_DEF_5F_WORD();
             WORD_ATOM(555, 21, "nip");
             mw_nip();
             WORD_ATOM(555, 25, "elab-args!");
@@ -24613,7 +24566,7 @@ static void mw_elab_atom_name_global_21_ (void){
             mw_ab_word_21_();
             break;
         case 4LL:
-            co_DEF_5F_TAG();
+            mp_DEF_5F_TAG();
             WORD_ATOM(556, 20, "nip");
             mw_nip();
             WORD_ATOM(556, 24, "elab-args!");
@@ -24622,7 +24575,7 @@ static void mw_elab_atom_name_global_21_ (void){
             mw_ab_tag_21_();
             break;
         case 5LL:
-            co_DEF_5F_PRIM();
+            mp_DEF_5F_PRIM();
             WORD_ATOM(557, 21, "nip");
             mw_nip();
             WORD_ATOM(557, 25, "elab-prim!");
@@ -24664,20 +24617,20 @@ static void mw_elab_atom_name_global_21_ (void){
             WORD_ATOM(562, 59, "!");
             mw_prim_mut_set();
             break;
-    
-}    WORD_EXIT(mw_elab_atom_name_global_21_);
+    }
+    WORD_EXIT(mw_elab_atom_name_global_21_);
 }
-static void mw_elab_prim_21_ (void){
+static void mw_elab_prim_21_ (void) {
     WORD_ENTER(mw_elab_prim_21_, "elab-prim!", "src/mirth/elab.mth", 566, 5);
     WORD_ATOM(566, 5, "match");
     switch (get_top_data_tag()) {
         case 10LL:
-            co_PRIM_5F_CORE_5F_MATCH();
+            mp_PRIM_5F_CORE_5F_MATCH();
             WORD_ATOM(567, 28, "elab-atom-match!");
             mw_elab_atom_match_21_();
             break;
         case 11LL:
-            co_PRIM_5F_CORE_5F_LAMBDA();
+            mp_PRIM_5F_CORE_5F_LAMBDA();
             WORD_ATOM(568, 29, "elab-atom-lambda!");
             mw_elab_atom_lambda_21_();
             break;
@@ -24687,10 +24640,10 @@ static void mw_elab_prim_21_ (void){
             WORD_ATOM(569, 25, "ab-prim!");
             mw_ab_prim_21_();
             break;
-    
-}    WORD_EXIT(mw_elab_prim_21_);
+    }
+    WORD_EXIT(mw_elab_prim_21_);
 }
-static void mw_elab_atom_assert_21_ (void){
+static void mw_elab_atom_assert_21_ (void) {
     WORD_ENTER(mw_elab_atom_assert_21_, "elab-atom-assert!", "src/mirth/elab.mth", 573, 5);
     WORD_ATOM(573, 5, "ab-token");
     mw_ab_token();
@@ -24728,7 +24681,7 @@ static void mw_elab_atom_assert_21_ (void){
     mw_drop2();
     WORD_EXIT(mw_elab_atom_assert_21_);
 }
-static void mw_elab_atom_lambda_21_ (void){
+static void mw_elab_atom_lambda_21_ (void) {
     WORD_ENTER(mw_elab_atom_lambda_21_, "elab-atom-lambda!", "src/mirth/elab.mth", 579, 5);
     WORD_ATOM(579, 5, "Lambda.alloc!");
     mw_Lambda_2E_alloc_21_();
@@ -24770,7 +24723,7 @@ static void mw_elab_atom_lambda_21_ (void){
     mw_ab_op_21_();
     WORD_EXIT(mw_elab_atom_lambda_21_);
 }
-static void mw_elab_match_at_21_ (void){
+static void mw_elab_match_at_21_ (void) {
     WORD_ENTER(mw_elab_match_at_21_, "elab-match-at!", "src/mirth/elab.mth", 590, 5);
     WORD_ATOM(590, 5, "Match.alloc!");
     mw_Match_2E_alloc_21_();
@@ -24826,7 +24779,7 @@ static void mw_elab_match_at_21_ (void){
     mw_ab_op_21_();
     WORD_EXIT(mw_elab_match_at_21_);
 }
-static void mw_elab_atom_match_21_ (void){
+static void mw_elab_atom_match_21_ (void) {
     WORD_ENTER(mw_elab_atom_match_21_, "elab-atom-match!", "src/mirth/elab.mth", 601, 5);
     WORD_ATOM(601, 5, "MetaVar.new!");
     mw_MetaVar_2E_new_21_();
@@ -24844,7 +24797,7 @@ static void mw_elab_atom_match_21_ (void){
     mw_elab_match_at_21_();
     WORD_EXIT(mw_elab_atom_match_21_);
 }
-static void mw_elab_lambda_21_ (void){
+static void mw_elab_lambda_21_ (void) {
     WORD_ENTER(mw_elab_lambda_21_, "elab-lambda!", "src/mirth/elab.mth", 606, 5);
     WORD_ATOM(606, 5, "elab-lambda-params!");
     mw_elab_lambda_params_21_();
@@ -24852,7 +24805,7 @@ static void mw_elab_lambda_21_ (void){
     mw_elab_lambda_body_21_();
     WORD_EXIT(mw_elab_lambda_21_);
 }
-static void mw_elab_expand_tensor_21_ (void){
+static void mw_elab_expand_tensor_21_ (void) {
     WORD_ENTER(mw_elab_expand_tensor_21_, "elab-expand-tensor!", "src/mirth/elab.mth", 610, 5);
     WORD_ATOM(610, 5, "swap");
     mw_prim_swap();
@@ -24861,7 +24814,7 @@ static void mw_elab_expand_tensor_21_ (void){
     WORD_ATOM(610, 17, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_STACK_5F_TYPE_5F_ERROR();
+            mp_STACK_5F_TYPE_5F_ERROR();
             WORD_ATOM(611, 29, "dip");
             {
                 VAL d4 = pop_value();
@@ -24873,12 +24826,12 @@ static void mw_elab_expand_tensor_21_ (void){
             }
             break;
         case 5LL:
-            co_STCons();
+            mp_STCons();
             WORD_ATOM(612, 19, "rotl");
             mw_rotl();
             break;
         case 4LL:
-            co_STMeta();
+            mp_STMeta();
             WORD_ATOM(614, 13, "dip");
             {
                 VAL d4 = pop_value();
@@ -24935,10 +24888,10 @@ static void mw_elab_expand_tensor_21_ (void){
                 push_value(d4);
             }
             break;
-    
-}    WORD_EXIT(mw_elab_expand_tensor_21_);
+    }
+    WORD_EXIT(mw_elab_expand_tensor_21_);
 }
-static void mw_elab_lambda_pop_from_mid_21_ (void){
+static void mw_elab_lambda_pop_from_mid_21_ (void) {
     WORD_ENTER(mw_elab_lambda_pop_from_mid_21_, "elab-lambda-pop-from-mid!", "src/mirth/elab.mth", 638, 5);
     WORD_ATOM(638, 5, "dip");
     {
@@ -24958,7 +24911,7 @@ static void mw_elab_lambda_pop_from_mid_21_ (void){
     mw_dip2();
     WORD_EXIT(mw_elab_lambda_pop_from_mid_21_);
 }
-static void mw_token_is_lambda_param_3F_ (void){
+static void mw_token_is_lambda_param_3F_ (void) {
     WORD_ENTER(mw_token_is_lambda_param_3F_, "token-is-lambda-param?", "src/mirth/elab.mth", 643, 5);
     WORD_ATOM(643, 5, "dup");
     mw_prim_dup();
@@ -24988,7 +24941,7 @@ static void mw_token_is_lambda_param_3F_ (void){
     }
     WORD_EXIT(mw_token_is_lambda_param_3F_);
 }
-static void mw_elab_lambda_params_21_ (void){
+static void mw_elab_lambda_params_21_ (void) {
     WORD_ENTER(mw_elab_lambda_params_21_, "elab-lambda-params!", "src/mirth/elab.mth", 654, 5);
     WORD_ATOM(654, 5, "L0");
     mw_L0();
@@ -25055,7 +25008,7 @@ static void mw_elab_lambda_params_21_ (void){
     mw_prim_drop();
     WORD_EXIT(mw_elab_lambda_params_21_);
 }
-static void mw_elab_lambda_body_21_ (void){
+static void mw_elab_lambda_body_21_ (void) {
     WORD_ENTER(mw_elab_lambda_body_21_, "elab-lambda-body!", "src/mirth/elab.mth", 678, 5);
     WORD_ATOM(678, 5, "dup");
     mw_prim_dup();
@@ -25111,7 +25064,7 @@ static void mw_elab_lambda_body_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_elab_lambda_body_21_);
 }
-static void mw_elab_match_exhaustive_21_ (void){
+static void mw_elab_match_exhaustive_21_ (void) {
     WORD_ENTER(mw_elab_match_exhaustive_21_, "elab-match-exhaustive!", "src/mirth/elab.mth", 687, 5);
     WORD_ATOM(687, 5, "dup");
     mw_prim_dup();
@@ -25124,7 +25077,7 @@ static void mw_elab_match_exhaustive_21_ (void){
     mw_Bool_2E_else();
     WORD_EXIT(mw_elab_match_exhaustive_21_);
 }
-static void mw_elab_match_cases_21_ (void){
+static void mw_elab_match_cases_21_ (void) {
     WORD_ENTER(mw_elab_match_cases_21_, "elab-match-cases!", "src/mirth/elab.mth", 693, 5);
     WORD_ATOM(693, 5, "L0");
     mw_L0();
@@ -25154,7 +25107,7 @@ static void mw_elab_match_cases_21_ (void){
     mw_prim_drop();
     WORD_EXIT(mw_elab_match_cases_21_);
 }
-static void mw_elab_match_case_21_ (void){
+static void mw_elab_match_case_21_ (void) {
     WORD_ENTER(mw_elab_match_case_21_, "elab-match-case!", "src/mirth/elab.mth", 700, 5);
     WORD_ATOM(700, 5, "Case.alloc!");
     mw_Case_2E_alloc_21_();
@@ -25205,7 +25158,7 @@ static void mw_elab_match_case_21_ (void){
     mw_Bool_2E_then();
     WORD_EXIT(mw_elab_match_case_21_);
 }
-static void mw_elab_case_pattern_21_ (void){
+static void mw_elab_case_pattern_21_ (void) {
     WORD_ENTER(mw_elab_case_pattern_21_, "elab-case-pattern!", "src/mirth/elab.mth", 711, 5);
     WORD_ATOM(711, 5, "dup");
     mw_prim_dup();
@@ -25274,7 +25227,7 @@ static void mw_elab_case_pattern_21_ (void){
     }
     WORD_EXIT(mw_elab_case_pattern_21_);
 }
-static void mw_elab_case_body_21_ (void){
+static void mw_elab_case_body_21_ (void) {
     WORD_ENTER(mw_elab_case_body_21_, "elab-case-body!", "src/mirth/elab.mth", 755, 5);
     WORD_ATOM(755, 5, "dip");
     {
@@ -25327,7 +25280,7 @@ static void mw_elab_case_body_21_ (void){
     mw_nip();
     WORD_EXIT(mw_elab_case_body_21_);
 }
-static void mw_elab_module_21_ (void){
+static void mw_elab_module_21_ (void) {
     WORD_ENTER(mw_elab_module_21_, "elab-module!", "src/mirth/elab.mth", 766, 5);
     WORD_ATOM(766, 5, "dup");
     mw_prim_dup();
@@ -25351,7 +25304,7 @@ static void mw_elab_module_21_ (void){
     mw_prim_drop();
     WORD_EXIT(mw_elab_module_21_);
 }
-static void mw_elab_module_header_21_ (void){
+static void mw_elab_module_header_21_ (void) {
     WORD_ENTER(mw_elab_module_header_21_, "elab-module-header!", "src/mirth/elab.mth", 774, 5);
     WORD_ATOM(774, 5, "dup");
     mw_prim_dup();
@@ -25448,7 +25401,7 @@ static void mw_elab_module_header_21_ (void){
     }
     WORD_EXIT(mw_elab_module_header_21_);
 }
-static void mw_elab_module_decl_21_ (void){
+static void mw_elab_module_decl_21_ (void) {
     WORD_ENTER(mw_elab_module_decl_21_, "elab-module-decl!", "src/mirth/elab.mth", 789, 5);
     WORD_ATOM(789, 5, "dup");
     mw_prim_dup();
@@ -25479,7 +25432,7 @@ static void mw_elab_module_decl_21_ (void){
     mw_prim_run();
     WORD_EXIT(mw_elab_module_decl_21_);
 }
-static void mw_elab_module_import_21_ (void){
+static void mw_elab_module_import_21_ (void) {
     WORD_ENTER(mw_elab_module_import_21_, "elab-module-import!", "src/mirth/elab.mth", 797, 5);
     WORD_ATOM(797, 5, "sip");
     push_u64(0);
@@ -25495,7 +25448,7 @@ static void mw_elab_module_import_21_ (void){
     WORD_ATOM(798, 22, "match");
     switch (get_top_data_tag()) {
         case 13LL:
-            co_TOKEN_5F_NAME();
+            mp_TOKEN_5F_NAME();
             WORD_ATOM(800, 13, "dup");
             mw_prim_dup();
             WORD_ATOM(800, 17, ">Def");
@@ -25503,7 +25456,7 @@ static void mw_elab_module_import_21_ (void){
             WORD_ATOM(800, 22, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
-                    co_DEF_5F_MODULE();
+                    mp_DEF_5F_MODULE();
                     WORD_ATOM(802, 21, "dip");
                     {
                         VAL d6 = pop_value();
@@ -25519,7 +25472,7 @@ static void mw_elab_module_import_21_ (void){
                     mw_Module_2E_add_import_21_();
                     break;
                 case 0LL:
-                    co_DEF_5F_NONE();
+                    mp_DEF_5F_NONE();
                     WORD_ATOM(806, 21, "to-module-path");
                     mw_Name_2E_to_module_path();
                     WORD_ATOM(806, 36, "run-lexer!");
@@ -25557,8 +25510,8 @@ static void mw_elab_module_import_21_ (void){
                     WORD_ATOM(814, 55, "emit-fatal-error!");
                     mw_emit_fatal_error_21_();
                     break;
-            
-}            break;
+            }
+            break;
         default:
             WORD_ATOM(817, 13, "drop");
             mw_prim_drop();
@@ -25576,10 +25529,10 @@ static void mw_elab_module_import_21_ (void){
             WORD_ATOM(817, 41, "emit-fatal-error!");
             mw_emit_fatal_error_21_();
             break;
-    
-}    WORD_EXIT(mw_elab_module_import_21_);
+    }
+    WORD_EXIT(mw_elab_module_import_21_);
 }
-static void mw_elab_data_21_ (void){
+static void mw_elab_data_21_ (void) {
     WORD_ENTER(mw_elab_data_21_, "elab-data!", "src/mirth/elab.mth", 822, 5);
     WORD_ATOM(822, 5, "sip");
     push_u64(0);
@@ -25590,7 +25543,7 @@ static void mw_elab_data_21_ (void){
     mw_Token_2E_next();
     WORD_EXIT(mw_elab_data_21_);
 }
-static void mw_elab_data_header_21_ (void){
+static void mw_elab_data_header_21_ (void) {
     WORD_ENTER(mw_elab_data_header_21_, "elab-data-header!", "src/mirth/elab.mth", 833, 5);
     WORD_ATOM(833, 5, "dup2");
     mw_dup2();
@@ -25657,7 +25610,7 @@ static void mw_elab_data_header_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_elab_data_header_21_);
 }
-static void mw_elab_data_tag_21_ (void){
+static void mw_elab_data_tag_21_ (void) {
     WORD_ENTER(mw_elab_data_tag_21_, "elab-data-tag!", "src/mirth/elab.mth", 844, 5);
     WORD_ATOM(844, 5, "dup");
     mw_prim_dup();
@@ -25805,7 +25758,7 @@ static void mw_elab_data_tag_21_ (void){
     mw_prim_drop();
     WORD_EXIT(mw_elab_data_tag_21_);
 }
-static void mw_expect_token_arrow (void){
+static void mw_expect_token_arrow (void) {
     WORD_ENTER(mw_expect_token_arrow, "expect-token-arrow", "src/mirth/elab.mth", 876, 5);
     WORD_ATOM(876, 5, "dup");
     mw_prim_dup();
@@ -25818,7 +25771,7 @@ static void mw_expect_token_arrow (void){
     mw_Bool_2E_else();
     WORD_EXIT(mw_expect_token_arrow);
 }
-static void mw_token_def_args (void){
+static void mw_token_def_args (void) {
     WORD_ENTER(mw_token_def_args, "token-def-args", "src/mirth/elab.mth", 883, 5);
     WORD_ATOM(883, 5, "dup");
     mw_prim_dup();
@@ -25877,7 +25830,7 @@ static void mw_token_def_args (void){
     mw_Maybe_2E_if_some();
     WORD_EXIT(mw_token_def_args);
 }
-static void mw_elab_alias_21_ (void){
+static void mw_elab_alias_21_ (void) {
     WORD_ENTER(mw_elab_alias_21_, "elab-alias!", "src/mirth/elab.mth", 897, 5);
     WORD_ATOM(897, 5, "sip");
     push_u64(0);
@@ -25937,7 +25890,7 @@ static void mw_elab_alias_21_ (void){
     mw_prim_drop();
     WORD_EXIT(mw_elab_alias_21_);
 }
-static void mw_elab_def_missing_21_ (void){
+static void mw_elab_def_missing_21_ (void) {
     WORD_ENTER(mw_elab_def_missing_21_, "elab-def-missing!", "src/mirth/elab.mth", 906, 5);
     WORD_ATOM(906, 5, "dup");
     mw_prim_dup();
@@ -25970,7 +25923,7 @@ static void mw_elab_def_missing_21_ (void){
     }
     WORD_EXIT(mw_elab_def_missing_21_);
 }
-static void mw_elab_def_21_ (void){
+static void mw_elab_def_21_ (void) {
     WORD_ENTER(mw_elab_def_21_, "elab-def!", "src/mirth/elab.mth", 913, 5);
     WORD_ATOM(913, 5, "sip");
     push_u64(0);
@@ -26095,7 +26048,7 @@ static void mw_elab_def_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_elab_def_21_);
 }
-static void mw_elab_def_params_21_ (void){
+static void mw_elab_def_params_21_ (void) {
     WORD_ENTER(mw_elab_def_params_21_, "elab-def-params!", "src/mirth/elab.mth", 941, 5);
     WORD_ATOM(941, 5, "L0");
     mw_L0();
@@ -26129,7 +26082,7 @@ static void mw_elab_def_params_21_ (void){
     mw_prim_drop();
     WORD_EXIT(mw_elab_def_params_21_);
 }
-static void mw_elab_def_body_21_ (void){
+static void mw_elab_def_body_21_ (void) {
     WORD_ENTER(mw_elab_def_body_21_, "elab-def-body!", "src/mirth/elab.mth", 956, 5);
     WORD_ATOM(956, 5, "ab-token");
     mw_ab_token();
@@ -26153,7 +26106,7 @@ static void mw_elab_def_body_21_ (void){
     }
     WORD_EXIT(mw_elab_def_body_21_);
 }
-static void mw_elab_def_external_21_ (void){
+static void mw_elab_def_external_21_ (void) {
     WORD_ENTER(mw_elab_def_external_21_, "elab-def-external!", "src/mirth/elab.mth", 963, 5);
     WORD_ATOM(963, 5, "sip");
     push_u64(0);
@@ -26221,7 +26174,7 @@ static void mw_elab_def_external_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_elab_def_external_21_);
 }
-static void mw_elab_def_type_21_ (void){
+static void mw_elab_def_type_21_ (void) {
     WORD_ENTER(mw_elab_def_type_21_, "elab-def-type!", "src/mirth/elab.mth", 978, 5);
     WORD_ATOM(978, 5, "sip");
     push_u64(0);
@@ -26270,7 +26223,7 @@ static void mw_elab_def_type_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_elab_def_type_21_);
 }
-static void mw_elab_buffer_21_ (void){
+static void mw_elab_buffer_21_ (void) {
     WORD_ENTER(mw_elab_buffer_21_, "elab-buffer!", "src/mirth/elab.mth", 985, 5);
     WORD_ATOM(985, 5, "sip");
     push_u64(0);
@@ -26316,7 +26269,7 @@ static void mw_elab_buffer_21_ (void){
     mw_prim_drop();
     WORD_EXIT(mw_elab_buffer_21_);
 }
-static void mw_elab_variable_21_ (void){
+static void mw_elab_variable_21_ (void) {
     WORD_ENTER(mw_elab_variable_21_, "elab-variable!", "src/mirth/elab.mth", 993, 5);
     WORD_ATOM(993, 5, "sip");
     push_u64(0);
@@ -26356,7 +26309,7 @@ static void mw_elab_variable_21_ (void){
     mw_prim_drop();
     WORD_EXIT(mw_elab_variable_21_);
 }
-static void mw_elab_table_21_ (void){
+static void mw_elab_table_21_ (void) {
     WORD_ENTER(mw_elab_table_21_, "elab-table!", "src/mirth/elab.mth", 1001, 5);
     WORD_ATOM(1001, 5, "sip");
     push_u64(0);
@@ -26393,7 +26346,7 @@ static void mw_elab_table_21_ (void){
     mw_prim_drop();
     WORD_EXIT(mw_elab_table_21_);
 }
-static void mw_elab_target_c99_21_ (void){
+static void mw_elab_target_c99_21_ (void) {
     WORD_ENTER(mw_elab_target_c99_21_, "elab-target-c99!", "src/mirth/elab.mth", 1008, 5);
     WORD_ATOM(1008, 5, "typecheck-everything!");
     mw_typecheck_everything_21_();
@@ -26451,7 +26404,7 @@ static void mw_elab_target_c99_21_ (void){
     mw_run_output_c99_21_();
     WORD_EXIT(mw_elab_target_c99_21_);
 }
-static void mw_elab_embed_str_21_ (void){
+static void mw_elab_embed_str_21_ (void) {
     WORD_ENTER(mw_elab_embed_str_21_, "elab-embed-str!", "src/mirth/elab.mth", 1018, 5);
     WORD_ATOM(1018, 5, "sip");
     push_u64(0);
@@ -26505,7 +26458,7 @@ static void mw_elab_embed_str_21_ (void){
     mw_prim_drop();
     WORD_EXIT(mw_elab_embed_str_21_);
 }
-static void mw_typecheck_everything_21_ (void){
+static void mw_typecheck_everything_21_ (void) {
     WORD_ENTER(mw_typecheck_everything_21_, "typecheck-everything!", "src/mirth/elab.mth", 1027, 5);
     WORD_ATOM(1027, 5, "Name.for");
     push_u64(0);
@@ -26519,13 +26472,13 @@ static void mw_typecheck_everything_21_ (void){
     mw_Block_2E_for();
     WORD_EXIT(mw_typecheck_everything_21_);
 }
-static void mw_TABLE_5F_MAX_5F_SIZE (void){
+static void mw_TABLE_5F_MAX_5F_SIZE (void) {
     WORD_ENTER(mw_TABLE_5F_MAX_5F_SIZE, "TABLE_MAX_SIZE", "src/mirth/elab.mth", 1034, 26);
     WORD_ATOM(1034, 26, "");
     push_i64(65536LL);
     WORD_EXIT(mw_TABLE_5F_MAX_5F_SIZE);
 }
-static void mw_table_word_new_21_ (void){
+static void mw_table_word_new_21_ (void) {
     WORD_ENTER(mw_table_word_new_21_, "table-word-new!", "src/mirth/elab.mth", 1037, 5);
     WORD_ATOM(1037, 5, "dip");
     {
@@ -26548,7 +26501,7 @@ static void mw_table_word_new_21_ (void){
     mw_Word_2E_new_21_();
     WORD_EXIT(mw_table_word_new_21_);
 }
-static void mw_table_new_21_ (void){
+static void mw_table_new_21_ (void) {
     WORD_ENTER(mw_table_new_21_, "table-new!", "src/mirth/elab.mth", 1040, 5);
     WORD_ATOM(1040, 5, "Table.alloc!");
     mw_Table_2E_alloc_21_();
@@ -27084,7 +27037,7 @@ static void mw_table_new_21_ (void){
     mw_prim_drop();
     WORD_EXIT(mw_table_new_21_);
 }
-static void mw_elab_field_21_ (void){
+static void mw_elab_field_21_ (void) {
     WORD_ENTER(mw_elab_field_21_, "elab-field!", "src/mirth/elab.mth", 1210, 5);
     WORD_ATOM(1210, 5, "sip");
     push_u64(0);
@@ -27102,7 +27055,7 @@ static void mw_elab_field_21_ (void){
     WORD_ATOM(1210, 37, "match");
     switch (get_top_data_tag()) {
         case 13LL:
-            co_TOKEN_5F_NAME();
+            mp_TOKEN_5F_NAME();
             WORD_ATOM(1212, 13, "name-undefined?");
             mw_name_undefined_3F_();
             WORD_ATOM(1212, 29, "if");
@@ -27148,10 +27101,10 @@ static void mw_elab_field_21_ (void){
             WORD_ATOM(1216, 40, "emit-fatal-error!");
             mw_emit_fatal_error_21_();
             break;
-    
-}    WORD_EXIT(mw_elab_field_21_);
+    }
+    WORD_EXIT(mw_elab_field_21_);
 }
-static void mw_field_new_21_ (void){
+static void mw_field_new_21_ (void) {
     WORD_ENTER(mw_field_new_21_, "field-new!", "src/mirth/elab.mth", 1220, 5);
     WORD_ATOM(1220, 5, "Field.alloc!");
     mw_Field_2E_alloc_21_();
@@ -27205,7 +27158,7 @@ static void mw_field_new_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_field_new_21_);
 }
-static void mw_Atom_2E_alloc_21_ (void){
+static void mw_Atom_2E_alloc_21_ (void) {
     WORD_ENTER(mw_Atom_2E_alloc_21_, "Atom.alloc!", "src/mirth/data/arrow.mth", 36, 7);
     WORD_ATOM(36, 7, "Atom");
     mw_Atom_2E_NUM();
@@ -27229,7 +27182,7 @@ static void mw_Atom_2E_alloc_21_ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Atom_2E_alloc_21_);
 }
-static void mw_Arrow_2E_nil (void){
+static void mw_Arrow_2E_nil (void) {
     WORD_ENTER(mw_Arrow_2E_nil, "Arrow.nil", "src/mirth/data/arrow.mth", 37, 7);
     WORD_ATOM(37, 7, "Arrow");
     push_i64(0LL);
@@ -27237,7 +27190,7 @@ static void mw_Arrow_2E_nil (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Arrow_2E_nil);
 }
-static void mw_Arrow_2E_alloc_21_ (void){
+static void mw_Arrow_2E_alloc_21_ (void) {
     WORD_ENTER(mw_Arrow_2E_alloc_21_, "Arrow.alloc!", "src/mirth/data/arrow.mth", 37, 7);
     WORD_ATOM(37, 7, "Arrow");
     mw_Arrow_2E_NUM();
@@ -27261,7 +27214,7 @@ static void mw_Arrow_2E_alloc_21_ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Arrow_2E_alloc_21_);
 }
-static void mw_Lambda_2E_alloc_21_ (void){
+static void mw_Lambda_2E_alloc_21_ (void) {
     WORD_ENTER(mw_Lambda_2E_alloc_21_, "Lambda.alloc!", "src/mirth/data/arrow.mth", 38, 7);
     WORD_ATOM(38, 7, "Lambda");
     mw_Lambda_2E_NUM();
@@ -27285,13 +27238,13 @@ static void mw_Lambda_2E_alloc_21_ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Lambda_2E_alloc_21_);
 }
-static void mw_Block_2E_id (void){
+static void mw_Block_2E_id (void) {
     WORD_ENTER(mw_Block_2E_id, "Block.id", "src/mirth/data/arrow.mth", 39, 7);
     WORD_ATOM(39, 7, "Block");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Block_2E_id);
 }
-static void mw_Block_2E_for (void){
+static void mw_Block_2E_for (void) {
     WORD_ENTER(mw_Block_2E_for, "Block.for", "src/mirth/data/arrow.mth", 39, 7);
     WORD_ATOM(39, 7, "Block");
     {
@@ -27338,7 +27291,7 @@ static void mw_Block_2E_for (void){
     }
     WORD_EXIT(mw_Block_2E_for);
 }
-static void mw_Block_2E_alloc_21_ (void){
+static void mw_Block_2E_alloc_21_ (void) {
     WORD_ENTER(mw_Block_2E_alloc_21_, "Block.alloc!", "src/mirth/data/arrow.mth", 39, 7);
     WORD_ATOM(39, 7, "Block");
     mw_Block_2E_NUM();
@@ -27362,20 +27315,20 @@ static void mw_Block_2E_alloc_21_ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Block_2E_alloc_21_);
 }
-static void mw_Var_3E_Param (void){
+static void mw_Var_3E_Param (void) {
     WORD_ENTER(mw_Var_3E_Param, "Var>Param", "src/mirth/data/arrow.mth", 61, 30);
     WORD_ATOM(61, 30, "PARAM");
     mw_PARAM();
     WORD_EXIT(mw_Var_3E_Param);
 }
-static void mw_Param_3E_Var (void){
+static void mw_Param_3E_Var (void) {
     WORD_ENTER(mw_Param_3E_Var, "Param>Var", "src/mirth/data/arrow.mth", 62, 30);
     WORD_ATOM(62, 30, "PARAM");
     WORD_ATOM(62, 39, "id");
     mw_prim_id();
     WORD_EXIT(mw_Param_3E_Var);
 }
-static void mw_Arrow_2E_token_start (void){
+static void mw_Arrow_2E_token_start (void) {
     WORD_ENTER(mw_Arrow_2E_token_start, "Arrow.token-start", "src/mirth/data/arrow.mth", 96, 40);
     WORD_ATOM(96, 40, "~token-start");
     mw_Arrow_7E_token_start();
@@ -27383,7 +27336,7 @@ static void mw_Arrow_2E_token_start (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Arrow_2E_token_start);
 }
-static void mw_Arrow_2E_token_end (void){
+static void mw_Arrow_2E_token_end (void) {
     WORD_ENTER(mw_Arrow_2E_token_end, "Arrow.token-end", "src/mirth/data/arrow.mth", 97, 38);
     WORD_ATOM(97, 38, "~token-end");
     mw_Arrow_7E_token_end();
@@ -27391,7 +27344,7 @@ static void mw_Arrow_2E_token_end (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Arrow_2E_token_end);
 }
-static void mw_Arrow_2E_home (void){
+static void mw_Arrow_2E_home (void) {
     WORD_ENTER(mw_Arrow_2E_home, "Arrow.home", "src/mirth/data/arrow.mth", 98, 39);
     WORD_ATOM(98, 39, "~home");
     mw_Arrow_7E_home();
@@ -27399,7 +27352,7 @@ static void mw_Arrow_2E_home (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Arrow_2E_home);
 }
-static void mw_Arrow_2E_homeidx (void){
+static void mw_Arrow_2E_homeidx (void) {
     WORD_ENTER(mw_Arrow_2E_homeidx, "Arrow.homeidx", "src/mirth/data/arrow.mth", 99, 34);
     WORD_ATOM(99, 34, "~homeidx");
     mw_Arrow_7E_homeidx();
@@ -27407,7 +27360,7 @@ static void mw_Arrow_2E_homeidx (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Arrow_2E_homeidx);
 }
-static void mw_Arrow_2E_ctx (void){
+static void mw_Arrow_2E_ctx (void) {
     WORD_ENTER(mw_Arrow_2E_ctx, "Arrow.ctx", "src/mirth/data/arrow.mth", 100, 30);
     WORD_ATOM(100, 30, "~ctx");
     mw_Arrow_7E_ctx();
@@ -27415,7 +27368,7 @@ static void mw_Arrow_2E_ctx (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Arrow_2E_ctx);
 }
-static void mw_Arrow_2E_dom (void){
+static void mw_Arrow_2E_dom (void) {
     WORD_ENTER(mw_Arrow_2E_dom, "Arrow.dom", "src/mirth/data/arrow.mth", 101, 36);
     WORD_ATOM(101, 36, "~dom");
     mw_Arrow_7E_dom();
@@ -27423,7 +27376,7 @@ static void mw_Arrow_2E_dom (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Arrow_2E_dom);
 }
-static void mw_Arrow_2E_cod (void){
+static void mw_Arrow_2E_cod (void) {
     WORD_ENTER(mw_Arrow_2E_cod, "Arrow.cod", "src/mirth/data/arrow.mth", 102, 36);
     WORD_ATOM(102, 36, "~cod");
     mw_Arrow_7E_cod();
@@ -27431,7 +27384,7 @@ static void mw_Arrow_2E_cod (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Arrow_2E_cod);
 }
-static void mw_Arrow_2E_type (void){
+static void mw_Arrow_2E_type (void) {
     WORD_ENTER(mw_Arrow_2E_type, "Arrow.type", "src/mirth/data/arrow.mth", 103, 37);
     WORD_ATOM(103, 37, "sip");
     push_u64(0);
@@ -27444,7 +27397,7 @@ static void mw_Arrow_2E_type (void){
     mw_T__3E_();
     WORD_EXIT(mw_Arrow_2E_type);
 }
-static void mw_Arrow_2E_atoms (void){
+static void mw_Arrow_2E_atoms (void) {
     WORD_ENTER(mw_Arrow_2E_atoms, "Arrow.atoms", "src/mirth/data/arrow.mth", 104, 39);
     WORD_ATOM(104, 39, "~atoms");
     mw_Arrow_7E_atoms();
@@ -27452,7 +27405,7 @@ static void mw_Arrow_2E_atoms (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Arrow_2E_atoms);
 }
-static void mw_Atom_2E_token (void){
+static void mw_Atom_2E_token (void) {
     WORD_ENTER(mw_Atom_2E_token, "Atom.token", "src/mirth/data/arrow.mth", 106, 32);
     WORD_ATOM(106, 32, "~token");
     mw_Atom_7E_token();
@@ -27460,7 +27413,7 @@ static void mw_Atom_2E_token (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Atom_2E_token);
 }
-static void mw_Atom_2E_op (void){
+static void mw_Atom_2E_op (void) {
     WORD_ENTER(mw_Atom_2E_op, "Atom.op", "src/mirth/data/arrow.mth", 108, 26);
     WORD_ATOM(108, 26, "~op");
     mw_Atom_7E_op();
@@ -27468,7 +27421,7 @@ static void mw_Atom_2E_op (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Atom_2E_op);
 }
-static void mw_Atom_2E_args (void){
+static void mw_Atom_2E_args (void) {
     WORD_ENTER(mw_Atom_2E_args, "Atom.args", "src/mirth/data/arrow.mth", 109, 35);
     WORD_ATOM(109, 35, "~args");
     mw_Atom_7E_args();
@@ -27476,7 +27429,7 @@ static void mw_Atom_2E_args (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Atom_2E_args);
 }
-static void mw_Atom_2E_cod (void){
+static void mw_Atom_2E_cod (void) {
     WORD_ENTER(mw_Atom_2E_cod, "Atom.cod", "src/mirth/data/arrow.mth", 111, 34);
     WORD_ATOM(111, 34, "~cod");
     mw_Atom_7E_cod();
@@ -27484,7 +27437,7 @@ static void mw_Atom_2E_cod (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Atom_2E_cod);
 }
-static void mw_Lambda_2E_token (void){
+static void mw_Lambda_2E_token (void) {
     WORD_ENTER(mw_Lambda_2E_token, "Lambda.token", "src/mirth/data/arrow.mth", 114, 36);
     WORD_ATOM(114, 36, "~token");
     mw_Lambda_7E_token();
@@ -27492,7 +27445,7 @@ static void mw_Lambda_2E_token (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Lambda_2E_token);
 }
-static void mw_Lambda_2E_outer_ctx (void){
+static void mw_Lambda_2E_outer_ctx (void) {
     WORD_ENTER(mw_Lambda_2E_outer_ctx, "Lambda.outer-ctx", "src/mirth/data/arrow.mth", 115, 38);
     WORD_ATOM(115, 38, "~outer-ctx");
     mw_Lambda_7E_outer_ctx();
@@ -27500,7 +27453,7 @@ static void mw_Lambda_2E_outer_ctx (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Lambda_2E_outer_ctx);
 }
-static void mw_Lambda_2E_inner_ctx (void){
+static void mw_Lambda_2E_inner_ctx (void) {
     WORD_ENTER(mw_Lambda_2E_inner_ctx, "Lambda.inner-ctx", "src/mirth/data/arrow.mth", 116, 38);
     WORD_ATOM(116, 38, "~inner-ctx");
     mw_Lambda_7E_inner_ctx();
@@ -27508,7 +27461,7 @@ static void mw_Lambda_2E_inner_ctx (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Lambda_2E_inner_ctx);
 }
-static void mw_Lambda_2E_dom (void){
+static void mw_Lambda_2E_dom (void) {
     WORD_ENTER(mw_Lambda_2E_dom, "Lambda.dom", "src/mirth/data/arrow.mth", 117, 38);
     WORD_ATOM(117, 38, "~dom");
     mw_Lambda_7E_dom();
@@ -27516,7 +27469,7 @@ static void mw_Lambda_2E_dom (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Lambda_2E_dom);
 }
-static void mw_Lambda_2E_mid (void){
+static void mw_Lambda_2E_mid (void) {
     WORD_ENTER(mw_Lambda_2E_mid, "Lambda.mid", "src/mirth/data/arrow.mth", 118, 38);
     WORD_ATOM(118, 38, "~mid");
     mw_Lambda_7E_mid();
@@ -27524,7 +27477,7 @@ static void mw_Lambda_2E_mid (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Lambda_2E_mid);
 }
-static void mw_Lambda_2E_cod (void){
+static void mw_Lambda_2E_cod (void) {
     WORD_ENTER(mw_Lambda_2E_cod, "Lambda.cod", "src/mirth/data/arrow.mth", 119, 38);
     WORD_ATOM(119, 38, "~cod");
     mw_Lambda_7E_cod();
@@ -27532,7 +27485,7 @@ static void mw_Lambda_2E_cod (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Lambda_2E_cod);
 }
-static void mw_Lambda_2E_params (void){
+static void mw_Lambda_2E_params (void) {
     WORD_ENTER(mw_Lambda_2E_params, "Lambda.params", "src/mirth/data/arrow.mth", 120, 43);
     WORD_ATOM(120, 43, "~params");
     mw_Lambda_7E_params();
@@ -27540,7 +27493,7 @@ static void mw_Lambda_2E_params (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Lambda_2E_params);
 }
-static void mw_Lambda_2E_body (void){
+static void mw_Lambda_2E_body (void) {
     WORD_ENTER(mw_Lambda_2E_body, "Lambda.body", "src/mirth/data/arrow.mth", 121, 35);
     WORD_ATOM(121, 35, "~body");
     mw_Lambda_7E_body();
@@ -27548,7 +27501,7 @@ static void mw_Lambda_2E_body (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Lambda_2E_body);
 }
-static void mw_Block_2E_ctx (void){
+static void mw_Block_2E_ctx (void) {
     WORD_ENTER(mw_Block_2E_ctx, "Block.ctx", "src/mirth/data/arrow.mth", 123, 30);
     WORD_ATOM(123, 30, "~ctx");
     mw_Block_7E_ctx();
@@ -27556,7 +27509,7 @@ static void mw_Block_2E_ctx (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Block_2E_ctx);
 }
-static void mw_Block_2E_token (void){
+static void mw_Block_2E_token (void) {
     WORD_ENTER(mw_Block_2E_token, "Block.token", "src/mirth/data/arrow.mth", 124, 34);
     WORD_ATOM(124, 34, "~token");
     mw_Block_7E_token();
@@ -27564,7 +27517,7 @@ static void mw_Block_2E_token (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Block_2E_token);
 }
-static void mw_Block_2E_dom (void){
+static void mw_Block_2E_dom (void) {
     WORD_ENTER(mw_Block_2E_dom, "Block.dom", "src/mirth/data/arrow.mth", 125, 36);
     WORD_ATOM(125, 36, "~dom");
     mw_Block_7E_dom();
@@ -27572,7 +27525,7 @@ static void mw_Block_2E_dom (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Block_2E_dom);
 }
-static void mw_Block_2E_cod (void){
+static void mw_Block_2E_cod (void) {
     WORD_ENTER(mw_Block_2E_cod, "Block.cod", "src/mirth/data/arrow.mth", 126, 36);
     WORD_ATOM(126, 36, "~cod");
     mw_Block_7E_cod();
@@ -27580,7 +27533,7 @@ static void mw_Block_2E_cod (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Block_2E_cod);
 }
-static void mw_Block_2E_type (void){
+static void mw_Block_2E_type (void) {
     WORD_ENTER(mw_Block_2E_type, "Block.type", "src/mirth/data/arrow.mth", 127, 37);
     WORD_ATOM(127, 37, "sip");
     push_u64(0);
@@ -27593,7 +27546,7 @@ static void mw_Block_2E_type (void){
     mw_T__3E_();
     WORD_EXIT(mw_Block_2E_type);
 }
-static void mw_Block_2E_arrow (void){
+static void mw_Block_2E_arrow (void) {
     WORD_ENTER(mw_Block_2E_arrow, "Block.arrow", "src/mirth/data/arrow.mth", 128, 34);
     WORD_ATOM(128, 34, "~arrow");
     mw_Block_7E_arrow();
@@ -27601,7 +27554,7 @@ static void mw_Block_2E_arrow (void){
     mw_force_21_();
     WORD_EXIT(mw_Block_2E_arrow);
 }
-static void mw_Atom_2E_add_arg_left_21_ (void){
+static void mw_Atom_2E_add_arg_left_21_ (void) {
     WORD_ENTER(mw_Atom_2E_add_arg_left_21_, "Atom.add-arg-left!", "src/mirth/data/arrow.mth", 137, 5);
     WORD_ATOM(137, 5, "~args");
     mw_Atom_7E_args();
@@ -27612,7 +27565,7 @@ static void mw_Atom_2E_add_arg_left_21_ (void){
     mw_modify();
     WORD_EXIT(mw_Atom_2E_add_arg_left_21_);
 }
-static void mw_Block_3D_ (void){
+static void mw_Block_3D_ (void) {
     WORD_ENTER(mw_Block_3D_, "Block=", "src/mirth/data/arrow.mth", 143, 34);
     WORD_ATOM(143, 34, "both");
     push_u64(0);
@@ -27623,7 +27576,7 @@ static void mw_Block_3D_ (void){
     mw_prim_int_eq();
     WORD_EXIT(mw_Block_3D_);
 }
-static void mw_Block_2E_new_21_ (void){
+static void mw_Block_2E_new_21_ (void) {
     WORD_ENTER(mw_Block_2E_new_21_, "Block.new!", "src/mirth/data/arrow.mth", 146, 5);
     WORD_ATOM(146, 5, "Block.alloc!");
     mw_Block_2E_alloc_21_();
@@ -27682,7 +27635,7 @@ static void mw_Block_2E_new_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_Block_2E_new_21_);
 }
-static void mw_Block_2E_new_deferred_21_ (void){
+static void mw_Block_2E_new_deferred_21_ (void) {
     WORD_ENTER(mw_Block_2E_new_deferred_21_, "Block.new-deferred!", "src/mirth/data/arrow.mth", 154, 5);
     WORD_ATOM(154, 5, "Block.alloc!");
     mw_Block_2E_alloc_21_();
@@ -27733,7 +27686,7 @@ static void mw_Block_2E_new_deferred_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_Block_2E_new_deferred_21_);
 }
-static void mw_Block_2E_typecheck_21_ (void){
+static void mw_Block_2E_typecheck_21_ (void) {
     WORD_ENTER(mw_Block_2E_typecheck_21_, "Block.typecheck!", "src/mirth/data/arrow.mth", 168, 5);
     WORD_ATOM(168, 5, "arrow");
     mw_Block_2E_arrow();
@@ -27741,7 +27694,7 @@ static void mw_Block_2E_typecheck_21_ (void){
     mw_prim_drop();
     WORD_EXIT(mw_Block_2E_typecheck_21_);
 }
-static void mw_block_unify_type_21_ (void){
+static void mw_block_unify_type_21_ (void) {
     WORD_ENTER(mw_block_unify_type_21_, "block-unify-type!", "src/mirth/data/arrow.mth", 171, 5);
     WORD_ATOM(171, 5, "dip");
     {
@@ -27769,22 +27722,22 @@ static void mw_block_unify_type_21_ (void){
     mw_Arrow_2E_type();
     WORD_EXIT(mw_block_unify_type_21_);
 }
-static void mw_PrimType_2E_is_physical_3F_ (void){
+static void mw_PrimType_2E_is_physical_3F_ (void) {
     WORD_ENTER(mw_PrimType_2E_is_physical_3F_, "PrimType.is-physical?", "src/mirth/data/type.mth", 51, 5);
     WORD_ATOM(51, 5, "PRIM_TYPE_TYPE");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_PRIM_5F_TYPE_5F_TYPE();
+            mp_PRIM_5F_TYPE_5F_TYPE();
             WORD_ATOM(51, 23, "F");
             mw_F();
             break;
         case 1LL:
-            co_PRIM_5F_TYPE_5F_STACK();
+            mp_PRIM_5F_TYPE_5F_STACK();
             WORD_ATOM(52, 24, "F");
             mw_F();
             break;
         case 2LL:
-            co_PRIM_5F_TYPE_5F_RESOURCE();
+            mp_PRIM_5F_TYPE_5F_RESOURCE();
             WORD_ATOM(53, 27, "F");
             mw_F();
             break;
@@ -27794,30 +27747,30 @@ static void mw_PrimType_2E_is_physical_3F_ (void){
             WORD_ATOM(54, 15, "T");
             mw_T();
             break;
-    
-}    WORD_EXIT(mw_PrimType_2E_is_physical_3F_);
+    }
+    WORD_EXIT(mw_PrimType_2E_is_physical_3F_);
 }
-static void mw_Type_2E_tycon_name (void){
+static void mw_Type_2E_tycon_name (void) {
     WORD_ENTER(mw_Type_2E_tycon_name, "Type.tycon-name", "src/mirth/data/type.mth", 58, 5);
     WORD_ATOM(58, 5, "TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_TYPE_5F_ERROR();
+            mp_TYPE_5F_ERROR();
             WORD_ATOM(58, 19, "NONE");
             mw_NONE();
             break;
         case 1LL:
-            co_TYPE_5F_DONT_5F_CARE();
+            mp_TYPE_5F_DONT_5F_CARE();
             WORD_ATOM(59, 23, "NONE");
             mw_NONE();
             break;
         case 2LL:
-            co_TPrim();
+            mp_TPrim();
             WORD_ATOM(60, 14, "tycon-name");
             mw_PrimType_2E_tycon_name();
             break;
         case 3LL:
-            co_TMeta();
+            mp_TMeta();
             WORD_ATOM(61, 14, "expand-if");
             push_u64(0);
             push_fnptr(&mb_Type_2E_tycon_name_5);
@@ -27828,89 +27781,89 @@ static void mw_Type_2E_tycon_name (void){
             mw_MetaVar_2E_expand_if();
             break;
         case 4LL:
-            co_THole();
+            mp_THole();
             WORD_ATOM(62, 14, "drop");
             mw_prim_drop();
             WORD_ATOM(62, 19, "NONE");
             mw_NONE();
             break;
         case 5LL:
-            co_TVar();
+            mp_TVar();
             WORD_ATOM(63, 13, "drop");
             mw_prim_drop();
             WORD_ATOM(63, 18, "NONE");
             mw_NONE();
             break;
         case 6LL:
-            co_TTable();
+            mp_TTable();
             WORD_ATOM(64, 15, "name");
             mw_Table_2E_name();
             WORD_ATOM(64, 20, "SOME");
             mw_SOME();
             break;
         case 7LL:
-            co_TData();
+            mp_TData();
             WORD_ATOM(65, 14, "name");
             mw_Data_2E_name();
             WORD_ATOM(65, 19, "SOME");
             mw_SOME();
             break;
         case 9LL:
-            co_TMorphism();
+            mp_TMorphism();
             WORD_ATOM(66, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(66, 23, "NONE");
             mw_NONE();
             break;
         case 8LL:
-            co_TTensor();
+            mp_TTensor();
             WORD_ATOM(67, 16, "drop");
             mw_prim_drop();
             WORD_ATOM(67, 21, "NONE");
             mw_NONE();
             break;
         case 10LL:
-            co_TApp();
+            mp_TApp();
             WORD_ATOM(68, 13, "drop");
             mw_prim_drop();
             WORD_ATOM(68, 18, "tycon-name");
             mw_Type_2E_tycon_name();
             break;
         case 11LL:
-            co_TMut();
+            mp_TMut();
             WORD_ATOM(69, 13, "tycon-name");
             mw_Type_2E_tycon_name();
             break;
         case 12LL:
-            co_TValue();
+            mp_TValue();
             WORD_ATOM(70, 15, "tycon-name");
             mw_Value_2E_tycon_name();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Type_2E_tycon_name);
+    }
+    WORD_EXIT(mw_Type_2E_tycon_name);
 }
-static void mw_PrimType_2E_tycon_name (void){
+static void mw_PrimType_2E_tycon_name (void) {
     WORD_ENTER(mw_PrimType_2E_tycon_name, "PrimType.tycon-name", "src/mirth/data/type.mth", 74, 5);
     WORD_ATOM(74, 5, "PRIM_TYPE_TYPE");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_PRIM_5F_TYPE_5F_TYPE();
+            mp_PRIM_5F_TYPE_5F_TYPE();
             WORD_ATOM(74, 23, "NONE");
             mw_NONE();
             break;
         case 1LL:
-            co_PRIM_5F_TYPE_5F_STACK();
+            mp_PRIM_5F_TYPE_5F_STACK();
             WORD_ATOM(75, 24, "NONE");
             mw_NONE();
             break;
         case 2LL:
-            co_PRIM_5F_TYPE_5F_RESOURCE();
+            mp_PRIM_5F_TYPE_5F_RESOURCE();
             WORD_ATOM(76, 27, "NONE");
             mw_NONE();
             break;
         case 3LL:
-            co_PRIM_5F_TYPE_5F_INT();
+            mp_PRIM_5F_TYPE_5F_INT();
             WORD_ATOM(77, 22, "");
             {
                 static bool vready = false;
@@ -27928,7 +27881,7 @@ static void mw_PrimType_2E_tycon_name (void){
             mw_SOME();
             break;
         case 5LL:
-            co_PRIM_5F_TYPE_5F_STR();
+            mp_PRIM_5F_TYPE_5F_STR();
             WORD_ATOM(78, 22, "");
             {
                 static bool vready = false;
@@ -27946,7 +27899,7 @@ static void mw_PrimType_2E_tycon_name (void){
             mw_SOME();
             break;
         case 4LL:
-            co_PRIM_5F_TYPE_5F_PTR();
+            mp_PRIM_5F_TYPE_5F_PTR();
             WORD_ATOM(79, 22, "");
             {
                 static bool vready = false;
@@ -27964,7 +27917,7 @@ static void mw_PrimType_2E_tycon_name (void){
             mw_SOME();
             break;
         case 6LL:
-            co_PRIM_5F_TYPE_5F__2B_PLATFORM();
+            mp_PRIM_5F_TYPE_5F__2B_PLATFORM();
             WORD_ATOM(80, 28, "");
             {
                 static bool vready = false;
@@ -27982,15 +27935,15 @@ static void mw_PrimType_2E_tycon_name (void){
             mw_SOME();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_PrimType_2E_tycon_name);
+    }
+    WORD_EXIT(mw_PrimType_2E_tycon_name);
 }
-static void mw_Value_2E_tycon_name (void){
+static void mw_Value_2E_tycon_name (void) {
     WORD_ENTER(mw_Value_2E_tycon_name, "Value.tycon-name", "src/mirth/data/type.mth", 84, 5);
     WORD_ATOM(84, 5, "VALUE_INT");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_VALUE_5F_INT();
+            mp_VALUE_5F_INT();
             WORD_ATOM(84, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(84, 23, "");
@@ -28010,7 +27963,7 @@ static void mw_Value_2E_tycon_name (void){
             mw_SOME();
             break;
         case 1LL:
-            co_VALUE_5F_STR();
+            mp_VALUE_5F_STR();
             WORD_ATOM(85, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(85, 23, "");
@@ -28030,23 +27983,23 @@ static void mw_Value_2E_tycon_name (void){
             mw_SOME();
             break;
         case 2LL:
-            co_VALUE_5F_BLOCK();
+            mp_VALUE_5F_BLOCK();
             WORD_ATOM(86, 20, "drop");
             mw_prim_drop();
             WORD_ATOM(86, 25, "NONE");
             mw_NONE();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Value_2E_tycon_name);
+    }
+    WORD_EXIT(mw_Value_2E_tycon_name);
 }
-static void mw_PrimType_3E_Int (void){
+static void mw_PrimType_3E_Int (void) {
     WORD_ENTER(mw_PrimType_3E_Int, "PrimType>Int", "src/mirth/data/type.mth", 88, 36);
     WORD_ATOM(88, 36, "prim-unsafe-cast");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_PrimType_3E_Int);
 }
-static void mw_PrimType_3D_ (void){
+static void mw_PrimType_3D_ (void) {
     WORD_ENTER(mw_PrimType_3D_, "PrimType=", "src/mirth/data/type.mth", 89, 43);
     WORD_ATOM(89, 43, "both");
     push_u64(0);
@@ -28057,7 +28010,7 @@ static void mw_PrimType_3D_ (void){
     mw_prim_int_eq();
     WORD_EXIT(mw_PrimType_3D_);
 }
-static void mw_def_type_21_ (void){
+static void mw_def_type_21_ (void) {
     WORD_ENTER(mw_def_type_21_, "def-type!", "src/mirth/data/type.mth", 91, 29);
     WORD_ATOM(91, 29, "dip");
     {
@@ -28074,7 +28027,7 @@ static void mw_def_type_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_def_type_21_);
 }
-static void mw_init_types_21_ (void){
+static void mw_init_types_21_ (void) {
     WORD_ENTER(mw_init_types_21_, "init-types!", "src/mirth/data/type.mth", 94, 5);
     WORD_ATOM(94, 5, "TYPE_INT");
     mw_TYPE_5F_INT();
@@ -28140,43 +28093,43 @@ static void mw_init_types_21_ (void){
     mw_init_data_21_();
     WORD_EXIT(mw_init_types_21_);
 }
-static void mw_T_2B_ (void){
+static void mw_T_2B_ (void) {
     WORD_ENTER(mw_T_2B_, "T+", "src/mirth/data/type.mth", 104, 42);
     WORD_ATOM(104, 42, "STWith");
     mw_STWith();
     WORD_EXIT(mw_T_2B_);
 }
-static void mw_T_2A_ (void){
+static void mw_T_2A_ (void) {
     WORD_ENTER(mw_T_2A_, "T*", "src/mirth/data/type.mth", 105, 38);
     WORD_ATOM(105, 38, "STCons");
     mw_STCons();
     WORD_EXIT(mw_T_2A_);
 }
-static void mw_T_2A__2B_ (void){
+static void mw_T_2A__2B_ (void) {
     WORD_ENTER(mw_T_2A__2B_, "T*+", "src/mirth/data/type.mth", 106, 57);
     WORD_ATOM(106, 57, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_LEFT();
+            mp_LEFT();
             WORD_ATOM(106, 71, "T*");
             mw_T_2A_();
             break;
         case 1LL:
-            co_RIGHT();
+            mp_RIGHT();
             WORD_ATOM(106, 84, "T+");
             mw_T_2B_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_T_2A__2B_);
+    }
+    WORD_EXIT(mw_T_2A__2B_);
 }
-static void mw_T__3E_ (void){
+static void mw_T__3E_ (void) {
     WORD_ENTER(mw_T__3E_, "T->", "src/mirth/data/type.mth", 107, 44);
     WORD_ATOM(107, 44, "ARROW_TYPE");
     mw_ARROW_5F_TYPE();
     WORD_EXIT(mw_T__3E_);
 }
-static void mw_TT (void){
+static void mw_TT (void) {
     WORD_ENTER(mw_TT, "TT", "src/mirth/data/type.mth", 109, 34);
     WORD_ATOM(109, 34, "T0");
     mw_T0();
@@ -28189,13 +28142,13 @@ static void mw_TT (void){
     mw_List_2E_for();
     WORD_EXIT(mw_TT);
 }
-static void mw_T0 (void){
+static void mw_T0 (void) {
     WORD_ENTER(mw_T0, "T0", "src/mirth/data/type.mth", 110, 20);
     WORD_ATOM(110, 20, "STACK_TYPE_UNIT");
     mw_STACK_5F_TYPE_5F_UNIT();
     WORD_EXIT(mw_T0);
 }
-static void mw_T1 (void){
+static void mw_T1 (void) {
     WORD_ENTER(mw_T1, "T1", "src/mirth/data/type.mth", 111, 28);
     WORD_ATOM(111, 28, "dip");
     {
@@ -28208,7 +28161,7 @@ static void mw_T1 (void){
     mw_T_2A_();
     WORD_EXIT(mw_T1);
 }
-static void mw_T2 (void){
+static void mw_T2 (void) {
     WORD_ENTER(mw_T2, "T2", "src/mirth/data/type.mth", 112, 33);
     WORD_ATOM(112, 33, "dip");
     {
@@ -28221,7 +28174,7 @@ static void mw_T2 (void){
     mw_T_2A_();
     WORD_EXIT(mw_T2);
 }
-static void mw_T3 (void){
+static void mw_T3 (void) {
     WORD_ENTER(mw_T3, "T3", "src/mirth/data/type.mth", 113, 38);
     WORD_ATOM(113, 38, "dip");
     {
@@ -28234,7 +28187,7 @@ static void mw_T3 (void){
     mw_T_2A_();
     WORD_EXIT(mw_T3);
 }
-static void mw_T4 (void){
+static void mw_T4 (void) {
     WORD_ENTER(mw_T4, "T4", "src/mirth/data/type.mth", 114, 43);
     WORD_ATOM(114, 43, "dip");
     {
@@ -28247,7 +28200,7 @@ static void mw_T4 (void){
     mw_T_2A_();
     WORD_EXIT(mw_T4);
 }
-static void mw_T5 (void){
+static void mw_T5 (void) {
     WORD_ENTER(mw_T5, "T5", "src/mirth/data/type.mth", 115, 48);
     WORD_ATOM(115, 48, "dip");
     {
@@ -28260,7 +28213,7 @@ static void mw_T5 (void){
     mw_T_2A_();
     WORD_EXIT(mw_T5);
 }
-static void mw_T6 (void){
+static void mw_T6 (void) {
     WORD_ENTER(mw_T6, "T6", "src/mirth/data/type.mth", 116, 53);
     WORD_ATOM(116, 53, "dip");
     {
@@ -28273,14 +28226,14 @@ static void mw_T6 (void){
     mw_T_2A_();
     WORD_EXIT(mw_T6);
 }
-static void mw_Type_2E_morphism_3F_ (void){
+static void mw_Type_2E_morphism_3F_ (void) {
     WORD_ENTER(mw_Type_2E_morphism_3F_, "Type.morphism?", "src/mirth/data/type.mth", 130, 47);
     WORD_ATOM(130, 47, "expand");
     mw_Type_2E_expand();
     WORD_ATOM(130, 54, "match");
     switch (get_top_data_tag()) {
         case 9LL:
-            co_TMorphism();
+            mp_TMorphism();
             WORD_ATOM(130, 73, "SOME");
             mw_SOME();
             break;
@@ -28290,17 +28243,17 @@ static void mw_Type_2E_morphism_3F_ (void){
             WORD_ATOM(130, 89, "NONE");
             mw_NONE();
             break;
-    
-}    WORD_EXIT(mw_Type_2E_morphism_3F_);
+    }
+    WORD_EXIT(mw_Type_2E_morphism_3F_);
 }
-static void mw_Type_2E_prim_3F_ (void){
+static void mw_Type_2E_prim_3F_ (void) {
     WORD_ENTER(mw_Type_2E_prim_3F_, "Type.prim?", "src/mirth/data/type.mth", 131, 42);
     WORD_ATOM(131, 42, "expand");
     mw_Type_2E_expand();
     WORD_ATOM(131, 49, "match");
     switch (get_top_data_tag()) {
         case 2LL:
-            co_TPrim();
+            mp_TPrim();
             WORD_ATOM(131, 64, "SOME");
             mw_SOME();
             break;
@@ -28310,15 +28263,15 @@ static void mw_Type_2E_prim_3F_ (void){
             WORD_ATOM(131, 80, "NONE");
             mw_NONE();
             break;
-    
-}    WORD_EXIT(mw_Type_2E_prim_3F_);
+    }
+    WORD_EXIT(mw_Type_2E_prim_3F_);
 }
-static void mw_Type_3D_meta (void){
+static void mw_Type_3D_meta (void) {
     WORD_ENTER(mw_Type_3D_meta, "Type=meta", "src/mirth/data/type.mth", 142, 5);
     WORD_ATOM(142, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
-            co_TMeta();
+            mp_TMeta();
             WORD_ATOM(142, 14, "=");
             mw_MetaVar_3D_();
             break;
@@ -28328,15 +28281,15 @@ static void mw_Type_3D_meta (void){
             WORD_ATOM(143, 16, "F");
             mw_F();
             break;
-    
-}    WORD_EXIT(mw_Type_3D_meta);
+    }
+    WORD_EXIT(mw_Type_3D_meta);
 }
-static void mw_Type_2E_is_physical_3F_ (void){
+static void mw_Type_2E_is_physical_3F_ (void) {
     WORD_ENTER(mw_Type_2E_is_physical_3F_, "Type.is-physical?", "src/mirth/data/type.mth", 146, 5);
     WORD_ATOM(146, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
-            co_TMeta();
+            mp_TMeta();
             WORD_ATOM(146, 14, "expand-if");
             push_u64(0);
             push_fnptr(&mb_Type_2E_is_physical_3F__2);
@@ -28347,7 +28300,7 @@ static void mw_Type_2E_is_physical_3F_ (void){
             mw_MetaVar_2E_expand_if();
             break;
         case 2LL:
-            co_TPrim();
+            mp_TPrim();
             WORD_ATOM(147, 14, "is-physical?");
             mw_PrimType_2E_is_physical_3F_();
             break;
@@ -28357,10 +28310,10 @@ static void mw_Type_2E_is_physical_3F_ (void){
             WORD_ATOM(148, 15, "T");
             mw_T();
             break;
-    
-}    WORD_EXIT(mw_Type_2E_is_physical_3F_);
+    }
+    WORD_EXIT(mw_Type_2E_is_physical_3F_);
 }
-static void mw_TYPE_5F_TYPE (void){
+static void mw_TYPE_5F_TYPE (void) {
     WORD_ENTER(mw_TYPE_5F_TYPE, "TYPE_TYPE", "src/mirth/data/type.mth", 151, 22);
     WORD_ATOM(151, 22, "PRIM_TYPE_TYPE");
     mw_PRIM_5F_TYPE_5F_TYPE();
@@ -28368,7 +28321,7 @@ static void mw_TYPE_5F_TYPE (void){
     mw_TPrim();
     WORD_EXIT(mw_TYPE_5F_TYPE);
 }
-static void mw_TYPE_5F_STACK (void){
+static void mw_TYPE_5F_STACK (void) {
     WORD_ENTER(mw_TYPE_5F_STACK, "TYPE_STACK", "src/mirth/data/type.mth", 152, 23);
     WORD_ATOM(152, 23, "PRIM_TYPE_STACK");
     mw_PRIM_5F_TYPE_5F_STACK();
@@ -28376,7 +28329,7 @@ static void mw_TYPE_5F_STACK (void){
     mw_TPrim();
     WORD_EXIT(mw_TYPE_5F_STACK);
 }
-static void mw_TYPE_5F_RESOURCE (void){
+static void mw_TYPE_5F_RESOURCE (void) {
     WORD_ENTER(mw_TYPE_5F_RESOURCE, "TYPE_RESOURCE", "src/mirth/data/type.mth", 153, 26);
     WORD_ATOM(153, 26, "PRIM_TYPE_RESOURCE");
     mw_PRIM_5F_TYPE_5F_RESOURCE();
@@ -28384,7 +28337,7 @@ static void mw_TYPE_5F_RESOURCE (void){
     mw_TPrim();
     WORD_EXIT(mw_TYPE_5F_RESOURCE);
 }
-static void mw_TYPE_5F_INT (void){
+static void mw_TYPE_5F_INT (void) {
     WORD_ENTER(mw_TYPE_5F_INT, "TYPE_INT", "src/mirth/data/type.mth", 154, 21);
     WORD_ATOM(154, 21, "PRIM_TYPE_INT");
     mw_PRIM_5F_TYPE_5F_INT();
@@ -28392,7 +28345,7 @@ static void mw_TYPE_5F_INT (void){
     mw_TPrim();
     WORD_EXIT(mw_TYPE_5F_INT);
 }
-static void mw_TYPE_5F_PTR (void){
+static void mw_TYPE_5F_PTR (void) {
     WORD_ENTER(mw_TYPE_5F_PTR, "TYPE_PTR", "src/mirth/data/type.mth", 155, 21);
     WORD_ATOM(155, 21, "PRIM_TYPE_PTR");
     mw_PRIM_5F_TYPE_5F_PTR();
@@ -28400,7 +28353,7 @@ static void mw_TYPE_5F_PTR (void){
     mw_TPrim();
     WORD_EXIT(mw_TYPE_5F_PTR);
 }
-static void mw_TYPE_5F_STR (void){
+static void mw_TYPE_5F_STR (void) {
     WORD_ENTER(mw_TYPE_5F_STR, "TYPE_STR", "src/mirth/data/type.mth", 156, 21);
     WORD_ATOM(156, 21, "PRIM_TYPE_STR");
     mw_PRIM_5F_TYPE_5F_STR();
@@ -28408,7 +28361,7 @@ static void mw_TYPE_5F_STR (void){
     mw_TPrim();
     WORD_EXIT(mw_TYPE_5F_STR);
 }
-static void mw_TYPE_5F__2B_PLATFORM (void){
+static void mw_TYPE_5F__2B_PLATFORM (void) {
     WORD_ENTER(mw_TYPE_5F__2B_PLATFORM, "TYPE_+PLATFORM", "src/mirth/data/type.mth", 165, 27);
     WORD_ATOM(165, 27, "PRIM_TYPE_+PLATFORM");
     mw_PRIM_5F_TYPE_5F__2B_PLATFORM();
@@ -28416,7 +28369,7 @@ static void mw_TYPE_5F__2B_PLATFORM (void){
     mw_TPrim();
     WORD_EXIT(mw_TYPE_5F__2B_PLATFORM);
 }
-static void mw_RESOURCE_5F__2B_PLATFORM (void){
+static void mw_RESOURCE_5F__2B_PLATFORM (void) {
     WORD_ENTER(mw_RESOURCE_5F__2B_PLATFORM, "RESOURCE_+PLATFORM", "src/mirth/data/type.mth", 166, 35);
     WORD_ATOM(166, 35, "TYPE_+PLATFORM");
     mw_TYPE_5F__2B_PLATFORM();
@@ -28424,12 +28377,12 @@ static void mw_RESOURCE_5F__2B_PLATFORM (void){
     mw_RESOURCE();
     WORD_EXIT(mw_RESOURCE_5F__2B_PLATFORM);
 }
-static void mw_Type_2E_expand (void){
+static void mw_Type_2E_expand (void) {
     WORD_ENTER(mw_Type_2E_expand, "Type.expand", "src/mirth/data/type.mth", 169, 5);
     WORD_ATOM(169, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
-            co_TMeta();
+            mp_TMeta();
             WORD_ATOM(169, 14, "expand");
             mw_MetaVar_2E_expand();
             break;
@@ -28437,17 +28390,17 @@ static void mw_Type_2E_expand (void){
             WORD_ATOM(170, 10, "id");
             mw_prim_id();
             break;
-    
-}    WORD_EXIT(mw_Type_2E_expand);
+    }
+    WORD_EXIT(mw_Type_2E_expand);
 }
-static void mw_Gamma_2E_token (void){
+static void mw_Gamma_2E_token (void) {
     WORD_ENTER(mw_Gamma_2E_token, "Gamma.token", "src/mirth/data/type.mth", 173, 34);
     WORD_ATOM(173, 34, "GAMMA");
     WORD_ATOM(173, 43, "id");
     mw_prim_id();
     WORD_EXIT(mw_Gamma_2E_token);
 }
-static void mw_Type_2E_unify_failed_21_ (void){
+static void mw_Type_2E_unify_failed_21_ (void) {
     WORD_ENTER(mw_Type_2E_unify_failed_21_, "Type.unify-failed!", "src/mirth/data/type.mth", 177, 5);
     WORD_ATOM(177, 5, "over2");
     mw_over2();
@@ -28505,18 +28458,18 @@ static void mw_Type_2E_unify_failed_21_ (void){
     mw_modify();
     WORD_EXIT(mw_Type_2E_unify_failed_21_);
 }
-static void mw_Type_2E_unify_simple_21_ (void){
+static void mw_Type_2E_unify_simple_21_ (void) {
     WORD_ENTER(mw_Type_2E_unify_simple_21_, "Type.unify-simple!", "src/mirth/data/type.mth", 188, 5);
     WORD_ATOM(188, 5, "TVar");
     switch (get_top_data_tag()) {
         case 5LL:
-            co_TVar();
+            mp_TVar();
             WORD_ATOM(188, 13, "swap");
             mw_prim_swap();
             WORD_ATOM(188, 18, "match");
             switch (get_top_data_tag()) {
                 case 5LL:
-                    co_TVar();
+                    mp_TVar();
                     WORD_ATOM(188, 32, "unify!");
                     mw_Var_2E_unify_21_();
                     break;
@@ -28531,16 +28484,16 @@ static void mw_Type_2E_unify_simple_21_ (void){
                     WORD_ATOM(188, 55, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
-            
-}            break;
+            }
+            break;
         case 2LL:
-            co_TPrim();
+            mp_TPrim();
             WORD_ATOM(189, 14, "swap");
             mw_prim_swap();
             WORD_ATOM(189, 19, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
-                    co_TPrim();
+                    mp_TPrim();
                     WORD_ATOM(189, 34, "unify!");
                     mw_PrimType_2E_unify_21_();
                     break;
@@ -28555,16 +28508,16 @@ static void mw_Type_2E_unify_simple_21_ (void){
                     WORD_ATOM(189, 58, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
-            
-}            break;
+            }
+            break;
         case 7LL:
-            co_TData();
+            mp_TData();
             WORD_ATOM(190, 14, "swap");
             mw_prim_swap();
             WORD_ATOM(190, 19, "match");
             switch (get_top_data_tag()) {
                 case 7LL:
-                    co_TData();
+                    mp_TData();
                     WORD_ATOM(190, 34, "unify!");
                     mw_Data_2E_unify_21_();
                     break;
@@ -28579,16 +28532,16 @@ static void mw_Type_2E_unify_simple_21_ (void){
                     WORD_ATOM(190, 58, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
-            
-}            break;
+            }
+            break;
         case 6LL:
-            co_TTable();
+            mp_TTable();
             WORD_ATOM(191, 15, "swap");
             mw_prim_swap();
             WORD_ATOM(191, 20, "match");
             switch (get_top_data_tag()) {
                 case 6LL:
-                    co_TTable();
+                    mp_TTable();
                     WORD_ATOM(191, 36, "unify!");
                     mw_Table_2E_unify_21_();
                     break;
@@ -28603,16 +28556,16 @@ static void mw_Type_2E_unify_simple_21_ (void){
                     WORD_ATOM(191, 61, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
-            
-}            break;
+            }
+            break;
         case 8LL:
-            co_TTensor();
+            mp_TTensor();
             WORD_ATOM(192, 16, "swap");
             mw_prim_swap();
             WORD_ATOM(192, 21, "match");
             switch (get_top_data_tag()) {
                 case 8LL:
-                    co_TTensor();
+                    mp_TTensor();
                     WORD_ATOM(192, 38, "unify!");
                     mw_StackType_2E_unify_21_();
                     WORD_ATOM(192, 45, ">Type");
@@ -28629,16 +28582,16 @@ static void mw_Type_2E_unify_simple_21_ (void){
                     WORD_ATOM(192, 70, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
-            
-}            break;
+            }
+            break;
         case 9LL:
-            co_TMorphism();
+            mp_TMorphism();
             WORD_ATOM(193, 18, "swap");
             mw_prim_swap();
             WORD_ATOM(193, 23, "match");
             switch (get_top_data_tag()) {
                 case 9LL:
-                    co_TMorphism();
+                    mp_TMorphism();
                     WORD_ATOM(193, 42, "unify!");
                     mw_ArrowType_2E_unify_21_();
                     WORD_ATOM(193, 49, "TMorphism");
@@ -28655,16 +28608,16 @@ static void mw_Type_2E_unify_simple_21_ (void){
                     WORD_ATOM(193, 80, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
-            
-}            break;
+            }
+            break;
         case 10LL:
-            co_TApp();
+            mp_TApp();
             WORD_ATOM(194, 13, "rotl");
             mw_rotl();
             WORD_ATOM(194, 18, "match");
             switch (get_top_data_tag()) {
                 case 10LL:
-                    co_TApp();
+                    mp_TApp();
                     WORD_ATOM(194, 32, "unify2!");
                     mw_Type_2E_unify2_21_();
                     WORD_ATOM(194, 40, "TApp");
@@ -28681,16 +28634,16 @@ static void mw_Type_2E_unify_simple_21_ (void){
                     WORD_ATOM(194, 61, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
-            
-}            break;
+            }
+            break;
         case 11LL:
-            co_TMut();
+            mp_TMut();
             WORD_ATOM(195, 13, "swap");
             mw_prim_swap();
             WORD_ATOM(195, 18, "match");
             switch (get_top_data_tag()) {
                 case 11LL:
-                    co_TMut();
+                    mp_TMut();
                     WORD_ATOM(195, 32, "unify!");
                     mw_Type_2E_unify_21_();
                     WORD_ATOM(195, 39, "TMut");
@@ -28707,56 +28660,56 @@ static void mw_Type_2E_unify_simple_21_ (void){
                     WORD_ATOM(195, 60, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
-            
-}            break;
+            }
+            break;
         default:
             WORD_ATOM(196, 10, "unify-failed!");
             mw_Type_2E_unify_failed_21_();
             break;
-    
-}    WORD_EXIT(mw_Type_2E_unify_simple_21_);
+    }
+    WORD_EXIT(mw_Type_2E_unify_simple_21_);
 }
-static void mw_Type_2E_unify_aux_21_ (void){
+static void mw_Type_2E_unify_aux_21_ (void) {
     WORD_ENTER(mw_Type_2E_unify_aux_21_, "Type.unify-aux!", "src/mirth/data/type.mth", 200, 5);
     WORD_ATOM(200, 5, "TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_TYPE_5F_ERROR();
+            mp_TYPE_5F_ERROR();
             WORD_ATOM(200, 19, "drop");
             mw_prim_drop();
             WORD_ATOM(200, 24, "TYPE_ERROR");
             mw_TYPE_5F_ERROR();
             break;
         case 1LL:
-            co_TYPE_5F_DONT_5F_CARE();
+            mp_TYPE_5F_DONT_5F_CARE();
             WORD_ATOM(201, 23, "id");
             mw_prim_id();
             break;
         case 4LL:
-            co_THole();
+            mp_THole();
             WORD_ATOM(202, 14, "type-hole-unify!");
             mw_type_hole_unify_21_();
             break;
         case 3LL:
-            co_TMeta();
+            mp_TMeta();
             WORD_ATOM(204, 9, "swap");
             mw_prim_swap();
             WORD_ATOM(204, 14, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    co_TYPE_5F_ERROR();
+                    mp_TYPE_5F_ERROR();
                     WORD_ATOM(205, 27, "drop");
                     mw_prim_drop();
                     WORD_ATOM(205, 32, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 case 1LL:
-                    co_TYPE_5F_DONT_5F_CARE();
+                    mp_TYPE_5F_DONT_5F_CARE();
                     WORD_ATOM(206, 31, "TMeta");
                     mw_TMeta();
                     break;
                 case 4LL:
-                    co_THole();
+                    mp_THole();
                     WORD_ATOM(207, 22, "dip");
                     {
                         VAL d6 = pop_value();
@@ -28768,7 +28721,7 @@ static void mw_Type_2E_unify_aux_21_ (void){
                     mw_type_hole_unify_21_();
                     break;
                 case 3LL:
-                    co_TMeta();
+                    mp_TMeta();
                     WORD_ATOM(208, 22, "dip");
                     {
                         VAL d6 = pop_value();
@@ -28780,7 +28733,7 @@ static void mw_Type_2E_unify_aux_21_ (void){
                     mw_MetaVar_2E_unify_21_();
                     break;
                 case 12LL:
-                    co_TValue();
+                    mp_TValue();
                     WORD_ATOM(209, 23, "dip");
                     {
                         VAL d6 = pop_value();
@@ -28797,28 +28750,28 @@ static void mw_Type_2E_unify_aux_21_ (void){
                     WORD_ATOM(210, 23, "unify!");
                     mw_MetaVar_2E_unify_21_();
                     break;
-            
-}            break;
+            }
+            break;
         case 12LL:
-            co_TValue();
+            mp_TValue();
             WORD_ATOM(213, 9, "swap");
             mw_prim_swap();
             WORD_ATOM(213, 14, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    co_TYPE_5F_ERROR();
+                    mp_TYPE_5F_ERROR();
                     WORD_ATOM(214, 27, "drop");
                     mw_prim_drop();
                     WORD_ATOM(214, 32, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 case 1LL:
-                    co_TYPE_5F_DONT_5F_CARE();
+                    mp_TYPE_5F_DONT_5F_CARE();
                     WORD_ATOM(215, 31, "TValue");
                     mw_TValue();
                     break;
                 case 4LL:
-                    co_THole();
+                    mp_THole();
                     WORD_ATOM(216, 22, "dip");
                     {
                         VAL d6 = pop_value();
@@ -28830,7 +28783,7 @@ static void mw_Type_2E_unify_aux_21_ (void){
                     mw_type_hole_unify_21_();
                     break;
                 case 3LL:
-                    co_TMeta();
+                    mp_TMeta();
                     WORD_ATOM(217, 22, "dip");
                     {
                         VAL d6 = pop_value();
@@ -28842,7 +28795,7 @@ static void mw_Type_2E_unify_aux_21_ (void){
                     mw_MetaVar_2E_unify_21_();
                     break;
                 case 12LL:
-                    co_TValue();
+                    mp_TValue();
                     WORD_ATOM(218, 23, "unify!");
                     mw_Value_2E_unify_21_();
                     break;
@@ -28852,37 +28805,37 @@ static void mw_Type_2E_unify_aux_21_ (void){
                     WORD_ATOM(219, 23, "unify-type!");
                     mw_Value_2E_unify_type_21_();
                     break;
-            
-}            break;
+            }
+            break;
         default:
             WORD_ATOM(222, 9, "swap");
             mw_prim_swap();
             WORD_ATOM(222, 14, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    co_TYPE_5F_ERROR();
+                    mp_TYPE_5F_ERROR();
                     WORD_ATOM(223, 27, "drop");
                     mw_prim_drop();
                     WORD_ATOM(223, 32, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 case 1LL:
-                    co_TYPE_5F_DONT_5F_CARE();
+                    mp_TYPE_5F_DONT_5F_CARE();
                     WORD_ATOM(224, 31, "id");
                     mw_prim_id();
                     break;
                 case 4LL:
-                    co_THole();
+                    mp_THole();
                     WORD_ATOM(225, 22, "type-hole-unify!");
                     mw_type_hole_unify_21_();
                     break;
                 case 3LL:
-                    co_TMeta();
+                    mp_TMeta();
                     WORD_ATOM(226, 22, "unify!");
                     mw_MetaVar_2E_unify_21_();
                     break;
                 case 12LL:
-                    co_TValue();
+                    mp_TValue();
                     WORD_ATOM(227, 23, "unify-type!");
                     mw_Value_2E_unify_type_21_();
                     break;
@@ -28890,12 +28843,12 @@ static void mw_Type_2E_unify_aux_21_ (void){
                     WORD_ATOM(228, 18, "unify-simple!");
                     mw_Type_2E_unify_simple_21_();
                     break;
-            
-}            break;
-    
-}    WORD_EXIT(mw_Type_2E_unify_aux_21_);
+            }
+            break;
+    }
+    WORD_EXIT(mw_Type_2E_unify_aux_21_);
 }
-static void mw_Type_2E_unify_21_ (void){
+static void mw_Type_2E_unify_21_ (void) {
     WORD_ENTER(mw_Type_2E_unify_21_, "Type.unify!", "src/mirth/data/type.mth", 234, 5);
     WORD_ATOM(234, 5, "both");
     push_u64(0);
@@ -28906,20 +28859,20 @@ static void mw_Type_2E_unify_21_ (void){
     mw_Type_2E_unify_aux_21_();
     WORD_EXIT(mw_Type_2E_unify_21_);
 }
-static void mw_Value_2E_unify_21_ (void){
+static void mw_Value_2E_unify_21_ (void) {
     WORD_ENTER(mw_Value_2E_unify_21_, "Value.unify!", "src/mirth/data/type.mth", 237, 5);
     WORD_ATOM(237, 5, "swap");
     mw_prim_swap();
     WORD_ATOM(237, 10, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_VALUE_5F_INT();
+            mp_VALUE_5F_INT();
             WORD_ATOM(238, 22, "swap");
             mw_prim_swap();
             WORD_ATOM(238, 27, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    co_VALUE_5F_INT();
+                    mp_VALUE_5F_INT();
                     WORD_ATOM(239, 26, "dup2");
                     mw_dup2();
                     WORD_ATOM(239, 31, "=");
@@ -28940,7 +28893,7 @@ static void mw_Value_2E_unify_21_ (void){
                     }
                     break;
                 case 1LL:
-                    co_VALUE_5F_STR();
+                    mp_VALUE_5F_STR();
                     WORD_ATOM(241, 17, "drop2");
                     mw_drop2();
                     WORD_ATOM(241, 23, "dup");
@@ -28964,7 +28917,7 @@ static void mw_Value_2E_unify_21_ (void){
                     mw_TYPE_5F_ERROR();
                     break;
                 case 2LL:
-                    co_VALUE_5F_BLOCK();
+                    mp_VALUE_5F_BLOCK();
                     WORD_ATOM(245, 17, "drop2");
                     mw_drop2();
                     WORD_ATOM(245, 23, "dup");
@@ -28988,16 +28941,16 @@ static void mw_Value_2E_unify_21_ (void){
                     mw_TYPE_5F_ERROR();
                     break;
                 default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-            
-}            break;
+            }
+            break;
         case 1LL:
-            co_VALUE_5F_STR();
+            mp_VALUE_5F_STR();
             WORD_ATOM(250, 22, "swap");
             mw_prim_swap();
             WORD_ATOM(250, 27, "match");
             switch (get_top_data_tag()) {
                 case 1LL:
-                    co_VALUE_5F_STR();
+                    mp_VALUE_5F_STR();
                     WORD_ATOM(251, 26, "dup2");
                     mw_dup2();
                     WORD_ATOM(251, 31, "=");
@@ -29018,7 +28971,7 @@ static void mw_Value_2E_unify_21_ (void){
                     }
                     break;
                 case 0LL:
-                    co_VALUE_5F_INT();
+                    mp_VALUE_5F_INT();
                     WORD_ATOM(253, 17, "drop2");
                     mw_drop2();
                     WORD_ATOM(253, 23, "dup");
@@ -29042,7 +28995,7 @@ static void mw_Value_2E_unify_21_ (void){
                     mw_TYPE_5F_ERROR();
                     break;
                 case 2LL:
-                    co_VALUE_5F_BLOCK();
+                    mp_VALUE_5F_BLOCK();
                     WORD_ATOM(257, 17, "drop2");
                     mw_drop2();
                     WORD_ATOM(257, 23, "dup");
@@ -29066,16 +29019,16 @@ static void mw_Value_2E_unify_21_ (void){
                     mw_TYPE_5F_ERROR();
                     break;
                 default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-            
-}            break;
+            }
+            break;
         case 2LL:
-            co_VALUE_5F_BLOCK();
+            mp_VALUE_5F_BLOCK();
             WORD_ATOM(262, 24, "swap");
             mw_prim_swap();
             WORD_ATOM(262, 29, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
-                    co_VALUE_5F_BLOCK();
+                    mp_VALUE_5F_BLOCK();
                     WORD_ATOM(264, 17, "dup2");
                     mw_dup2();
                     WORD_ATOM(264, 22, "=");
@@ -29100,7 +29053,7 @@ static void mw_Value_2E_unify_21_ (void){
                     }
                     break;
                 case 0LL:
-                    co_VALUE_5F_INT();
+                    mp_VALUE_5F_INT();
                     WORD_ATOM(269, 17, "drop2");
                     mw_drop2();
                     WORD_ATOM(269, 23, "dup");
@@ -29124,7 +29077,7 @@ static void mw_Value_2E_unify_21_ (void){
                     mw_TYPE_5F_ERROR();
                     break;
                 case 1LL:
-                    co_VALUE_5F_STR();
+                    mp_VALUE_5F_STR();
                     WORD_ATOM(273, 17, "drop2");
                     mw_drop2();
                     WORD_ATOM(273, 23, "dup");
@@ -29148,18 +29101,18 @@ static void mw_Value_2E_unify_21_ (void){
                     mw_TYPE_5F_ERROR();
                     break;
                 default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-            
-}            break;
+            }
+            break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Value_2E_unify_21_);
+    }
+    WORD_EXIT(mw_Value_2E_unify_21_);
 }
-static void mw_Value_2E_unify_type_21_ (void){
+static void mw_Value_2E_unify_type_21_ (void) {
     WORD_ENTER(mw_Value_2E_unify_type_21_, "Value.unify-type!", "src/mirth/data/type.mth", 280, 5);
     WORD_ATOM(280, 5, "VALUE_INT");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_VALUE_5F_INT();
+            mp_VALUE_5F_INT();
             WORD_ATOM(280, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(280, 23, "TYPE_INT");
@@ -29168,7 +29121,7 @@ static void mw_Value_2E_unify_type_21_ (void){
             mw_Type_2E_unify_21_();
             break;
         case 1LL:
-            co_VALUE_5F_STR();
+            mp_VALUE_5F_STR();
             WORD_ATOM(281, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(281, 23, "TYPE_STR");
@@ -29177,24 +29130,24 @@ static void mw_Value_2E_unify_type_21_ (void){
             mw_Type_2E_unify_21_();
             break;
         case 2LL:
-            co_VALUE_5F_BLOCK();
+            mp_VALUE_5F_BLOCK();
             WORD_ATOM(282, 20, "swap");
             mw_prim_swap();
             WORD_ATOM(282, 25, "unify-block!");
             mw_Type_2E_unify_block_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Value_2E_unify_type_21_);
+    }
+    WORD_EXIT(mw_Value_2E_unify_type_21_);
 }
-static void mw_Type_2E_unify_block_21_ (void){
+static void mw_Type_2E_unify_block_21_ (void) {
     WORD_ENTER(mw_Type_2E_unify_block_21_, "Type.unify-block!", "src/mirth/data/type.mth", 285, 5);
     WORD_ATOM(285, 5, "expand");
     mw_Type_2E_expand();
     WORD_ATOM(285, 12, "match");
     switch (get_top_data_tag()) {
         case 3LL:
-            co_TMeta();
+            mp_TMeta();
             WORD_ATOM(286, 18, "over");
             mw_over();
             WORD_ATOM(286, 23, "dip");
@@ -29223,7 +29176,7 @@ static void mw_Type_2E_unify_block_21_ (void){
             mw_ArrowType_3E_Type();
             break;
         case 9LL:
-            co_TMorphism();
+            mp_TMorphism();
             WORD_ATOM(287, 22, "block-unify-type!");
             mw_block_unify_type_21_();
             WORD_ATOM(287, 40, ">Type");
@@ -29242,10 +29195,10 @@ static void mw_Type_2E_unify_block_21_ (void){
             WORD_ATOM(288, 30, "unify!");
             mw_Type_2E_unify_21_();
             break;
-    
-}    WORD_EXIT(mw_Type_2E_unify_block_21_);
+    }
+    WORD_EXIT(mw_Type_2E_unify_block_21_);
 }
-static void mw_Type_2E_unify2_21_ (void){
+static void mw_Type_2E_unify2_21_ (void) {
     WORD_ENTER(mw_Type_2E_unify2_21_, "Type.unify2!", "src/mirth/data/type.mth", 292, 5);
     WORD_ATOM(292, 5, "dip");
     {
@@ -29274,7 +29227,7 @@ static void mw_Type_2E_unify2_21_ (void){
     }
     WORD_EXIT(mw_Type_2E_unify2_21_);
 }
-static void mw_PrimType_2E_unify_21_ (void){
+static void mw_PrimType_2E_unify_21_ (void) {
     WORD_ENTER(mw_PrimType_2E_unify_21_, "PrimType.unify!", "src/mirth/data/type.mth", 295, 5);
     WORD_ATOM(295, 5, "dup2");
     mw_dup2();
@@ -29297,7 +29250,7 @@ static void mw_PrimType_2E_unify_21_ (void){
     }
     WORD_EXIT(mw_PrimType_2E_unify_21_);
 }
-static void mw_Data_2E_unify_21_ (void){
+static void mw_Data_2E_unify_21_ (void) {
     WORD_ENTER(mw_Data_2E_unify_21_, "Data.unify!", "src/mirth/data/type.mth", 297, 5);
     WORD_ATOM(297, 5, "dup2");
     mw_dup2();
@@ -29320,7 +29273,7 @@ static void mw_Data_2E_unify_21_ (void){
     }
     WORD_EXIT(mw_Data_2E_unify_21_);
 }
-static void mw_Table_2E_unify_21_ (void){
+static void mw_Table_2E_unify_21_ (void) {
     WORD_ENTER(mw_Table_2E_unify_21_, "Table.unify!", "src/mirth/data/type.mth", 299, 5);
     WORD_ATOM(299, 5, "dup2");
     mw_dup2();
@@ -29343,7 +29296,7 @@ static void mw_Table_2E_unify_21_ (void){
     }
     WORD_EXIT(mw_Table_2E_unify_21_);
 }
-static void mw_Var_2E_unify_21_ (void){
+static void mw_Var_2E_unify_21_ (void) {
     WORD_ENTER(mw_Var_2E_unify_21_, "Var.unify!", "src/mirth/data/type.mth", 301, 5);
     WORD_ATOM(301, 5, "dup2");
     mw_dup2();
@@ -29366,94 +29319,94 @@ static void mw_Var_2E_unify_21_ (void){
     }
     WORD_EXIT(mw_Var_2E_unify_21_);
 }
-static void mw_Type_2E_has_meta_3F_ (void){
+static void mw_Type_2E_has_meta_3F_ (void) {
     WORD_ENTER(mw_Type_2E_has_meta_3F_, "Type.has-meta?", "src/mirth/data/type.mth", 304, 5);
     WORD_ATOM(304, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
-            co_TMeta();
+            mp_TMeta();
             WORD_ATOM(304, 14, "has-meta?");
             mw_MetaVar_2E_has_meta_3F_();
             break;
         case 0LL:
-            co_TYPE_5F_ERROR();
+            mp_TYPE_5F_ERROR();
             WORD_ATOM(305, 19, "drop");
             mw_prim_drop();
             WORD_ATOM(305, 24, "F");
             mw_F();
             break;
         case 1LL:
-            co_TYPE_5F_DONT_5F_CARE();
+            mp_TYPE_5F_DONT_5F_CARE();
             WORD_ATOM(306, 23, "drop");
             mw_prim_drop();
             WORD_ATOM(306, 28, "F");
             mw_F();
             break;
         case 2LL:
-            co_TPrim();
+            mp_TPrim();
             WORD_ATOM(307, 14, "drop2");
             mw_drop2();
             WORD_ATOM(307, 20, "F");
             mw_F();
             break;
         case 5LL:
-            co_TVar();
+            mp_TVar();
             WORD_ATOM(308, 13, "drop2");
             mw_drop2();
             WORD_ATOM(308, 19, "F");
             mw_F();
             break;
         case 4LL:
-            co_THole();
+            mp_THole();
             WORD_ATOM(309, 14, "drop2");
             mw_drop2();
             WORD_ATOM(309, 20, "F");
             mw_F();
             break;
         case 8LL:
-            co_TTensor();
+            mp_TTensor();
             WORD_ATOM(310, 16, "has-meta?");
             mw_StackType_2E_has_meta_3F_();
             break;
         case 9LL:
-            co_TMorphism();
+            mp_TMorphism();
             WORD_ATOM(311, 18, "has-meta?");
             mw_ArrowType_2E_has_meta_3F_();
             break;
         case 10LL:
-            co_TApp();
+            mp_TApp();
             WORD_ATOM(312, 13, "has-meta2?");
             mw_Type_2E_has_meta2_3F_();
             break;
         case 7LL:
-            co_TData();
+            mp_TData();
             WORD_ATOM(313, 14, "drop2");
             mw_drop2();
             WORD_ATOM(313, 20, "F");
             mw_F();
             break;
         case 6LL:
-            co_TTable();
+            mp_TTable();
             WORD_ATOM(314, 15, "drop2");
             mw_drop2();
             WORD_ATOM(314, 21, "F");
             mw_F();
             break;
         case 12LL:
-            co_TValue();
+            mp_TValue();
             WORD_ATOM(315, 15, "has-meta?");
             mw_Value_2E_has_meta_3F_();
             break;
         case 11LL:
-            co_TMut();
+            mp_TMut();
             WORD_ATOM(316, 13, "has-meta?");
             mw_Type_2E_has_meta_3F_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Type_2E_has_meta_3F_);
+    }
+    WORD_EXIT(mw_Type_2E_has_meta_3F_);
 }
-static void mw_Type_2E_has_meta2_3F_ (void){
+static void mw_Type_2E_has_meta2_3F_ (void) {
     WORD_ENTER(mw_Type_2E_has_meta2_3F_, "Type.has-meta2?", "src/mirth/data/type.mth", 319, 5);
     WORD_ATOM(319, 5, "dip");
     {
@@ -29476,7 +29429,7 @@ static void mw_Type_2E_has_meta2_3F_ (void){
     }
     WORD_EXIT(mw_Type_2E_has_meta2_3F_);
 }
-static void mw_Value_2E_has_meta_3F_ (void){
+static void mw_Value_2E_has_meta_3F_ (void) {
     WORD_ENTER(mw_Value_2E_has_meta_3F_, "Value.has-meta?", "src/mirth/data/type.mth", 322, 5);
     WORD_ATOM(322, 5, "type");
     mw_Value_2E_type();
@@ -29484,12 +29437,12 @@ static void mw_Value_2E_has_meta_3F_ (void){
     mw_Type_2E_has_meta_3F_();
     WORD_EXIT(mw_Value_2E_has_meta_3F_);
 }
-static void mw_Type_2E_trace_sig_21_ (void){
+static void mw_Type_2E_trace_sig_21_ (void) {
     WORD_ENTER(mw_Type_2E_trace_sig_21_, "Type.trace-sig!", "src/mirth/data/type.mth", 325, 5);
     WORD_ATOM(325, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
-            co_TMeta();
+            mp_TMeta();
             WORD_ATOM(325, 14, "expand-if");
             push_u64(0);
             push_fnptr(&mb_Type_2E_trace_sig_21__2);
@@ -29500,7 +29453,7 @@ static void mw_Type_2E_trace_sig_21_ (void){
             mw_MetaVar_2E_expand_if();
             break;
         case 0LL:
-            co_TYPE_5F_ERROR();
+            mp_TYPE_5F_ERROR();
             WORD_ATOM(326, 19, "");
             {
                 static bool vready = false;
@@ -29516,7 +29469,7 @@ static void mw_Type_2E_trace_sig_21_ (void){
             mw_Str_2E_trace_21_();
             break;
         case 9LL:
-            co_TMorphism();
+            mp_TMorphism();
             WORD_ATOM(327, 18, "trace!");
             mw_ArrowType_2E_trace_21_();
             break;
@@ -29524,15 +29477,15 @@ static void mw_Type_2E_trace_sig_21_ (void){
             WORD_ATOM(328, 10, "trace!");
             mw_Type_2E_trace_21_();
             break;
-    
-}    WORD_EXIT(mw_Type_2E_trace_sig_21_);
+    }
+    WORD_EXIT(mw_Type_2E_trace_sig_21_);
 }
-static void mw_Type_2E_trace_21_ (void){
+static void mw_Type_2E_trace_21_ (void) {
     WORD_ENTER(mw_Type_2E_trace_21_, "Type.trace!", "src/mirth/data/type.mth", 331, 5);
     WORD_ATOM(331, 5, "TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_TYPE_5F_ERROR();
+            mp_TYPE_5F_ERROR();
             WORD_ATOM(331, 19, "");
             {
                 static bool vready = false;
@@ -29548,7 +29501,7 @@ static void mw_Type_2E_trace_21_ (void){
             mw_Str_2E_trace_21_();
             break;
         case 1LL:
-            co_TYPE_5F_DONT_5F_CARE();
+            mp_TYPE_5F_DONT_5F_CARE();
             WORD_ATOM(332, 23, "");
             {
                 static bool vready = false;
@@ -29564,22 +29517,22 @@ static void mw_Type_2E_trace_21_ (void){
             mw_Str_2E_trace_21_();
             break;
         case 2LL:
-            co_TPrim();
+            mp_TPrim();
             WORD_ATOM(333, 14, "trace!");
             mw_PrimType_2E_trace_21_();
             break;
         case 5LL:
-            co_TVar();
+            mp_TVar();
             WORD_ATOM(334, 13, "trace!");
             mw_Var_2E_trace_21_();
             break;
         case 3LL:
-            co_TMeta();
+            mp_TMeta();
             WORD_ATOM(335, 14, "trace!");
             mw_MetaVar_2E_trace_21_();
             break;
         case 8LL:
-            co_TTensor();
+            mp_TTensor();
             WORD_ATOM(336, 16, "");
             {
                 static bool vready = false;
@@ -29610,7 +29563,7 @@ static void mw_Type_2E_trace_21_ (void){
             mw_Str_2E_trace_21_();
             break;
         case 9LL:
-            co_TMorphism();
+            mp_TMorphism();
             WORD_ATOM(337, 18, "");
             {
                 static bool vready = false;
@@ -29643,38 +29596,38 @@ static void mw_Type_2E_trace_21_ (void){
             mw_Str_2E_trace_21_();
             break;
         case 7LL:
-            co_TData();
+            mp_TData();
             WORD_ATOM(338, 14, "name");
             mw_Data_2E_name();
             WORD_ATOM(338, 19, "trace!");
             mw_Name_2E_trace_21_();
             break;
         case 6LL:
-            co_TTable();
+            mp_TTable();
             WORD_ATOM(339, 15, "name");
             mw_Table_2E_name();
             WORD_ATOM(339, 20, "trace!");
             mw_Name_2E_trace_21_();
             break;
         case 4LL:
-            co_THole();
+            mp_THole();
             WORD_ATOM(340, 14, "trace!");
             mw_Name_2E_trace_21_();
             break;
         case 10LL:
-            co_TApp();
+            mp_TApp();
             WORD_ATOM(341, 13, "trace-app!");
             mw_Type_2E_trace_app_21_();
             break;
         case 12LL:
-            co_TValue();
+            mp_TValue();
             WORD_ATOM(342, 15, "type");
             mw_Value_2E_type();
             WORD_ATOM(342, 20, "trace!");
             mw_Type_2E_trace_21_();
             break;
         case 11LL:
-            co_TMut();
+            mp_TMut();
             WORD_ATOM(343, 13, "");
             {
                 static bool vready = false;
@@ -29705,15 +29658,15 @@ static void mw_Type_2E_trace_21_ (void){
             mw_Str_2E_trace_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Type_2E_trace_21_);
+    }
+    WORD_EXIT(mw_Type_2E_trace_21_);
 }
-static void mw_Value_2E_type (void){
+static void mw_Value_2E_type (void) {
     WORD_ENTER(mw_Value_2E_type, "Value.type", "src/mirth/data/type.mth", 346, 5);
     WORD_ATOM(346, 5, "VALUE_INT");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_VALUE_5F_INT();
+            mp_VALUE_5F_INT();
             WORD_ATOM(346, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(346, 23, "PRIM_TYPE_INT");
@@ -29722,7 +29675,7 @@ static void mw_Value_2E_type (void){
             mw_TPrim();
             break;
         case 1LL:
-            co_VALUE_5F_STR();
+            mp_VALUE_5F_STR();
             WORD_ATOM(347, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(347, 23, "PRIM_TYPE_STR");
@@ -29731,22 +29684,22 @@ static void mw_Value_2E_type (void){
             mw_TPrim();
             break;
         case 2LL:
-            co_VALUE_5F_BLOCK();
+            mp_VALUE_5F_BLOCK();
             WORD_ATOM(348, 20, "type");
             mw_Block_2E_type();
             WORD_ATOM(348, 25, ">Type");
             mw_ArrowType_3E_Type();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Value_2E_type);
+    }
+    WORD_EXIT(mw_Value_2E_type);
 }
-static void mw_PrimType_2E_trace_21_ (void){
+static void mw_PrimType_2E_trace_21_ (void) {
     WORD_ENTER(mw_PrimType_2E_trace_21_, "PrimType.trace!", "src/mirth/data/type.mth", 351, 5);
     WORD_ATOM(351, 5, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_PRIM_5F_TYPE_5F_TYPE();
+            mp_PRIM_5F_TYPE_5F_TYPE();
             WORD_ATOM(352, 27, "");
             {
                 static bool vready = false;
@@ -29760,7 +29713,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             }
             break;
         case 1LL:
-            co_PRIM_5F_TYPE_5F_STACK();
+            mp_PRIM_5F_TYPE_5F_STACK();
             WORD_ATOM(353, 28, "");
             {
                 static bool vready = false;
@@ -29774,7 +29727,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             }
             break;
         case 2LL:
-            co_PRIM_5F_TYPE_5F_RESOURCE();
+            mp_PRIM_5F_TYPE_5F_RESOURCE();
             WORD_ATOM(354, 31, "");
             {
                 static bool vready = false;
@@ -29788,7 +29741,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             }
             break;
         case 3LL:
-            co_PRIM_5F_TYPE_5F_INT();
+            mp_PRIM_5F_TYPE_5F_INT();
             WORD_ATOM(355, 26, "");
             {
                 static bool vready = false;
@@ -29802,7 +29755,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             }
             break;
         case 4LL:
-            co_PRIM_5F_TYPE_5F_PTR();
+            mp_PRIM_5F_TYPE_5F_PTR();
             WORD_ATOM(356, 26, "");
             {
                 static bool vready = false;
@@ -29816,7 +29769,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             }
             break;
         case 5LL:
-            co_PRIM_5F_TYPE_5F_STR();
+            mp_PRIM_5F_TYPE_5F_STR();
             WORD_ATOM(357, 26, "");
             {
                 static bool vready = false;
@@ -29830,7 +29783,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             }
             break;
         case 6LL:
-            co_PRIM_5F_TYPE_5F__2B_PLATFORM();
+            mp_PRIM_5F_TYPE_5F__2B_PLATFORM();
             WORD_ATOM(358, 32, "");
             {
                 static bool vready = false;
@@ -29844,93 +29797,93 @@ static void mw_PrimType_2E_trace_21_ (void){
             }
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_ATOM(359, 7, "trace!");
+    }
+    WORD_ATOM(359, 7, "trace!");
     mw_Str_2E_trace_21_();
     WORD_EXIT(mw_PrimType_2E_trace_21_);
 }
-static void mw_Type_2E_freshen (void){
+static void mw_Type_2E_freshen (void) {
     WORD_ENTER(mw_Type_2E_freshen, "Type.freshen", "src/mirth/data/type.mth", 380, 5);
     WORD_ATOM(380, 5, "TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_TYPE_5F_ERROR();
+            mp_TYPE_5F_ERROR();
             WORD_ATOM(380, 19, "TYPE_ERROR");
             mw_TYPE_5F_ERROR();
             break;
         case 1LL:
-            co_TYPE_5F_DONT_5F_CARE();
+            mp_TYPE_5F_DONT_5F_CARE();
             WORD_ATOM(381, 23, "TYPE_DONT_CARE");
             mw_TYPE_5F_DONT_5F_CARE();
             break;
         case 2LL:
-            co_TPrim();
+            mp_TPrim();
             WORD_ATOM(382, 14, "TPrim");
             mw_TPrim();
             break;
         case 4LL:
-            co_THole();
+            mp_THole();
             WORD_ATOM(383, 14, "THole");
             mw_THole();
             break;
         case 7LL:
-            co_TData();
+            mp_TData();
             WORD_ATOM(384, 14, "TData");
             mw_TData();
             break;
         case 6LL:
-            co_TTable();
+            mp_TTable();
             WORD_ATOM(385, 15, "TTable");
             mw_TTable();
             break;
         case 12LL:
-            co_TValue();
+            mp_TValue();
             WORD_ATOM(386, 15, "TValue");
             mw_TValue();
             break;
         case 5LL:
-            co_TVar();
+            mp_TVar();
             WORD_ATOM(387, 13, "freshen");
             mw_Var_2E_freshen();
             break;
         case 3LL:
-            co_TMeta();
+            mp_TMeta();
             WORD_ATOM(388, 14, "freshen");
             mw_MetaVar_2E_freshen();
             break;
         case 8LL:
-            co_TTensor();
+            mp_TTensor();
             WORD_ATOM(389, 16, "freshen");
             mw_StackType_2E_freshen();
             WORD_ATOM(389, 24, "TTensor");
             mw_TTensor();
             break;
         case 9LL:
-            co_TMorphism();
+            mp_TMorphism();
             WORD_ATOM(390, 18, "freshen");
             mw_ArrowType_2E_freshen();
             WORD_ATOM(390, 26, "TMorphism");
             mw_TMorphism();
             break;
         case 10LL:
-            co_TApp();
+            mp_TApp();
             WORD_ATOM(391, 13, "freshen2");
             mw_Type_2E_freshen2();
             WORD_ATOM(391, 22, "TApp");
             mw_TApp();
             break;
         case 11LL:
-            co_TMut();
+            mp_TMut();
             WORD_ATOM(392, 13, "freshen");
             mw_Type_2E_freshen();
             WORD_ATOM(392, 21, "TMut");
             mw_TMut();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Type_2E_freshen);
+    }
+    WORD_EXIT(mw_Type_2E_freshen);
 }
-static void mw_Type_2E_freshen2 (void){
+static void mw_Type_2E_freshen2 (void) {
     WORD_ENTER(mw_Type_2E_freshen2, "Type.freshen2", "src/mirth/data/type.mth", 396, 5);
     WORD_ATOM(396, 5, "dip");
     {
@@ -29952,7 +29905,7 @@ static void mw_Type_2E_freshen2 (void){
     }
     WORD_EXIT(mw_Type_2E_freshen2);
 }
-static void mw_MetaVar_2E_freshen (void){
+static void mw_MetaVar_2E_freshen (void) {
     WORD_ENTER(mw_MetaVar_2E_freshen, "MetaVar.freshen", "src/mirth/data/type.mth", 399, 5);
     WORD_ATOM(399, 5, "expand-if");
     push_u64(0);
@@ -29964,7 +29917,7 @@ static void mw_MetaVar_2E_freshen (void){
     mw_MetaVar_2E_expand_if();
     WORD_EXIT(mw_MetaVar_2E_freshen);
 }
-static void mw_Var_2E_freshen (void){
+static void mw_Var_2E_freshen (void) {
     WORD_ENTER(mw_Var_2E_freshen, "Var.freshen", "src/mirth/data/type.mth", 402, 5);
     WORD_ATOM(402, 5, "swap");
     mw_prim_swap();
@@ -29997,12 +29950,12 @@ static void mw_Var_2E_freshen (void){
     }
     WORD_EXIT(mw_Var_2E_freshen);
 }
-static void mw_Type_2E_arity (void){
+static void mw_Type_2E_arity (void) {
     WORD_ENTER(mw_Type_2E_arity, "Type.arity", "src/mirth/data/type.mth", 445, 5);
     WORD_ATOM(445, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
-            co_TMeta();
+            mp_TMeta();
             WORD_ATOM(445, 14, "expand-if");
             push_u64(0);
             push_fnptr(&mb_Type_2E_arity_2);
@@ -30013,12 +29966,12 @@ static void mw_Type_2E_arity (void){
             mw_MetaVar_2E_expand_if();
             break;
         case 7LL:
-            co_TData();
+            mp_TData();
             WORD_ATOM(446, 14, "arity");
             mw_Data_2E_arity();
             break;
         case 10LL:
-            co_TApp();
+            mp_TApp();
             WORD_ATOM(447, 13, "drop");
             mw_prim_drop();
             WORD_ATOM(447, 18, "arity");
@@ -30032,16 +29985,16 @@ static void mw_Type_2E_arity (void){
             WORD_ATOM(448, 15, "");
             push_i64(0LL);
             break;
-    
-}    WORD_EXIT(mw_Type_2E_arity);
+    }
+    WORD_EXIT(mw_Type_2E_arity);
 }
-static void mw_MetaVar_2E_id (void){
+static void mw_MetaVar_2E_id (void) {
     WORD_ENTER(mw_MetaVar_2E_id, "MetaVar.id", "src/mirth/data/type.mth", 476, 7);
     WORD_ATOM(476, 7, "MetaVar");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_MetaVar_2E_id);
 }
-static void mw_MetaVar_2E_alloc_21_ (void){
+static void mw_MetaVar_2E_alloc_21_ (void) {
     WORD_ENTER(mw_MetaVar_2E_alloc_21_, "MetaVar.alloc!", "src/mirth/data/type.mth", 476, 7);
     WORD_ATOM(476, 7, "MetaVar");
     mw_MetaVar_2E_NUM();
@@ -30065,7 +30018,7 @@ static void mw_MetaVar_2E_alloc_21_ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_MetaVar_2E_alloc_21_);
 }
-static void mw_MetaVar_2E_type_3F_ (void){
+static void mw_MetaVar_2E_type_3F_ (void) {
     WORD_ENTER(mw_MetaVar_2E_type_3F_, "MetaVar.type?", "src/mirth/data/type.mth", 478, 44);
     WORD_ATOM(478, 44, "~type?");
     mw_MetaVar_7E_type_3F_();
@@ -30073,7 +30026,7 @@ static void mw_MetaVar_2E_type_3F_ (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_MetaVar_2E_type_3F_);
 }
-static void mw_MetaVar_2E_has_meta_3F_ (void){
+static void mw_MetaVar_2E_has_meta_3F_ (void) {
     WORD_ENTER(mw_MetaVar_2E_has_meta_3F_, "MetaVar.has-meta?", "src/mirth/data/type.mth", 481, 5);
     WORD_ATOM(481, 5, "dup");
     mw_prim_dup();
@@ -30082,22 +30035,22 @@ static void mw_MetaVar_2E_has_meta_3F_ (void){
     WORD_ATOM(481, 15, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_NONE();
+            mp_NONE();
             WORD_ATOM(482, 17, "=");
             mw_MetaVar_3D_();
             break;
         case 1LL:
-            co_SOME();
+            mp_SOME();
             WORD_ATOM(483, 17, "nip");
             mw_nip();
             WORD_ATOM(483, 21, "has-meta?");
             mw_Type_2E_has_meta_3F_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_MetaVar_2E_has_meta_3F_);
+    }
+    WORD_EXIT(mw_MetaVar_2E_has_meta_3F_);
 }
-static void mw_MetaVar_2E_trace_21_ (void){
+static void mw_MetaVar_2E_trace_21_ (void) {
     WORD_ENTER(mw_MetaVar_2E_trace_21_, "MetaVar.trace!", "src/mirth/data/type.mth", 487, 5);
     WORD_ATOM(487, 5, "dup");
     mw_prim_dup();
@@ -30106,7 +30059,7 @@ static void mw_MetaVar_2E_trace_21_ (void){
     WORD_ATOM(487, 15, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_NONE();
+            mp_NONE();
             WORD_ATOM(488, 17, "");
             {
                 static bool vready = false;
@@ -30126,17 +30079,17 @@ static void mw_MetaVar_2E_trace_21_ (void){
             mw_Int_2E_trace_21_();
             break;
         case 1LL:
-            co_SOME();
+            mp_SOME();
             WORD_ATOM(489, 17, "nip");
             mw_nip();
             WORD_ATOM(489, 21, "trace!");
             mw_Type_2E_trace_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_MetaVar_2E_trace_21_);
+    }
+    WORD_EXIT(mw_MetaVar_2E_trace_21_);
 }
-static void mw_MetaVar_2E_new_21_ (void){
+static void mw_MetaVar_2E_new_21_ (void) {
     WORD_ENTER(mw_MetaVar_2E_new_21_, "MetaVar.new!", "src/mirth/data/type.mth", 492, 5);
     WORD_ATOM(492, 5, "MetaVar.alloc!");
     mw_MetaVar_2E_alloc_21_();
@@ -30150,7 +30103,7 @@ static void mw_MetaVar_2E_new_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_MetaVar_2E_new_21_);
 }
-static void mw_MetaVar_2E_expand_if (void){
+static void mw_MetaVar_2E_expand_if (void) {
     WORD_ENTER(mw_MetaVar_2E_expand_if, "MetaVar.expand-if", "src/mirth/data/type.mth", 496, 5);
     WORD_ATOM(496, 5, "dup");
     {
@@ -30163,13 +30116,13 @@ static void mw_MetaVar_2E_expand_if (void){
         WORD_ATOM(496, 15, "match");
         switch (get_top_data_tag()) {
             case 0LL:
-                co_NONE();
+                mp_NONE();
                 WORD_ATOM(497, 17, "g");
                 incref(var_g);
                 run_value(var_g);
                 break;
             case 1LL:
-                co_SOME();
+                mp_SOME();
                 WORD_ATOM(498, 17, "expand");
                 mw_Type_2E_expand();
                 WORD_ATOM(498, 24, "tuck");
@@ -30187,13 +30140,13 @@ static void mw_MetaVar_2E_expand_if (void){
                 run_value(var_f);
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-        
-}        decref(var_g);
+        }
+        decref(var_g);
         decref(var_f);
     }
     WORD_EXIT(mw_MetaVar_2E_expand_if);
 }
-static void mw_MetaVar_2E_expand (void){
+static void mw_MetaVar_2E_expand (void) {
     WORD_ENTER(mw_MetaVar_2E_expand, "MetaVar.expand", "src/mirth/data/type.mth", 501, 5);
     WORD_ATOM(501, 5, "expand-if");
     push_u64(0);
@@ -30205,7 +30158,7 @@ static void mw_MetaVar_2E_expand (void){
     mw_MetaVar_2E_expand_if();
     WORD_EXIT(mw_MetaVar_2E_expand);
 }
-static void mw_MetaVar_2E_unify_21_ (void){
+static void mw_MetaVar_2E_unify_21_ (void) {
     WORD_ENTER(mw_MetaVar_2E_unify_21_, "MetaVar.unify!", "src/mirth/data/type.mth", 503, 5);
     WORD_ATOM(503, 5, "dup");
     mw_prim_dup();
@@ -30214,14 +30167,14 @@ static void mw_MetaVar_2E_unify_21_ (void){
     WORD_ATOM(503, 15, "match");
     switch (get_top_data_tag()) {
         case 1LL:
-            co_SOME();
+            mp_SOME();
             WORD_ATOM(504, 17, "nip");
             mw_nip();
             WORD_ATOM(504, 21, "unify!");
             mw_Type_2E_unify_21_();
             break;
         case 0LL:
-            co_NONE();
+            mp_NONE();
             WORD_ATOM(505, 17, "dup2");
             mw_dup2();
             WORD_ATOM(505, 22, "swap");
@@ -30262,10 +30215,10 @@ static void mw_MetaVar_2E_unify_21_ (void){
             }
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_MetaVar_2E_unify_21_);
+    }
+    WORD_EXIT(mw_MetaVar_2E_unify_21_);
 }
-static void mw_MetaVar_3D_ (void){
+static void mw_MetaVar_3D_ (void) {
     WORD_ENTER(mw_MetaVar_3D_, "MetaVar=", "src/mirth/data/type.mth", 519, 40);
     WORD_ATOM(519, 40, "both");
     push_u64(0);
@@ -30276,7 +30229,7 @@ static void mw_MetaVar_3D_ (void){
     mw_prim_int_eq();
     WORD_EXIT(mw_MetaVar_3D_);
 }
-static void mw_type_hole_unify_21_ (void){
+static void mw_type_hole_unify_21_ (void) {
     WORD_ENTER(mw_type_hole_unify_21_, "type-hole-unify!", "src/mirth/data/type.mth", 526, 5);
     WORD_ATOM(526, 5, "THole");
     mw_THole();
@@ -30303,7 +30256,7 @@ static void mw_type_hole_unify_21_ (void){
     mw_line_trace_21_();
     WORD_EXIT(mw_type_hole_unify_21_);
 }
-static void mw_Type_2E_trace_app_21_ (void){
+static void mw_Type_2E_trace_app_21_ (void) {
     WORD_ENTER(mw_Type_2E_trace_app_21_, "Type.trace-app!", "src/mirth/data/type.mth", 536, 5);
     WORD_ATOM(536, 5, "trace-app-open!");
     mw_Type_2E_trace_app_open_21_();
@@ -30322,7 +30275,7 @@ static void mw_Type_2E_trace_app_21_ (void){
     mw_Str_2E_trace_21_();
     WORD_EXIT(mw_Type_2E_trace_app_21_);
 }
-static void mw_Type_2E_trace_app_open_21_ (void){
+static void mw_Type_2E_trace_app_open_21_ (void) {
     WORD_ENTER(mw_Type_2E_trace_app_open_21_, "Type.trace-app-open!", "src/mirth/data/type.mth", 539, 5);
     WORD_ATOM(539, 5, "swap");
     mw_prim_swap();
@@ -30331,7 +30284,7 @@ static void mw_Type_2E_trace_app_open_21_ (void){
     WORD_ATOM(539, 17, "match");
     switch (get_top_data_tag()) {
         case 10LL:
-            co_TApp();
+            mp_TApp();
             WORD_ATOM(541, 13, "trace-app-open!");
             mw_Type_2E_trace_app_open_21_();
             WORD_ATOM(542, 13, "");
@@ -30369,23 +30322,23 @@ static void mw_Type_2E_trace_app_open_21_ (void){
             WORD_ATOM(547, 13, "trace!");
             mw_Type_2E_trace_21_();
             break;
-    
-}    WORD_EXIT(mw_Type_2E_trace_app_open_21_);
+    }
+    WORD_EXIT(mw_Type_2E_trace_app_open_21_);
 }
-static void mw_Resource_3E_Type (void){
+static void mw_Resource_3E_Type (void) {
     WORD_ENTER(mw_Resource_3E_Type, "Resource>Type", "src/mirth/data/type.mth", 555, 38);
     WORD_ATOM(555, 38, "RESOURCE");
     WORD_ATOM(555, 50, "id");
     mw_prim_id();
     WORD_EXIT(mw_Resource_3E_Type);
 }
-static void mw_Type_3E_Resource (void){
+static void mw_Type_3E_Resource (void) {
     WORD_ENTER(mw_Type_3E_Resource, "Type>Resource", "src/mirth/data/type.mth", 556, 38);
     WORD_ATOM(556, 38, "RESOURCE");
     mw_RESOURCE();
     WORD_EXIT(mw_Type_3E_Resource);
 }
-static void mw_Resource_2E_has_meta_3F_ (void){
+static void mw_Resource_2E_has_meta_3F_ (void) {
     WORD_ENTER(mw_Resource_2E_has_meta_3F_, "Resource.has-meta?", "src/mirth/data/type.mth", 557, 51);
     WORD_ATOM(557, 51, ">Type");
     mw_Resource_3E_Type();
@@ -30393,7 +30346,7 @@ static void mw_Resource_2E_has_meta_3F_ (void){
     mw_Type_2E_has_meta_3F_();
     WORD_EXIT(mw_Resource_2E_has_meta_3F_);
 }
-static void mw_Resource_2E_unify_21_ (void){
+static void mw_Resource_2E_unify_21_ (void) {
     WORD_ENTER(mw_Resource_2E_unify_21_, "Resource.unify!", "src/mirth/data/type.mth", 559, 5);
     WORD_ATOM(559, 5, "both");
     push_u64(0);
@@ -30406,7 +30359,7 @@ static void mw_Resource_2E_unify_21_ (void){
     mw_Type_3E_Resource();
     WORD_EXIT(mw_Resource_2E_unify_21_);
 }
-static void mw_Resource_2E_trace_21_ (void){
+static void mw_Resource_2E_trace_21_ (void) {
     WORD_ENTER(mw_Resource_2E_trace_21_, "Resource.trace!", "src/mirth/data/type.mth", 560, 35);
     WORD_ATOM(560, 35, ">Type");
     mw_Resource_3E_Type();
@@ -30414,7 +30367,7 @@ static void mw_Resource_2E_trace_21_ (void){
     mw_Type_2E_trace_21_();
     WORD_EXIT(mw_Resource_2E_trace_21_);
 }
-static void mw_Resource_2E_freshen (void){
+static void mw_Resource_2E_freshen (void) {
     WORD_ENTER(mw_Resource_2E_freshen, "Resource.freshen", "src/mirth/data/type.mth", 562, 5);
     WORD_ATOM(562, 5, ">Type");
     mw_Resource_3E_Type();
@@ -30424,32 +30377,32 @@ static void mw_Resource_2E_freshen (void){
     mw_Type_3E_Resource();
     WORD_EXIT(mw_Resource_2E_freshen);
 }
-static void mw_Type_3E_StackType (void){
+static void mw_Type_3E_StackType (void) {
     WORD_ENTER(mw_Type_3E_StackType, "Type>StackType", "src/mirth/data/type.mth", 580, 5);
     WORD_ATOM(580, 5, "TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_TYPE_5F_ERROR();
+            mp_TYPE_5F_ERROR();
             WORD_ATOM(580, 19, "STACK_TYPE_ERROR");
             mw_STACK_5F_TYPE_5F_ERROR();
             break;
         case 1LL:
-            co_TYPE_5F_DONT_5F_CARE();
+            mp_TYPE_5F_DONT_5F_CARE();
             WORD_ATOM(581, 23, "STACK_TYPE_DONT_CARE");
             mw_STACK_5F_TYPE_5F_DONT_5F_CARE();
             break;
         case 5LL:
-            co_TVar();
+            mp_TVar();
             WORD_ATOM(582, 13, "STVar");
             mw_STVar();
             break;
         case 3LL:
-            co_TMeta();
+            mp_TMeta();
             WORD_ATOM(583, 14, "STMeta");
             mw_STMeta();
             break;
         case 8LL:
-            co_TTensor();
+            mp_TTensor();
             WORD_ATOM(584, 16, "id");
             mw_prim_id();
             break;
@@ -30468,30 +30421,30 @@ static void mw_Type_3E_StackType (void){
             WORD_ATOM(585, 63, "panic!");
             mw_prim_panic();
             break;
-    
-}    WORD_EXIT(mw_Type_3E_StackType);
+    }
+    WORD_EXIT(mw_Type_3E_StackType);
 }
-static void mw_StackType_3E_Type (void){
+static void mw_StackType_3E_Type (void) {
     WORD_ENTER(mw_StackType_3E_Type, "StackType>Type", "src/mirth/data/type.mth", 588, 5);
     WORD_ATOM(588, 5, "STACK_TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_STACK_5F_TYPE_5F_ERROR();
+            mp_STACK_5F_TYPE_5F_ERROR();
             WORD_ATOM(588, 25, "TYPE_ERROR");
             mw_TYPE_5F_ERROR();
             break;
         case 1LL:
-            co_STACK_5F_TYPE_5F_DONT_5F_CARE();
+            mp_STACK_5F_TYPE_5F_DONT_5F_CARE();
             WORD_ATOM(589, 29, "TYPE_DONT_CARE");
             mw_TYPE_5F_DONT_5F_CARE();
             break;
         case 3LL:
-            co_STVar();
+            mp_STVar();
             WORD_ATOM(590, 14, "TVar");
             mw_TVar();
             break;
         case 4LL:
-            co_STMeta();
+            mp_STMeta();
             WORD_ATOM(591, 15, "TMeta");
             mw_TMeta();
             break;
@@ -30499,15 +30452,15 @@ static void mw_StackType_3E_Type (void){
             WORD_ATOM(592, 10, "TTensor");
             mw_TTensor();
             break;
-    
-}    WORD_EXIT(mw_StackType_3E_Type);
+    }
+    WORD_EXIT(mw_StackType_3E_Type);
 }
-static void mw_StackType_2E_expand (void){
+static void mw_StackType_2E_expand (void) {
     WORD_ENTER(mw_StackType_2E_expand, "StackType.expand", "src/mirth/data/type.mth", 595, 5);
     WORD_ATOM(595, 5, "STMeta");
     switch (get_top_data_tag()) {
         case 4LL:
-            co_STMeta();
+            mp_STMeta();
             WORD_ATOM(595, 15, "expand");
             mw_MetaVar_2E_expand();
             WORD_ATOM(595, 22, ">StackType");
@@ -30517,17 +30470,17 @@ static void mw_StackType_2E_expand (void){
             WORD_ATOM(596, 10, "id");
             mw_prim_id();
             break;
-    
-}    WORD_EXIT(mw_StackType_2E_expand);
+    }
+    WORD_EXIT(mw_StackType_2E_expand);
 }
-static void mw_StackType_2E_unit_3F_ (void){
+static void mw_StackType_2E_unit_3F_ (void) {
     WORD_ENTER(mw_StackType_2E_unit_3F_, "StackType.unit?", "src/mirth/data/type.mth", 599, 5);
     WORD_ATOM(599, 5, "expand");
     mw_StackType_2E_expand();
     WORD_ATOM(599, 12, "match");
     switch (get_top_data_tag()) {
         case 2LL:
-            co_STACK_5F_TYPE_5F_UNIT();
+            mp_STACK_5F_TYPE_5F_UNIT();
             WORD_ATOM(600, 28, "T");
             mw_T();
             break;
@@ -30537,17 +30490,17 @@ static void mw_StackType_2E_unit_3F_ (void){
             WORD_ATOM(601, 19, "F");
             mw_F();
             break;
-    
-}    WORD_EXIT(mw_StackType_2E_unit_3F_);
+    }
+    WORD_EXIT(mw_StackType_2E_unit_3F_);
 }
-static void mw_StackType_2E_split3 (void){
+static void mw_StackType_2E_split3 (void) {
     WORD_ENTER(mw_StackType_2E_split3, "StackType.split3", "src/mirth/data/type.mth", 606, 5);
     WORD_ATOM(606, 5, "expand");
     mw_StackType_2E_expand();
     WORD_ATOM(606, 12, "match");
     switch (get_top_data_tag()) {
         case 5LL:
-            co_STCons();
+            mp_STCons();
             WORD_ATOM(607, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -30566,7 +30519,7 @@ static void mw_StackType_2E_split3 (void){
             }
             break;
         case 6LL:
-            co_STWith();
+            mp_STWith();
             WORD_ATOM(608, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -30583,10 +30536,10 @@ static void mw_StackType_2E_split3 (void){
             WORD_ATOM(609, 17, "L0");
             mw_L0();
             break;
-    
-}    WORD_EXIT(mw_StackType_2E_split3);
+    }
+    WORD_EXIT(mw_StackType_2E_split3);
 }
-static void mw_StackType_2E_base (void){
+static void mw_StackType_2E_base (void) {
     WORD_ENTER(mw_StackType_2E_base, "StackType.base", "src/mirth/data/type.mth", 613, 45);
     WORD_ATOM(613, 45, "split3");
     mw_StackType_2E_split3();
@@ -30594,21 +30547,21 @@ static void mw_StackType_2E_base (void){
     mw_drop2();
     WORD_EXIT(mw_StackType_2E_base);
 }
-static void mw_StackType_2E_top_type (void){
+static void mw_StackType_2E_top_type (void) {
     WORD_ENTER(mw_StackType_2E_top_type, "StackType.top-type", "src/mirth/data/type.mth", 623, 5);
     WORD_ATOM(623, 5, "expand");
     mw_StackType_2E_expand();
     WORD_ATOM(623, 12, "match");
     switch (get_top_data_tag()) {
         case 5LL:
-            co_STCons();
+            mp_STCons();
             WORD_ATOM(624, 19, "nip");
             mw_nip();
             WORD_ATOM(624, 23, "SOME");
             mw_SOME();
             break;
         case 6LL:
-            co_STWith();
+            mp_STWith();
             WORD_ATOM(625, 19, "drop");
             mw_prim_drop();
             WORD_ATOM(625, 24, "top-type");
@@ -30620,10 +30573,10 @@ static void mw_StackType_2E_top_type (void){
             WORD_ATOM(626, 19, "NONE");
             mw_NONE();
             break;
-    
-}    WORD_EXIT(mw_StackType_2E_top_type);
+    }
+    WORD_EXIT(mw_StackType_2E_top_type);
 }
-static void mw_StackType_2E_top_tycon_name (void){
+static void mw_StackType_2E_top_tycon_name (void) {
     WORD_ENTER(mw_StackType_2E_top_tycon_name, "StackType.top-tycon-name", "src/mirth/data/type.mth", 631, 5);
     WORD_ATOM(631, 5, "top-type");
     mw_StackType_2E_top_type();
@@ -30634,21 +30587,21 @@ static void mw_StackType_2E_top_tycon_name (void){
     mw_Maybe_2E_bind();
     WORD_EXIT(mw_StackType_2E_top_tycon_name);
 }
-static void mw_StackType_2E_top_resource (void){
+static void mw_StackType_2E_top_resource (void) {
     WORD_ENTER(mw_StackType_2E_top_resource, "StackType.top-resource", "src/mirth/data/type.mth", 635, 5);
     WORD_ATOM(635, 5, "expand");
     mw_StackType_2E_expand();
     WORD_ATOM(635, 12, "match");
     switch (get_top_data_tag()) {
         case 6LL:
-            co_STWith();
+            mp_STWith();
             WORD_ATOM(636, 19, "nip");
             mw_nip();
             WORD_ATOM(636, 23, "SOME");
             mw_SOME();
             break;
         case 5LL:
-            co_STCons();
+            mp_STCons();
             WORD_ATOM(637, 19, "drop");
             mw_prim_drop();
             WORD_ATOM(637, 24, "top-resource");
@@ -30660,10 +30613,10 @@ static void mw_StackType_2E_top_resource (void){
             WORD_ATOM(638, 19, "NONE");
             mw_NONE();
             break;
-    
-}    WORD_EXIT(mw_StackType_2E_top_resource);
+    }
+    WORD_EXIT(mw_StackType_2E_top_resource);
 }
-static void mw_StackType_2E_top_resource_name (void){
+static void mw_StackType_2E_top_resource_name (void) {
     WORD_ENTER(mw_StackType_2E_top_resource_name, "StackType.top-resource-name", "src/mirth/data/type.mth", 643, 5);
     WORD_ATOM(643, 5, "top-resource");
     mw_StackType_2E_top_resource();
@@ -30674,47 +30627,47 @@ static void mw_StackType_2E_top_resource_name (void){
     mw_Maybe_2E_bind();
     WORD_EXIT(mw_StackType_2E_top_resource_name);
 }
-static void mw_StackType_2E_has_meta_3F_ (void){
+static void mw_StackType_2E_has_meta_3F_ (void) {
     WORD_ENTER(mw_StackType_2E_has_meta_3F_, "StackType.has-meta?", "src/mirth/data/type.mth", 646, 5);
     WORD_ATOM(646, 5, "expand");
     mw_StackType_2E_expand();
     WORD_ATOM(646, 12, "match");
     switch (get_top_data_tag()) {
         case 4LL:
-            co_STMeta();
+            mp_STMeta();
             WORD_ATOM(647, 19, "=");
             mw_MetaVar_3D_();
             break;
         case 0LL:
-            co_STACK_5F_TYPE_5F_ERROR();
+            mp_STACK_5F_TYPE_5F_ERROR();
             WORD_ATOM(648, 29, "drop");
             mw_prim_drop();
             WORD_ATOM(648, 34, "F");
             mw_F();
             break;
         case 1LL:
-            co_STACK_5F_TYPE_5F_DONT_5F_CARE();
+            mp_STACK_5F_TYPE_5F_DONT_5F_CARE();
             WORD_ATOM(649, 33, "drop");
             mw_prim_drop();
             WORD_ATOM(649, 38, "F");
             mw_F();
             break;
         case 3LL:
-            co_STVar();
+            mp_STVar();
             WORD_ATOM(650, 18, "drop2");
             mw_drop2();
             WORD_ATOM(650, 24, "F");
             mw_F();
             break;
         case 2LL:
-            co_STACK_5F_TYPE_5F_UNIT();
+            mp_STACK_5F_TYPE_5F_UNIT();
             WORD_ATOM(651, 28, "drop");
             mw_prim_drop();
             WORD_ATOM(651, 33, "F");
             mw_F();
             break;
         case 5LL:
-            co_STCons();
+            mp_STCons();
             WORD_ATOM(652, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -30736,7 +30689,7 @@ static void mw_StackType_2E_has_meta_3F_ (void){
             }
             break;
         case 6LL:
-            co_STWith();
+            mp_STWith();
             WORD_ATOM(653, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -30758,10 +30711,10 @@ static void mw_StackType_2E_has_meta_3F_ (void){
             }
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_StackType_2E_has_meta_3F_);
+    }
+    WORD_EXIT(mw_StackType_2E_has_meta_3F_);
 }
-static void mw_StackType_2E_unify_failed_21_ (void){
+static void mw_StackType_2E_unify_failed_21_ (void) {
     WORD_ENTER(mw_StackType_2E_unify_failed_21_, "StackType.unify-failed!", "src/mirth/data/type.mth", 658, 4);
     WORD_ATOM(658, 4, "both");
     push_u64(0);
@@ -30774,7 +30727,7 @@ static void mw_StackType_2E_unify_failed_21_ (void){
     mw_Type_3E_StackType();
     WORD_EXIT(mw_StackType_2E_unify_failed_21_);
 }
-static void mw_StackType_2E_unify_21_ (void){
+static void mw_StackType_2E_unify_21_ (void) {
     WORD_ENTER(mw_StackType_2E_unify_21_, "StackType.unify!", "src/mirth/data/type.mth", 661, 5);
     WORD_ATOM(661, 5, "swap");
     mw_prim_swap();
@@ -30783,19 +30736,19 @@ static void mw_StackType_2E_unify_21_ (void){
     WORD_ATOM(661, 17, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_STACK_5F_TYPE_5F_ERROR();
+            mp_STACK_5F_TYPE_5F_ERROR();
             WORD_ATOM(662, 29, "drop");
             mw_prim_drop();
             WORD_ATOM(662, 34, "STACK_TYPE_ERROR");
             mw_STACK_5F_TYPE_5F_ERROR();
             break;
         case 1LL:
-            co_STACK_5F_TYPE_5F_DONT_5F_CARE();
+            mp_STACK_5F_TYPE_5F_DONT_5F_CARE();
             WORD_ATOM(663, 33, "id");
             mw_prim_id();
             break;
         case 4LL:
-            co_STMeta();
+            mp_STMeta();
             WORD_ATOM(664, 19, "swap");
             mw_prim_swap();
             WORD_ATOM(664, 24, "expand");
@@ -30803,19 +30756,19 @@ static void mw_StackType_2E_unify_21_ (void){
             WORD_ATOM(664, 31, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    co_STACK_5F_TYPE_5F_ERROR();
+                    mp_STACK_5F_TYPE_5F_ERROR();
                     WORD_ATOM(665, 33, "drop");
                     mw_prim_drop();
                     WORD_ATOM(665, 38, "STACK_TYPE_ERROR");
                     mw_STACK_5F_TYPE_5F_ERROR();
                     break;
                 case 1LL:
-                    co_STACK_5F_TYPE_5F_DONT_5F_CARE();
+                    mp_STACK_5F_TYPE_5F_DONT_5F_CARE();
                     WORD_ATOM(666, 37, "STMeta");
                     mw_STMeta();
                     break;
                 case 4LL:
-                    co_STMeta();
+                    mp_STMeta();
                     WORD_ATOM(667, 23, "dip");
                     {
                         VAL d6 = pop_value();
@@ -30838,10 +30791,10 @@ static void mw_StackType_2E_unify_21_ (void){
                     WORD_ATOM(668, 36, ">StackType");
                     mw_Type_3E_StackType();
                     break;
-            
-}            break;
+            }
+            break;
         case 3LL:
-            co_STVar();
+            mp_STVar();
             WORD_ATOM(670, 18, "swap");
             mw_prim_swap();
             WORD_ATOM(670, 23, "expand");
@@ -30849,19 +30802,19 @@ static void mw_StackType_2E_unify_21_ (void){
             WORD_ATOM(670, 30, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    co_STACK_5F_TYPE_5F_ERROR();
+                    mp_STACK_5F_TYPE_5F_ERROR();
                     WORD_ATOM(671, 33, "drop");
                     mw_prim_drop();
                     WORD_ATOM(671, 38, "STACK_TYPE_ERROR");
                     mw_STACK_5F_TYPE_5F_ERROR();
                     break;
                 case 1LL:
-                    co_STACK_5F_TYPE_5F_DONT_5F_CARE();
+                    mp_STACK_5F_TYPE_5F_DONT_5F_CARE();
                     WORD_ATOM(672, 37, "STVar");
                     mw_STVar();
                     break;
                 case 4LL:
-                    co_STMeta();
+                    mp_STMeta();
                     WORD_ATOM(673, 23, "dip");
                     {
                         VAL d6 = pop_value();
@@ -30875,7 +30828,7 @@ static void mw_StackType_2E_unify_21_ (void){
                     mw_Type_3E_StackType();
                     break;
                 case 3LL:
-                    co_STVar();
+                    mp_STVar();
                     WORD_ATOM(674, 22, "unify!");
                     mw_Var_2E_unify_21_();
                     WORD_ATOM(674, 29, ">StackType");
@@ -30892,21 +30845,21 @@ static void mw_StackType_2E_unify_21_ (void){
                     WORD_ATOM(675, 29, "unify-failed!");
                     mw_StackType_2E_unify_failed_21_();
                     break;
-            
-}            break;
+            }
+            break;
         case 2LL:
-            co_STACK_5F_TYPE_5F_UNIT();
+            mp_STACK_5F_TYPE_5F_UNIT();
             WORD_ATOM(677, 28, "expand");
             mw_StackType_2E_expand();
             WORD_ATOM(677, 35, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    co_STACK_5F_TYPE_5F_ERROR();
+                    mp_STACK_5F_TYPE_5F_ERROR();
                     WORD_ATOM(678, 33, "STACK_TYPE_ERROR");
                     mw_STACK_5F_TYPE_5F_ERROR();
                     break;
                 case 4LL:
-                    co_STMeta();
+                    mp_STMeta();
                     WORD_ATOM(679, 23, "dip");
                     {
                         VAL d6 = pop_value();
@@ -30922,12 +30875,12 @@ static void mw_StackType_2E_unify_21_ (void){
                     mw_Type_3E_StackType();
                     break;
                 case 1LL:
-                    co_STACK_5F_TYPE_5F_DONT_5F_CARE();
+                    mp_STACK_5F_TYPE_5F_DONT_5F_CARE();
                     WORD_ATOM(680, 37, "STACK_TYPE_UNIT");
                     mw_STACK_5F_TYPE_5F_UNIT();
                     break;
                 case 2LL:
-                    co_STACK_5F_TYPE_5F_UNIT();
+                    mp_STACK_5F_TYPE_5F_UNIT();
                     WORD_ATOM(681, 32, "STACK_TYPE_UNIT");
                     mw_STACK_5F_TYPE_5F_UNIT();
                     break;
@@ -30937,10 +30890,10 @@ static void mw_StackType_2E_unify_21_ (void){
                     WORD_ATOM(682, 34, "unify-failed!");
                     mw_StackType_2E_unify_failed_21_();
                     break;
-            
-}            break;
+            }
+            break;
         case 5LL:
-            co_STCons();
+            mp_STCons();
             WORD_ATOM(684, 19, "rotl");
             mw_rotl();
             WORD_ATOM(684, 24, "expand");
@@ -30948,14 +30901,14 @@ static void mw_StackType_2E_unify_21_ (void){
             WORD_ATOM(684, 31, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    co_STACK_5F_TYPE_5F_ERROR();
+                    mp_STACK_5F_TYPE_5F_ERROR();
                     WORD_ATOM(685, 33, "drop2");
                     mw_drop2();
                     WORD_ATOM(685, 39, "STACK_TYPE_ERROR");
                     mw_STACK_5F_TYPE_5F_ERROR();
                     break;
                 case 4LL:
-                    co_STMeta();
+                    mp_STMeta();
                     WORD_ATOM(686, 23, "dip");
                     {
                         VAL d6 = pop_value();
@@ -30971,7 +30924,7 @@ static void mw_StackType_2E_unify_21_ (void){
                     mw_Type_3E_StackType();
                     break;
                 case 1LL:
-                    co_STACK_5F_TYPE_5F_DONT_5F_CARE();
+                    mp_STACK_5F_TYPE_5F_DONT_5F_CARE();
                     WORD_ATOM(687, 37, "STCons");
                     mw_STCons();
                     break;
@@ -30989,10 +30942,10 @@ static void mw_StackType_2E_unify_21_ (void){
                     mw_prim_pack_cons();
                     mw_Maybe_2E_if_some();
                     break;
-            
-}            break;
+            }
+            break;
         case 6LL:
-            co_STWith();
+            mp_STWith();
             WORD_ATOM(693, 19, "rotl");
             mw_rotl();
             WORD_ATOM(693, 24, "expand");
@@ -31000,14 +30953,14 @@ static void mw_StackType_2E_unify_21_ (void){
             WORD_ATOM(693, 31, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    co_STACK_5F_TYPE_5F_ERROR();
+                    mp_STACK_5F_TYPE_5F_ERROR();
                     WORD_ATOM(694, 33, "drop2");
                     mw_drop2();
                     WORD_ATOM(694, 39, "STACK_TYPE_ERROR");
                     mw_STACK_5F_TYPE_5F_ERROR();
                     break;
                 case 4LL:
-                    co_STMeta();
+                    mp_STMeta();
                     WORD_ATOM(695, 23, "dip");
                     {
                         VAL d6 = pop_value();
@@ -31023,7 +30976,7 @@ static void mw_StackType_2E_unify_21_ (void){
                     mw_Type_3E_StackType();
                     break;
                 case 1LL:
-                    co_STACK_5F_TYPE_5F_DONT_5F_CARE();
+                    mp_STACK_5F_TYPE_5F_DONT_5F_CARE();
                     WORD_ATOM(696, 37, "STWith");
                     mw_STWith();
                     break;
@@ -31041,27 +30994,27 @@ static void mw_StackType_2E_unify_21_ (void){
                     mw_prim_pack_cons();
                     mw_Maybe_2E_if_some();
                     break;
-            
-}            break;
+            }
+            break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_StackType_2E_unify_21_);
+    }
+    WORD_EXIT(mw_StackType_2E_unify_21_);
 }
-static void mw_StackType_2E_force_cons_3F__21_ (void){
+static void mw_StackType_2E_force_cons_3F__21_ (void) {
     WORD_ENTER(mw_StackType_2E_force_cons_3F__21_, "StackType.force-cons?!", "src/mirth/data/type.mth", 705, 5);
     WORD_ATOM(705, 5, "expand");
     mw_StackType_2E_expand();
     WORD_ATOM(705, 12, "match");
     switch (get_top_data_tag()) {
         case 5LL:
-            co_STCons();
+            mp_STCons();
             WORD_ATOM(706, 19, "pack2");
             mw_pack2();
             WORD_ATOM(706, 25, "SOME");
             mw_SOME();
             break;
         case 6LL:
-            co_STWith();
+            mp_STWith();
             WORD_ATOM(707, 19, "swap");
             mw_prim_swap();
             WORD_ATOM(707, 24, "force-cons?!");
@@ -31075,7 +31028,7 @@ static void mw_StackType_2E_force_cons_3F__21_ (void){
             mw_nip();
             break;
         case 4LL:
-            co_STMeta();
+            mp_STMeta();
             WORD_ATOM(709, 13, "dip");
             {
                 VAL d4 = pop_value();
@@ -31112,24 +31065,24 @@ static void mw_StackType_2E_force_cons_3F__21_ (void){
             WORD_ATOM(713, 19, "NONE");
             mw_NONE();
             break;
-    
-}    WORD_EXIT(mw_StackType_2E_force_cons_3F__21_);
+    }
+    WORD_EXIT(mw_StackType_2E_force_cons_3F__21_);
 }
-static void mw_StackType_2E_force_with_3F__21_ (void){
+static void mw_StackType_2E_force_with_3F__21_ (void) {
     WORD_ENTER(mw_StackType_2E_force_with_3F__21_, "StackType.force-with?!", "src/mirth/data/type.mth", 717, 5);
     WORD_ATOM(717, 5, "expand");
     mw_StackType_2E_expand();
     WORD_ATOM(717, 12, "match");
     switch (get_top_data_tag()) {
         case 6LL:
-            co_STWith();
+            mp_STWith();
             WORD_ATOM(718, 19, "pack2");
             mw_pack2();
             WORD_ATOM(718, 25, "SOME");
             mw_SOME();
             break;
         case 5LL:
-            co_STCons();
+            mp_STCons();
             WORD_ATOM(719, 19, "swap");
             mw_prim_swap();
             WORD_ATOM(719, 24, "force-with?!");
@@ -31143,7 +31096,7 @@ static void mw_StackType_2E_force_with_3F__21_ (void){
             mw_nip();
             break;
         case 4LL:
-            co_STMeta();
+            mp_STMeta();
             WORD_ATOM(721, 13, "dip");
             {
                 VAL d4 = pop_value();
@@ -31182,10 +31135,10 @@ static void mw_StackType_2E_force_with_3F__21_ (void){
             WORD_ATOM(725, 19, "NONE");
             mw_NONE();
             break;
-    
-}    WORD_EXIT(mw_StackType_2E_force_with_3F__21_);
+    }
+    WORD_EXIT(mw_StackType_2E_force_with_3F__21_);
 }
-static void mw_StackType_2E_trace_dom_21_ (void){
+static void mw_StackType_2E_trace_dom_21_ (void) {
     WORD_ENTER(mw_StackType_2E_trace_dom_21_, "StackType.trace-dom!", "src/mirth/data/type.mth", 729, 5);
     WORD_ATOM(729, 5, "expand");
     mw_StackType_2E_expand();
@@ -31216,7 +31169,7 @@ static void mw_StackType_2E_trace_dom_21_ (void){
     }
     WORD_EXIT(mw_StackType_2E_trace_dom_21_);
 }
-static void mw_StackType_2E_trace_cod_21_ (void){
+static void mw_StackType_2E_trace_cod_21_ (void) {
     WORD_ENTER(mw_StackType_2E_trace_cod_21_, "StackType.trace-cod!", "src/mirth/data/type.mth", 736, 5);
     WORD_ATOM(736, 5, "expand");
     mw_StackType_2E_expand();
@@ -31247,19 +31200,19 @@ static void mw_StackType_2E_trace_cod_21_ (void){
     }
     WORD_EXIT(mw_StackType_2E_trace_cod_21_);
 }
-static void mw_StackType_2E_trace_base_21_ (void){
+static void mw_StackType_2E_trace_base_21_ (void) {
     WORD_ENTER(mw_StackType_2E_trace_base_21_, "StackType.trace-base!", "src/mirth/data/type.mth", 743, 5);
     WORD_ATOM(743, 5, "match");
     switch (get_top_data_tag()) {
         case 2LL:
-            co_STACK_5F_TYPE_5F_UNIT();
+            mp_STACK_5F_TYPE_5F_UNIT();
             WORD_ATOM(744, 28, "id");
             mw_prim_id();
             WORD_ATOM(744, 31, "F");
             mw_F();
             break;
         case 4LL:
-            co_STMeta();
+            mp_STMeta();
             WORD_ATOM(745, 19, "");
             {
                 static bool vready = false;
@@ -31279,7 +31232,7 @@ static void mw_StackType_2E_trace_base_21_ (void){
             mw_T();
             break;
         case 3LL:
-            co_STVar();
+            mp_STVar();
             WORD_ATOM(746, 18, "dup");
             mw_prim_dup();
             WORD_ATOM(746, 22, "trace!");
@@ -31302,10 +31255,10 @@ static void mw_StackType_2E_trace_base_21_ (void){
             WORD_ATOM(747, 27, "T");
             mw_T();
             break;
-    
-}    WORD_EXIT(mw_StackType_2E_trace_base_21_);
+    }
+    WORD_EXIT(mw_StackType_2E_trace_base_21_);
 }
-static void mw_StackType_2E_trace_21_ (void){
+static void mw_StackType_2E_trace_21_ (void) {
     WORD_ENTER(mw_StackType_2E_trace_21_, "StackType.trace!", "src/mirth/data/type.mth", 751, 5);
     WORD_ATOM(751, 5, "split3");
     mw_StackType_2E_split3();
@@ -31333,19 +31286,19 @@ static void mw_StackType_2E_trace_21_ (void){
     mw_prim_drop();
     WORD_EXIT(mw_StackType_2E_trace_21_);
 }
-static void mw_StackType_2E_semifreshen (void){
+static void mw_StackType_2E_semifreshen (void) {
     WORD_ENTER(mw_StackType_2E_semifreshen, "StackType.semifreshen", "src/mirth/data/type.mth", 775, 5);
     WORD_ATOM(775, 5, "expand");
     mw_StackType_2E_expand();
     WORD_ATOM(775, 12, "match");
     switch (get_top_data_tag()) {
         case 2LL:
-            co_STACK_5F_TYPE_5F_UNIT();
+            mp_STACK_5F_TYPE_5F_UNIT();
             WORD_ATOM(776, 28, "dup");
             mw_prim_dup();
             break;
         case 5LL:
-            co_STCons();
+            mp_STCons();
             WORD_ATOM(777, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -31357,7 +31310,7 @@ static void mw_StackType_2E_semifreshen (void){
             mw_STCons();
             break;
         case 6LL:
-            co_STWith();
+            mp_STWith();
             WORD_ATOM(778, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -31383,22 +31336,22 @@ static void mw_StackType_2E_semifreshen (void){
             WORD_ATOM(779, 58, "panic!");
             mw_prim_panic();
             break;
-    
-}    WORD_EXIT(mw_StackType_2E_semifreshen);
+    }
+    WORD_EXIT(mw_StackType_2E_semifreshen);
 }
-static void mw_StackType_2E_freshen (void){
+static void mw_StackType_2E_freshen (void) {
     WORD_ENTER(mw_StackType_2E_freshen, "StackType.freshen", "src/mirth/data/type.mth", 783, 5);
     WORD_ATOM(783, 5, "expand");
     mw_StackType_2E_expand();
     WORD_ATOM(783, 12, "match");
     switch (get_top_data_tag()) {
         case 2LL:
-            co_STACK_5F_TYPE_5F_UNIT();
+            mp_STACK_5F_TYPE_5F_UNIT();
             WORD_ATOM(784, 28, "STACK_TYPE_UNIT");
             mw_STACK_5F_TYPE_5F_UNIT();
             break;
         case 5LL:
-            co_STCons();
+            mp_STCons();
             WORD_ATOM(785, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -31421,7 +31374,7 @@ static void mw_StackType_2E_freshen (void){
             mw_STCons();
             break;
         case 6LL:
-            co_STWith();
+            mp_STWith();
             WORD_ATOM(786, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -31451,22 +31404,22 @@ static void mw_StackType_2E_freshen (void){
             WORD_ATOM(787, 28, ">StackType");
             mw_Type_3E_StackType();
             break;
-    
-}    WORD_EXIT(mw_StackType_2E_freshen);
+    }
+    WORD_EXIT(mw_StackType_2E_freshen);
 }
-static void mw_StackType_2E_freshen_aux (void){
+static void mw_StackType_2E_freshen_aux (void) {
     WORD_ENTER(mw_StackType_2E_freshen_aux, "StackType.freshen-aux", "src/mirth/data/type.mth", 791, 5);
     WORD_ATOM(791, 5, "expand");
     mw_StackType_2E_expand();
     WORD_ATOM(791, 12, "match");
     switch (get_top_data_tag()) {
         case 2LL:
-            co_STACK_5F_TYPE_5F_UNIT();
+            mp_STACK_5F_TYPE_5F_UNIT();
             WORD_ATOM(792, 28, "over");
             mw_over();
             break;
         case 5LL:
-            co_STCons();
+            mp_STCons();
             WORD_ATOM(793, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -31489,7 +31442,7 @@ static void mw_StackType_2E_freshen_aux (void){
             mw_STCons();
             break;
         case 6LL:
-            co_STWith();
+            mp_STWith();
             WORD_ATOM(794, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -31519,15 +31472,15 @@ static void mw_StackType_2E_freshen_aux (void){
             WORD_ATOM(795, 28, ">StackType");
             mw_Type_3E_StackType();
             break;
-    
-}    WORD_EXIT(mw_StackType_2E_freshen_aux);
+    }
+    WORD_EXIT(mw_StackType_2E_freshen_aux);
 }
-static void mw_StackType_2E_num_morphisms_on_top (void){
+static void mw_StackType_2E_num_morphisms_on_top (void) {
     WORD_ENTER(mw_StackType_2E_num_morphisms_on_top, "StackType.num-morphisms-on-top", "src/mirth/data/type.mth", 808, 5);
     WORD_ATOM(808, 5, "STMeta");
     switch (get_top_data_tag()) {
         case 4LL:
-            co_STMeta();
+            mp_STMeta();
             WORD_ATOM(808, 15, "expand-if");
             push_u64(0);
             push_fnptr(&mb_StackType_2E_num_morphisms_on_top_2);
@@ -31538,7 +31491,7 @@ static void mw_StackType_2E_num_morphisms_on_top (void){
             mw_MetaVar_2E_expand_if();
             break;
         case 5LL:
-            co_STCons();
+            mp_STCons();
             WORD_ATOM(809, 15, "morphism?");
             mw_Type_2E_morphism_3F_();
             WORD_ATOM(809, 25, ".if");
@@ -31551,7 +31504,7 @@ static void mw_StackType_2E_num_morphisms_on_top (void){
             mw_Maybe_2E_if();
             break;
         case 6LL:
-            co_STWith();
+            mp_STWith();
             WORD_ATOM(810, 15, "drop");
             mw_prim_drop();
             WORD_ATOM(810, 20, "num-morphisms-on-top");
@@ -31563,29 +31516,29 @@ static void mw_StackType_2E_num_morphisms_on_top (void){
             WORD_ATOM(811, 15, "");
             push_i64(0LL);
             break;
-    
-}    WORD_EXIT(mw_StackType_2E_num_morphisms_on_top);
+    }
+    WORD_EXIT(mw_StackType_2E_num_morphisms_on_top);
 }
-static void mw_ArrowType_3E_Type (void){
+static void mw_ArrowType_3E_Type (void) {
     WORD_ENTER(mw_ArrowType_3E_Type, "ArrowType>Type", "src/mirth/data/type.mth", 818, 40);
     WORD_ATOM(818, 40, "TMorphism");
     mw_TMorphism();
     WORD_EXIT(mw_ArrowType_3E_Type);
 }
-static void mw_ArrowType_2E_unpack (void){
+static void mw_ArrowType_2E_unpack (void) {
     WORD_ENTER(mw_ArrowType_2E_unpack, "ArrowType.unpack", "src/mirth/data/type.mth", 820, 57);
     WORD_ATOM(820, 57, "ARROW_TYPE");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_ARROW_5F_TYPE();
+            mp_ARROW_5F_TYPE();
             WORD_ATOM(820, 71, "id");
             mw_prim_id();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_ArrowType_2E_unpack);
+    }
+    WORD_EXIT(mw_ArrowType_2E_unpack);
 }
-static void mw_ArrowType_2E_dom (void){
+static void mw_ArrowType_2E_dom (void) {
     WORD_ENTER(mw_ArrowType_2E_dom, "ArrowType.dom", "src/mirth/data/type.mth", 821, 44);
     WORD_ATOM(821, 44, "unpack");
     mw_ArrowType_2E_unpack();
@@ -31593,7 +31546,7 @@ static void mw_ArrowType_2E_dom (void){
     mw_prim_drop();
     WORD_EXIT(mw_ArrowType_2E_dom);
 }
-static void mw_ArrowType_2E_unify_21_ (void){
+static void mw_ArrowType_2E_unify_21_ (void) {
     WORD_ENTER(mw_ArrowType_2E_unify_21_, "ArrowType.unify!", "src/mirth/data/type.mth", 824, 5);
     WORD_ATOM(824, 5, "dip");
     {
@@ -31633,7 +31586,7 @@ static void mw_ArrowType_2E_unify_21_ (void){
     mw_ARROW_5F_TYPE();
     WORD_EXIT(mw_ArrowType_2E_unify_21_);
 }
-static void mw_ArrowType_2E_has_meta_3F_ (void){
+static void mw_ArrowType_2E_has_meta_3F_ (void) {
     WORD_ENTER(mw_ArrowType_2E_has_meta_3F_, "ArrowType.has-meta?", "src/mirth/data/type.mth", 829, 5);
     WORD_ATOM(829, 5, "unpack");
     mw_ArrowType_2E_unpack();
@@ -31658,7 +31611,7 @@ static void mw_ArrowType_2E_has_meta_3F_ (void){
     }
     WORD_EXIT(mw_ArrowType_2E_has_meta_3F_);
 }
-static void mw_ArrowType_2E_trace_21_ (void){
+static void mw_ArrowType_2E_trace_21_ (void) {
     WORD_ENTER(mw_ArrowType_2E_trace_21_, "ArrowType.trace!", "src/mirth/data/type.mth", 832, 5);
     WORD_ATOM(832, 5, "unpack");
     mw_ArrowType_2E_unpack();
@@ -31683,7 +31636,7 @@ static void mw_ArrowType_2E_trace_21_ (void){
     mw_StackType_2E_trace_cod_21_();
     WORD_EXIT(mw_ArrowType_2E_trace_21_);
 }
-static void mw_ArrowType_2E_semifreshen_sig (void){
+static void mw_ArrowType_2E_semifreshen_sig (void) {
     WORD_ENTER(mw_ArrowType_2E_semifreshen_sig, "ArrowType.semifreshen-sig", "src/mirth/data/type.mth", 839, 5);
     WORD_ATOM(839, 5, "dup");
     mw_prim_dup();
@@ -31696,7 +31649,7 @@ static void mw_ArrowType_2E_semifreshen_sig (void){
     mw_Bool_2E_then();
     WORD_EXIT(mw_ArrowType_2E_semifreshen_sig);
 }
-static void mw_ArrowType_2E_semifreshen_aux (void){
+static void mw_ArrowType_2E_semifreshen_aux (void) {
     WORD_ENTER(mw_ArrowType_2E_semifreshen_aux, "ArrowType.semifreshen-aux", "src/mirth/data/type.mth", 842, 5);
     WORD_ATOM(842, 5, "MetaVar.new!");
     mw_MetaVar_2E_new_21_();
@@ -31730,7 +31683,7 @@ static void mw_ArrowType_2E_semifreshen_aux (void){
     mw_nip();
     WORD_EXIT(mw_ArrowType_2E_semifreshen_aux);
 }
-static void mw_ArrowType_2E_needs_fresh_stack_rest_3F_ (void){
+static void mw_ArrowType_2E_needs_fresh_stack_rest_3F_ (void) {
     WORD_ENTER(mw_ArrowType_2E_needs_fresh_stack_rest_3F_, "ArrowType.needs-fresh-stack-rest?", "src/mirth/data/type.mth", 848, 5);
     WORD_ATOM(848, 5, "unpack");
     mw_ArrowType_2E_unpack();
@@ -31752,7 +31705,7 @@ static void mw_ArrowType_2E_needs_fresh_stack_rest_3F_ (void){
     }
     WORD_EXIT(mw_ArrowType_2E_needs_fresh_stack_rest_3F_);
 }
-static void mw_ArrowType_2E_freshen_sig (void){
+static void mw_ArrowType_2E_freshen_sig (void) {
     WORD_ENTER(mw_ArrowType_2E_freshen_sig, "ArrowType.freshen-sig", "src/mirth/data/type.mth", 854, 5);
     WORD_ATOM(854, 5, "dup");
     mw_prim_dup();
@@ -31768,7 +31721,7 @@ static void mw_ArrowType_2E_freshen_sig (void){
     }
     WORD_EXIT(mw_ArrowType_2E_freshen_sig);
 }
-static void mw_ArrowType_2E_freshen_sig_aux (void){
+static void mw_ArrowType_2E_freshen_sig_aux (void) {
     WORD_ENTER(mw_ArrowType_2E_freshen_sig_aux, "ArrowType.freshen-sig-aux", "src/mirth/data/type.mth", 860, 5);
     WORD_ATOM(860, 5, "MetaVar.new!");
     mw_MetaVar_2E_new_21_();
@@ -31807,7 +31760,7 @@ static void mw_ArrowType_2E_freshen_sig_aux (void){
     }
     WORD_EXIT(mw_ArrowType_2E_freshen_sig_aux);
 }
-static void mw_ArrowType_2E_freshen (void){
+static void mw_ArrowType_2E_freshen (void) {
     WORD_ENTER(mw_ArrowType_2E_freshen, "ArrowType.freshen", "src/mirth/data/type.mth", 866, 5);
     WORD_ATOM(866, 5, "unpack");
     mw_ArrowType_2E_unpack();
@@ -31833,7 +31786,7 @@ static void mw_ArrowType_2E_freshen (void){
     mw_ARROW_5F_TYPE();
     WORD_EXIT(mw_ArrowType_2E_freshen);
 }
-static void mw_ArrowType_2E_max_num_params (void){
+static void mw_ArrowType_2E_max_num_params (void) {
     WORD_ENTER(mw_ArrowType_2E_max_num_params, "ArrowType.max-num-params", "src/mirth/data/type.mth", 878, 5);
     WORD_ATOM(878, 5, "dom");
     mw_ArrowType_2E_dom();
@@ -31841,13 +31794,13 @@ static void mw_ArrowType_2E_max_num_params (void){
     mw_StackType_2E_num_morphisms_on_top();
     WORD_EXIT(mw_ArrowType_2E_max_num_params);
 }
-static void mw_Subst_2E_nil (void){
+static void mw_Subst_2E_nil (void) {
     WORD_ENTER(mw_Subst_2E_nil, "Subst.nil", "src/mirth/data/type.mth", 894, 23);
     WORD_ATOM(894, 23, "SUBST_NIL");
     mw_SUBST_5F_NIL();
     WORD_EXIT(mw_Subst_2E_nil);
 }
-static void mw_Subst_2E_cons (void){
+static void mw_Subst_2E_cons (void) {
     WORD_ENTER(mw_Subst_2E_cons, "Subst.cons", "src/mirth/data/type.mth", 895, 42);
     WORD_ATOM(895, 42, "rotr");
     mw_rotr();
@@ -31855,19 +31808,19 @@ static void mw_Subst_2E_cons (void){
     mw_SUBST_5F_CON();
     WORD_EXIT(mw_Subst_2E_cons);
 }
-static void mw_Subst_2E_has_var_3F_ (void){
+static void mw_Subst_2E_has_var_3F_ (void) {
     WORD_ENTER(mw_Subst_2E_has_var_3F_, "Subst.has-var?", "src/mirth/data/type.mth", 897, 5);
     WORD_ATOM(897, 5, "SUBST_NIL");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_SUBST_5F_NIL();
+            mp_SUBST_5F_NIL();
             WORD_ATOM(897, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(897, 23, "F");
             mw_F();
             break;
         case 1LL:
-            co_SUBST_5F_CON();
+            mp_SUBST_5F_CON();
             WORD_ATOM(898, 18, "nip");
             mw_nip();
             WORD_ATOM(898, 22, "over2");
@@ -31886,22 +31839,22 @@ static void mw_Subst_2E_has_var_3F_ (void){
             }
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Subst_2E_has_var_3F_);
+    }
+    WORD_EXIT(mw_Subst_2E_has_var_3F_);
 }
-static void mw_Subst_2E_get_var (void){
+static void mw_Subst_2E_get_var (void) {
     WORD_ENTER(mw_Subst_2E_get_var, "Subst.get-var", "src/mirth/data/type.mth", 900, 5);
     WORD_ATOM(900, 5, "SUBST_NIL");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_SUBST_5F_NIL();
+            mp_SUBST_5F_NIL();
             WORD_ATOM(900, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(900, 23, "TYPE_ERROR");
             mw_TYPE_5F_ERROR();
             break;
         case 1LL:
-            co_SUBST_5F_CON();
+            mp_SUBST_5F_CON();
             WORD_ATOM(901, 18, "over3");
             mw_over3();
             WORD_ATOM(901, 24, "=");
@@ -31923,10 +31876,10 @@ static void mw_Subst_2E_get_var (void){
             }
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Subst_2E_get_var);
+    }
+    WORD_EXIT(mw_Subst_2E_get_var);
 }
-static void mw_Prim_2E_name (void){
+static void mw_Prim_2E_name (void) {
     WORD_ENTER(mw_Prim_2E_name, "Prim.name", "src/mirth/data/prim.mth", 125, 30);
     WORD_ATOM(125, 30, "~name");
     mw_Prim_7E_name();
@@ -31934,7 +31887,7 @@ static void mw_Prim_2E_name (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Prim_2E_name);
 }
-static void mw_Prim_2E_type (void){
+static void mw_Prim_2E_type (void) {
     WORD_ENTER(mw_Prim_2E_type, "Prim.type", "src/mirth/data/prim.mth", 127, 35);
     WORD_ATOM(127, 35, "~type");
     mw_Prim_7E_type();
@@ -31942,7 +31895,7 @@ static void mw_Prim_2E_type (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Prim_2E_type);
 }
-static void mw_Prim_2E_decl (void){
+static void mw_Prim_2E_decl (void) {
     WORD_ENTER(mw_Prim_2E_decl, "Prim.decl", "src/mirth/data/prim.mth", 128, 49);
     WORD_ATOM(128, 49, "~decl");
     mw_Prim_7E_decl();
@@ -31950,7 +31903,7 @@ static void mw_Prim_2E_decl (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Prim_2E_decl);
 }
-static void mw_def_prim_21_ (void){
+static void mw_def_prim_21_ (void) {
     WORD_ENTER(mw_def_prim_21_, "def-prim!", "src/mirth/data/prim.mth", 135, 5);
     WORD_ATOM(135, 5, ">Name");
     mw_Str_3E_Name();
@@ -31975,7 +31928,7 @@ static void mw_def_prim_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_def_prim_21_);
 }
-static void mw_Prim_2E_ctx_type_21_ (void){
+static void mw_Prim_2E_ctx_type_21_ (void) {
     WORD_ENTER(mw_Prim_2E_ctx_type_21_, "Prim.ctx-type!", "src/mirth/data/prim.mth", 140, 5);
     WORD_ATOM(140, 5, "tuck");
     mw_tuck();
@@ -31989,7 +31942,7 @@ static void mw_Prim_2E_ctx_type_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_Prim_2E_ctx_type_21_);
 }
-static void mw_init_prims_21_ (void){
+static void mw_init_prims_21_ (void) {
     WORD_ENTER(mw_init_prims_21_, "init-prims!", "src/mirth/data/prim.mth", 145, 5);
     WORD_ATOM(145, 5, "PRIM_SYNTAX_MODULE");
     mw_PRIM_5F_SYNTAX_5F_MODULE();
@@ -35187,12 +35140,12 @@ static void mw_init_prims_21_ (void){
     }
     WORD_EXIT(mw_init_prims_21_);
 }
-static void mw_TokenValue_2E_none_3F_ (void){
+static void mw_TokenValue_2E_none_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_none_3F_, "TokenValue.none?", "src/mirth/data/token.mth", 32, 43);
     WORD_ATOM(32, 43, "TOKEN_NONE");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_TOKEN_5F_NONE();
+            mp_TOKEN_5F_NONE();
             WORD_ATOM(32, 57, "T");
             mw_T();
             break;
@@ -35202,15 +35155,15 @@ static void mw_TokenValue_2E_none_3F_ (void){
             WORD_ATOM(32, 70, "F");
             mw_F();
             break;
-    
-}    WORD_EXIT(mw_TokenValue_2E_none_3F_);
+    }
+    WORD_EXIT(mw_TokenValue_2E_none_3F_);
 }
-static void mw_TokenValue_2E_comma_3F_ (void){
+static void mw_TokenValue_2E_comma_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_comma_3F_, "TokenValue.comma?", "src/mirth/data/token.mth", 33, 44);
     WORD_ATOM(33, 44, "TOKEN_COMMA");
     switch (get_top_data_tag()) {
         case 1LL:
-            co_TOKEN_5F_COMMA();
+            mp_TOKEN_5F_COMMA();
             WORD_ATOM(33, 59, "T");
             mw_T();
             break;
@@ -35220,15 +35173,15 @@ static void mw_TokenValue_2E_comma_3F_ (void){
             WORD_ATOM(33, 72, "F");
             mw_F();
             break;
-    
-}    WORD_EXIT(mw_TokenValue_2E_comma_3F_);
+    }
+    WORD_EXIT(mw_TokenValue_2E_comma_3F_);
 }
-static void mw_TokenValue_2E_lparen_open_3F_ (void){
+static void mw_TokenValue_2E_lparen_open_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_lparen_open_3F_, "TokenValue.lparen-open?", "src/mirth/data/token.mth", 34, 50);
     WORD_ATOM(34, 50, "TOKEN_LPAREN_OPEN");
     switch (get_top_data_tag()) {
         case 2LL:
-            co_TOKEN_5F_LPAREN_5F_OPEN();
+            mp_TOKEN_5F_LPAREN_5F_OPEN();
             WORD_ATOM(34, 71, "T");
             mw_T();
             break;
@@ -35238,15 +35191,15 @@ static void mw_TokenValue_2E_lparen_open_3F_ (void){
             WORD_ATOM(34, 84, "F");
             mw_F();
             break;
-    
-}    WORD_EXIT(mw_TokenValue_2E_lparen_open_3F_);
+    }
+    WORD_EXIT(mw_TokenValue_2E_lparen_open_3F_);
 }
-static void mw_TokenValue_2E_lparen_3F_ (void){
+static void mw_TokenValue_2E_lparen_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_lparen_3F_, "TokenValue.lparen?", "src/mirth/data/token.mth", 35, 53);
     WORD_ATOM(35, 53, "TOKEN_LPAREN");
     switch (get_top_data_tag()) {
         case 3LL:
-            co_TOKEN_5F_LPAREN();
+            mp_TOKEN_5F_LPAREN();
             WORD_ATOM(35, 69, "SOME");
             mw_SOME();
             break;
@@ -35256,15 +35209,15 @@ static void mw_TokenValue_2E_lparen_3F_ (void){
             WORD_ATOM(35, 85, "NONE");
             mw_NONE();
             break;
-    
-}    WORD_EXIT(mw_TokenValue_2E_lparen_3F_);
+    }
+    WORD_EXIT(mw_TokenValue_2E_lparen_3F_);
 }
-static void mw_TokenValue_2E_rparen_3F_ (void){
+static void mw_TokenValue_2E_rparen_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_rparen_3F_, "TokenValue.rparen?", "src/mirth/data/token.mth", 36, 53);
     WORD_ATOM(36, 53, "TOKEN_RPAREN");
     switch (get_top_data_tag()) {
         case 4LL:
-            co_TOKEN_5F_RPAREN();
+            mp_TOKEN_5F_RPAREN();
             WORD_ATOM(36, 69, "SOME");
             mw_SOME();
             break;
@@ -35274,15 +35227,15 @@ static void mw_TokenValue_2E_rparen_3F_ (void){
             WORD_ATOM(36, 85, "NONE");
             mw_NONE();
             break;
-    
-}    WORD_EXIT(mw_TokenValue_2E_rparen_3F_);
+    }
+    WORD_EXIT(mw_TokenValue_2E_rparen_3F_);
 }
-static void mw_TokenValue_2E_lsquare_open_3F_ (void){
+static void mw_TokenValue_2E_lsquare_open_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_lsquare_open_3F_, "TokenValue.lsquare-open?", "src/mirth/data/token.mth", 37, 51);
     WORD_ATOM(37, 51, "TOKEN_LSQUARE_OPEN");
     switch (get_top_data_tag()) {
         case 5LL:
-            co_TOKEN_5F_LSQUARE_5F_OPEN();
+            mp_TOKEN_5F_LSQUARE_5F_OPEN();
             WORD_ATOM(37, 73, "T");
             mw_T();
             break;
@@ -35292,15 +35245,15 @@ static void mw_TokenValue_2E_lsquare_open_3F_ (void){
             WORD_ATOM(37, 86, "F");
             mw_F();
             break;
-    
-}    WORD_EXIT(mw_TokenValue_2E_lsquare_open_3F_);
+    }
+    WORD_EXIT(mw_TokenValue_2E_lsquare_open_3F_);
 }
-static void mw_TokenValue_2E_lsquare_3F_ (void){
+static void mw_TokenValue_2E_lsquare_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_lsquare_3F_, "TokenValue.lsquare?", "src/mirth/data/token.mth", 38, 54);
     WORD_ATOM(38, 54, "TOKEN_LSQUARE");
     switch (get_top_data_tag()) {
         case 6LL:
-            co_TOKEN_5F_LSQUARE();
+            mp_TOKEN_5F_LSQUARE();
             WORD_ATOM(38, 71, "SOME");
             mw_SOME();
             break;
@@ -35310,15 +35263,15 @@ static void mw_TokenValue_2E_lsquare_3F_ (void){
             WORD_ATOM(38, 87, "NONE");
             mw_NONE();
             break;
-    
-}    WORD_EXIT(mw_TokenValue_2E_lsquare_3F_);
+    }
+    WORD_EXIT(mw_TokenValue_2E_lsquare_3F_);
 }
-static void mw_TokenValue_2E_rsquare_3F_ (void){
+static void mw_TokenValue_2E_rsquare_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_rsquare_3F_, "TokenValue.rsquare?", "src/mirth/data/token.mth", 39, 54);
     WORD_ATOM(39, 54, "TOKEN_RSQUARE");
     switch (get_top_data_tag()) {
         case 7LL:
-            co_TOKEN_5F_RSQUARE();
+            mp_TOKEN_5F_RSQUARE();
             WORD_ATOM(39, 71, "SOME");
             mw_SOME();
             break;
@@ -35328,15 +35281,15 @@ static void mw_TokenValue_2E_rsquare_3F_ (void){
             WORD_ATOM(39, 87, "NONE");
             mw_NONE();
             break;
-    
-}    WORD_EXIT(mw_TokenValue_2E_rsquare_3F_);
+    }
+    WORD_EXIT(mw_TokenValue_2E_rsquare_3F_);
 }
-static void mw_TokenValue_2E_lcurly_open_3F_ (void){
+static void mw_TokenValue_2E_lcurly_open_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_lcurly_open_3F_, "TokenValue.lcurly-open?", "src/mirth/data/token.mth", 40, 50);
     WORD_ATOM(40, 50, "TOKEN_LCURLY_OPEN");
     switch (get_top_data_tag()) {
         case 8LL:
-            co_TOKEN_5F_LCURLY_5F_OPEN();
+            mp_TOKEN_5F_LCURLY_5F_OPEN();
             WORD_ATOM(40, 71, "T");
             mw_T();
             break;
@@ -35346,15 +35299,15 @@ static void mw_TokenValue_2E_lcurly_open_3F_ (void){
             WORD_ATOM(40, 84, "F");
             mw_F();
             break;
-    
-}    WORD_EXIT(mw_TokenValue_2E_lcurly_open_3F_);
+    }
+    WORD_EXIT(mw_TokenValue_2E_lcurly_open_3F_);
 }
-static void mw_TokenValue_2E_int_3F_ (void){
+static void mw_TokenValue_2E_int_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_int_3F_, "TokenValue.int?", "src/mirth/data/token.mth", 43, 48);
     WORD_ATOM(43, 48, "TOKEN_INT");
     switch (get_top_data_tag()) {
         case 11LL:
-            co_TOKEN_5F_INT();
+            mp_TOKEN_5F_INT();
             WORD_ATOM(43, 61, "SOME");
             mw_SOME();
             break;
@@ -35364,15 +35317,15 @@ static void mw_TokenValue_2E_int_3F_ (void){
             WORD_ATOM(43, 77, "NONE");
             mw_NONE();
             break;
-    
-}    WORD_EXIT(mw_TokenValue_2E_int_3F_);
+    }
+    WORD_EXIT(mw_TokenValue_2E_int_3F_);
 }
-static void mw_TokenValue_2E_str_3F_ (void){
+static void mw_TokenValue_2E_str_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_str_3F_, "TokenValue.str?", "src/mirth/data/token.mth", 44, 48);
     WORD_ATOM(44, 48, "TOKEN_STR");
     switch (get_top_data_tag()) {
         case 12LL:
-            co_TOKEN_5F_STR();
+            mp_TOKEN_5F_STR();
             WORD_ATOM(44, 61, "SOME");
             mw_SOME();
             break;
@@ -35382,15 +35335,15 @@ static void mw_TokenValue_2E_str_3F_ (void){
             WORD_ATOM(44, 77, "NONE");
             mw_NONE();
             break;
-    
-}    WORD_EXIT(mw_TokenValue_2E_str_3F_);
+    }
+    WORD_EXIT(mw_TokenValue_2E_str_3F_);
 }
-static void mw_TokenValue_2E_name_3F_ (void){
+static void mw_TokenValue_2E_name_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_name_3F_, "TokenValue.name?", "src/mirth/data/token.mth", 45, 50);
     WORD_ATOM(45, 50, "TOKEN_NAME");
     switch (get_top_data_tag()) {
         case 13LL:
-            co_TOKEN_5F_NAME();
+            mp_TOKEN_5F_NAME();
             WORD_ATOM(45, 64, "SOME");
             mw_SOME();
             break;
@@ -35400,34 +35353,34 @@ static void mw_TokenValue_2E_name_3F_ (void){
             WORD_ATOM(45, 80, "NONE");
             mw_NONE();
             break;
-    
-}    WORD_EXIT(mw_TokenValue_2E_name_3F_);
+    }
+    WORD_EXIT(mw_TokenValue_2E_name_3F_);
 }
-static void mw_TokenValue_2E_arg_end_3F_ (void){
+static void mw_TokenValue_2E_arg_end_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_arg_end_3F_, "TokenValue.arg-end?", "src/mirth/data/token.mth", 47, 5);
     WORD_ATOM(47, 5, "TOKEN_COMMA");
     switch (get_top_data_tag()) {
         case 1LL:
-            co_TOKEN_5F_COMMA();
+            mp_TOKEN_5F_COMMA();
             WORD_ATOM(47, 20, "T");
             mw_T();
             break;
         case 4LL:
-            co_TOKEN_5F_RPAREN();
+            mp_TOKEN_5F_RPAREN();
             WORD_ATOM(48, 21, "drop");
             mw_prim_drop();
             WORD_ATOM(48, 26, "T");
             mw_T();
             break;
         case 10LL:
-            co_TOKEN_5F_RCURLY();
+            mp_TOKEN_5F_RCURLY();
             WORD_ATOM(49, 21, "drop");
             mw_prim_drop();
             WORD_ATOM(49, 26, "T");
             mw_T();
             break;
         case 7LL:
-            co_TOKEN_5F_RSQUARE();
+            mp_TOKEN_5F_RSQUARE();
             WORD_ATOM(50, 22, "drop");
             mw_prim_drop();
             WORD_ATOM(50, 27, "T");
@@ -35439,29 +35392,29 @@ static void mw_TokenValue_2E_arg_end_3F_ (void){
             WORD_ATOM(51, 15, "F");
             mw_F();
             break;
-    
-}    WORD_EXIT(mw_TokenValue_2E_arg_end_3F_);
+    }
+    WORD_EXIT(mw_TokenValue_2E_arg_end_3F_);
 }
-static void mw_TokenValue_2E_left_enclosure_3F_ (void){
+static void mw_TokenValue_2E_left_enclosure_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_left_enclosure_3F_, "TokenValue.left-enclosure?", "src/mirth/data/token.mth", 53, 5);
     WORD_ATOM(53, 5, "TOKEN_LPAREN");
     switch (get_top_data_tag()) {
         case 3LL:
-            co_TOKEN_5F_LPAREN();
+            mp_TOKEN_5F_LPAREN();
             WORD_ATOM(53, 21, "drop");
             mw_prim_drop();
             WORD_ATOM(53, 26, "T");
             mw_T();
             break;
         case 6LL:
-            co_TOKEN_5F_LSQUARE();
+            mp_TOKEN_5F_LSQUARE();
             WORD_ATOM(54, 22, "drop");
             mw_prim_drop();
             WORD_ATOM(54, 27, "T");
             mw_T();
             break;
         case 9LL:
-            co_TOKEN_5F_LCURLY();
+            mp_TOKEN_5F_LCURLY();
             WORD_ATOM(55, 22, "drop");
             mw_prim_drop();
             WORD_ATOM(55, 27, "T");
@@ -35473,29 +35426,29 @@ static void mw_TokenValue_2E_left_enclosure_3F_ (void){
             WORD_ATOM(56, 15, "F");
             mw_F();
             break;
-    
-}    WORD_EXIT(mw_TokenValue_2E_left_enclosure_3F_);
+    }
+    WORD_EXIT(mw_TokenValue_2E_left_enclosure_3F_);
 }
-static void mw_TokenValue_2E_right_enclosure_3F_ (void){
+static void mw_TokenValue_2E_right_enclosure_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_right_enclosure_3F_, "TokenValue.right-enclosure?", "src/mirth/data/token.mth", 58, 5);
     WORD_ATOM(58, 5, "TOKEN_RPAREN");
     switch (get_top_data_tag()) {
         case 4LL:
-            co_TOKEN_5F_RPAREN();
+            mp_TOKEN_5F_RPAREN();
             WORD_ATOM(58, 21, "drop");
             mw_prim_drop();
             WORD_ATOM(58, 26, "T");
             mw_T();
             break;
         case 7LL:
-            co_TOKEN_5F_RSQUARE();
+            mp_TOKEN_5F_RSQUARE();
             WORD_ATOM(59, 22, "drop");
             mw_prim_drop();
             WORD_ATOM(59, 27, "T");
             mw_T();
             break;
         case 10LL:
-            co_TOKEN_5F_RCURLY();
+            mp_TOKEN_5F_RCURLY();
             WORD_ATOM(60, 22, "drop");
             mw_prim_drop();
             WORD_ATOM(60, 27, "T");
@@ -35507,10 +35460,10 @@ static void mw_TokenValue_2E_right_enclosure_3F_ (void){
             WORD_ATOM(61, 15, "F");
             mw_F();
             break;
-    
-}    WORD_EXIT(mw_TokenValue_2E_right_enclosure_3F_);
+    }
+    WORD_EXIT(mw_TokenValue_2E_right_enclosure_3F_);
 }
-static void mw_TokenValue_2E_sig_type_3F_ (void){
+static void mw_TokenValue_2E_sig_type_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_sig_type_3F_, "TokenValue.sig-type?", "src/mirth/data/token.mth", 63, 47);
     WORD_ATOM(63, 47, "name?");
     mw_TokenValue_2E_name_3F_();
@@ -35521,7 +35474,7 @@ static void mw_TokenValue_2E_sig_type_3F_ (void){
     mw_Maybe_2E_and_some();
     WORD_EXIT(mw_TokenValue_2E_sig_type_3F_);
 }
-static void mw_TokenValue_2E_sig_type_con_3F_ (void){
+static void mw_TokenValue_2E_sig_type_con_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_sig_type_con_3F_, "TokenValue.sig-type-con?", "src/mirth/data/token.mth", 64, 51);
     WORD_ATOM(64, 51, "name?");
     mw_TokenValue_2E_name_3F_();
@@ -35532,7 +35485,7 @@ static void mw_TokenValue_2E_sig_type_con_3F_ (void){
     mw_Maybe_2E_and_some();
     WORD_EXIT(mw_TokenValue_2E_sig_type_con_3F_);
 }
-static void mw_TokenValue_2E_sig_type_hole_3F_ (void){
+static void mw_TokenValue_2E_sig_type_hole_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_sig_type_hole_3F_, "TokenValue.sig-type-hole?", "src/mirth/data/token.mth", 65, 52);
     WORD_ATOM(65, 52, "name?");
     mw_TokenValue_2E_name_3F_();
@@ -35543,7 +35496,7 @@ static void mw_TokenValue_2E_sig_type_hole_3F_ (void){
     mw_Maybe_2E_and_some();
     WORD_EXIT(mw_TokenValue_2E_sig_type_hole_3F_);
 }
-static void mw_TokenValue_2E_sig_type_var_3F_ (void){
+static void mw_TokenValue_2E_sig_type_var_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_sig_type_var_3F_, "TokenValue.sig-type-var?", "src/mirth/data/token.mth", 66, 51);
     WORD_ATOM(66, 51, "name?");
     mw_TokenValue_2E_name_3F_();
@@ -35554,13 +35507,13 @@ static void mw_TokenValue_2E_sig_type_var_3F_ (void){
     mw_Maybe_2E_and_some();
     WORD_EXIT(mw_TokenValue_2E_sig_type_var_3F_);
 }
-static void mw_TokenValue_2E_sig_param_name_3F_ (void){
+static void mw_TokenValue_2E_sig_param_name_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_sig_param_name_3F_, "TokenValue.sig-param-name?", "src/mirth/data/token.mth", 67, 53);
     WORD_ATOM(67, 53, "sig-type-var?");
     mw_TokenValue_2E_sig_type_var_3F_();
     WORD_EXIT(mw_TokenValue_2E_sig_param_name_3F_);
 }
-static void mw_TokenValue_2E_sig_stack_var_3F_ (void){
+static void mw_TokenValue_2E_sig_stack_var_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_sig_stack_var_3F_, "TokenValue.sig-stack-var?", "src/mirth/data/token.mth", 68, 52);
     WORD_ATOM(68, 52, "name?");
     mw_TokenValue_2E_name_3F_();
@@ -35571,7 +35524,7 @@ static void mw_TokenValue_2E_sig_stack_var_3F_ (void){
     mw_Maybe_2E_and_some();
     WORD_EXIT(mw_TokenValue_2E_sig_stack_var_3F_);
 }
-static void mw_TokenValue_2E_sig_resource_var_3F_ (void){
+static void mw_TokenValue_2E_sig_resource_var_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_sig_resource_var_3F_, "TokenValue.sig-resource-var?", "src/mirth/data/token.mth", 69, 55);
     WORD_ATOM(69, 55, "name?");
     mw_TokenValue_2E_name_3F_();
@@ -35582,7 +35535,7 @@ static void mw_TokenValue_2E_sig_resource_var_3F_ (void){
     mw_Maybe_2E_and_some();
     WORD_EXIT(mw_TokenValue_2E_sig_resource_var_3F_);
 }
-static void mw_TokenValue_2E_sig_resource_con_3F_ (void){
+static void mw_TokenValue_2E_sig_resource_con_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_sig_resource_con_3F_, "TokenValue.sig-resource-con?", "src/mirth/data/token.mth", 70, 55);
     WORD_ATOM(70, 55, "name?");
     mw_TokenValue_2E_name_3F_();
@@ -35593,7 +35546,7 @@ static void mw_TokenValue_2E_sig_resource_con_3F_ (void){
     mw_Maybe_2E_and_some();
     WORD_EXIT(mw_TokenValue_2E_sig_resource_con_3F_);
 }
-static void mw_TokenValue_2E_sig_dashes_3F_ (void){
+static void mw_TokenValue_2E_sig_dashes_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_sig_dashes_3F_, "TokenValue.sig-dashes?", "src/mirth/data/token.mth", 71, 49);
     WORD_ATOM(71, 49, "name?");
     mw_TokenValue_2E_name_3F_();
@@ -35604,7 +35557,7 @@ static void mw_TokenValue_2E_sig_dashes_3F_ (void){
     mw_Maybe_2E_and_some();
     WORD_EXIT(mw_TokenValue_2E_sig_dashes_3F_);
 }
-static void mw_TokenValue_2E_pat_arrow_3F_ (void){
+static void mw_TokenValue_2E_pat_arrow_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_pat_arrow_3F_, "TokenValue.pat-arrow?", "src/mirth/data/token.mth", 72, 48);
     WORD_ATOM(72, 48, "name?");
     mw_TokenValue_2E_name_3F_();
@@ -35615,7 +35568,7 @@ static void mw_TokenValue_2E_pat_arrow_3F_ (void){
     mw_Maybe_2E_and_some();
     WORD_EXIT(mw_TokenValue_2E_pat_arrow_3F_);
 }
-static void mw_TokenValue_2E_pat_underscore_3F_ (void){
+static void mw_TokenValue_2E_pat_underscore_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_pat_underscore_3F_, "TokenValue.pat-underscore?", "src/mirth/data/token.mth", 73, 53);
     WORD_ATOM(73, 53, "name?");
     mw_TokenValue_2E_name_3F_();
@@ -35626,7 +35579,7 @@ static void mw_TokenValue_2E_pat_underscore_3F_ (void){
     mw_Maybe_2E_and_some();
     WORD_EXIT(mw_TokenValue_2E_pat_underscore_3F_);
 }
-static void mw_TokenValue_2E_module_header_3F_ (void){
+static void mw_TokenValue_2E_module_header_3F_ (void) {
     WORD_ENTER(mw_TokenValue_2E_module_header_3F_, "TokenValue.module-header?", "src/mirth/data/token.mth", 74, 52);
     WORD_ATOM(74, 52, "name?");
     mw_TokenValue_2E_name_3F_();
@@ -35637,7 +35590,7 @@ static void mw_TokenValue_2E_module_header_3F_ (void){
     mw_Maybe_2E_and_some();
     WORD_EXIT(mw_TokenValue_2E_module_header_3F_);
 }
-static void mw_Token_2E_succ (void){
+static void mw_Token_2E_succ (void) {
     WORD_ENTER(mw_Token_2E_succ, "Token.succ", "src/mirth/data/token.mth", 76, 7);
     WORD_ATOM(76, 7, "Token");
     mw_prim_unsafe_cast();
@@ -35661,7 +35614,7 @@ static void mw_Token_2E_succ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Token_2E_succ);
 }
-static void mw_Token_2E_pred (void){
+static void mw_Token_2E_pred (void) {
     WORD_ENTER(mw_Token_2E_pred, "Token.pred", "src/mirth/data/token.mth", 76, 7);
     WORD_ATOM(76, 7, "Token");
     mw_prim_unsafe_cast();
@@ -35683,7 +35636,7 @@ static void mw_Token_2E_pred (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Token_2E_pred);
 }
-static void mw_Token_2E_alloc_21_ (void){
+static void mw_Token_2E_alloc_21_ (void) {
     WORD_ENTER(mw_Token_2E_alloc_21_, "Token.alloc!", "src/mirth/data/token.mth", 76, 7);
     WORD_ATOM(76, 7, "Token");
     mw_Token_2E_NUM();
@@ -35707,7 +35660,7 @@ static void mw_Token_2E_alloc_21_ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Token_2E_alloc_21_);
 }
-static void mw_Token_2E_value (void){
+static void mw_Token_2E_value (void) {
     WORD_ENTER(mw_Token_2E_value, "Token.value", "src/mirth/data/token.mth", 82, 39);
     WORD_ATOM(82, 39, "~value");
     mw_Token_7E_value();
@@ -35715,7 +35668,7 @@ static void mw_Token_2E_value (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Token_2E_value);
 }
-static void mw_Token_2E_module (void){
+static void mw_Token_2E_module (void) {
     WORD_ENTER(mw_Token_2E_module, "Token.module", "src/mirth/data/token.mth", 83, 36);
     WORD_ATOM(83, 36, "~module");
     mw_Token_7E_module();
@@ -35723,7 +35676,7 @@ static void mw_Token_2E_module (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Token_2E_module);
 }
-static void mw_Token_2E_col (void){
+static void mw_Token_2E_col (void) {
     WORD_ENTER(mw_Token_2E_col, "Token.col", "src/mirth/data/token.mth", 84, 30);
     WORD_ATOM(84, 30, "~col");
     mw_Token_7E_col();
@@ -35731,7 +35684,7 @@ static void mw_Token_2E_col (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Token_2E_col);
 }
-static void mw_Token_2E_row (void){
+static void mw_Token_2E_row (void) {
     WORD_ENTER(mw_Token_2E_row, "Token.row", "src/mirth/data/token.mth", 85, 30);
     WORD_ATOM(85, 30, "~row");
     mw_Token_7E_row();
@@ -35739,7 +35692,7 @@ static void mw_Token_2E_row (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Token_2E_row);
 }
-static void mw_Token_2E_none_3F_ (void){
+static void mw_Token_2E_none_3F_ (void) {
     WORD_ENTER(mw_Token_2E_none_3F_, "Token.none?", "src/mirth/data/token.mth", 87, 33);
     WORD_ATOM(87, 33, "value");
     mw_Token_2E_value();
@@ -35747,7 +35700,7 @@ static void mw_Token_2E_none_3F_ (void){
     mw_TokenValue_2E_none_3F_();
     WORD_EXIT(mw_Token_2E_none_3F_);
 }
-static void mw_Token_2E_comma_3F_ (void){
+static void mw_Token_2E_comma_3F_ (void) {
     WORD_ENTER(mw_Token_2E_comma_3F_, "Token.comma?", "src/mirth/data/token.mth", 88, 34);
     WORD_ATOM(88, 34, "value");
     mw_Token_2E_value();
@@ -35755,7 +35708,7 @@ static void mw_Token_2E_comma_3F_ (void){
     mw_TokenValue_2E_comma_3F_();
     WORD_EXIT(mw_Token_2E_comma_3F_);
 }
-static void mw_Token_2E_lparen_open_3F_ (void){
+static void mw_Token_2E_lparen_open_3F_ (void) {
     WORD_ENTER(mw_Token_2E_lparen_open_3F_, "Token.lparen-open?", "src/mirth/data/token.mth", 89, 40);
     WORD_ATOM(89, 40, "value");
     mw_Token_2E_value();
@@ -35763,7 +35716,7 @@ static void mw_Token_2E_lparen_open_3F_ (void){
     mw_TokenValue_2E_lparen_open_3F_();
     WORD_EXIT(mw_Token_2E_lparen_open_3F_);
 }
-static void mw_Token_2E_lparen_3F_ (void){
+static void mw_Token_2E_lparen_3F_ (void) {
     WORD_ENTER(mw_Token_2E_lparen_3F_, "Token.lparen?", "src/mirth/data/token.mth", 90, 43);
     WORD_ATOM(90, 43, "value");
     mw_Token_2E_value();
@@ -35771,7 +35724,7 @@ static void mw_Token_2E_lparen_3F_ (void){
     mw_TokenValue_2E_lparen_3F_();
     WORD_EXIT(mw_Token_2E_lparen_3F_);
 }
-static void mw_Token_2E_rparen_3F_ (void){
+static void mw_Token_2E_rparen_3F_ (void) {
     WORD_ENTER(mw_Token_2E_rparen_3F_, "Token.rparen?", "src/mirth/data/token.mth", 91, 43);
     WORD_ATOM(91, 43, "value");
     mw_Token_2E_value();
@@ -35779,7 +35732,7 @@ static void mw_Token_2E_rparen_3F_ (void){
     mw_TokenValue_2E_rparen_3F_();
     WORD_EXIT(mw_Token_2E_rparen_3F_);
 }
-static void mw_Token_2E_lsquare_open_3F_ (void){
+static void mw_Token_2E_lsquare_open_3F_ (void) {
     WORD_ENTER(mw_Token_2E_lsquare_open_3F_, "Token.lsquare-open?", "src/mirth/data/token.mth", 92, 41);
     WORD_ATOM(92, 41, "value");
     mw_Token_2E_value();
@@ -35787,7 +35740,7 @@ static void mw_Token_2E_lsquare_open_3F_ (void){
     mw_TokenValue_2E_lsquare_open_3F_();
     WORD_EXIT(mw_Token_2E_lsquare_open_3F_);
 }
-static void mw_Token_2E_lsquare_3F_ (void){
+static void mw_Token_2E_lsquare_3F_ (void) {
     WORD_ENTER(mw_Token_2E_lsquare_3F_, "Token.lsquare?", "src/mirth/data/token.mth", 93, 44);
     WORD_ATOM(93, 44, "value");
     mw_Token_2E_value();
@@ -35795,7 +35748,7 @@ static void mw_Token_2E_lsquare_3F_ (void){
     mw_TokenValue_2E_lsquare_3F_();
     WORD_EXIT(mw_Token_2E_lsquare_3F_);
 }
-static void mw_Token_2E_rsquare_3F_ (void){
+static void mw_Token_2E_rsquare_3F_ (void) {
     WORD_ENTER(mw_Token_2E_rsquare_3F_, "Token.rsquare?", "src/mirth/data/token.mth", 94, 44);
     WORD_ATOM(94, 44, "value");
     mw_Token_2E_value();
@@ -35803,7 +35756,7 @@ static void mw_Token_2E_rsquare_3F_ (void){
     mw_TokenValue_2E_rsquare_3F_();
     WORD_EXIT(mw_Token_2E_rsquare_3F_);
 }
-static void mw_Token_2E_lcurly_open_3F_ (void){
+static void mw_Token_2E_lcurly_open_3F_ (void) {
     WORD_ENTER(mw_Token_2E_lcurly_open_3F_, "Token.lcurly-open?", "src/mirth/data/token.mth", 95, 40);
     WORD_ATOM(95, 40, "value");
     mw_Token_2E_value();
@@ -35811,7 +35764,7 @@ static void mw_Token_2E_lcurly_open_3F_ (void){
     mw_TokenValue_2E_lcurly_open_3F_();
     WORD_EXIT(mw_Token_2E_lcurly_open_3F_);
 }
-static void mw_Token_2E_int_3F_ (void){
+static void mw_Token_2E_int_3F_ (void) {
     WORD_ENTER(mw_Token_2E_int_3F_, "Token.int?", "src/mirth/data/token.mth", 98, 38);
     WORD_ATOM(98, 38, "value");
     mw_Token_2E_value();
@@ -35819,7 +35772,7 @@ static void mw_Token_2E_int_3F_ (void){
     mw_TokenValue_2E_int_3F_();
     WORD_EXIT(mw_Token_2E_int_3F_);
 }
-static void mw_Token_2E_str_3F_ (void){
+static void mw_Token_2E_str_3F_ (void) {
     WORD_ENTER(mw_Token_2E_str_3F_, "Token.str?", "src/mirth/data/token.mth", 99, 38);
     WORD_ATOM(99, 38, "value");
     mw_Token_2E_value();
@@ -35827,7 +35780,7 @@ static void mw_Token_2E_str_3F_ (void){
     mw_TokenValue_2E_str_3F_();
     WORD_EXIT(mw_Token_2E_str_3F_);
 }
-static void mw_Token_2E_name_3F_ (void){
+static void mw_Token_2E_name_3F_ (void) {
     WORD_ENTER(mw_Token_2E_name_3F_, "Token.name?", "src/mirth/data/token.mth", 100, 40);
     WORD_ATOM(100, 40, "value");
     mw_Token_2E_value();
@@ -35835,7 +35788,7 @@ static void mw_Token_2E_name_3F_ (void){
     mw_TokenValue_2E_name_3F_();
     WORD_EXIT(mw_Token_2E_name_3F_);
 }
-static void mw_Token_2E_arg_end_3F_ (void){
+static void mw_Token_2E_arg_end_3F_ (void) {
     WORD_ENTER(mw_Token_2E_arg_end_3F_, "Token.arg-end?", "src/mirth/data/token.mth", 101, 36);
     WORD_ATOM(101, 36, "value");
     mw_Token_2E_value();
@@ -35843,7 +35796,7 @@ static void mw_Token_2E_arg_end_3F_ (void){
     mw_TokenValue_2E_arg_end_3F_();
     WORD_EXIT(mw_Token_2E_arg_end_3F_);
 }
-static void mw_Token_2E_left_enclosure_3F_ (void){
+static void mw_Token_2E_left_enclosure_3F_ (void) {
     WORD_ENTER(mw_Token_2E_left_enclosure_3F_, "Token.left-enclosure?", "src/mirth/data/token.mth", 102, 43);
     WORD_ATOM(102, 43, "value");
     mw_Token_2E_value();
@@ -35851,7 +35804,7 @@ static void mw_Token_2E_left_enclosure_3F_ (void){
     mw_TokenValue_2E_left_enclosure_3F_();
     WORD_EXIT(mw_Token_2E_left_enclosure_3F_);
 }
-static void mw_Token_2E_right_enclosure_3F_ (void){
+static void mw_Token_2E_right_enclosure_3F_ (void) {
     WORD_ENTER(mw_Token_2E_right_enclosure_3F_, "Token.right-enclosure?", "src/mirth/data/token.mth", 103, 44);
     WORD_ATOM(103, 44, "value");
     mw_Token_2E_value();
@@ -35859,7 +35812,7 @@ static void mw_Token_2E_right_enclosure_3F_ (void){
     mw_TokenValue_2E_right_enclosure_3F_();
     WORD_EXIT(mw_Token_2E_right_enclosure_3F_);
 }
-static void mw_Token_2E_sig_type_3F_ (void){
+static void mw_Token_2E_sig_type_3F_ (void) {
     WORD_ENTER(mw_Token_2E_sig_type_3F_, "Token.sig-type?", "src/mirth/data/token.mth", 104, 37);
     WORD_ATOM(104, 37, "value");
     mw_Token_2E_value();
@@ -35867,7 +35820,7 @@ static void mw_Token_2E_sig_type_3F_ (void){
     mw_TokenValue_2E_sig_type_3F_();
     WORD_EXIT(mw_Token_2E_sig_type_3F_);
 }
-static void mw_Token_2E_sig_type_con_3F_ (void){
+static void mw_Token_2E_sig_type_con_3F_ (void) {
     WORD_ENTER(mw_Token_2E_sig_type_con_3F_, "Token.sig-type-con?", "src/mirth/data/token.mth", 105, 41);
     WORD_ATOM(105, 41, "value");
     mw_Token_2E_value();
@@ -35875,7 +35828,7 @@ static void mw_Token_2E_sig_type_con_3F_ (void){
     mw_TokenValue_2E_sig_type_con_3F_();
     WORD_EXIT(mw_Token_2E_sig_type_con_3F_);
 }
-static void mw_Token_2E_sig_type_hole_3F_ (void){
+static void mw_Token_2E_sig_type_hole_3F_ (void) {
     WORD_ENTER(mw_Token_2E_sig_type_hole_3F_, "Token.sig-type-hole?", "src/mirth/data/token.mth", 106, 42);
     WORD_ATOM(106, 42, "value");
     mw_Token_2E_value();
@@ -35883,7 +35836,7 @@ static void mw_Token_2E_sig_type_hole_3F_ (void){
     mw_TokenValue_2E_sig_type_hole_3F_();
     WORD_EXIT(mw_Token_2E_sig_type_hole_3F_);
 }
-static void mw_Token_2E_sig_type_var_3F_ (void){
+static void mw_Token_2E_sig_type_var_3F_ (void) {
     WORD_ENTER(mw_Token_2E_sig_type_var_3F_, "Token.sig-type-var?", "src/mirth/data/token.mth", 107, 41);
     WORD_ATOM(107, 41, "value");
     mw_Token_2E_value();
@@ -35891,7 +35844,7 @@ static void mw_Token_2E_sig_type_var_3F_ (void){
     mw_TokenValue_2E_sig_type_var_3F_();
     WORD_EXIT(mw_Token_2E_sig_type_var_3F_);
 }
-static void mw_Token_2E_sig_param_name_3F_ (void){
+static void mw_Token_2E_sig_param_name_3F_ (void) {
     WORD_ENTER(mw_Token_2E_sig_param_name_3F_, "Token.sig-param-name?", "src/mirth/data/token.mth", 108, 43);
     WORD_ATOM(108, 43, "value");
     mw_Token_2E_value();
@@ -35899,7 +35852,7 @@ static void mw_Token_2E_sig_param_name_3F_ (void){
     mw_TokenValue_2E_sig_param_name_3F_();
     WORD_EXIT(mw_Token_2E_sig_param_name_3F_);
 }
-static void mw_Token_2E_sig_stack_var_3F_ (void){
+static void mw_Token_2E_sig_stack_var_3F_ (void) {
     WORD_ENTER(mw_Token_2E_sig_stack_var_3F_, "Token.sig-stack-var?", "src/mirth/data/token.mth", 109, 42);
     WORD_ATOM(109, 42, "value");
     mw_Token_2E_value();
@@ -35907,7 +35860,7 @@ static void mw_Token_2E_sig_stack_var_3F_ (void){
     mw_TokenValue_2E_sig_stack_var_3F_();
     WORD_EXIT(mw_Token_2E_sig_stack_var_3F_);
 }
-static void mw_Token_2E_sig_resource_var_3F_ (void){
+static void mw_Token_2E_sig_resource_var_3F_ (void) {
     WORD_ENTER(mw_Token_2E_sig_resource_var_3F_, "Token.sig-resource-var?", "src/mirth/data/token.mth", 110, 45);
     WORD_ATOM(110, 45, "value");
     mw_Token_2E_value();
@@ -35915,7 +35868,7 @@ static void mw_Token_2E_sig_resource_var_3F_ (void){
     mw_TokenValue_2E_sig_resource_var_3F_();
     WORD_EXIT(mw_Token_2E_sig_resource_var_3F_);
 }
-static void mw_Token_2E_sig_resource_con_3F_ (void){
+static void mw_Token_2E_sig_resource_con_3F_ (void) {
     WORD_ENTER(mw_Token_2E_sig_resource_con_3F_, "Token.sig-resource-con?", "src/mirth/data/token.mth", 111, 45);
     WORD_ATOM(111, 45, "value");
     mw_Token_2E_value();
@@ -35923,7 +35876,7 @@ static void mw_Token_2E_sig_resource_con_3F_ (void){
     mw_TokenValue_2E_sig_resource_con_3F_();
     WORD_EXIT(mw_Token_2E_sig_resource_con_3F_);
 }
-static void mw_Token_2E_sig_dashes_3F_ (void){
+static void mw_Token_2E_sig_dashes_3F_ (void) {
     WORD_ENTER(mw_Token_2E_sig_dashes_3F_, "Token.sig-dashes?", "src/mirth/data/token.mth", 112, 39);
     WORD_ATOM(112, 39, "value");
     mw_Token_2E_value();
@@ -35931,7 +35884,7 @@ static void mw_Token_2E_sig_dashes_3F_ (void){
     mw_TokenValue_2E_sig_dashes_3F_();
     WORD_EXIT(mw_Token_2E_sig_dashes_3F_);
 }
-static void mw_Token_2E_pat_arrow_3F_ (void){
+static void mw_Token_2E_pat_arrow_3F_ (void) {
     WORD_ENTER(mw_Token_2E_pat_arrow_3F_, "Token.pat-arrow?", "src/mirth/data/token.mth", 113, 38);
     WORD_ATOM(113, 38, "value");
     mw_Token_2E_value();
@@ -35939,7 +35892,7 @@ static void mw_Token_2E_pat_arrow_3F_ (void){
     mw_TokenValue_2E_pat_arrow_3F_();
     WORD_EXIT(mw_Token_2E_pat_arrow_3F_);
 }
-static void mw_Token_2E_pat_underscore_3F_ (void){
+static void mw_Token_2E_pat_underscore_3F_ (void) {
     WORD_ENTER(mw_Token_2E_pat_underscore_3F_, "Token.pat-underscore?", "src/mirth/data/token.mth", 114, 43);
     WORD_ATOM(114, 43, "value");
     mw_Token_2E_value();
@@ -35947,7 +35900,7 @@ static void mw_Token_2E_pat_underscore_3F_ (void){
     mw_TokenValue_2E_pat_underscore_3F_();
     WORD_EXIT(mw_Token_2E_pat_underscore_3F_);
 }
-static void mw_Token_2E_module_header_3F_ (void){
+static void mw_Token_2E_module_header_3F_ (void) {
     WORD_ENTER(mw_Token_2E_module_header_3F_, "Token.module-header?", "src/mirth/data/token.mth", 115, 42);
     WORD_ATOM(115, 42, "value");
     mw_Token_2E_value();
@@ -35955,7 +35908,7 @@ static void mw_Token_2E_module_header_3F_ (void){
     mw_TokenValue_2E_module_header_3F_();
     WORD_EXIT(mw_Token_2E_module_header_3F_);
 }
-static void mw_Token_2E_alloc_none_21_ (void){
+static void mw_Token_2E_alloc_none_21_ (void) {
     WORD_ENTER(mw_Token_2E_alloc_none_21_, "Token.alloc-none!", "src/mirth/data/token.mth", 118, 5);
     WORD_ATOM(118, 5, "Token.alloc!");
     mw_Token_2E_alloc_21_();
@@ -35969,7 +35922,7 @@ static void mw_Token_2E_alloc_none_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_Token_2E_alloc_none_21_);
 }
-static void mw_Token_2E_location (void){
+static void mw_Token_2E_location (void) {
     WORD_ENTER(mw_Token_2E_location, "Token.location", "src/mirth/data/token.mth", 122, 5);
     WORD_ATOM(122, 5, "sip");
     push_u64(0);
@@ -35987,7 +35940,7 @@ static void mw_Token_2E_location (void){
     mw_LOCATION();
     WORD_EXIT(mw_Token_2E_location);
 }
-static void mw_Token_2E_next (void){
+static void mw_Token_2E_next (void) {
     WORD_ENTER(mw_Token_2E_next, "Token.next", "src/mirth/data/token.mth", 126, 5);
     WORD_ATOM(126, 5, "dup");
     mw_prim_dup();
@@ -35996,28 +35949,28 @@ static void mw_Token_2E_next (void){
     WORD_ATOM(126, 15, "match");
     switch (get_top_data_tag()) {
         case 3LL:
-            co_TOKEN_5F_LPAREN();
+            mp_TOKEN_5F_LPAREN();
             WORD_ATOM(127, 25, "nip");
             mw_nip();
             WORD_ATOM(127, 29, "succ");
             mw_Token_2E_succ();
             break;
         case 6LL:
-            co_TOKEN_5F_LSQUARE();
+            mp_TOKEN_5F_LSQUARE();
             WORD_ATOM(128, 26, "nip");
             mw_nip();
             WORD_ATOM(128, 30, "succ");
             mw_Token_2E_succ();
             break;
         case 9LL:
-            co_TOKEN_5F_LCURLY();
+            mp_TOKEN_5F_LCURLY();
             WORD_ATOM(129, 25, "nip");
             mw_nip();
             WORD_ATOM(129, 29, "succ");
             mw_Token_2E_succ();
             break;
         case 13LL:
-            co_TOKEN_5F_NAME();
+            mp_TOKEN_5F_NAME();
             WORD_ATOM(130, 23, "drop");
             mw_prim_drop();
             WORD_ATOM(130, 28, "succ");
@@ -36038,10 +35991,10 @@ static void mw_Token_2E_next (void){
             WORD_ATOM(131, 19, "succ");
             mw_Token_2E_succ();
             break;
-    
-}    WORD_EXIT(mw_Token_2E_next);
+    }
+    WORD_EXIT(mw_Token_2E_next);
 }
-static void mw_Token_2E_prev (void){
+static void mw_Token_2E_prev (void) {
     WORD_ENTER(mw_Token_2E_prev, "Token.prev", "src/mirth/data/token.mth", 136, 5);
     WORD_ATOM(136, 5, "pred");
     mw_Token_2E_pred();
@@ -36052,17 +36005,17 @@ static void mw_Token_2E_prev (void){
     WORD_ATOM(136, 20, "match");
     switch (get_top_data_tag()) {
         case 7LL:
-            co_TOKEN_5F_RSQUARE();
+            mp_TOKEN_5F_RSQUARE();
             WORD_ATOM(137, 26, "nip");
             mw_nip();
             break;
         case 10LL:
-            co_TOKEN_5F_RCURLY();
+            mp_TOKEN_5F_RCURLY();
             WORD_ATOM(138, 25, "nip");
             mw_nip();
             break;
         case 4LL:
-            co_TOKEN_5F_RPAREN();
+            mp_TOKEN_5F_RPAREN();
             WORD_ATOM(139, 25, "nip");
             mw_nip();
             WORD_ATOM(139, 29, "dup");
@@ -36086,10 +36039,10 @@ static void mw_Token_2E_prev (void){
             WORD_ATOM(140, 14, "drop");
             mw_prim_drop();
             break;
-    
-}    WORD_EXIT(mw_Token_2E_prev);
+    }
+    WORD_EXIT(mw_Token_2E_prev);
 }
-static void mw_Token_2E_next_arg_end (void){
+static void mw_Token_2E_next_arg_end (void) {
     WORD_ENTER(mw_Token_2E_next_arg_end, "Token.next-arg-end", "src/mirth/data/token.mth", 146, 5);
     WORD_ATOM(146, 5, "while");
     while(1) {
@@ -36105,7 +36058,7 @@ static void mw_Token_2E_next_arg_end (void){
     }
     WORD_EXIT(mw_Token_2E_next_arg_end);
 }
-static void mw_Token_2E_has_args_3F_ (void){
+static void mw_Token_2E_has_args_3F_ (void) {
     WORD_ENTER(mw_Token_2E_has_args_3F_, "Token.has-args?", "src/mirth/data/token.mth", 149, 5);
     WORD_ATOM(149, 5, "dup");
     mw_prim_dup();
@@ -36125,7 +36078,7 @@ static void mw_Token_2E_has_args_3F_ (void){
     mw_Maybe_3E_Bool();
     WORD_EXIT(mw_Token_2E_has_args_3F_);
 }
-static void mw_Token_2E_args_start (void){
+static void mw_Token_2E_args_start (void) {
     WORD_ENTER(mw_Token_2E_args_start, "Token.args-start", "src/mirth/data/token.mth", 153, 5);
     WORD_ATOM(153, 5, "dup");
     mw_prim_dup();
@@ -36141,7 +36094,7 @@ static void mw_Token_2E_args_start (void){
     mw_Maybe_2E_if();
     WORD_EXIT(mw_Token_2E_args_start);
 }
-static void mw_Token_2E_num_args (void){
+static void mw_Token_2E_num_args (void) {
     WORD_ENTER(mw_Token_2E_num_args, "Token.num-args", "src/mirth/data/token.mth", 160, 5);
     WORD_ATOM(160, 5, "args-start");
     mw_Token_2E_args_start();
@@ -36189,7 +36142,7 @@ static void mw_Token_2E_num_args (void){
     }
     WORD_EXIT(mw_Token_2E_num_args);
 }
-static void mw_Token_2E_args_0 (void){
+static void mw_Token_2E_args_0 (void) {
     WORD_ENTER(mw_Token_2E_args_0, "Token.args-0", "src/mirth/data/token.mth", 171, 5);
     WORD_ATOM(171, 5, "dup");
     mw_prim_dup();
@@ -36218,7 +36171,7 @@ static void mw_Token_2E_args_0 (void){
     }
     WORD_EXIT(mw_Token_2E_args_0);
 }
-static void mw_Token_2E_args_1 (void){
+static void mw_Token_2E_args_1 (void) {
     WORD_ENTER(mw_Token_2E_args_1, "Token.args-1", "src/mirth/data/token.mth", 179, 5);
     WORD_ATOM(179, 5, "dup");
     mw_prim_dup();
@@ -36276,7 +36229,7 @@ static void mw_Token_2E_args_1 (void){
     }
     WORD_EXIT(mw_Token_2E_args_1);
 }
-static void mw_Token_2E_args_2 (void){
+static void mw_Token_2E_args_2 (void) {
     WORD_ENTER(mw_Token_2E_args_2, "Token.args-2", "src/mirth/data/token.mth", 190, 5);
     WORD_ATOM(190, 5, "dup");
     mw_prim_dup();
@@ -36340,7 +36293,7 @@ static void mw_Token_2E_args_2 (void){
     }
     WORD_EXIT(mw_Token_2E_args_2);
 }
-static void mw_Token_2E_args_3 (void){
+static void mw_Token_2E_args_3 (void) {
     WORD_ENTER(mw_Token_2E_args_3, "Token.args-3", "src/mirth/data/token.mth", 202, 5);
     WORD_ATOM(202, 5, "dup");
     mw_prim_dup();
@@ -36410,7 +36363,7 @@ static void mw_Token_2E_args_3 (void){
     }
     WORD_EXIT(mw_Token_2E_args_3);
 }
-static void mw_Token_2E_args (void){
+static void mw_Token_2E_args (void) {
     WORD_ENTER(mw_Token_2E_args, "Token.args", "src/mirth/data/token.mth", 214, 5);
     WORD_ATOM(214, 5, "dup");
     mw_prim_dup();
@@ -36438,7 +36391,7 @@ static void mw_Token_2E_args (void){
     }
     WORD_EXIT(mw_Token_2E_args);
 }
-static void mw_Token_2E_args_end_3F_ (void){
+static void mw_Token_2E_args_end_3F_ (void) {
     WORD_ENTER(mw_Token_2E_args_end_3F_, "Token.args-end?", "src/mirth/data/token.mth", 224, 5);
     WORD_ATOM(224, 5, "dup");
     mw_prim_dup();
@@ -36453,7 +36406,7 @@ static void mw_Token_2E_args_end_3F_ (void){
     mw_Token_2E_right_enclosure_3F_();
     WORD_EXIT(mw_Token_2E_args_end_3F_);
 }
-static void mw_Token_2E_args_2B_ (void){
+static void mw_Token_2E_args_2B_ (void) {
     WORD_ENTER(mw_Token_2E_args_2B_, "Token.args+", "src/mirth/data/token.mth", 230, 5);
     WORD_ATOM(230, 5, "dup");
     mw_prim_dup();
@@ -36470,7 +36423,7 @@ static void mw_Token_2E_args_2B_ (void){
     mw_nip();
     WORD_EXIT(mw_Token_2E_args_2B_);
 }
-static void mw_emit_error_21_ (void){
+static void mw_emit_error_21_ (void) {
     WORD_ENTER(mw_emit_error_21_, "emit-error!", "src/mirth/data/token.mth", 235, 5);
     WORD_ATOM(235, 5, "dip");
     {
@@ -36483,7 +36436,7 @@ static void mw_emit_error_21_ (void){
     mw_emit_error_at_21_();
     WORD_EXIT(mw_emit_error_21_);
 }
-static void mw_emit_fatal_error_21_ (void){
+static void mw_emit_fatal_error_21_ (void) {
     WORD_ENTER(mw_emit_fatal_error_21_, "emit-fatal-error!", "src/mirth/data/token.mth", 237, 5);
     WORD_ATOM(237, 5, "dip");
     {
@@ -36496,44 +36449,44 @@ static void mw_emit_fatal_error_21_ (void){
     mw_emit_fatal_error_at_21_();
     WORD_EXIT(mw_emit_fatal_error_21_);
 }
-static void mw_Token_2E_module_end_3F_ (void){
+static void mw_Token_2E_module_end_3F_ (void) {
     WORD_ENTER(mw_Token_2E_module_end_3F_, "Token.module-end?", "src/mirth/data/token.mth", 244, 39);
     WORD_ATOM(244, 39, "none?");
     mw_Token_2E_none_3F_();
     WORD_EXIT(mw_Token_2E_module_end_3F_);
 }
-static void mw_Token_2E_run_end_3F_ (void){
+static void mw_Token_2E_run_end_3F_ (void) {
     WORD_ENTER(mw_Token_2E_run_end_3F_, "Token.run-end?", "src/mirth/data/token.mth", 248, 5);
     WORD_ATOM(248, 5, "value");
     mw_Token_2E_value();
     WORD_ATOM(248, 11, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_TOKEN_5F_NONE();
+            mp_TOKEN_5F_NONE();
             WORD_ATOM(249, 23, "T");
             mw_T();
             break;
         case 1LL:
-            co_TOKEN_5F_COMMA();
+            mp_TOKEN_5F_COMMA();
             WORD_ATOM(250, 24, "T");
             mw_T();
             break;
         case 4LL:
-            co_TOKEN_5F_RPAREN();
+            mp_TOKEN_5F_RPAREN();
             WORD_ATOM(251, 25, "drop");
             mw_prim_drop();
             WORD_ATOM(251, 30, "T");
             mw_T();
             break;
         case 7LL:
-            co_TOKEN_5F_RSQUARE();
+            mp_TOKEN_5F_RSQUARE();
             WORD_ATOM(252, 26, "drop");
             mw_prim_drop();
             WORD_ATOM(252, 31, "T");
             mw_T();
             break;
         case 10LL:
-            co_TOKEN_5F_RCURLY();
+            mp_TOKEN_5F_RCURLY();
             WORD_ATOM(253, 25, "drop");
             mw_prim_drop();
             WORD_ATOM(253, 30, "T");
@@ -36545,10 +36498,10 @@ static void mw_Token_2E_run_end_3F_ (void){
             WORD_ATOM(254, 19, "F");
             mw_F();
             break;
-    
-}    WORD_EXIT(mw_Token_2E_run_end_3F_);
+    }
+    WORD_EXIT(mw_Token_2E_run_end_3F_);
 }
-static void mw_Token_2E_run_tokens (void){
+static void mw_Token_2E_run_tokens (void) {
     WORD_ENTER(mw_Token_2E_run_tokens, "Token.run-tokens", "src/mirth/data/token.mth", 258, 5);
     WORD_ATOM(258, 5, "collect-while");
     push_u64(0);
@@ -36562,7 +36515,7 @@ static void mw_Token_2E_run_tokens (void){
     mw_nip();
     WORD_EXIT(mw_Token_2E_run_tokens);
 }
-static void mw_Token_2E_run_length (void){
+static void mw_Token_2E_run_length (void) {
     WORD_ENTER(mw_Token_2E_run_length, "Token.run-length", "src/mirth/data/token.mth", 261, 5);
     WORD_ATOM(261, 5, "dip");
     {
@@ -36594,7 +36547,7 @@ static void mw_Token_2E_run_length (void){
     mw_prim_drop();
     WORD_EXIT(mw_Token_2E_run_length);
 }
-static void mw_Token_2E_run_has_arrow_3F_ (void){
+static void mw_Token_2E_run_has_arrow_3F_ (void) {
     WORD_ENTER(mw_Token_2E_run_has_arrow_3F_, "Token.run-has-arrow?", "src/mirth/data/token.mth", 264, 5);
     WORD_ATOM(264, 5, "run-tokens");
     mw_Token_2E_run_tokens();
@@ -36605,7 +36558,7 @@ static void mw_Token_2E_run_has_arrow_3F_ (void){
     mw_List_2E_any();
     WORD_EXIT(mw_Token_2E_run_has_arrow_3F_);
 }
-static void mw_Token_2E_sig_stack_end_3F_ (void){
+static void mw_Token_2E_sig_stack_end_3F_ (void) {
     WORD_ENTER(mw_Token_2E_sig_stack_end_3F_, "Token.sig-stack-end?", "src/mirth/data/token.mth", 271, 5);
     WORD_ATOM(271, 5, "dup");
     mw_prim_dup();
@@ -36620,7 +36573,7 @@ static void mw_Token_2E_sig_stack_end_3F_ (void){
     mw_nip();
     WORD_EXIT(mw_Token_2E_sig_stack_end_3F_);
 }
-static void mw_Token_2E_sig_next_stack_end (void){
+static void mw_Token_2E_sig_next_stack_end (void) {
     WORD_ENTER(mw_Token_2E_sig_next_stack_end, "Token.sig-next-stack-end", "src/mirth/data/token.mth", 274, 5);
     WORD_ATOM(274, 5, "while");
     while(1) {
@@ -36636,7 +36589,7 @@ static void mw_Token_2E_sig_next_stack_end (void){
     }
     WORD_EXIT(mw_Token_2E_sig_next_stack_end);
 }
-static void mw_Token_2E_sig_has_dashes_3F_ (void){
+static void mw_Token_2E_sig_has_dashes_3F_ (void) {
     WORD_ENTER(mw_Token_2E_sig_has_dashes_3F_, "Token.sig-has-dashes?", "src/mirth/data/token.mth", 277, 5);
     WORD_ATOM(277, 5, "sig-next-stack-end");
     mw_Token_2E_sig_next_stack_end();
@@ -36644,7 +36597,7 @@ static void mw_Token_2E_sig_has_dashes_3F_ (void){
     mw_Token_2E_sig_dashes_3F_();
     WORD_EXIT(mw_Token_2E_sig_has_dashes_3F_);
 }
-static void mw_Token_2E_sig_arity (void){
+static void mw_Token_2E_sig_arity (void) {
     WORD_ENTER(mw_Token_2E_sig_arity, "Token.sig-arity", "src/mirth/data/token.mth", 280, 5);
     WORD_ATOM(280, 5, "dup");
     mw_prim_dup();
@@ -36672,7 +36625,7 @@ static void mw_Token_2E_sig_arity (void){
     }
     WORD_EXIT(mw_Token_2E_sig_arity);
 }
-static void mw_Token_2E_sig_count_types (void){
+static void mw_Token_2E_sig_count_types (void) {
     WORD_ENTER(mw_Token_2E_sig_count_types, "Token.sig-count-types", "src/mirth/data/token.mth", 291, 5);
     WORD_ATOM(291, 5, "");
     push_i64(0LL);
@@ -36709,7 +36662,7 @@ static void mw_Token_2E_sig_count_types (void){
     }
     WORD_EXIT(mw_Token_2E_sig_count_types);
 }
-static void mw_Alias_2E_alloc_21_ (void){
+static void mw_Alias_2E_alloc_21_ (void) {
     WORD_ENTER(mw_Alias_2E_alloc_21_, "Alias.alloc!", "src/mirth/data/alias.mth", 8, 7);
     WORD_ATOM(8, 7, "Alias");
     mw_Alias_2E_NUM();
@@ -36733,7 +36686,7 @@ static void mw_Alias_2E_alloc_21_ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Alias_2E_alloc_21_);
 }
-static void mw_Alias_2E_head (void){
+static void mw_Alias_2E_head (void) {
     WORD_ENTER(mw_Alias_2E_head, "Alias.head", "src/mirth/data/alias.mth", 13, 33);
     WORD_ATOM(13, 33, "~head");
     mw_Alias_7E_head();
@@ -36741,7 +36694,7 @@ static void mw_Alias_2E_head (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Alias_2E_head);
 }
-static void mw_Alias_2E_target (void){
+static void mw_Alias_2E_target (void) {
     WORD_ENTER(mw_Alias_2E_target, "Alias.target", "src/mirth/data/alias.mth", 15, 34);
     WORD_ATOM(15, 34, "~target");
     mw_Alias_7E_target();
@@ -36749,7 +36702,7 @@ static void mw_Alias_2E_target (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Alias_2E_target);
 }
-static void mw_Alias_2E_new_21_ (void){
+static void mw_Alias_2E_new_21_ (void) {
     WORD_ENTER(mw_Alias_2E_new_21_, "Alias.new!", "src/mirth/data/alias.mth", 19, 5);
     WORD_ATOM(19, 5, "Alias.alloc!");
     mw_Alias_2E_alloc_21_();
@@ -36783,17 +36736,17 @@ static void mw_Alias_2E_new_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_Alias_2E_new_21_);
 }
-static void mw_Def_3E_Module_3F_ (void){
+static void mw_Def_3E_Module_3F_ (void) {
     WORD_ENTER(mw_Def_3E_Module_3F_, "Def>Module?", "src/mirth/data/def.mth", 32, 5);
     WORD_ATOM(32, 5, "DEF_NONE");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_DEF_5F_NONE();
+            mp_DEF_5F_NONE();
             WORD_ATOM(32, 17, "NONE");
             mw_NONE();
             break;
         case 1LL:
-            co_DEF_5F_ALIAS();
+            mp_DEF_5F_ALIAS();
             WORD_ATOM(33, 18, "head");
             mw_Alias_2E_head();
             WORD_ATOM(33, 23, ".module");
@@ -36802,21 +36755,21 @@ static void mw_Def_3E_Module_3F_ (void){
             mw_SOME();
             break;
         case 2LL:
-            co_DEF_5F_MODULE();
+            mp_DEF_5F_MODULE();
             WORD_ATOM(34, 19, "drop");
             mw_prim_drop();
             WORD_ATOM(34, 24, "NONE");
             mw_NONE();
             break;
         case 3LL:
-            co_DEF_5F_TYPE();
+            mp_DEF_5F_TYPE();
             WORD_ATOM(35, 17, "drop");
             mw_prim_drop();
             WORD_ATOM(35, 22, "NONE");
             mw_NONE();
             break;
         case 4LL:
-            co_DEF_5F_TAG();
+            mp_DEF_5F_TAG();
             WORD_ATOM(36, 16, ".data");
             mw_Tag_2E_data();
             WORD_ATOM(36, 22, "head?");
@@ -36828,14 +36781,14 @@ static void mw_Def_3E_Module_3F_ (void){
             mw_Maybe_2E_map();
             break;
         case 5LL:
-            co_DEF_5F_PRIM();
+            mp_DEF_5F_PRIM();
             WORD_ATOM(37, 17, "drop");
             mw_prim_drop();
             WORD_ATOM(37, 22, "NONE");
             mw_NONE();
             break;
         case 6LL:
-            co_DEF_5F_WORD();
+            mp_DEF_5F_WORD();
             WORD_ATOM(38, 17, "head");
             mw_Word_2E_head();
             WORD_ATOM(38, 22, ".module");
@@ -36844,7 +36797,7 @@ static void mw_Def_3E_Module_3F_ (void){
             mw_SOME();
             break;
         case 7LL:
-            co_DEF_5F_BUFFER();
+            mp_DEF_5F_BUFFER();
             WORD_ATOM(39, 19, "head");
             mw_Buffer_2E_head();
             WORD_ATOM(39, 24, ".module");
@@ -36853,7 +36806,7 @@ static void mw_Def_3E_Module_3F_ (void){
             mw_SOME();
             break;
         case 8LL:
-            co_DEF_5F_VARIABLE();
+            mp_DEF_5F_VARIABLE();
             WORD_ATOM(40, 21, "head");
             mw_Variable_2E_head();
             WORD_ATOM(40, 26, ".module");
@@ -36862,7 +36815,7 @@ static void mw_Def_3E_Module_3F_ (void){
             mw_SOME();
             break;
         case 9LL:
-            co_DEF_5F_CONSTANT();
+            mp_DEF_5F_CONSTANT();
             WORD_ATOM(41, 21, "head");
             mw_Constant_2E_head();
             WORD_ATOM(41, 26, ".module");
@@ -36871,7 +36824,7 @@ static void mw_Def_3E_Module_3F_ (void){
             mw_SOME();
             break;
         case 10LL:
-            co_DEF_5F_EXTERNAL();
+            mp_DEF_5F_EXTERNAL();
             WORD_ATOM(42, 21, "sig");
             mw_External_2E_sig();
             WORD_ATOM(42, 25, ".module");
@@ -36880,7 +36833,7 @@ static void mw_Def_3E_Module_3F_ (void){
             mw_SOME();
             break;
         case 11LL:
-            co_DEF_5F_FIELD();
+            mp_DEF_5F_FIELD();
             WORD_ATOM(43, 18, "head");
             mw_Field_2E_head();
             WORD_ATOM(43, 23, ".module");
@@ -36889,15 +36842,15 @@ static void mw_Def_3E_Module_3F_ (void){
             mw_SOME();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Def_3E_Module_3F_);
+    }
+    WORD_EXIT(mw_Def_3E_Module_3F_);
 }
-static void mw_Def_2E_none_3F_ (void){
+static void mw_Def_2E_none_3F_ (void) {
     WORD_ENTER(mw_Def_2E_none_3F_, "Def.none?", "src/mirth/data/def.mth", 45, 29);
     WORD_ATOM(45, 29, "DEF_NONE");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_DEF_5F_NONE();
+            mp_DEF_5F_NONE();
             WORD_ATOM(45, 41, "T");
             mw_T();
             break;
@@ -36907,15 +36860,15 @@ static void mw_Def_2E_none_3F_ (void){
             WORD_ATOM(45, 54, "F");
             mw_F();
             break;
-    
-}    WORD_EXIT(mw_Def_2E_none_3F_);
+    }
+    WORD_EXIT(mw_Def_2E_none_3F_);
 }
-static void mw_Def_2E_prim_3F_ (void){
+static void mw_Def_2E_prim_3F_ (void) {
     WORD_ENTER(mw_Def_2E_prim_3F_, "Def.prim?", "src/mirth/data/def.mth", 50, 36);
     WORD_ATOM(50, 36, "DEF_PRIM");
     switch (get_top_data_tag()) {
         case 5LL:
-            co_DEF_5F_PRIM();
+            mp_DEF_5F_PRIM();
             WORD_ATOM(50, 48, "SOME");
             mw_SOME();
             break;
@@ -36925,20 +36878,20 @@ static void mw_Def_2E_prim_3F_ (void){
             WORD_ATOM(50, 64, "NONE");
             mw_NONE();
             break;
-    
-}    WORD_EXIT(mw_Def_2E_prim_3F_);
+    }
+    WORD_EXIT(mw_Def_2E_prim_3F_);
 }
-static void mw_Def_2E_typecheck_21_ (void){
+static void mw_Def_2E_typecheck_21_ (void) {
     WORD_ENTER(mw_Def_2E_typecheck_21_, "Def.typecheck!", "src/mirth/data/def.mth", 59, 5);
     WORD_ATOM(59, 5, "DEF_NONE");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_DEF_5F_NONE();
+            mp_DEF_5F_NONE();
             WORD_ATOM(59, 17, "id");
             mw_prim_id();
             break;
         case 1LL:
-            co_DEF_5F_ALIAS();
+            mp_DEF_5F_ALIAS();
             WORD_ATOM(60, 18, "target");
             mw_Alias_2E_target();
             WORD_ATOM(60, 25, ">Def");
@@ -36947,80 +36900,80 @@ static void mw_Def_2E_typecheck_21_ (void){
             mw_Def_2E_typecheck_21_();
             break;
         case 2LL:
-            co_DEF_5F_MODULE();
+            mp_DEF_5F_MODULE();
             WORD_ATOM(61, 19, "drop");
             mw_prim_drop();
             break;
         case 7LL:
-            co_DEF_5F_BUFFER();
+            mp_DEF_5F_BUFFER();
             WORD_ATOM(62, 19, "drop");
             mw_prim_drop();
             break;
         case 5LL:
-            co_DEF_5F_PRIM();
+            mp_DEF_5F_PRIM();
             WORD_ATOM(63, 17, "drop");
             mw_prim_drop();
             break;
         case 3LL:
-            co_DEF_5F_TYPE();
+            mp_DEF_5F_TYPE();
             WORD_ATOM(64, 17, "drop");
             mw_prim_drop();
             break;
         case 10LL:
-            co_DEF_5F_EXTERNAL();
+            mp_DEF_5F_EXTERNAL();
             WORD_ATOM(65, 21, "type");
             mw_External_2E_type();
             WORD_ATOM(65, 26, "drop");
             mw_prim_drop();
             break;
         case 6LL:
-            co_DEF_5F_WORD();
+            mp_DEF_5F_WORD();
             WORD_ATOM(66, 17, "arrow");
             mw_Word_2E_arrow();
             WORD_ATOM(66, 23, "drop");
             mw_prim_drop();
             break;
         case 11LL:
-            co_DEF_5F_FIELD();
+            mp_DEF_5F_FIELD();
             WORD_ATOM(67, 18, "type");
             mw_Field_2E_type();
             WORD_ATOM(67, 23, "drop");
             mw_prim_drop();
             break;
         case 4LL:
-            co_DEF_5F_TAG();
+            mp_DEF_5F_TAG();
             WORD_ATOM(68, 16, "type");
             mw_Tag_2E_type();
             WORD_ATOM(68, 21, "drop");
             mw_prim_drop();
             break;
         case 8LL:
-            co_DEF_5F_VARIABLE();
+            mp_DEF_5F_VARIABLE();
             WORD_ATOM(69, 21, "type");
             mw_Variable_2E_type();
             WORD_ATOM(69, 26, "drop");
             mw_prim_drop();
             break;
         case 9LL:
-            co_DEF_5F_CONSTANT();
+            mp_DEF_5F_CONSTANT();
             WORD_ATOM(70, 21, "drop");
             mw_prim_drop();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Def_2E_typecheck_21_);
+    }
+    WORD_EXIT(mw_Def_2E_typecheck_21_);
 }
-static void mw_Def_2E_callable_3F_ (void){
+static void mw_Def_2E_callable_3F_ (void) {
     WORD_ENTER(mw_Def_2E_callable_3F_, "Def.callable?", "src/mirth/data/def.mth", 73, 5);
     WORD_ATOM(73, 5, "DEF_NONE");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_DEF_5F_NONE();
+            mp_DEF_5F_NONE();
             WORD_ATOM(73, 17, "F");
             mw_F();
             break;
         case 1LL:
-            co_DEF_5F_ALIAS();
+            mp_DEF_5F_ALIAS();
             WORD_ATOM(74, 18, "target");
             mw_Alias_2E_target();
             WORD_ATOM(74, 25, ">Def");
@@ -37029,92 +36982,92 @@ static void mw_Def_2E_callable_3F_ (void){
             mw_Def_2E_callable_3F_();
             break;
         case 2LL:
-            co_DEF_5F_MODULE();
+            mp_DEF_5F_MODULE();
             WORD_ATOM(75, 19, "drop");
             mw_prim_drop();
             WORD_ATOM(75, 24, "F");
             mw_F();
             break;
         case 7LL:
-            co_DEF_5F_BUFFER();
+            mp_DEF_5F_BUFFER();
             WORD_ATOM(76, 19, "drop");
             mw_prim_drop();
             WORD_ATOM(76, 24, "T");
             mw_T();
             break;
         case 5LL:
-            co_DEF_5F_PRIM();
+            mp_DEF_5F_PRIM();
             WORD_ATOM(77, 17, "drop");
             mw_prim_drop();
             WORD_ATOM(77, 22, "T");
             mw_T();
             break;
         case 3LL:
-            co_DEF_5F_TYPE();
+            mp_DEF_5F_TYPE();
             WORD_ATOM(78, 17, "drop");
             mw_prim_drop();
             WORD_ATOM(78, 22, "F");
             mw_F();
             break;
         case 10LL:
-            co_DEF_5F_EXTERNAL();
+            mp_DEF_5F_EXTERNAL();
             WORD_ATOM(79, 21, "drop");
             mw_prim_drop();
             WORD_ATOM(79, 26, "T");
             mw_T();
             break;
         case 6LL:
-            co_DEF_5F_WORD();
+            mp_DEF_5F_WORD();
             WORD_ATOM(80, 17, "drop");
             mw_prim_drop();
             WORD_ATOM(80, 22, "T");
             mw_T();
             break;
         case 11LL:
-            co_DEF_5F_FIELD();
+            mp_DEF_5F_FIELD();
             WORD_ATOM(81, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(81, 23, "T");
             mw_T();
             break;
         case 4LL:
-            co_DEF_5F_TAG();
+            mp_DEF_5F_TAG();
             WORD_ATOM(82, 16, "drop");
             mw_prim_drop();
             WORD_ATOM(82, 21, "T");
             mw_T();
             break;
         case 8LL:
-            co_DEF_5F_VARIABLE();
+            mp_DEF_5F_VARIABLE();
             WORD_ATOM(83, 21, "drop");
             mw_prim_drop();
             WORD_ATOM(83, 26, "T");
             mw_T();
             break;
         case 9LL:
-            co_DEF_5F_CONSTANT();
+            mp_DEF_5F_CONSTANT();
             WORD_ATOM(84, 21, "drop");
             mw_prim_drop();
             WORD_ATOM(84, 26, "T");
             mw_T();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Def_2E_callable_3F_);
+    }
+    WORD_EXIT(mw_Def_2E_callable_3F_);
 }
-static void mw_Name_2E_id (void){
+static void mw_Name_2E_id (void) {
     WORD_ENTER(mw_Name_2E_id, "Name.id", "src/mirth/data/name.mth", 16, 7);
     WORD_ATOM(16, 7, "Name");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Name_2E_id);
 }
-static void mw_Name_2E_from_id (void){
+static void mw_Name_2E_from_id (void) {
     WORD_ENTER(mw_Name_2E_from_id, "Name.from-id", "src/mirth/data/name.mth", 16, 7);
     WORD_ATOM(16, 7, "Name");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Name_2E_from_id);
 }
-static void mw_Name_2E_for (void){
+static void mw_Name_2E_for (void) {
     WORD_ENTER(mw_Name_2E_for, "Name.for", "src/mirth/data/name.mth", 16, 7);
     WORD_ATOM(16, 7, "Name");
     {
@@ -37161,7 +37114,7 @@ static void mw_Name_2E_for (void){
     }
     WORD_EXIT(mw_Name_2E_for);
 }
-static void mw_Name_2E_alloc_21_ (void){
+static void mw_Name_2E_alloc_21_ (void) {
     WORD_ENTER(mw_Name_2E_alloc_21_, "Name.alloc!", "src/mirth/data/name.mth", 16, 7);
     WORD_ATOM(16, 7, "Name");
     mw_Name_2E_NUM();
@@ -37185,7 +37138,7 @@ static void mw_Name_2E_alloc_21_ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Name_2E_alloc_21_);
 }
-static void mw_Name_3E_Str (void){
+static void mw_Name_3E_Str (void) {
     WORD_ENTER(mw_Name_3E_Str, "Name>Str", "src/mirth/data/name.mth", 21, 28);
     WORD_ATOM(21, 28, "~Str");
     mw_Name_7E_Str();
@@ -37193,7 +37146,7 @@ static void mw_Name_3E_Str (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Name_3E_Str);
 }
-static void mw_Name_3E_Def (void){
+static void mw_Name_3E_Def (void) {
     WORD_ENTER(mw_Name_3E_Def, "Name>Def", "src/mirth/data/name.mth", 22, 28);
     WORD_ATOM(22, 28, "~Def");
     mw_Name_7E_Def();
@@ -37201,7 +37154,7 @@ static void mw_Name_3E_Def (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Name_3E_Def);
 }
-static void mw_Name_2E_mangled (void){
+static void mw_Name_2E_mangled (void) {
     WORD_ENTER(mw_Name_2E_mangled, "Name.mangled", "src/mirth/data/name.mth", 23, 32);
     WORD_ATOM(23, 32, "~mangled");
     mw_Name_7E_mangled();
@@ -37209,7 +37162,7 @@ static void mw_Name_2E_mangled (void){
     mw_force_21_();
     WORD_EXIT(mw_Name_2E_mangled);
 }
-static void mw_Name_3D_ (void){
+static void mw_Name_3D_ (void) {
     WORD_ENTER(mw_Name_3D_, "Name=", "src/mirth/data/name.mth", 25, 31);
     WORD_ATOM(25, 31, "both");
     push_u64(0);
@@ -37220,14 +37173,14 @@ static void mw_Name_3D_ (void){
     mw_prim_int_eq();
     WORD_EXIT(mw_Name_3D_);
 }
-static void mw_Hash_3E_Int (void){
+static void mw_Hash_3E_Int (void) {
     WORD_ENTER(mw_Hash_3E_Int, "Hash>Int", "src/mirth/data/name.mth", 28, 28);
     WORD_ATOM(28, 28, "HASH");
     WORD_ATOM(28, 36, "id");
     mw_prim_id();
     WORD_EXIT(mw_Hash_3E_Int);
 }
-static void mw_Int_3E_Hash (void){
+static void mw_Int_3E_Hash (void) {
     WORD_ENTER(mw_Int_3E_Hash, "Int>Hash", "src/mirth/data/name.mth", 29, 28);
     WORD_ATOM(29, 28, "HASH_MAX");
     mw_HASH_5F_MAX();
@@ -37237,13 +37190,13 @@ static void mw_Int_3E_Hash (void){
     mw_HASH();
     WORD_EXIT(mw_Int_3E_Hash);
 }
-static void mw_HASH_5F_MAX (void){
+static void mw_HASH_5F_MAX (void) {
     WORD_ENTER(mw_HASH_5F_MAX, "HASH_MAX", "src/mirth/data/name.mth", 31, 20);
     WORD_ATOM(31, 20, "");
     push_i64(65536LL);
     WORD_EXIT(mw_HASH_5F_MAX);
 }
-static void mw_hash_name_40_ (void){
+static void mw_hash_name_40_ (void) {
     WORD_ENTER(mw_hash_name_40_, "hash-name@", "src/mirth/data/name.mth", 34, 5);
     WORD_ATOM(34, 5, ">Int");
     mw_Hash_3E_Int();
@@ -37271,7 +37224,7 @@ static void mw_hash_name_40_ (void){
     }
     WORD_EXIT(mw_hash_name_40_);
 }
-static void mw_hash_name_21_ (void){
+static void mw_hash_name_21_ (void) {
     WORD_ENTER(mw_hash_name_21_, "hash-name!", "src/mirth/data/name.mth", 37, 5);
     WORD_ATOM(37, 5, "dip");
     {
@@ -37290,7 +37243,7 @@ static void mw_hash_name_21_ (void){
     mw_Ptr_21__21_I64();
     WORD_EXIT(mw_hash_name_21_);
 }
-static void mw_Str_2E_hash (void){
+static void mw_Str_2E_hash (void) {
     WORD_ENTER(mw_Str_2E_hash, "Str.hash", "src/mirth/data/name.mth", 42, 5);
     WORD_ATOM(42, 5, "");
     push_i64(0LL);
@@ -37305,7 +37258,7 @@ static void mw_Str_2E_hash (void){
     mw_Int_3E_Hash();
     WORD_EXIT(mw_Str_2E_hash);
 }
-static void mw_Hash_2E_next (void){
+static void mw_Hash_2E_next (void) {
     WORD_ENTER(mw_Hash_2E_next, "Hash.next", "src/mirth/data/name.mth", 46, 30);
     WORD_ATOM(46, 30, ">Int");
     mw_Hash_3E_Int();
@@ -37315,7 +37268,7 @@ static void mw_Hash_2E_next (void){
     mw_Int_3E_Hash();
     WORD_EXIT(mw_Hash_2E_next);
 }
-static void mw_Hash_2E_keep_going_3F_ (void){
+static void mw_Hash_2E_keep_going_3F_ (void) {
     WORD_ENTER(mw_Hash_2E_keep_going_3F_, "Hash.keep-going?", "src/mirth/data/name.mth", 49, 5);
     WORD_ATOM(49, 5, "dup");
     mw_prim_dup();
@@ -37324,12 +37277,12 @@ static void mw_Hash_2E_keep_going_3F_ (void){
     WORD_ATOM(49, 20, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_NONE();
+            mp_NONE();
             WORD_ATOM(50, 17, "F");
             mw_F();
             break;
         case 1LL:
-            co_SOME();
+            mp_SOME();
             WORD_ATOM(51, 17, ">Str");
             mw_Name_3E_Str();
             WORD_ATOM(51, 22, "over2");
@@ -37338,10 +37291,10 @@ static void mw_Hash_2E_keep_going_3F_ (void){
             mw_Str_3C__3E_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Hash_2E_keep_going_3F_);
+    }
+    WORD_EXIT(mw_Hash_2E_keep_going_3F_);
 }
-static void mw_Name_2E_search (void){
+static void mw_Name_2E_search (void) {
     WORD_ENTER(mw_Name_2E_search, "Name.search", "src/mirth/data/name.mth", 55, 5);
     WORD_ATOM(55, 5, "dup");
     mw_prim_dup();
@@ -37361,7 +37314,7 @@ static void mw_Name_2E_search (void){
     mw_hash_name_40_();
     WORD_EXIT(mw_Name_2E_search);
 }
-static void mw_Str_3E_Name (void){
+static void mw_Str_3E_Name (void) {
     WORD_ENTER(mw_Str_3E_Name, "Str>Name", "src/mirth/data/name.mth", 60, 5);
     WORD_ATOM(60, 5, "dup");
     mw_prim_dup();
@@ -37382,7 +37335,7 @@ static void mw_Str_3E_Name (void){
     WORD_ATOM(62, 20, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_NONE();
+            mp_NONE();
             WORD_ATOM(64, 13, "Name.alloc!");
             mw_Name_2E_alloc_21_();
             WORD_ATOM(65, 13, "tuck");
@@ -37420,7 +37373,7 @@ static void mw_Str_3E_Name (void){
             mw_prim_mut_set();
             break;
         case 1LL:
-            co_SOME();
+            mp_SOME();
             WORD_ATOM(70, 13, "dip");
             {
                 VAL d4 = pop_value();
@@ -37430,10 +37383,10 @@ static void mw_Str_3E_Name (void){
             }
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Str_3E_Name);
+    }
+    WORD_EXIT(mw_Str_3E_Name);
 }
-static void mw_Name_2E_cat (void){
+static void mw_Name_2E_cat (void) {
     WORD_ENTER(mw_Name_2E_cat, "Name.cat", "src/mirth/data/name.mth", 75, 5);
     WORD_ATOM(75, 5, "dip");
     {
@@ -37448,7 +37401,7 @@ static void mw_Name_2E_cat (void){
     mw_Str_3E_Name();
     WORD_EXIT(mw_Name_2E_cat);
 }
-static void mw_Name_2E_trace_21_ (void){
+static void mw_Name_2E_trace_21_ (void) {
     WORD_ENTER(mw_Name_2E_trace_21_, "Name.trace!", "src/mirth/data/name.mth", 77, 27);
     WORD_ATOM(77, 27, ">Str");
     mw_Name_3E_Str();
@@ -37456,7 +37409,7 @@ static void mw_Name_2E_trace_21_ (void){
     mw_Str_2E_trace_21_();
     WORD_EXIT(mw_Name_2E_trace_21_);
 }
-static void mw_Name_2E_head (void){
+static void mw_Name_2E_head (void) {
     WORD_ENTER(mw_Name_2E_head, "Name.head", "src/mirth/data/name.mth", 81, 5);
     WORD_ATOM(81, 5, ">Str");
     mw_Name_3E_Str();
@@ -37467,7 +37420,7 @@ static void mw_Name_2E_head (void){
     mw_with_str_data();
     WORD_EXIT(mw_Name_2E_head);
 }
-static void mw_Name_2E_tail_head (void){
+static void mw_Name_2E_tail_head (void) {
     WORD_ENTER(mw_Name_2E_tail_head, "Name.tail-head", "src/mirth/data/name.mth", 83, 5);
     WORD_ATOM(83, 5, ">Str");
     mw_Name_3E_Str();
@@ -37478,7 +37431,7 @@ static void mw_Name_2E_tail_head (void){
     mw_with_str_data();
     WORD_EXIT(mw_Name_2E_tail_head);
 }
-static void mw_Name_2E_could_be_type (void){
+static void mw_Name_2E_could_be_type (void) {
     WORD_ENTER(mw_Name_2E_could_be_type, "Name.could-be-type", "src/mirth/data/name.mth", 90, 39);
     WORD_ATOM(90, 39, "head");
     mw_Name_2E_head();
@@ -37486,7 +37439,7 @@ static void mw_Name_2E_could_be_type (void){
     mw_Byte_2E_is_alpha();
     WORD_EXIT(mw_Name_2E_could_be_type);
 }
-static void mw_Name_2E_could_be_type_var (void){
+static void mw_Name_2E_could_be_type_var (void) {
     WORD_ENTER(mw_Name_2E_could_be_type_var, "Name.could-be-type-var", "src/mirth/data/name.mth", 91, 43);
     WORD_ATOM(91, 43, "head");
     mw_Name_2E_head();
@@ -37494,7 +37447,7 @@ static void mw_Name_2E_could_be_type_var (void){
     mw_Byte_2E_is_lower();
     WORD_EXIT(mw_Name_2E_could_be_type_var);
 }
-static void mw_Name_2E_could_be_type_con (void){
+static void mw_Name_2E_could_be_type_con (void) {
     WORD_ENTER(mw_Name_2E_could_be_type_con, "Name.could-be-type-con", "src/mirth/data/name.mth", 92, 43);
     WORD_ATOM(92, 43, "head");
     mw_Name_2E_head();
@@ -37502,7 +37455,7 @@ static void mw_Name_2E_could_be_type_con (void){
     mw_Byte_2E_is_upper();
     WORD_EXIT(mw_Name_2E_could_be_type_con);
 }
-static void mw_Name_2E_is_type_hole (void){
+static void mw_Name_2E_is_type_hole (void) {
     WORD_ENTER(mw_Name_2E_is_type_hole, "Name.is-type-hole", "src/mirth/data/name.mth", 93, 38);
     WORD_ATOM(93, 38, "dup");
     mw_prim_dup();
@@ -37532,7 +37485,7 @@ static void mw_Name_2E_is_type_hole (void){
     mw_Bool_26__26_();
     WORD_EXIT(mw_Name_2E_is_type_hole);
 }
-static void mw_Name_2E_is_underscore (void){
+static void mw_Name_2E_is_underscore (void) {
     WORD_ENTER(mw_Name_2E_is_underscore, "Name.is-underscore", "src/mirth/data/name.mth", 94, 39);
     WORD_ATOM(94, 39, "dup");
     mw_prim_dup();
@@ -37554,7 +37507,7 @@ static void mw_Name_2E_is_underscore (void){
     mw_Bool_26__26_();
     WORD_EXIT(mw_Name_2E_is_underscore);
 }
-static void mw_Name_2E_could_be_stack_var (void){
+static void mw_Name_2E_could_be_stack_var (void) {
     WORD_ENTER(mw_Name_2E_could_be_stack_var, "Name.could-be-stack-var", "src/mirth/data/name.mth", 95, 44);
     WORD_ATOM(95, 44, "dup");
     mw_prim_dup();
@@ -37574,7 +37527,7 @@ static void mw_Name_2E_could_be_stack_var (void){
     mw_Bool_26__26_();
     WORD_EXIT(mw_Name_2E_could_be_stack_var);
 }
-static void mw_Name_2E_could_be_resource_var (void){
+static void mw_Name_2E_could_be_resource_var (void) {
     WORD_ENTER(mw_Name_2E_could_be_resource_var, "Name.could-be-resource-var", "src/mirth/data/name.mth", 96, 47);
     WORD_ATOM(96, 47, "dup");
     mw_prim_dup();
@@ -37594,7 +37547,7 @@ static void mw_Name_2E_could_be_resource_var (void){
     mw_Bool_26__26_();
     WORD_EXIT(mw_Name_2E_could_be_resource_var);
 }
-static void mw_Name_2E_could_be_resource_con (void){
+static void mw_Name_2E_could_be_resource_con (void) {
     WORD_ENTER(mw_Name_2E_could_be_resource_con, "Name.could-be-resource-con", "src/mirth/data/name.mth", 97, 47);
     WORD_ATOM(97, 47, "dup");
     mw_prim_dup();
@@ -37614,7 +37567,7 @@ static void mw_Name_2E_could_be_resource_con (void){
     mw_Bool_26__26_();
     WORD_EXIT(mw_Name_2E_could_be_resource_con);
 }
-static void mw_Name_2E_mangle_compute_21_ (void){
+static void mw_Name_2E_mangle_compute_21_ (void) {
     WORD_ENTER(mw_Name_2E_mangle_compute_21_, "Name.mangle-compute!", "src/mirth/data/name.mth", 100, 5);
     WORD_ATOM(100, 5, "build-str!");
     push_u64(0);
@@ -37623,7 +37576,7 @@ static void mw_Name_2E_mangle_compute_21_ (void){
     mw_build_str_21_();
     WORD_EXIT(mw_Name_2E_mangle_compute_21_);
 }
-static void mw_name_undefined_3F_ (void){
+static void mw_name_undefined_3F_ (void) {
     WORD_ENTER(mw_name_undefined_3F_, "name-undefined?", "src/mirth/data/name.mth", 125, 41);
     WORD_ATOM(125, 41, "dup");
     mw_prim_dup();
@@ -37633,7 +37586,7 @@ static void mw_name_undefined_3F_ (void){
     mw_Def_2E_none_3F_();
     WORD_EXIT(mw_name_undefined_3F_);
 }
-static void mw_name_defined_3F_ (void){
+static void mw_name_defined_3F_ (void) {
     WORD_ENTER(mw_name_defined_3F_, "name-defined?", "src/mirth/data/name.mth", 126, 39);
     WORD_ATOM(126, 39, "name-undefined?");
     mw_name_undefined_3F_();
@@ -37641,13 +37594,13 @@ static void mw_name_defined_3F_ (void){
     mw_Bool_2E_not();
     WORD_EXIT(mw_name_defined_3F_);
 }
-static void mw_Module_2E_id (void){
+static void mw_Module_2E_id (void) {
     WORD_ENTER(mw_Module_2E_id, "Module.id", "src/mirth/data/module.mth", 11, 7);
     WORD_ATOM(11, 7, "Module");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Module_2E_id);
 }
-static void mw_Module_2E_alloc_21_ (void){
+static void mw_Module_2E_alloc_21_ (void) {
     WORD_ENTER(mw_Module_2E_alloc_21_, "Module.alloc!", "src/mirth/data/module.mth", 11, 7);
     WORD_ATOM(11, 7, "Module");
     mw_Module_2E_NUM();
@@ -37671,7 +37624,7 @@ static void mw_Module_2E_alloc_21_ (void){
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Module_2E_alloc_21_);
 }
-static void mw_Module_2E_name (void){
+static void mw_Module_2E_name (void) {
     WORD_ENTER(mw_Module_2E_name, "Module.name", "src/mirth/data/module.mth", 18, 34);
     WORD_ATOM(18, 34, "~name");
     mw_Module_7E_name();
@@ -37679,7 +37632,7 @@ static void mw_Module_2E_name (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Module_2E_name);
 }
-static void mw_Module_2E_path (void){
+static void mw_Module_2E_path (void) {
     WORD_ENTER(mw_Module_2E_path, "Module.path", "src/mirth/data/module.mth", 19, 34);
     WORD_ATOM(19, 34, "~path");
     mw_Module_7E_path();
@@ -37687,7 +37640,7 @@ static void mw_Module_2E_path (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Module_2E_path);
 }
-static void mw_Module_2E_start (void){
+static void mw_Module_2E_start (void) {
     WORD_ENTER(mw_Module_2E_start, "Module.start", "src/mirth/data/module.mth", 20, 36);
     WORD_ATOM(20, 36, "~start");
     mw_Module_7E_start();
@@ -37695,7 +37648,7 @@ static void mw_Module_2E_start (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Module_2E_start);
 }
-static void mw_Module_2E_imports (void){
+static void mw_Module_2E_imports (void) {
     WORD_ENTER(mw_Module_2E_imports, "Module.imports", "src/mirth/data/module.mth", 22, 45);
     WORD_ATOM(22, 45, "~imports");
     mw_Module_7E_imports();
@@ -37703,7 +37656,7 @@ static void mw_Module_2E_imports (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Module_2E_imports);
 }
-static void mw_Module_3D_ (void){
+static void mw_Module_3D_ (void) {
     WORD_ENTER(mw_Module_3D_, "Module=", "src/mirth/data/module.mth", 24, 37);
     WORD_ATOM(24, 37, "both");
     push_u64(0);
@@ -37714,7 +37667,7 @@ static void mw_Module_3D_ (void){
     mw_prim_int_eq();
     WORD_EXIT(mw_Module_3D_);
 }
-static void mw_Module_2E_new_21_ (void){
+static void mw_Module_2E_new_21_ (void) {
     WORD_ENTER(mw_Module_2E_new_21_, "Module.new!", "src/mirth/data/module.mth", 27, 5);
     WORD_ATOM(27, 5, "Module.alloc!");
     mw_Module_2E_alloc_21_();
@@ -37734,7 +37687,7 @@ static void mw_Module_2E_new_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_Module_2E_new_21_);
 }
-static void mw_Module_2E_add_import_21_ (void){
+static void mw_Module_2E_add_import_21_ (void) {
     WORD_ENTER(mw_Module_2E_add_import_21_, "Module.add-import!", "src/mirth/data/module.mth", 34, 5);
     WORD_ATOM(34, 5, "swap");
     mw_prim_swap();
@@ -37747,7 +37700,7 @@ static void mw_Module_2E_add_import_21_ (void){
     mw_modify();
     WORD_EXIT(mw_Module_2E_add_import_21_);
 }
-static void mw_Module_2E_source_path (void){
+static void mw_Module_2E_source_path (void) {
     WORD_ENTER(mw_Module_2E_source_path, "Module.source-path", "src/mirth/data/module.mth", 38, 5);
     WORD_ATOM(38, 5, "path");
     mw_Module_2E_path();
@@ -37755,7 +37708,7 @@ static void mw_Module_2E_source_path (void){
     mw_Path_2E_to_source_path();
     WORD_EXIT(mw_Module_2E_source_path);
 }
-static void mw_Name_2E_to_module_path (void){
+static void mw_Name_2E_to_module_path (void) {
     WORD_ENTER(mw_Name_2E_to_module_path, "Name.to-module-path", "src/mirth/data/module.mth", 41, 5);
     WORD_ATOM(41, 5, "build-str!");
     push_u64(0);
@@ -37766,7 +37719,7 @@ static void mw_Name_2E_to_module_path (void){
     mw_Str_3E_Path();
     WORD_EXIT(mw_Name_2E_to_module_path);
 }
-static void mw_Module_2E_visible (void){
+static void mw_Module_2E_visible (void) {
     WORD_ENTER(mw_Module_2E_visible, "Module.visible", "src/mirth/data/module.mth", 54, 5);
     WORD_ATOM(54, 5, "dup2");
     mw_dup2();
@@ -37791,20 +37744,20 @@ static void mw_Module_2E_visible (void){
     }
     WORD_EXIT(mw_Module_2E_visible);
 }
-static void mw_Int_3E_Row (void){
+static void mw_Int_3E_Row (void) {
     WORD_ENTER(mw_Int_3E_Row, "Int>Row", "src/mirth/data/location.mth", 10, 26);
     WORD_ATOM(10, 26, "ROW");
     mw_ROW();
     WORD_EXIT(mw_Int_3E_Row);
 }
-static void mw_Row_3E_Int (void){
+static void mw_Row_3E_Int (void) {
     WORD_ENTER(mw_Row_3E_Int, "Row>Int", "src/mirth/data/location.mth", 11, 26);
     WORD_ATOM(11, 26, "ROW");
     WORD_ATOM(11, 33, "id");
     mw_prim_id();
     WORD_EXIT(mw_Row_3E_Int);
 }
-static void mw_Row_2E_trace_21_ (void){
+static void mw_Row_2E_trace_21_ (void) {
     WORD_ENTER(mw_Row_2E_trace_21_, "Row.trace!", "src/mirth/data/location.mth", 12, 25);
     WORD_ATOM(12, 25, ">Int");
     mw_Row_3E_Int();
@@ -37812,20 +37765,20 @@ static void mw_Row_2E_trace_21_ (void){
     mw_Int_2E_trace_21_();
     WORD_EXIT(mw_Row_2E_trace_21_);
 }
-static void mw_Int_3E_Col (void){
+static void mw_Int_3E_Col (void) {
     WORD_ENTER(mw_Int_3E_Col, "Int>Col", "src/mirth/data/location.mth", 15, 26);
     WORD_ATOM(15, 26, "COL");
     mw_COL();
     WORD_EXIT(mw_Int_3E_Col);
 }
-static void mw_Col_3E_Int (void){
+static void mw_Col_3E_Int (void) {
     WORD_ENTER(mw_Col_3E_Int, "Col>Int", "src/mirth/data/location.mth", 16, 26);
     WORD_ATOM(16, 26, "COL");
     WORD_ATOM(16, 33, "id");
     mw_prim_id();
     WORD_EXIT(mw_Col_3E_Int);
 }
-static void mw_Col_2E_trace_21_ (void){
+static void mw_Col_2E_trace_21_ (void) {
     WORD_ENTER(mw_Col_2E_trace_21_, "Col.trace!", "src/mirth/data/location.mth", 17, 25);
     WORD_ATOM(17, 25, ">Int");
     mw_Col_3E_Int();
@@ -37833,20 +37786,20 @@ static void mw_Col_2E_trace_21_ (void){
     mw_Int_2E_trace_21_();
     WORD_EXIT(mw_Col_2E_trace_21_);
 }
-static void mw_Location_2E_unpack (void){
+static void mw_Location_2E_unpack (void) {
     WORD_ENTER(mw_Location_2E_unpack, "Location.unpack", "src/mirth/data/location.mth", 20, 50);
     WORD_ATOM(20, 50, "LOCATION");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_LOCATION();
+            mp_LOCATION();
             WORD_ATOM(20, 62, "id");
             mw_prim_id();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_Location_2E_unpack);
+    }
+    WORD_EXIT(mw_Location_2E_unpack);
 }
-static void mw_Location_2E_trace_21_ (void){
+static void mw_Location_2E_trace_21_ (void) {
     WORD_ENTER(mw_Location_2E_trace_21_, "Location.trace!", "src/mirth/data/location.mth", 22, 5);
     WORD_ATOM(22, 5, "unpack");
     mw_Location_2E_unpack();
@@ -37890,7 +37843,7 @@ static void mw_Location_2E_trace_21_ (void){
     mw_Col_2E_trace_21_();
     WORD_EXIT(mw_Location_2E_trace_21_);
 }
-static void mw_init_errors_21_ (void){
+static void mw_init_errors_21_ (void) {
     WORD_ENTER(mw_init_errors_21_, "init-errors!", "src/mirth/data/error.mth", 16, 5);
     WORD_ATOM(16, 5, "");
     push_i64(0LL);
@@ -37906,7 +37859,7 @@ static void mw_init_errors_21_ (void){
     mw_prim_mut_set();
     WORD_EXIT(mw_init_errors_21_);
 }
-static void mw_emit_warning_at_21_ (void){
+static void mw_emit_warning_at_21_ (void) {
     WORD_ENTER(mw_emit_warning_at_21_, "emit-warning-at!", "src/mirth/data/error.mth", 20, 5);
     WORD_ATOM(20, 5, "dip");
     {
@@ -37939,7 +37892,7 @@ static void mw_emit_warning_at_21_ (void){
     mw_modify();
     WORD_EXIT(mw_emit_warning_at_21_);
 }
-static void mw_emit_error_at_21_ (void){
+static void mw_emit_error_at_21_ (void) {
     WORD_ENTER(mw_emit_error_at_21_, "emit-error-at!", "src/mirth/data/error.mth", 25, 5);
     WORD_ATOM(25, 5, "dip");
     {
@@ -37972,7 +37925,7 @@ static void mw_emit_error_at_21_ (void){
     mw_modify();
     WORD_EXIT(mw_emit_error_at_21_);
 }
-static void mw_emit_fatal_error_at_21_ (void){
+static void mw_emit_fatal_error_at_21_ (void) {
     WORD_ENTER(mw_emit_fatal_error_at_21_, "emit-fatal-error-at!", "src/mirth/data/error.mth", 30, 5);
     WORD_ATOM(30, 5, "emit-error-at!");
     mw_emit_error_at_21_();
@@ -37982,7 +37935,7 @@ static void mw_emit_fatal_error_at_21_ (void){
     mw_prim_posix_exit();
     WORD_EXIT(mw_emit_fatal_error_at_21_);
 }
-static void mw_init_21_ (void){
+static void mw_init_21_ (void) {
     WORD_ENTER(mw_init_21_, "init!", "src/mirth.mth", 16, 5);
     WORD_ATOM(16, 5, "init-errors!");
     mw_init_errors_21_();
@@ -37996,7 +37949,7 @@ static void mw_init_21_ (void){
     mw_init_elab_21_();
     WORD_EXIT(mw_init_21_);
 }
-static void mw_compile_21_ (void){
+static void mw_compile_21_ (void) {
     WORD_ENTER(mw_compile_21_, "compile!", "src/mirth.mth", 27, 5);
     WORD_ATOM(27, 5, "");
     {
@@ -38086,7 +38039,7 @@ static void mw_compile_21_ (void){
     }
     WORD_EXIT(mw_compile_21_);
 }
-static void mw_main (void){
+static void mw_main (void) {
     WORD_ENTER(mw_main, "main", "src/mirth.mth", 49, 5);
     WORD_ATOM(49, 5, "init!");
     mw_init_21_();
@@ -41073,7 +41026,7 @@ static void mb_Match_2E_is_exhaustive_3F__1 (void) {
     WORD_ATOM(44, 29, "match");
     switch (get_top_data_tag()) {
         case 1LL:
-            co_SOME();
+            mp_SOME();
             WORD_ATOM(46, 17, "num-tags");
             mw_Data_2E_num_tags();
             WORD_ATOM(47, 17, "over");
@@ -41086,7 +41039,7 @@ static void mb_Match_2E_is_exhaustive_3F__1 (void) {
             mw_prim_int_eq();
             break;
         case 0LL:
-            co_NONE();
+            mp_NONE();
             WORD_ATOM(49, 17, "dup");
             mw_prim_dup();
             WORD_ATOM(49, 21, "cases");
@@ -41097,8 +41050,8 @@ static void mb_Match_2E_is_exhaustive_3F__1 (void) {
             mw_0_3E_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mb_Match_2E_is_exhaustive_3F__1);
+    }
+    WORD_EXIT(mb_Match_2E_is_exhaustive_3F__1);
 }
 
 static void mb_Match_2E_has_default_case_3F__1 (void) {
@@ -42200,7 +42153,7 @@ static void mb_elab_case_pattern_21__6 (void) {
     WORD_ATOM(723, 14, "match");
     switch (get_top_data_tag()) {
         case 4LL:
-            co_DEF_5F_TAG();
+            mp_DEF_5F_TAG();
             WORD_ATOM(727, 17, "dup");
             mw_prim_dup();
             WORD_ATOM(727, 21, "PATTERN_TAG");
@@ -42276,7 +42229,7 @@ static void mb_elab_case_pattern_21__6 (void) {
             mw_Token_2E_succ();
             break;
         case 0LL:
-            co_DEF_5F_NONE();
+            mp_DEF_5F_NONE();
             WORD_ATOM(744, 17, "");
             {
                 static bool vready = false;
@@ -42308,8 +42261,8 @@ static void mb_elab_case_pattern_21__6 (void) {
             WORD_ATOM(747, 43, "emit-fatal-error!");
             mw_emit_fatal_error_21_();
             break;
-    
-}    WORD_EXIT(mb_elab_case_pattern_21__6);
+    }
+    WORD_EXIT(mb_elab_case_pattern_21__6);
 }
 
 static void mb_elab_case_pattern_21__17 (void) {
@@ -43679,20 +43632,20 @@ static void mb_determine_transitive_needs_21__2 (void) {
     WORD_ATOM(67, 34, "match");
     switch (get_top_data_tag()) {
         case 1LL:
-            co_NEED_5F_BLOCK();
+            mp_NEED_5F_BLOCK();
             WORD_ATOM(68, 23, "need-block-run");
             mw_need_block_run();
             break;
         case 0LL:
-            co_NEED_5F_WORD();
+            mp_NEED_5F_WORD();
             WORD_ATOM(69, 22, "arrow");
             mw_Word_2E_arrow();
             WORD_ATOM(69, 28, "need-arrow-run");
             mw_need_arrow_run();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mb_determine_transitive_needs_21__2);
+    }
+    WORD_EXIT(mb_determine_transitive_needs_21__2);
 }
 
 static void mb_need_atom_run_1 (void) {
@@ -43721,12 +43674,12 @@ static void mb_need_match_1 (void) {
     WORD_EXIT(mb_need_match_1);
 }
 
-static void mb_Str_2B_C99_2E__3 (void) {
-    WORD_ENTER(mb_Str_2B_C99_2E__3, "Str+C99. block", "src/mirth/codegen.mth", 140, 16);
+static void mb_Str_2B_C99_2E_put_3 (void) {
+    WORD_ENTER(mb_Str_2B_C99_2E_put_3, "Str+C99.put block", "src/mirth/codegen.mth", 141, 16);
     mw_prim_drop();
-    WORD_ATOM(140, 16, "codegen-flush!");
+    WORD_ATOM(141, 16, "codegen-flush!");
     mw_codegen_flush_21_();
-    WORD_EXIT(mb_Str_2B_C99_2E__3);
+    WORD_EXIT(mb_Str_2B_C99_2E_put_3);
 }
 
 static void mb_c99_tags_21__1 (void) {
@@ -43762,33 +43715,33 @@ static void mb_c99_externals_21__1 (void) {
 }
 
 static void mb_c99_word_sigs_21__1 (void) {
-    WORD_ENTER(mb_c99_word_sigs_21__1, "c99-word-sigs! block", "src/mirth/codegen.mth", 547, 52);
+    WORD_ENTER(mb_c99_word_sigs_21__1, "c99-word-sigs! block", "src/mirth/codegen.mth", 548, 52);
     mw_prim_drop();
-    WORD_ATOM(547, 52, "c99-word-sig!");
+    WORD_ATOM(548, 52, "c99-word-sig!");
     mw_c99_word_sig_21_();
     WORD_EXIT(mb_c99_word_sigs_21__1);
 }
 
 static void mb_c99_block_sigs_21__1 (void) {
-    WORD_ENTER(mb_c99_block_sigs_21__1, "c99-block-sigs! block", "src/mirth/codegen.mth", 551, 54);
+    WORD_ENTER(mb_c99_block_sigs_21__1, "c99-block-sigs! block", "src/mirth/codegen.mth", 552, 54);
     mw_prim_drop();
-    WORD_ATOM(551, 54, "c99-block-sig!");
+    WORD_ATOM(552, 54, "c99-block-sig!");
     mw_c99_block_sig_21_();
     WORD_EXIT(mb_c99_block_sigs_21__1);
 }
 
 static void mb_c99_field_sigs_21__1 (void) {
-    WORD_ENTER(mb_c99_field_sigs_21__1, "c99-field-sigs! block", "src/mirth/codegen.mth", 555, 46);
+    WORD_ENTER(mb_c99_field_sigs_21__1, "c99-field-sigs! block", "src/mirth/codegen.mth", 556, 46);
     mw_prim_drop();
-    WORD_ATOM(555, 46, "c99-field-sig!");
+    WORD_ATOM(556, 46, "c99-field-sig!");
     mw_c99_field_sig_21_();
     WORD_EXIT(mb_c99_field_sigs_21__1);
 }
 
 static void mb_c99_main_21__1 (void) {
-    WORD_ENTER(mb_c99_main_21__1, "c99-main! block", "src/mirth/codegen.mth", 641, 14);
+    WORD_ENTER(mb_c99_main_21__1, "c99-main! block", "src/mirth/codegen.mth", 642, 14);
     mw_prim_drop();
-    WORD_ATOM(641, 14, "");
+    WORD_ATOM(642, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43799,37 +43752,37 @@ static void mb_c99_main_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(641, 51, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(642, 51, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_main_21__1);
 }
 
 static void mb_c99_main_21__2 (void) {
-    WORD_ENTER(mb_c99_main_21__2, "c99-main! block", "src/mirth/codegen.mth", 643, 9);
+    WORD_ENTER(mb_c99_main_21__2, "c99-main! block", "src/mirth/codegen.mth", 644, 9);
     mw_prim_drop();
-    WORD_ATOM(643, 9, "c99-line");
+    WORD_ATOM(644, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(644, 9, "c99-line");
+    WORD_ATOM(645, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__4);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(645, 9, "c99-line");
+    WORD_ATOM(646, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__5);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(651, 9, "c99-arrow!");
+    WORD_ATOM(652, 9, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(652, 9, "c99-line");
+    WORD_ATOM(653, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__6);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(653, 9, "c99-line");
+    WORD_ATOM(654, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__7);
     mw_prim_pack_cons();
@@ -43838,9 +43791,9 @@ static void mb_c99_main_21__2 (void) {
 }
 
 static void mb_c99_main_21__3 (void) {
-    WORD_ENTER(mb_c99_main_21__3, "c99-main! block", "src/mirth/codegen.mth", 643, 18);
+    WORD_ENTER(mb_c99_main_21__3, "c99-main! block", "src/mirth/codegen.mth", 644, 18);
     mw_prim_drop();
-    WORD_ATOM(643, 18, "");
+    WORD_ATOM(644, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43851,15 +43804,15 @@ static void mb_c99_main_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(643, 40, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(644, 40, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_main_21__3);
 }
 
 static void mb_c99_main_21__4 (void) {
-    WORD_ENTER(mb_c99_main_21__4, "c99-main! block", "src/mirth/codegen.mth", 644, 18);
+    WORD_ENTER(mb_c99_main_21__4, "c99-main! block", "src/mirth/codegen.mth", 645, 18);
     mw_prim_drop();
-    WORD_ATOM(644, 18, "");
+    WORD_ATOM(645, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43870,15 +43823,15 @@ static void mb_c99_main_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(644, 40, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(645, 40, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_main_21__4);
 }
 
 static void mb_c99_main_21__5 (void) {
-    WORD_ENTER(mb_c99_main_21__5, "c99-main! block", "src/mirth/codegen.mth", 645, 18);
+    WORD_ENTER(mb_c99_main_21__5, "c99-main! block", "src/mirth/codegen.mth", 646, 18);
     mw_prim_drop();
-    WORD_ATOM(645, 18, "");
+    WORD_ATOM(646, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43889,9 +43842,9 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(645, 32, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(646, 13, "");
+    WORD_ATOM(646, 32, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(647, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43902,9 +43855,9 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(646, 34, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(647, 13, "");
+    WORD_ATOM(647, 34, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(648, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43915,44 +43868,21 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(647, 28, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(648, 13, "dup");
-    mw_prim_dup();
-    WORD_ATOM(648, 17, "token-start");
-    mw_Arrow_2E_token_start();
-    WORD_ATOM(648, 29, ".module");
-    mw_Token_2E_module();
-    WORD_ATOM(648, 37, "source-path");
-    mw_Module_2E_source_path();
-    WORD_ATOM(648, 49, ">Str");
-    mw_Path_3E_Str();
-    WORD_ATOM(648, 54, ".str");
-    mw__2E_str();
-    WORD_ATOM(648, 59, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr(", ", 2);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(648, 64, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(648, 28, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_ATOM(649, 13, "dup");
     mw_prim_dup();
     WORD_ATOM(649, 17, "token-start");
     mw_Arrow_2E_token_start();
-    WORD_ATOM(649, 29, "row");
-    mw_Token_2E_row();
-    WORD_ATOM(649, 33, ">Int");
-    mw_Row_3E_Int();
-    WORD_ATOM(649, 38, ".n");
-    mw_Int_2B_C99_2E_n();
-    WORD_ATOM(649, 41, "");
+    WORD_ATOM(649, 29, ".module");
+    mw_Token_2E_module();
+    WORD_ATOM(649, 37, "source-path");
+    mw_Module_2E_source_path();
+    WORD_ATOM(649, 49, ">Str");
+    mw_Path_3E_Str();
+    WORD_ATOM(649, 54, "put-cstr");
+    mw__2B_C99_2E_put_cstr();
+    WORD_ATOM(649, 63, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43963,19 +43893,42 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(649, 46, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(649, 68, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_ATOM(650, 13, "dup");
     mw_prim_dup();
     WORD_ATOM(650, 17, "token-start");
     mw_Arrow_2E_token_start();
-    WORD_ATOM(650, 29, "col");
-    mw_Token_2E_col();
+    WORD_ATOM(650, 29, "row");
+    mw_Token_2E_row();
     WORD_ATOM(650, 33, ">Int");
+    mw_Row_3E_Int();
+    WORD_ATOM(650, 38, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(650, 42, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr(", ", 2);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(650, 47, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(651, 13, "dup");
+    mw_prim_dup();
+    WORD_ATOM(651, 17, "token-start");
+    mw_Arrow_2E_token_start();
+    WORD_ATOM(651, 29, "col");
+    mw_Token_2E_col();
+    WORD_ATOM(651, 33, ">Int");
     mw_Col_3E_Int();
-    WORD_ATOM(650, 38, ".n");
-    mw_Int_2B_C99_2E_n();
-    WORD_ATOM(650, 41, "");
+    WORD_ATOM(651, 38, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(651, 42, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43986,15 +43939,15 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(650, 46, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(651, 47, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_main_21__5);
 }
 
 static void mb_c99_main_21__6 (void) {
-    WORD_ENTER(mb_c99_main_21__6, "c99-main! block", "src/mirth/codegen.mth", 652, 18);
+    WORD_ENTER(mb_c99_main_21__6, "c99-main! block", "src/mirth/codegen.mth", 653, 18);
     mw_prim_drop();
-    WORD_ATOM(652, 18, "");
+    WORD_ATOM(653, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44005,15 +43958,15 @@ static void mb_c99_main_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(652, 49, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(653, 49, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_main_21__6);
 }
 
 static void mb_c99_main_21__7 (void) {
-    WORD_ENTER(mb_c99_main_21__7, "c99-main! block", "src/mirth/codegen.mth", 653, 18);
+    WORD_ENTER(mb_c99_main_21__7, "c99-main! block", "src/mirth/codegen.mth", 654, 18);
     mw_prim_drop();
-    WORD_ATOM(653, 18, "");
+    WORD_ATOM(654, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44024,15 +43977,15 @@ static void mb_c99_main_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(653, 30, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(654, 30, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_main_21__7);
 }
 
 static void mb_c99_main_21__8 (void) {
-    WORD_ENTER(mb_c99_main_21__8, "c99-main! block", "src/mirth/codegen.mth", 655, 14);
+    WORD_ENTER(mb_c99_main_21__8, "c99-main! block", "src/mirth/codegen.mth", 656, 14);
     mw_prim_drop();
-    WORD_ATOM(655, 14, "");
+    WORD_ATOM(656, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44043,31 +43996,31 @@ static void mb_c99_main_21__8 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(655, 18, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(656, 18, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_main_21__8);
 }
 
 static void mb_c99_field_defs_21__1 (void) {
-    WORD_ENTER(mb_c99_field_defs_21__1, "c99-field-defs! block", "src/mirth/codegen.mth", 621, 46);
+    WORD_ENTER(mb_c99_field_defs_21__1, "c99-field-defs! block", "src/mirth/codegen.mth", 622, 46);
     mw_prim_drop();
-    WORD_ATOM(621, 46, "c99-field-def!");
+    WORD_ATOM(622, 46, "c99-field-def!");
     mw_c99_field_def_21_();
     WORD_EXIT(mb_c99_field_defs_21__1);
 }
 
 static void mb_c99_word_defs_21__1 (void) {
-    WORD_ENTER(mb_c99_word_defs_21__1, "c99-word-defs! block", "src/mirth/codegen.mth", 610, 52);
+    WORD_ENTER(mb_c99_word_defs_21__1, "c99-word-defs! block", "src/mirth/codegen.mth", 611, 52);
     mw_prim_drop();
-    WORD_ATOM(610, 52, "c99-word-def!");
+    WORD_ATOM(611, 52, "c99-word-def!");
     mw_c99_word_def_21_();
     WORD_EXIT(mb_c99_word_defs_21__1);
 }
 
 static void mb_c99_block_defs_21__1 (void) {
-    WORD_ENTER(mb_c99_block_defs_21__1, "c99-block-defs! block", "src/mirth/codegen.mth", 574, 54);
+    WORD_ENTER(mb_c99_block_defs_21__1, "c99-block-defs! block", "src/mirth/codegen.mth", 575, 54);
     mw_prim_drop();
-    WORD_ATOM(574, 54, "c99-block-def!");
+    WORD_ATOM(575, 54, "c99-block-def!");
     mw_c99_block_def_21_();
     WORD_EXIT(mb_c99_block_defs_21__1);
 }
@@ -44086,8 +44039,10 @@ static void mb_c99_tag_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(213, 29, ";");
-    mw_Str_2B_C99_3B_();
+    WORD_ATOM(213, 29, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(213, 33, "line");
+    mw__2B_C99_2E_line();
     WORD_ATOM(214, 13, "");
     {
         static bool vready = false;
@@ -44099,8 +44054,8 @@ static void mb_c99_tag_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(214, 38, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(214, 38, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_tag_21__3);
 }
 
@@ -44118,8 +44073,10 @@ static void mb_c99_tag_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(217, 32, ";");
-    mw_Str_2B_C99_3B_();
+    WORD_ATOM(217, 32, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(217, 36, "line");
+    mw__2B_C99_2E_line();
     WORD_ATOM(218, 13, "");
     {
         static bool vready = false;
@@ -44131,8 +44088,8 @@ static void mb_c99_tag_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(218, 38, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(218, 38, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_tag_21__4);
 }
 
@@ -44150,11 +44107,13 @@ static void mb_c99_tag_21__11 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(238, 52, ";");
-    mw_Str_2B_C99_3B_();
-    WORD_ATOM(239, 13, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(239, 15, "");
+    WORD_ATOM(238, 52, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(238, 56, "line");
+    mw__2B_C99_2E_line();
+    WORD_ATOM(239, 13, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(239, 17, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44165,8 +44124,10 @@ static void mb_c99_tag_21__11 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(239, 23, ";");
-    mw_Str_2B_C99_3B_();
+    WORD_ATOM(239, 25, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(239, 29, "line");
+    mw__2B_C99_2E_line();
     WORD_ATOM(240, 13, "");
     {
         static bool vready = false;
@@ -44195,11 +44156,13 @@ static void mb_c99_tag_21__12 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(243, 52, ";");
-    mw_Str_2B_C99_3B_();
-    WORD_ATOM(244, 13, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(244, 15, "");
+    WORD_ATOM(243, 52, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(243, 56, "line");
+    mw__2B_C99_2E_line();
+    WORD_ATOM(244, 13, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(244, 17, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44210,8 +44173,10 @@ static void mb_c99_tag_21__12 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(244, 23, ";");
-    mw_Str_2B_C99_3B_();
+    WORD_ATOM(244, 25, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(244, 29, "line");
+    mw__2B_C99_2E_line();
     WORD_ATOM(245, 13, "");
     {
         static bool vready = false;
@@ -44235,15 +44200,15 @@ static void mb_c99_external_21__5 (void) {
     mw_External_2E_name();
     WORD_ATOM(267, 19, ">Str");
     mw_Name_3E_Str();
-    WORD_ATOM(267, 24, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(267, 24, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_external_21__5);
 }
 
 static void mb_c99_external_21__7 (void) {
-    WORD_ENTER(mb_c99_external_21__7, "c99-external! block", "src/mirth/codegen.mth", 270, 42);
+    WORD_ENTER(mb_c99_external_21__7, "c99-external! block", "src/mirth/codegen.mth", 270, 44);
     mw_prim_drop();
-    WORD_ATOM(270, 42, "");
+    WORD_ATOM(270, 44, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44254,20 +44219,22 @@ static void mb_c99_external_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(270, 54, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(270, 56, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_external_21__7);
 }
 
 static void mb_c99_external_21__9 (void) {
-    WORD_ENTER(mb_c99_external_21__9, "c99-external! block", "src/mirth/codegen.mth", 273, 30);
+    WORD_ENTER(mb_c99_external_21__9, "c99-external! block", "src/mirth/codegen.mth", 273, 10);
     mw_prim_drop();
-    WORD_ATOM(273, 30, "dup");
+    WORD_ATOM(273, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(273, 34, "name");
+    WORD_ATOM(273, 14, "name");
     mw_External_2E_name();
-    WORD_ATOM(273, 39, ".name");
-    mw_Name_2B_C99_2E_name();
+    WORD_ATOM(273, 19, "sig");
+    mw_Name_2B_C99_2E_sig();
+    WORD_ATOM(273, 23, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_external_21__9);
 }
 
@@ -44285,11 +44252,11 @@ static void mb_c99_external_21__10 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(274, 36, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(274, 38, ".n");
-    mw_Int_2B_C99_2E_n();
-    WORD_ATOM(274, 41, "");
+    WORD_ATOM(274, 36, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(274, 40, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(274, 44, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44300,8 +44267,10 @@ static void mb_c99_external_21__10 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(274, 57, ";");
-    mw_Str_2B_C99_3B_();
+    WORD_ATOM(274, 60, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(274, 64, "line");
+    mw__2B_C99_2E_line();
     WORD_EXIT(mb_c99_external_21__10);
 }
 
@@ -44314,8 +44283,8 @@ static void mb_c99_external_21__13 (void) {
     mw_External_2E_name();
     WORD_ATOM(276, 19, ">Str");
     mw_Name_3E_Str();
-    WORD_ATOM(276, 24, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(276, 24, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_external_21__13);
 }
 
@@ -44333,11 +44302,11 @@ static void mb_c99_external_21__16 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(279, 30, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(279, 32, ".n");
-    mw_Int_2B_C99_2E_n();
-    WORD_ATOM(279, 35, "");
+    WORD_ATOM(279, 30, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(279, 34, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(279, 38, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44348,8 +44317,8 @@ static void mb_c99_external_21__16 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(279, 40, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(279, 43, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_external_21__16);
 }
 
@@ -44367,8 +44336,8 @@ static void mb_c99_indent_1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(292, 52, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(292, 52, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_indent_1);
 }
 
@@ -44386,10 +44355,10 @@ static void mb_c99_call_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(297, 20, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(297, 22, ".name");
-    mw_Name_2B_C99_2E_name();
+    WORD_ATOM(297, 20, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(297, 24, "put");
+    mw_Name_2B_C99_2E_put();
     WORD_ATOM(297, 28, "");
     {
         static bool vready = false;
@@ -44401,15 +44370,15 @@ static void mb_c99_call_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(297, 34, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(297, 34, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_call_21__2);
 }
 
 static void mb_c99_args_push_21__1 (void) {
-    WORD_ENTER(mb_c99_args_push_21__1, "c99-args-push! block", "src/mirth/codegen.mth", 442, 9);
+    WORD_ENTER(mb_c99_args_push_21__1, "c99-args-push! block", "src/mirth/codegen.mth", 443, 9);
     mw_prim_drop();
-    WORD_ATOM(442, 9, "c99-arg-push!");
+    WORD_ATOM(443, 9, "c99-arg-push!");
     mw_c99_arg_push_21_();
     WORD_EXIT(mb_c99_args_push_21__1);
 }
@@ -44436,8 +44405,8 @@ static void mb_c99_atom_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(301, 27, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(301, 27, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_ATOM(302, 9, "dup");
     mw_prim_dup();
     WORD_ATOM(302, 13, "token");
@@ -44446,9 +44415,9 @@ static void mb_c99_atom_21__1 (void) {
     mw_Token_2E_row();
     WORD_ATOM(302, 23, ">Int");
     mw_Row_3E_Int();
-    WORD_ATOM(302, 28, ".n");
-    mw_Int_2B_C99_2E_n();
-    WORD_ATOM(302, 31, "");
+    WORD_ATOM(302, 28, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(302, 32, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44459,8 +44428,8 @@ static void mb_c99_atom_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(302, 36, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(302, 37, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_ATOM(303, 9, "dup");
     mw_prim_dup();
     WORD_ATOM(303, 13, "token");
@@ -44469,9 +44438,9 @@ static void mb_c99_atom_21__1 (void) {
     mw_Token_2E_col();
     WORD_ATOM(303, 23, ">Int");
     mw_Col_3E_Int();
-    WORD_ATOM(303, 28, ".n");
-    mw_Int_2B_C99_2E_n();
-    WORD_ATOM(303, 31, "");
+    WORD_ATOM(303, 28, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(303, 32, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44482,8 +44451,8 @@ static void mb_c99_atom_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(303, 36, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(303, 37, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_ATOM(304, 9, "dup");
     mw_prim_dup();
     WORD_ATOM(304, 13, "token");
@@ -44498,8 +44467,8 @@ static void mb_c99_atom_21__1 (void) {
     push_fnptr(&mb_c99_atom_21__3);
     mw_prim_pack_cons();
     mw_Maybe_2E_if_some();
-    WORD_ATOM(304, 43, ".str");
-    mw__2E_str();
+    WORD_ATOM(304, 43, "put-cstr");
+    mw__2B_C99_2E_put_cstr();
     WORD_ATOM(305, 9, "");
     {
         static bool vready = false;
@@ -44511,8 +44480,8 @@ static void mb_c99_atom_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(305, 14, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(305, 14, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_atom_21__1);
 }
 
@@ -44549,14 +44518,6 @@ static void mb_c99_atom_21__4 (void) {
     WORD_EXIT(mb_c99_atom_21__4);
 }
 
-static void mb__2E_str_1 (void) {
-    WORD_ENTER(mb__2E_str_1, ".str block", "src/mirth/codegen.mth", 357, 50);
-    mw_prim_drop();
-    WORD_ATOM(357, 50, "c99-string-byte!");
-    mw_c99_string_byte_21_();
-    WORD_EXIT(mb__2E_str_1);
-}
-
 static void mb_c99_int_21__1 (void) {
     WORD_ENTER(mb_c99_int_21__1, "c99-int! block", "src/mirth/codegen.mth", 327, 14);
     mw_prim_drop();
@@ -44571,11 +44532,11 @@ static void mb_c99_int_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(327, 26, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(327, 28, ".n");
-    mw_Int_2B_C99_2E_n();
-    WORD_ATOM(327, 31, "");
+    WORD_ATOM(327, 26, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(327, 30, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(327, 34, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44586,8 +44547,8 @@ static void mb_c99_int_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(327, 38, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(327, 41, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_int_21__1);
 }
 
@@ -44605,8 +44566,8 @@ static void mb_c99_str_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(330, 18, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(330, 18, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__1);
 }
 
@@ -44665,8 +44626,8 @@ static void mb_c99_str_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(332, 48, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(332, 48, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__3);
 }
 
@@ -44684,8 +44645,8 @@ static void mb_c99_str_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(333, 34, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(333, 34, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__4);
 }
 
@@ -44703,8 +44664,8 @@ static void mb_c99_str_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(334, 36, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(334, 36, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__5);
 }
 
@@ -44732,8 +44693,8 @@ static void mb_c99_str_21__6 (void) {
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(337, 42, ".");
-        mw_Str_2B_C99_2E_();
+        WORD_ATOM(337, 42, "put");
+        mw_Str_2B_C99_2E_put();
         WORD_ATOM(338, 17, "c99-nest");
         push_u64(0);
         push_fnptr(&mb_c99_str_21__8);
@@ -44776,8 +44737,8 @@ static void mb_c99_str_21__8 (void) {
     push_fnptr(&mb_c99_str_21__9);
     mw_prim_pack_cons();
     mw_str_bytes_for();
-    WORD_ATOM(342, 23, ".lf");
-    mw__2B_C99_2E_lf();
+    WORD_ATOM(342, 23, "line");
+    mw__2B_C99_2E_line();
     WORD_EXIT(mb_c99_str_21__8);
 }
 
@@ -44788,9 +44749,9 @@ static void mb_c99_str_21__9 (void) {
     mw_Byte_3E_Int();
     WORD_ATOM(340, 30, "dup");
     mw_prim_dup();
-    WORD_ATOM(340, 34, ".n");
-    mw_Int_2B_C99_2E_n();
-    WORD_ATOM(340, 37, "");
+    WORD_ATOM(340, 34, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(340, 38, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44801,20 +44762,20 @@ static void mb_c99_str_21__9 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(340, 41, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(340, 42, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_ATOM(341, 25, "");
     push_i64(10LL);
     WORD_ATOM(341, 28, "=");
     mw_prim_int_eq();
     WORD_ATOM(341, 30, "if");
     if (pop_u64()) {
-        WORD_ATOM(341, 33, ".lf");
-        mw__2B_C99_2E_lf();
-        WORD_ATOM(341, 37, "c99-indent");
+        WORD_ATOM(341, 33, "line");
+        mw__2B_C99_2E_line();
+        WORD_ATOM(341, 38, "c99-indent");
         mw_c99_indent();
     } else {
-        WORD_ATOM(341, 49, "id");
+        WORD_ATOM(341, 50, "id");
         mw_prim_id();
     }
     WORD_EXIT(mb_c99_str_21__9);
@@ -44834,8 +44795,8 @@ static void mb_c99_str_21__12 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(344, 31, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(344, 31, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__12);
 }
 
@@ -44853,15 +44814,15 @@ static void mb_c99_str_21__13 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(345, 49, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(345, 51, "dup");
+    WORD_ATOM(345, 49, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(345, 53, "dup");
     mw_prim_dup();
-    WORD_ATOM(345, 55, "num-bytes");
+    WORD_ATOM(345, 57, "num-bytes");
     mw_prim_str_num_bytes();
-    WORD_ATOM(345, 65, ".n");
-    mw_Int_2B_C99_2E_n();
-    WORD_ATOM(345, 68, "");
+    WORD_ATOM(345, 67, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(345, 71, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44872,8 +44833,8 @@ static void mb_c99_str_21__13 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(345, 73, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(345, 76, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__13);
 }
 
@@ -44891,13 +44852,13 @@ static void mb_c99_str_21__15 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(346, 39, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(346, 41, "dup");
+    WORD_ATOM(346, 39, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(346, 43, "dup");
     mw_prim_dup();
-    WORD_ATOM(346, 45, ".str");
-    mw__2E_str();
-    WORD_ATOM(346, 50, "");
+    WORD_ATOM(346, 47, "put-cstr");
+    mw__2B_C99_2E_put_cstr();
+    WORD_ATOM(346, 56, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44908,15 +44869,15 @@ static void mb_c99_str_21__15 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(346, 55, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(346, 57, "dup");
+    WORD_ATOM(346, 61, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(346, 65, "dup");
     mw_prim_dup();
-    WORD_ATOM(346, 61, "num-bytes");
+    WORD_ATOM(346, 69, "num-bytes");
     mw_prim_str_num_bytes();
-    WORD_ATOM(346, 71, ".n");
-    mw_Int_2B_C99_2E_n();
-    WORD_ATOM(346, 74, "");
+    WORD_ATOM(346, 79, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(346, 83, "");
     {
         static bool vready = false;
         static VAL v;
@@ -44927,8 +44888,8 @@ static void mb_c99_str_21__15 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(346, 79, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(346, 88, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__15);
 }
 
@@ -44946,8 +44907,8 @@ static void mb_c99_str_21__16 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(348, 39, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(348, 39, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__16);
 }
 
@@ -44965,8 +44926,8 @@ static void mb_c99_str_21__17 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(350, 22, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(350, 22, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__17);
 }
 
@@ -44984,8 +44945,8 @@ static void mb_c99_str_21__18 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(351, 35, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(351, 35, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__18);
 }
 
@@ -45003,8 +44964,8 @@ static void mb_c99_str_21__19 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(352, 31, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(352, 31, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__19);
 }
 
@@ -45022,15 +44983,15 @@ static void mb_c99_str_21__20 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(354, 18, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(354, 18, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_str_21__20);
 }
 
 static void mb_c99_prim_21__3 (void) {
-    WORD_ENTER(mb_c99_prim_21__3, "c99-prim! block", "src/mirth/codegen.mth", 384, 26);
+    WORD_ENTER(mb_c99_prim_21__3, "c99-prim! block", "src/mirth/codegen.mth", 385, 26);
     mw_prim_drop();
-    WORD_ATOM(384, 26, "");
+    WORD_ATOM(385, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45041,22 +45002,22 @@ static void mb_c99_prim_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(384, 30, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(385, 30, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__3);
 }
 
 static void mb_c99_prim_21__4 (void) {
-    WORD_ENTER(mb_c99_prim_21__4, "c99-prim! block", "src/mirth/codegen.mth", 386, 21);
+    WORD_ENTER(mb_c99_prim_21__4, "c99-prim! block", "src/mirth/codegen.mth", 387, 21);
     mw_prim_drop();
-    WORD_ATOM(386, 21, "c99-line");
+    WORD_ATOM(387, 21, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_prim_21__5);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(387, 21, "c99-arg-run!");
+    WORD_ATOM(388, 21, "c99-arg-run!");
     mw_c99_arg_run_21_();
-    WORD_ATOM(388, 21, "c99-line");
+    WORD_ATOM(389, 21, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_prim_21__6);
     mw_prim_pack_cons();
@@ -45065,9 +45026,9 @@ static void mb_c99_prim_21__4 (void) {
 }
 
 static void mb_c99_prim_21__5 (void) {
-    WORD_ENTER(mb_c99_prim_21__5, "c99-prim! block", "src/mirth/codegen.mth", 386, 30);
+    WORD_ENTER(mb_c99_prim_21__5, "c99-prim! block", "src/mirth/codegen.mth", 387, 30);
     mw_prim_drop();
-    WORD_ATOM(386, 30, "");
+    WORD_ATOM(387, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45078,13 +45039,13 @@ static void mb_c99_prim_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(386, 38, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(386, 40, "depth@");
+    WORD_ATOM(387, 38, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(387, 42, "depth@");
     mw__2B_C99_2E_depth_40_();
-    WORD_ATOM(386, 47, ".n");
-    mw_Int_2B_C99_2E_n();
-    WORD_ATOM(386, 50, "");
+    WORD_ATOM(387, 49, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(387, 53, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45095,15 +45056,15 @@ static void mb_c99_prim_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(386, 68, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(387, 71, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__5);
 }
 
 static void mb_c99_prim_21__6 (void) {
-    WORD_ENTER(mb_c99_prim_21__6, "c99-prim! block", "src/mirth/codegen.mth", 388, 30);
+    WORD_ENTER(mb_c99_prim_21__6, "c99-prim! block", "src/mirth/codegen.mth", 389, 30);
     mw_prim_drop();
-    WORD_ATOM(388, 30, "");
+    WORD_ATOM(389, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45114,13 +45075,13 @@ static void mb_c99_prim_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(388, 45, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(388, 47, "depth@");
+    WORD_ATOM(389, 45, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(389, 49, "depth@");
     mw__2B_C99_2E_depth_40_();
-    WORD_ATOM(388, 54, ".n");
-    mw_Int_2B_C99_2E_n();
-    WORD_ATOM(388, 57, "");
+    WORD_ATOM(389, 56, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(389, 60, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45131,15 +45092,15 @@ static void mb_c99_prim_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(388, 62, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(389, 65, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__6);
 }
 
 static void mb_c99_prim_21__7 (void) {
-    WORD_ENTER(mb_c99_prim_21__7, "c99-prim! block", "src/mirth/codegen.mth", 390, 26);
+    WORD_ENTER(mb_c99_prim_21__7, "c99-prim! block", "src/mirth/codegen.mth", 391, 26);
     mw_prim_drop();
-    WORD_ATOM(390, 26, "");
+    WORD_ATOM(391, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45150,15 +45111,15 @@ static void mb_c99_prim_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(390, 30, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(391, 30, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__7);
 }
 
 static void mb_c99_prim_21__11 (void) {
-    WORD_ENTER(mb_c99_prim_21__11, "c99-prim! block", "src/mirth/codegen.mth", 398, 26);
+    WORD_ENTER(mb_c99_prim_21__11, "c99-prim! block", "src/mirth/codegen.mth", 399, 26);
     mw_prim_drop();
-    WORD_ATOM(398, 26, "");
+    WORD_ATOM(399, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45169,22 +45130,22 @@ static void mb_c99_prim_21__11 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(398, 30, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(399, 30, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__11);
 }
 
 static void mb_c99_prim_21__12 (void) {
-    WORD_ENTER(mb_c99_prim_21__12, "c99-prim! block", "src/mirth/codegen.mth", 400, 21);
+    WORD_ENTER(mb_c99_prim_21__12, "c99-prim! block", "src/mirth/codegen.mth", 401, 21);
     mw_prim_drop();
-    WORD_ATOM(400, 21, "c99-line");
+    WORD_ATOM(401, 21, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_prim_21__13);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(401, 21, "c99-arg-run!");
+    WORD_ATOM(402, 21, "c99-arg-run!");
     mw_c99_arg_run_21_();
-    WORD_ATOM(402, 21, "c99-line");
+    WORD_ATOM(403, 21, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_prim_21__14);
     mw_prim_pack_cons();
@@ -45193,9 +45154,9 @@ static void mb_c99_prim_21__12 (void) {
 }
 
 static void mb_c99_prim_21__13 (void) {
-    WORD_ENTER(mb_c99_prim_21__13, "c99-prim! block", "src/mirth/codegen.mth", 400, 30);
+    WORD_ENTER(mb_c99_prim_21__13, "c99-prim! block", "src/mirth/codegen.mth", 401, 30);
     mw_prim_drop();
-    WORD_ATOM(400, 30, "");
+    WORD_ATOM(401, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45206,13 +45167,13 @@ static void mb_c99_prim_21__13 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(400, 38, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(400, 40, "depth@");
+    WORD_ATOM(401, 38, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(401, 42, "depth@");
     mw__2B_C99_2E_depth_40_();
-    WORD_ATOM(400, 47, ".n");
-    mw_Int_2B_C99_2E_n();
-    WORD_ATOM(400, 50, "");
+    WORD_ATOM(401, 49, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(401, 53, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45223,15 +45184,15 @@ static void mb_c99_prim_21__13 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(400, 71, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(401, 74, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__13);
 }
 
 static void mb_c99_prim_21__14 (void) {
-    WORD_ENTER(mb_c99_prim_21__14, "c99-prim! block", "src/mirth/codegen.mth", 402, 30);
+    WORD_ENTER(mb_c99_prim_21__14, "c99-prim! block", "src/mirth/codegen.mth", 403, 30);
     mw_prim_drop();
-    WORD_ATOM(402, 30, "");
+    WORD_ATOM(403, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45242,13 +45203,13 @@ static void mb_c99_prim_21__14 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(402, 48, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(402, 50, "depth@");
+    WORD_ATOM(403, 48, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(403, 52, "depth@");
     mw__2B_C99_2E_depth_40_();
-    WORD_ATOM(402, 57, ".n");
-    mw_Int_2B_C99_2E_n();
-    WORD_ATOM(402, 60, "");
+    WORD_ATOM(403, 59, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(403, 63, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45259,15 +45220,15 @@ static void mb_c99_prim_21__14 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(402, 65, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(403, 68, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__14);
 }
 
 static void mb_c99_prim_21__15 (void) {
-    WORD_ENTER(mb_c99_prim_21__15, "c99-prim! block", "src/mirth/codegen.mth", 404, 26);
+    WORD_ENTER(mb_c99_prim_21__15, "c99-prim! block", "src/mirth/codegen.mth", 405, 26);
     mw_prim_drop();
-    WORD_ATOM(404, 26, "");
+    WORD_ATOM(405, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45278,15 +45239,15 @@ static void mb_c99_prim_21__15 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(404, 30, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(405, 30, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__15);
 }
 
 static void mb_c99_prim_21__19 (void) {
-    WORD_ENTER(mb_c99_prim_21__19, "c99-prim! block", "src/mirth/codegen.mth", 412, 26);
+    WORD_ENTER(mb_c99_prim_21__19, "c99-prim! block", "src/mirth/codegen.mth", 413, 26);
     mw_prim_drop();
-    WORD_ATOM(412, 26, "");
+    WORD_ATOM(413, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45297,25 +45258,25 @@ static void mb_c99_prim_21__19 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(412, 45, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(413, 45, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__19);
 }
 
 static void mb_c99_prim_21__20 (void) {
-    WORD_ENTER(mb_c99_prim_21__20, "c99-prim! block", "src/mirth/codegen.mth", 413, 26);
+    WORD_ENTER(mb_c99_prim_21__20, "c99-prim! block", "src/mirth/codegen.mth", 414, 26);
     mw_prim_drop();
-    WORD_ATOM(413, 26, "swap");
+    WORD_ATOM(414, 26, "swap");
     mw_prim_swap();
-    WORD_ATOM(413, 31, "c99-arg-run!");
+    WORD_ATOM(414, 31, "c99-arg-run!");
     mw_c99_arg_run_21_();
     WORD_EXIT(mb_c99_prim_21__20);
 }
 
 static void mb_c99_prim_21__21 (void) {
-    WORD_ENTER(mb_c99_prim_21__21, "c99-prim! block", "src/mirth/codegen.mth", 414, 26);
+    WORD_ENTER(mb_c99_prim_21__21, "c99-prim! block", "src/mirth/codegen.mth", 415, 26);
     mw_prim_drop();
-    WORD_ATOM(414, 26, "");
+    WORD_ATOM(415, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45326,23 +45287,23 @@ static void mb_c99_prim_21__21 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(414, 37, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(415, 37, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__21);
 }
 
 static void mb_c99_prim_21__22 (void) {
-    WORD_ENTER(mb_c99_prim_21__22, "c99-prim! block", "src/mirth/codegen.mth", 415, 26);
+    WORD_ENTER(mb_c99_prim_21__22, "c99-prim! block", "src/mirth/codegen.mth", 416, 26);
     mw_prim_drop();
-    WORD_ATOM(415, 26, "c99-arg-run!");
+    WORD_ATOM(416, 26, "c99-arg-run!");
     mw_c99_arg_run_21_();
     WORD_EXIT(mb_c99_prim_21__22);
 }
 
 static void mb_c99_prim_21__23 (void) {
-    WORD_ENTER(mb_c99_prim_21__23, "c99-prim! block", "src/mirth/codegen.mth", 416, 26);
+    WORD_ENTER(mb_c99_prim_21__23, "c99-prim! block", "src/mirth/codegen.mth", 417, 26);
     mw_prim_drop();
-    WORD_ATOM(416, 26, "");
+    WORD_ATOM(417, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45353,15 +45314,15 @@ static void mb_c99_prim_21__23 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(416, 30, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(417, 30, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__23);
 }
 
 static void mb_c99_prim_21__27 (void) {
-    WORD_ENTER(mb_c99_prim_21__27, "c99-prim! block", "src/mirth/codegen.mth", 424, 26);
+    WORD_ENTER(mb_c99_prim_21__27, "c99-prim! block", "src/mirth/codegen.mth", 425, 26);
     mw_prim_drop();
-    WORD_ATOM(424, 26, "");
+    WORD_ATOM(425, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45372,32 +45333,32 @@ static void mb_c99_prim_21__27 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(424, 39, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(425, 39, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__27);
 }
 
 static void mb_c99_prim_21__28 (void) {
-    WORD_ENTER(mb_c99_prim_21__28, "c99-prim! block", "src/mirth/codegen.mth", 426, 21);
+    WORD_ENTER(mb_c99_prim_21__28, "c99-prim! block", "src/mirth/codegen.mth", 427, 21);
     mw_prim_drop();
-    WORD_ATOM(426, 21, "swap");
+    WORD_ATOM(427, 21, "swap");
     mw_prim_swap();
-    WORD_ATOM(426, 26, "c99-arg-run!");
+    WORD_ATOM(427, 26, "c99-arg-run!");
     mw_c99_arg_run_21_();
-    WORD_ATOM(427, 21, "c99-line");
+    WORD_ATOM(428, 21, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_prim_21__29);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(428, 21, "c99-arg-run!");
+    WORD_ATOM(429, 21, "c99-arg-run!");
     mw_c99_arg_run_21_();
     WORD_EXIT(mb_c99_prim_21__28);
 }
 
 static void mb_c99_prim_21__29 (void) {
-    WORD_ENTER(mb_c99_prim_21__29, "c99-prim! block", "src/mirth/codegen.mth", 427, 30);
+    WORD_ENTER(mb_c99_prim_21__29, "c99-prim! block", "src/mirth/codegen.mth", 428, 30);
     mw_prim_drop();
-    WORD_ATOM(427, 30, "");
+    WORD_ATOM(428, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45408,15 +45369,15 @@ static void mb_c99_prim_21__29 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(427, 56, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(428, 56, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__29);
 }
 
 static void mb_c99_prim_21__30 (void) {
-    WORD_ENTER(mb_c99_prim_21__30, "c99-prim! block", "src/mirth/codegen.mth", 430, 26);
+    WORD_ENTER(mb_c99_prim_21__30, "c99-prim! block", "src/mirth/codegen.mth", 431, 26);
     mw_prim_drop();
-    WORD_ATOM(430, 26, "");
+    WORD_ATOM(431, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45427,17 +45388,17 @@ static void mb_c99_prim_21__30 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(430, 30, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(431, 30, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_prim_21__30);
 }
 
 static void mb_c99_match_21__3 (void) {
-    WORD_ENTER(mb_c99_match_21__3, "c99-match! block", "src/mirth/codegen.mth", 515, 19);
+    WORD_ENTER(mb_c99_match_21__3, "c99-match! block", "src/mirth/codegen.mth", 516, 19);
     mw_prim_drop();
-    WORD_ATOM(515, 19, "token");
+    WORD_ATOM(516, 19, "token");
     mw_Match_2E_token();
-    WORD_ATOM(515, 25, "");
+    WORD_ATOM(516, 25, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45448,15 +45409,15 @@ static void mb_c99_match_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(515, 71, "emit-fatal-error!");
+    WORD_ATOM(516, 71, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_c99_match_21__3);
 }
 
 static void mb_c99_match_21__5 (void) {
-    WORD_ENTER(mb_c99_match_21__5, "c99-match! block", "src/mirth/codegen.mth", 517, 22);
+    WORD_ENTER(mb_c99_match_21__5, "c99-match! block", "src/mirth/codegen.mth", 518, 22);
     mw_prim_drop();
-    WORD_ATOM(517, 22, "");
+    WORD_ATOM(518, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45467,15 +45428,15 @@ static void mb_c99_match_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(517, 63, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(518, 63, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_match_21__5);
 }
 
 static void mb_c99_match_21__7 (void) {
-    WORD_ENTER(mb_c99_match_21__7, "c99-match! block", "src/mirth/codegen.mth", 518, 22);
+    WORD_ENTER(mb_c99_match_21__7, "c99-match! block", "src/mirth/codegen.mth", 519, 22);
     mw_prim_drop();
-    WORD_ATOM(518, 22, "");
+    WORD_ATOM(519, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45486,26 +45447,26 @@ static void mb_c99_match_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(518, 54, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(519, 54, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_match_21__7);
 }
 
 static void mb_c99_match_21__8 (void) {
-    WORD_ENTER(mb_c99_match_21__8, "c99-match! block", "src/mirth/codegen.mth", 521, 13);
+    WORD_ENTER(mb_c99_match_21__8, "c99-match! block", "src/mirth/codegen.mth", 522, 13);
     mw_prim_drop();
-    WORD_ATOM(521, 13, "dup");
+    WORD_ATOM(522, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(521, 17, "cases");
+    WORD_ATOM(522, 17, "cases");
     mw_Match_2E_cases();
-    WORD_ATOM(521, 23, "for");
+    WORD_ATOM(522, 23, "for");
     push_u64(0);
     push_fnptr(&mb_c99_match_21__9);
     mw_prim_pack_cons();
     mw_List_2E_for();
-    WORD_ATOM(522, 13, "has-default-case?");
+    WORD_ATOM(523, 13, "has-default-case?");
     mw_Match_2E_has_default_case_3F_();
-    WORD_ATOM(522, 31, "else");
+    WORD_ATOM(523, 31, "else");
     push_u64(0);
     push_fnptr(&mb_c99_match_21__10);
     mw_prim_pack_cons();
@@ -45514,17 +45475,17 @@ static void mb_c99_match_21__8 (void) {
 }
 
 static void mb_c99_match_21__9 (void) {
-    WORD_ENTER(mb_c99_match_21__9, "c99-match! block", "src/mirth/codegen.mth", 521, 27);
+    WORD_ENTER(mb_c99_match_21__9, "c99-match! block", "src/mirth/codegen.mth", 522, 27);
     mw_prim_drop();
-    WORD_ATOM(521, 27, "c99-case!");
+    WORD_ATOM(522, 27, "c99-case!");
     mw_c99_case_21_();
     WORD_EXIT(mb_c99_match_21__9);
 }
 
 static void mb_c99_match_21__10 (void) {
-    WORD_ENTER(mb_c99_match_21__10, "c99-match! block", "src/mirth/codegen.mth", 523, 17);
+    WORD_ENTER(mb_c99_match_21__10, "c99-match! block", "src/mirth/codegen.mth", 524, 17);
     mw_prim_drop();
-    WORD_ATOM(523, 17, "c99-line");
+    WORD_ATOM(524, 17, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_match_21__11);
     mw_prim_pack_cons();
@@ -45533,9 +45494,9 @@ static void mb_c99_match_21__10 (void) {
 }
 
 static void mb_c99_match_21__11 (void) {
-    WORD_ENTER(mb_c99_match_21__11, "c99-match! block", "src/mirth/codegen.mth", 523, 26);
+    WORD_ENTER(mb_c99_match_21__11, "c99-match! block", "src/mirth/codegen.mth", 524, 26);
     mw_prim_drop();
-    WORD_ATOM(523, 26, "");
+    WORD_ATOM(524, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45546,15 +45507,15 @@ static void mb_c99_match_21__11 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(523, 118, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(524, 118, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_match_21__11);
 }
 
 static void mb_c99_match_21__12 (void) {
-    WORD_ENTER(mb_c99_match_21__12, "c99-match! block", "src/mirth/codegen.mth", 526, 18);
+    WORD_ENTER(mb_c99_match_21__12, "c99-match! block", "src/mirth/codegen.mth", 527, 18);
     mw_prim_drop();
-    WORD_ATOM(526, 18, "");
+    WORD_ATOM(527, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45565,13 +45526,15 @@ static void mb_c99_match_21__12 (void) {
         push_value(v);
         incref(v);
     }
+    WORD_ATOM(527, 22, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_match_21__12);
 }
 
 static void mb_c99_lambda_21__1 (void) {
-    WORD_ENTER(mb_c99_lambda_21__1, "c99-lambda! block", "src/mirth/codegen.mth", 498, 14);
+    WORD_ENTER(mb_c99_lambda_21__1, "c99-lambda! block", "src/mirth/codegen.mth", 499, 14);
     mw_prim_drop();
-    WORD_ATOM(498, 14, "");
+    WORD_ATOM(499, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45582,32 +45545,32 @@ static void mb_c99_lambda_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(498, 18, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(499, 18, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_lambda_21__1);
 }
 
 static void mb_c99_lambda_21__2 (void) {
-    WORD_ENTER(mb_c99_lambda_21__2, "c99-lambda! block", "src/mirth/codegen.mth", 500, 9);
+    WORD_ENTER(mb_c99_lambda_21__2, "c99-lambda! block", "src/mirth/codegen.mth", 501, 9);
     mw_prim_drop();
-    WORD_ATOM(500, 9, "dup");
+    WORD_ATOM(501, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(500, 13, "params");
+    WORD_ATOM(501, 13, "params");
     mw_Lambda_2E_params();
-    WORD_ATOM(500, 20, "reverse-for");
+    WORD_ATOM(501, 20, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__3);
     mw_prim_pack_cons();
     mw_List_2E_reverse_for();
-    WORD_ATOM(503, 9, "dup");
+    WORD_ATOM(504, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(503, 13, "body");
+    WORD_ATOM(504, 13, "body");
     mw_Lambda_2E_body();
-    WORD_ATOM(503, 18, "c99-arrow!");
+    WORD_ATOM(504, 18, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(504, 9, "params");
+    WORD_ATOM(505, 9, "params");
     mw_Lambda_2E_params();
-    WORD_ATOM(504, 16, "reverse-for");
+    WORD_ATOM(505, 16, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__5);
     mw_prim_pack_cons();
@@ -45616,9 +45579,9 @@ static void mb_c99_lambda_21__2 (void) {
 }
 
 static void mb_c99_lambda_21__3 (void) {
-    WORD_ENTER(mb_c99_lambda_21__3, "c99-lambda! block", "src/mirth/codegen.mth", 501, 13);
+    WORD_ENTER(mb_c99_lambda_21__3, "c99-lambda! block", "src/mirth/codegen.mth", 502, 13);
     mw_prim_drop();
-    WORD_ATOM(501, 13, "c99-line");
+    WORD_ATOM(502, 13, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__4);
     mw_prim_pack_cons();
@@ -45627,9 +45590,9 @@ static void mb_c99_lambda_21__3 (void) {
 }
 
 static void mb_c99_lambda_21__4 (void) {
-    WORD_ENTER(mb_c99_lambda_21__4, "c99-lambda! block", "src/mirth/codegen.mth", 501, 22);
+    WORD_ENTER(mb_c99_lambda_21__4, "c99-lambda! block", "src/mirth/codegen.mth", 502, 22);
     mw_prim_drop();
-    WORD_ATOM(501, 22, "");
+    WORD_ATOM(502, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45640,11 +45603,11 @@ static void mb_c99_lambda_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(501, 29, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(501, 31, ".param");
-    mw_Param_2B_C99_2E_param();
-    WORD_ATOM(501, 38, "");
+    WORD_ATOM(502, 29, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(502, 33, "put");
+    mw_Param_2B_C99_2E_put();
+    WORD_ATOM(502, 37, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45655,15 +45618,15 @@ static void mb_c99_lambda_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(501, 56, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(502, 55, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_lambda_21__4);
 }
 
 static void mb_c99_lambda_21__5 (void) {
-    WORD_ENTER(mb_c99_lambda_21__5, "c99-lambda! block", "src/mirth/codegen.mth", 505, 13);
+    WORD_ENTER(mb_c99_lambda_21__5, "c99-lambda! block", "src/mirth/codegen.mth", 506, 13);
     mw_prim_drop();
-    WORD_ATOM(505, 13, "c99-line");
+    WORD_ATOM(506, 13, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__6);
     mw_prim_pack_cons();
@@ -45672,9 +45635,9 @@ static void mb_c99_lambda_21__5 (void) {
 }
 
 static void mb_c99_lambda_21__6 (void) {
-    WORD_ENTER(mb_c99_lambda_21__6, "c99-lambda! block", "src/mirth/codegen.mth", 505, 22);
+    WORD_ENTER(mb_c99_lambda_21__6, "c99-lambda! block", "src/mirth/codegen.mth", 506, 22);
     mw_prim_drop();
-    WORD_ATOM(505, 22, "");
+    WORD_ATOM(506, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45685,11 +45648,11 @@ static void mb_c99_lambda_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(505, 32, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(505, 34, ".param");
-    mw_Param_2B_C99_2E_param();
-    WORD_ATOM(505, 41, "");
+    WORD_ATOM(506, 32, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(506, 36, "put");
+    mw_Param_2B_C99_2E_put();
+    WORD_ATOM(506, 40, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45700,15 +45663,15 @@ static void mb_c99_lambda_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(505, 46, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(506, 45, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_lambda_21__6);
 }
 
 static void mb_c99_lambda_21__7 (void) {
-    WORD_ENTER(mb_c99_lambda_21__7, "c99-lambda! block", "src/mirth/codegen.mth", 508, 14);
+    WORD_ENTER(mb_c99_lambda_21__7, "c99-lambda! block", "src/mirth/codegen.mth", 509, 14);
     mw_prim_drop();
-    WORD_ATOM(508, 14, "");
+    WORD_ATOM(509, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45719,15 +45682,15 @@ static void mb_c99_lambda_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(508, 18, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(509, 18, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_lambda_21__7);
 }
 
 static void mb_c99_block_push_21__3 (void) {
-    WORD_ENTER(mb_c99_block_push_21__3, "c99-block-push! block", "src/mirth/codegen.mth", 480, 22);
+    WORD_ENTER(mb_c99_block_push_21__3, "c99-block-push! block", "src/mirth/codegen.mth", 481, 22);
     mw_prim_drop();
-    WORD_ATOM(480, 22, "");
+    WORD_ATOM(481, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45738,11 +45701,11 @@ static void mb_c99_block_push_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(480, 37, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(480, 39, ".block");
-    mw_Block_2B_C99_2E_block();
-    WORD_ATOM(480, 46, "");
+    WORD_ATOM(481, 37, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(481, 41, "put");
+    mw_Block_2B_C99_2E_put();
+    WORD_ATOM(481, 45, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45753,15 +45716,15 @@ static void mb_c99_block_push_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(480, 51, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(481, 50, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_block_push_21__3);
 }
 
 static void mb_c99_block_push_21__4 (void) {
-    WORD_ENTER(mb_c99_block_push_21__4, "c99-block-push! block", "src/mirth/codegen.mth", 481, 22);
+    WORD_ENTER(mb_c99_block_push_21__4, "c99-block-push! block", "src/mirth/codegen.mth", 482, 22);
     mw_prim_drop();
-    WORD_ATOM(481, 22, "");
+    WORD_ATOM(482, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45772,15 +45735,23 @@ static void mb_c99_block_push_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(481, 45, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(482, 45, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_block_push_21__4);
 }
 
-static void mb_c99_pack_ctx_21__1 (void) {
-    WORD_ENTER(mb_c99_pack_ctx_21__1, "c99-pack-ctx! block", "src/mirth/codegen.mth", 457, 14);
+static void mb__2B_C99_2E_put_cstr_1 (void) {
+    WORD_ENTER(mb__2B_C99_2E_put_cstr_1, "+C99.put-cstr block", "src/mirth/codegen.mth", 358, 28);
     mw_prim_drop();
-    WORD_ATOM(457, 14, "");
+    WORD_ATOM(358, 28, "c99-string-byte!");
+    mw_c99_string_byte_21_();
+    WORD_EXIT(mb__2B_C99_2E_put_cstr_1);
+}
+
+static void mb_c99_pack_ctx_21__1 (void) {
+    WORD_ENTER(mb_c99_pack_ctx_21__1, "c99-pack-ctx! block", "src/mirth/codegen.mth", 458, 14);
+    mw_prim_drop();
+    WORD_ATOM(458, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45791,17 +45762,17 @@ static void mb_c99_pack_ctx_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(457, 29, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(458, 29, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_pack_ctx_21__1);
 }
 
 static void mb_c99_pack_ctx_21__2 (void) {
-    WORD_ENTER(mb_c99_pack_ctx_21__2, "c99-pack-ctx! block", "src/mirth/codegen.mth", 459, 9);
+    WORD_ENTER(mb_c99_pack_ctx_21__2, "c99-pack-ctx! block", "src/mirth/codegen.mth", 460, 9);
     mw_prim_drop();
-    WORD_ATOM(459, 9, "c99-var-push!");
+    WORD_ATOM(460, 9, "c99-var-push!");
     mw_c99_var_push_21_();
-    WORD_ATOM(460, 9, "c99-line");
+    WORD_ATOM(461, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_pack_ctx_21__3);
     mw_prim_pack_cons();
@@ -45810,9 +45781,9 @@ static void mb_c99_pack_ctx_21__2 (void) {
 }
 
 static void mb_c99_pack_ctx_21__3 (void) {
-    WORD_ENTER(mb_c99_pack_ctx_21__3, "c99-pack-ctx! block", "src/mirth/codegen.mth", 460, 18);
+    WORD_ENTER(mb_c99_pack_ctx_21__3, "c99-pack-ctx! block", "src/mirth/codegen.mth", 461, 18);
     mw_prim_drop();
-    WORD_ATOM(460, 18, "");
+    WORD_ATOM(461, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45823,15 +45794,15 @@ static void mb_c99_pack_ctx_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(460, 41, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(461, 41, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_pack_ctx_21__3);
 }
 
 static void mb_c99_var_push_21__1 (void) {
-    WORD_ENTER(mb_c99_var_push_21__1, "c99-var-push! block", "src/mirth/codegen.mth", 493, 14);
+    WORD_ENTER(mb_c99_var_push_21__1, "c99-var-push! block", "src/mirth/codegen.mth", 494, 14);
     mw_prim_drop();
-    WORD_ATOM(493, 14, "");
+    WORD_ATOM(494, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45842,13 +45813,13 @@ static void mb_c99_var_push_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(493, 24, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(493, 26, "dup");
+    WORD_ATOM(494, 24, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(494, 28, "dup");
     mw_prim_dup();
-    WORD_ATOM(493, 30, ".var");
-    mw_Var_2B_C99_2E_var();
-    WORD_ATOM(493, 35, "");
+    WORD_ATOM(494, 32, "put");
+    mw_Var_2B_C99_2E_put();
+    WORD_ATOM(494, 36, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45859,15 +45830,15 @@ static void mb_c99_var_push_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(493, 40, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(494, 41, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_var_push_21__1);
 }
 
 static void mb_c99_var_push_21__2 (void) {
-    WORD_ENTER(mb_c99_var_push_21__2, "c99-var-push! block", "src/mirth/codegen.mth", 494, 14);
+    WORD_ENTER(mb_c99_var_push_21__2, "c99-var-push! block", "src/mirth/codegen.mth", 495, 14);
     mw_prim_drop();
-    WORD_ATOM(494, 14, "");
+    WORD_ATOM(495, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45878,13 +45849,13 @@ static void mb_c99_var_push_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(494, 28, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(494, 30, "dup");
+    WORD_ATOM(495, 28, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(495, 32, "dup");
     mw_prim_dup();
-    WORD_ATOM(494, 34, ".var");
-    mw_Var_2B_C99_2E_var();
-    WORD_ATOM(494, 39, "");
+    WORD_ATOM(495, 36, "put");
+    mw_Var_2B_C99_2E_put();
+    WORD_ATOM(495, 40, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45895,20 +45866,20 @@ static void mb_c99_var_push_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(494, 44, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(495, 45, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_var_push_21__2);
 }
 
 static void mb_c99_unpack_ctx_21__1 (void) {
-    WORD_ENTER(mb_c99_unpack_ctx_21__1, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 465, 9);
+    WORD_ENTER(mb_c99_unpack_ctx_21__1, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 466, 9);
     mw_prim_drop();
-    WORD_ATOM(465, 9, "c99-line");
+    WORD_ATOM(466, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_unpack_ctx_21__2);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(466, 9, "c99-line");
+    WORD_ATOM(467, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_unpack_ctx_21__3);
     mw_prim_pack_cons();
@@ -45917,9 +45888,9 @@ static void mb_c99_unpack_ctx_21__1 (void) {
 }
 
 static void mb_c99_unpack_ctx_21__2 (void) {
-    WORD_ENTER(mb_c99_unpack_ctx_21__2, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 465, 18);
+    WORD_ENTER(mb_c99_unpack_ctx_21__2, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 466, 18);
     mw_prim_drop();
-    WORD_ATOM(465, 18, "");
+    WORD_ATOM(466, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45930,15 +45901,15 @@ static void mb_c99_unpack_ctx_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(465, 43, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(466, 43, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_unpack_ctx_21__2);
 }
 
 static void mb_c99_unpack_ctx_21__3 (void) {
-    WORD_ENTER(mb_c99_unpack_ctx_21__3, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 466, 18);
+    WORD_ENTER(mb_c99_unpack_ctx_21__3, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 467, 18);
     mw_prim_drop();
-    WORD_ATOM(466, 18, "");
+    WORD_ATOM(467, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45949,11 +45920,11 @@ static void mb_c99_unpack_ctx_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(466, 25, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(466, 27, ".var");
-    mw_Var_2B_C99_2E_var();
-    WORD_ATOM(466, 32, "");
+    WORD_ATOM(467, 25, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(467, 29, "put");
+    mw_Var_2B_C99_2E_put();
+    WORD_ATOM(467, 33, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45964,15 +45935,15 @@ static void mb_c99_unpack_ctx_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(466, 50, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(467, 51, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_unpack_ctx_21__3);
 }
 
 static void mb_c99_unpack_ctx_21__4 (void) {
-    WORD_ENTER(mb_c99_unpack_ctx_21__4, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 468, 14);
+    WORD_ENTER(mb_c99_unpack_ctx_21__4, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 469, 14);
     mw_prim_drop();
-    WORD_ATOM(468, 14, "");
+    WORD_ATOM(469, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -45983,15 +45954,15 @@ static void mb_c99_unpack_ctx_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(468, 32, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(469, 32, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_unpack_ctx_21__4);
 }
 
 static void mb_c99_decref_ctx_21__1 (void) {
-    WORD_ENTER(mb_c99_decref_ctx_21__1, "c99-decref-ctx! block", "src/mirth/codegen.mth", 472, 9);
+    WORD_ENTER(mb_c99_decref_ctx_21__1, "c99-decref-ctx! block", "src/mirth/codegen.mth", 473, 9);
     mw_prim_drop();
-    WORD_ATOM(472, 9, "c99-line");
+    WORD_ATOM(473, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_decref_ctx_21__2);
     mw_prim_pack_cons();
@@ -46000,9 +45971,9 @@ static void mb_c99_decref_ctx_21__1 (void) {
 }
 
 static void mb_c99_decref_ctx_21__2 (void) {
-    WORD_ENTER(mb_c99_decref_ctx_21__2, "c99-decref-ctx! block", "src/mirth/codegen.mth", 472, 18);
+    WORD_ENTER(mb_c99_decref_ctx_21__2, "c99-decref-ctx! block", "src/mirth/codegen.mth", 473, 18);
     mw_prim_drop();
-    WORD_ATOM(472, 18, "");
+    WORD_ATOM(473, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46013,11 +45984,11 @@ static void mb_c99_decref_ctx_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(472, 28, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(472, 30, ".var");
-    mw_Var_2B_C99_2E_var();
-    WORD_ATOM(472, 35, "");
+    WORD_ATOM(473, 28, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(473, 32, "put");
+    mw_Var_2B_C99_2E_put();
+    WORD_ATOM(473, 36, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46028,15 +45999,15 @@ static void mb_c99_decref_ctx_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(472, 40, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(473, 41, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_decref_ctx_21__2);
 }
 
 static void mb_c99_var_run_21__1 (void) {
-    WORD_ENTER(mb_c99_var_run_21__1, "c99-var-run! block", "src/mirth/codegen.mth", 488, 14);
+    WORD_ENTER(mb_c99_var_run_21__1, "c99-var-run! block", "src/mirth/codegen.mth", 489, 14);
     mw_prim_drop();
-    WORD_ATOM(488, 14, "");
+    WORD_ATOM(489, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46047,13 +46018,13 @@ static void mb_c99_var_run_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(488, 24, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(488, 26, "dup");
+    WORD_ATOM(489, 24, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(489, 28, "dup");
     mw_prim_dup();
-    WORD_ATOM(488, 30, ".var");
-    mw_Var_2B_C99_2E_var();
-    WORD_ATOM(488, 35, "");
+    WORD_ATOM(489, 32, "put");
+    mw_Var_2B_C99_2E_put();
+    WORD_ATOM(489, 36, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46064,15 +46035,15 @@ static void mb_c99_var_run_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(488, 40, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(489, 41, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_var_run_21__1);
 }
 
 static void mb_c99_var_run_21__2 (void) {
-    WORD_ENTER(mb_c99_var_run_21__2, "c99-var-run! block", "src/mirth/codegen.mth", 489, 14);
+    WORD_ENTER(mb_c99_var_run_21__2, "c99-var-run! block", "src/mirth/codegen.mth", 490, 14);
     mw_prim_drop();
-    WORD_ATOM(489, 14, "");
+    WORD_ATOM(490, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46083,13 +46054,13 @@ static void mb_c99_var_run_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(489, 27, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(489, 29, "dup");
+    WORD_ATOM(490, 27, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(490, 31, "dup");
     mw_prim_dup();
-    WORD_ATOM(489, 33, ".var");
-    mw_Var_2B_C99_2E_var();
-    WORD_ATOM(489, 38, "");
+    WORD_ATOM(490, 35, "put");
+    mw_Var_2B_C99_2E_put();
+    WORD_ATOM(490, 39, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46100,19 +46071,19 @@ static void mb_c99_var_run_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(489, 43, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(490, 44, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_var_run_21__2);
 }
 
 static void mb_c99_case_21__1 (void) {
-    WORD_ENTER(mb_c99_case_21__1, "c99-case! block", "src/mirth/codegen.mth", 532, 9);
+    WORD_ENTER(mb_c99_case_21__1, "c99-case! block", "src/mirth/codegen.mth", 533, 9);
     mw_prim_drop();
-    WORD_ATOM(532, 9, "body");
+    WORD_ATOM(533, 9, "body");
     mw_Case_2E_body();
-    WORD_ATOM(532, 14, "c99-arrow!");
+    WORD_ATOM(533, 14, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(533, 9, "c99-line");
+    WORD_ATOM(534, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_case_21__2);
     mw_prim_pack_cons();
@@ -46121,9 +46092,9 @@ static void mb_c99_case_21__1 (void) {
 }
 
 static void mb_c99_case_21__2 (void) {
-    WORD_ENTER(mb_c99_case_21__2, "c99-case! block", "src/mirth/codegen.mth", 533, 18);
+    WORD_ENTER(mb_c99_case_21__2, "c99-case! block", "src/mirth/codegen.mth", 534, 18);
     mw_prim_drop();
-    WORD_ATOM(533, 18, "");
+    WORD_ATOM(534, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46134,15 +46105,15 @@ static void mb_c99_case_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(533, 27, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(534, 27, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_case_21__2);
 }
 
 static void mb_c99_pattern_21__2 (void) {
-    WORD_ENTER(mb_c99_pattern_21__2, "c99-pattern! block", "src/mirth/codegen.mth", 538, 18);
+    WORD_ENTER(mb_c99_pattern_21__2, "c99-pattern! block", "src/mirth/codegen.mth", 539, 18);
     mw_prim_drop();
-    WORD_ATOM(538, 18, "");
+    WORD_ATOM(539, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46153,15 +46124,15 @@ static void mb_c99_pattern_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(538, 29, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(539, 29, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_pattern_21__2);
 }
 
 static void mb_c99_pattern_21__4 (void) {
-    WORD_ENTER(mb_c99_pattern_21__4, "c99-pattern! block", "src/mirth/codegen.mth", 541, 18);
+    WORD_ENTER(mb_c99_pattern_21__4, "c99-pattern! block", "src/mirth/codegen.mth", 542, 18);
     mw_prim_drop();
-    WORD_ATOM(541, 18, "");
+    WORD_ATOM(542, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46172,15 +46143,15 @@ static void mb_c99_pattern_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(541, 26, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(541, 28, "dup");
+    WORD_ATOM(542, 26, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(542, 30, "dup");
     mw_prim_dup();
-    WORD_ATOM(541, 32, "value");
+    WORD_ATOM(542, 34, "value");
     mw_Tag_2E_value();
-    WORD_ATOM(541, 38, ".n");
-    mw_Int_2B_C99_2E_n();
-    WORD_ATOM(541, 41, "");
+    WORD_ATOM(542, 40, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(542, 44, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46191,15 +46162,15 @@ static void mb_c99_pattern_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(541, 47, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(542, 50, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_pattern_21__4);
 }
 
 static void mb_c99_pattern_21__5 (void) {
-    WORD_ENTER(mb_c99_pattern_21__5, "c99-pattern! block", "src/mirth/codegen.mth", 543, 13);
+    WORD_ENTER(mb_c99_pattern_21__5, "c99-pattern! block", "src/mirth/codegen.mth", 544, 13);
     mw_prim_drop();
-    WORD_ATOM(543, 13, "c99-line");
+    WORD_ATOM(544, 13, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_pattern_21__6);
     mw_prim_pack_cons();
@@ -46208,26 +46179,26 @@ static void mb_c99_pattern_21__5 (void) {
 }
 
 static void mb_c99_pattern_21__6 (void) {
-    WORD_ENTER(mb_c99_pattern_21__6, "c99-pattern! block", "src/mirth/codegen.mth", 543, 22);
+    WORD_ENTER(mb_c99_pattern_21__6, "c99-pattern! block", "src/mirth/codegen.mth", 544, 22);
     mw_prim_drop();
-    WORD_ATOM(543, 22, "");
+    WORD_ATOM(544, 22, "");
     {
         static bool vready = false;
         static VAL v;
         if (! vready) {
-            v = mkstr("co_", 3);
+            v = mkstr("mp_", 3);
             vready = true;
         }
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(543, 28, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(543, 30, "name");
+    WORD_ATOM(544, 28, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(544, 32, "name");
     mw_Tag_2E_name();
-    WORD_ATOM(543, 35, ".name");
-    mw_Name_2B_C99_2E_name();
-    WORD_ATOM(543, 41, "");
+    WORD_ATOM(544, 37, "put");
+    mw_Name_2B_C99_2E_put();
+    WORD_ATOM(544, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46238,15 +46209,15 @@ static void mb_c99_pattern_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(543, 47, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(544, 47, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_pattern_21__6);
 }
 
 static void mb_c99_word_sig_21__1 (void) {
-    WORD_ENTER(mb_c99_word_sig_21__1, "c99-word-sig! block", "src/mirth/codegen.mth", 549, 14);
+    WORD_ENTER(mb_c99_word_sig_21__1, "c99-word-sig! block", "src/mirth/codegen.mth", 550, 14);
     mw_prim_drop();
-    WORD_ATOM(549, 14, "");
+    WORD_ATOM(550, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46257,13 +46228,13 @@ static void mb_c99_word_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(549, 32, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(549, 34, "name");
+    WORD_ATOM(550, 32, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(550, 36, "name");
     mw_Word_2E_name();
-    WORD_ATOM(549, 39, ".name");
-    mw_Name_2B_C99_2E_name();
-    WORD_ATOM(549, 45, "");
+    WORD_ATOM(550, 41, "put");
+    mw_Name_2B_C99_2E_put();
+    WORD_ATOM(550, 45, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46274,15 +46245,15 @@ static void mb_c99_word_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(549, 56, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(550, 56, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_word_sig_21__1);
 }
 
 static void mb_c99_block_sig_21__1 (void) {
-    WORD_ENTER(mb_c99_block_sig_21__1, "c99-block-sig! block", "src/mirth/codegen.mth", 553, 14);
+    WORD_ENTER(mb_c99_block_sig_21__1, "c99-block-sig! block", "src/mirth/codegen.mth", 554, 14);
     mw_prim_drop();
-    WORD_ATOM(553, 14, "");
+    WORD_ATOM(554, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46293,11 +46264,11 @@ static void mb_c99_block_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(553, 29, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(553, 31, ".block");
-    mw_Block_2B_C99_2E_block();
-    WORD_ATOM(553, 38, "");
+    WORD_ATOM(554, 29, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(554, 33, "put");
+    mw_Block_2B_C99_2E_put();
+    WORD_ATOM(554, 37, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46308,15 +46279,15 @@ static void mb_c99_block_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(553, 49, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(554, 48, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_block_sig_21__1);
 }
 
 static void mb_c99_field_sig_21__1 (void) {
-    WORD_ENTER(mb_c99_field_sig_21__1, "c99-field-sig! block", "src/mirth/codegen.mth", 557, 14);
+    WORD_ENTER(mb_c99_field_sig_21__1, "c99-field-sig! block", "src/mirth/codegen.mth", 558, 14);
     mw_prim_drop();
-    WORD_ATOM(557, 14, "");
+    WORD_ATOM(558, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46327,13 +46298,13 @@ static void mb_c99_field_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(557, 32, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(557, 34, "name");
+    WORD_ATOM(558, 32, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(558, 36, "name");
     mw_Field_2E_name();
-    WORD_ATOM(557, 39, ".name");
-    mw_Name_2B_C99_2E_name();
-    WORD_ATOM(557, 45, "");
+    WORD_ATOM(558, 41, "put");
+    mw_Name_2B_C99_2E_put();
+    WORD_ATOM(558, 45, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46344,15 +46315,15 @@ static void mb_c99_field_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(557, 56, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(558, 56, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_field_sig_21__1);
 }
 
 static void mb_c99_block_enter_21__1 (void) {
-    WORD_ENTER(mb_c99_block_enter_21__1, "c99-block-enter! block", "src/mirth/codegen.mth", 560, 14);
+    WORD_ENTER(mb_c99_block_enter_21__1, "c99-block-enter! block", "src/mirth/codegen.mth", 561, 14);
     mw_prim_drop();
-    WORD_ATOM(560, 14, "");
+    WORD_ATOM(561, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46363,13 +46334,13 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(560, 28, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(561, 9, "dup");
+    WORD_ATOM(561, 28, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(562, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(561, 13, ".block");
-    mw_Block_2B_C99_2E_block();
-    WORD_ATOM(561, 20, "");
+    WORD_ATOM(562, 13, "put");
+    mw_Block_2B_C99_2E_put();
+    WORD_ATOM(562, 17, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46380,19 +46351,19 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(561, 25, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(562, 9, "dup");
+    WORD_ATOM(562, 22, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(563, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(562, 13, "arrow");
+    WORD_ATOM(563, 13, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(562, 19, "home");
+    WORD_ATOM(563, 19, "home");
     mw_Arrow_2E_home();
-    WORD_ATOM(562, 24, "match");
+    WORD_ATOM(563, 24, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            co_NONE();
-            WORD_ATOM(563, 21, "");
+            mp_NONE();
+            WORD_ATOM(564, 21, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -46405,12 +46376,12 @@ static void mb_c99_block_enter_21__1 (void) {
             }
             break;
         case 1LL:
-            co_SOME();
-            WORD_ATOM(564, 21, "name");
+            mp_SOME();
+            WORD_ATOM(565, 21, "name");
             mw_Word_2E_name();
-            WORD_ATOM(564, 26, ">Str");
+            WORD_ATOM(565, 26, ">Str");
             mw_Name_3E_Str();
-            WORD_ATOM(564, 31, "");
+            WORD_ATOM(565, 31, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -46421,14 +46392,14 @@ static void mb_c99_block_enter_21__1 (void) {
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(564, 40, "cat");
+            WORD_ATOM(565, 40, "cat");
             mw_prim_str_cat();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_ATOM(565, 11, ".str");
-    mw__2E_str();
-    WORD_ATOM(565, 16, "");
+    }
+    WORD_ATOM(566, 11, "put-cstr");
+    mw__2B_C99_2E_put_cstr();
+    WORD_ATOM(566, 20, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46439,44 +46410,21 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(565, 21, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(566, 9, "dup");
-    mw_prim_dup();
-    WORD_ATOM(566, 13, "token");
-    mw_Block_2E_token();
-    WORD_ATOM(566, 19, ".module");
-    mw_Token_2E_module();
-    WORD_ATOM(566, 27, "source-path");
-    mw_Module_2E_source_path();
-    WORD_ATOM(566, 39, ">Str");
-    mw_Path_3E_Str();
-    WORD_ATOM(566, 44, ".str");
-    mw__2E_str();
-    WORD_ATOM(566, 49, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr(", ", 2);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(566, 54, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(566, 25, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_ATOM(567, 9, "dup");
     mw_prim_dup();
     WORD_ATOM(567, 13, "token");
     mw_Block_2E_token();
-    WORD_ATOM(567, 19, "row");
-    mw_Token_2E_row();
-    WORD_ATOM(567, 23, ">Int");
-    mw_Row_3E_Int();
-    WORD_ATOM(567, 28, ".n");
-    mw_Int_2B_C99_2E_n();
-    WORD_ATOM(567, 31, "");
+    WORD_ATOM(567, 19, ".module");
+    mw_Token_2E_module();
+    WORD_ATOM(567, 27, "source-path");
+    mw_Module_2E_source_path();
+    WORD_ATOM(567, 39, ">Str");
+    mw_Path_3E_Str();
+    WORD_ATOM(567, 44, "put-cstr");
+    mw__2B_C99_2E_put_cstr();
+    WORD_ATOM(567, 53, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46487,19 +46435,42 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(567, 36, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(567, 58, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_ATOM(568, 9, "dup");
     mw_prim_dup();
     WORD_ATOM(568, 13, "token");
     mw_Block_2E_token();
-    WORD_ATOM(568, 19, "col");
-    mw_Token_2E_col();
+    WORD_ATOM(568, 19, "row");
+    mw_Token_2E_row();
     WORD_ATOM(568, 23, ">Int");
+    mw_Row_3E_Int();
+    WORD_ATOM(568, 28, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(568, 32, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr(", ", 2);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(568, 37, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(569, 9, "dup");
+    mw_prim_dup();
+    WORD_ATOM(569, 13, "token");
+    mw_Block_2E_token();
+    WORD_ATOM(569, 19, "col");
+    mw_Token_2E_col();
+    WORD_ATOM(569, 23, ">Int");
     mw_Col_3E_Int();
-    WORD_ATOM(568, 28, ".n");
-    mw_Int_2B_C99_2E_n();
-    WORD_ATOM(568, 31, "");
+    WORD_ATOM(569, 28, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(569, 32, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46510,15 +46481,15 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(568, 36, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(569, 37, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_block_enter_21__1);
 }
 
 static void mb_c99_block_exit_21__1 (void) {
-    WORD_ENTER(mb_c99_block_exit_21__1, "c99-block-exit! block", "src/mirth/codegen.mth", 572, 14);
+    WORD_ENTER(mb_c99_block_exit_21__1, "c99-block-exit! block", "src/mirth/codegen.mth", 573, 14);
     mw_prim_drop();
-    WORD_ATOM(572, 14, "");
+    WORD_ATOM(573, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46529,11 +46500,11 @@ static void mb_c99_block_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(572, 27, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(572, 29, ".block");
-    mw_Block_2B_C99_2E_block();
-    WORD_ATOM(572, 36, "");
+    WORD_ATOM(573, 27, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(573, 31, "put");
+    mw_Block_2B_C99_2E_put();
+    WORD_ATOM(573, 35, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46544,15 +46515,15 @@ static void mb_c99_block_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(572, 41, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(573, 40, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_block_exit_21__1);
 }
 
 static void mb_c99_block_def_21__1 (void) {
-    WORD_ENTER(mb_c99_block_def_21__1, "c99-block-def! block", "src/mirth/codegen.mth", 576, 14);
+    WORD_ENTER(mb_c99_block_def_21__1, "c99-block-def! block", "src/mirth/codegen.mth", 577, 14);
     mw_prim_drop();
-    WORD_ATOM(576, 14, "");
+    WORD_ATOM(577, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46563,13 +46534,13 @@ static void mb_c99_block_def_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(576, 29, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(576, 31, "dup");
+    WORD_ATOM(577, 29, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(577, 33, "dup");
     mw_prim_dup();
-    WORD_ATOM(576, 35, ".block");
-    mw_Block_2B_C99_2E_block();
-    WORD_ATOM(576, 42, "");
+    WORD_ATOM(577, 37, "put");
+    mw_Block_2B_C99_2E_put();
+    WORD_ATOM(577, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46580,45 +46551,45 @@ static void mb_c99_block_def_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(576, 54, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(577, 53, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_block_def_21__1);
 }
 
 static void mb_c99_block_def_21__2 (void) {
-    WORD_ENTER(mb_c99_block_def_21__2, "c99-block-def! block", "src/mirth/codegen.mth", 578, 9);
+    WORD_ENTER(mb_c99_block_def_21__2, "c99-block-def! block", "src/mirth/codegen.mth", 579, 9);
     mw_prim_drop();
-    WORD_ATOM(578, 9, "dup");
-    mw_prim_dup();
-    WORD_ATOM(578, 13, "c99-block-enter!");
-    mw_c99_block_enter_21_();
     WORD_ATOM(579, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(579, 13, "arrow");
-    mw_Block_2E_arrow();
+    WORD_ATOM(579, 13, "c99-block-enter!");
+    mw_c99_block_enter_21_();
     WORD_ATOM(580, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(580, 13, "ctx");
-    mw_Arrow_2E_ctx();
-    WORD_ATOM(580, 17, "c99-unpack-ctx!");
-    mw_c99_unpack_ctx_21_();
+    WORD_ATOM(580, 13, "arrow");
+    mw_Block_2E_arrow();
     WORD_ATOM(581, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(581, 13, "c99-arrow!");
-    mw_c99_arrow_21_();
-    WORD_ATOM(582, 9, "ctx");
+    WORD_ATOM(581, 13, "ctx");
     mw_Arrow_2E_ctx();
-    WORD_ATOM(582, 13, "c99-decref-ctx!");
+    WORD_ATOM(581, 17, "c99-unpack-ctx!");
+    mw_c99_unpack_ctx_21_();
+    WORD_ATOM(582, 9, "dup");
+    mw_prim_dup();
+    WORD_ATOM(582, 13, "c99-arrow!");
+    mw_c99_arrow_21_();
+    WORD_ATOM(583, 9, "ctx");
+    mw_Arrow_2E_ctx();
+    WORD_ATOM(583, 13, "c99-decref-ctx!");
     mw_c99_decref_ctx_21_();
-    WORD_ATOM(583, 9, "c99-block-exit!");
+    WORD_ATOM(584, 9, "c99-block-exit!");
     mw_c99_block_exit_21_();
     WORD_EXIT(mb_c99_block_def_21__2);
 }
 
 static void mb_c99_block_def_21__3 (void) {
-    WORD_ENTER(mb_c99_block_def_21__3, "c99-block-def! block", "src/mirth/codegen.mth", 585, 14);
+    WORD_ENTER(mb_c99_block_def_21__3, "c99-block-def! block", "src/mirth/codegen.mth", 586, 14);
     mw_prim_drop();
-    WORD_ATOM(585, 14, "");
+    WORD_ATOM(586, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46629,15 +46600,15 @@ static void mb_c99_block_def_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(585, 18, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(586, 18, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_block_def_21__3);
 }
 
 static void mb_c99_word_enter_21__1 (void) {
-    WORD_ENTER(mb_c99_word_enter_21__1, "c99-word-enter! block", "src/mirth/codegen.mth", 597, 14);
+    WORD_ENTER(mb_c99_word_enter_21__1, "c99-word-enter! block", "src/mirth/codegen.mth", 598, 14);
     mw_prim_drop();
-    WORD_ATOM(597, 14, "");
+    WORD_ATOM(598, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46648,9 +46619,9 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(597, 28, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(598, 9, "");
+    WORD_ATOM(598, 28, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(599, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46661,15 +46632,15 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(598, 15, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(598, 17, "dup");
+    WORD_ATOM(599, 15, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(599, 19, "dup");
     mw_prim_dup();
-    WORD_ATOM(598, 21, "name");
+    WORD_ATOM(599, 23, "name");
     mw_Word_2E_name();
-    WORD_ATOM(598, 26, ".name");
-    mw_Name_2B_C99_2E_name();
-    WORD_ATOM(598, 32, "");
+    WORD_ATOM(599, 28, "put");
+    mw_Name_2B_C99_2E_put();
+    WORD_ATOM(599, 32, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46680,42 +46651,17 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(598, 37, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(599, 9, "dup");
-    mw_prim_dup();
-    WORD_ATOM(599, 13, "name");
-    mw_Word_2E_name();
-    WORD_ATOM(599, 18, ">Str");
-    mw_Name_3E_Str();
-    WORD_ATOM(599, 23, ".str");
-    mw__2E_str();
-    WORD_ATOM(599, 28, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr(", ", 2);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(599, 33, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(599, 37, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_ATOM(600, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(600, 13, "body");
-    mw_Word_2E_body();
-    WORD_ATOM(600, 18, ".module");
-    mw_Token_2E_module();
-    WORD_ATOM(600, 26, "source-path");
-    mw_Module_2E_source_path();
-    WORD_ATOM(600, 38, ">Str");
-    mw_Path_3E_Str();
-    WORD_ATOM(600, 43, ".str");
-    mw__2E_str();
-    WORD_ATOM(600, 48, "");
+    WORD_ATOM(600, 13, "name");
+    mw_Word_2E_name();
+    WORD_ATOM(600, 18, ">Str");
+    mw_Name_3E_Str();
+    WORD_ATOM(600, 23, "put-cstr");
+    mw__2B_C99_2E_put_cstr();
+    WORD_ATOM(600, 32, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46726,19 +46672,21 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(600, 53, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(600, 37, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_ATOM(601, 9, "dup");
     mw_prim_dup();
     WORD_ATOM(601, 13, "body");
     mw_Word_2E_body();
-    WORD_ATOM(601, 18, "row");
-    mw_Token_2E_row();
-    WORD_ATOM(601, 22, ">Int");
-    mw_Row_3E_Int();
-    WORD_ATOM(601, 27, ".n");
-    mw_Int_2B_C99_2E_n();
-    WORD_ATOM(601, 30, "");
+    WORD_ATOM(601, 18, ".module");
+    mw_Token_2E_module();
+    WORD_ATOM(601, 26, "source-path");
+    mw_Module_2E_source_path();
+    WORD_ATOM(601, 38, ">Str");
+    mw_Path_3E_Str();
+    WORD_ATOM(601, 43, "put-cstr");
+    mw__2B_C99_2E_put_cstr();
+    WORD_ATOM(601, 52, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46749,19 +46697,42 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(601, 35, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(601, 57, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_ATOM(602, 9, "dup");
     mw_prim_dup();
     WORD_ATOM(602, 13, "body");
     mw_Word_2E_body();
-    WORD_ATOM(602, 18, "col");
-    mw_Token_2E_col();
+    WORD_ATOM(602, 18, "row");
+    mw_Token_2E_row();
     WORD_ATOM(602, 22, ">Int");
+    mw_Row_3E_Int();
+    WORD_ATOM(602, 27, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(602, 31, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr(", ", 2);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(602, 36, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(603, 9, "dup");
+    mw_prim_dup();
+    WORD_ATOM(603, 13, "body");
+    mw_Word_2E_body();
+    WORD_ATOM(603, 18, "col");
+    mw_Token_2E_col();
+    WORD_ATOM(603, 22, ">Int");
     mw_Col_3E_Int();
-    WORD_ATOM(602, 27, ".n");
-    mw_Int_2B_C99_2E_n();
-    WORD_ATOM(602, 30, "");
+    WORD_ATOM(603, 27, "put");
+    mw_Int_2B_C99_2E_put();
+    WORD_ATOM(603, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46772,15 +46743,15 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(602, 35, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(603, 36, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_word_enter_21__1);
 }
 
 static void mb_c99_word_exit_21__1 (void) {
-    WORD_ENTER(mb_c99_word_exit_21__1, "c99-word-exit! block", "src/mirth/codegen.mth", 606, 14);
+    WORD_ENTER(mb_c99_word_exit_21__1, "c99-word-exit! block", "src/mirth/codegen.mth", 607, 14);
     mw_prim_drop();
-    WORD_ATOM(606, 14, "");
+    WORD_ATOM(607, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46791,9 +46762,9 @@ static void mb_c99_word_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(606, 27, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(607, 9, "");
+    WORD_ATOM(607, 27, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(608, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46804,15 +46775,15 @@ static void mb_c99_word_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(607, 15, ".");
-    mw_Str_2B_C99_2E_();
-    WORD_ATOM(607, 17, "dup");
+    WORD_ATOM(608, 15, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(608, 19, "dup");
     mw_prim_dup();
-    WORD_ATOM(607, 21, "name");
+    WORD_ATOM(608, 23, "name");
     mw_Word_2E_name();
-    WORD_ATOM(607, 26, ".name");
-    mw_Name_2B_C99_2E_name();
-    WORD_ATOM(607, 32, "");
+    WORD_ATOM(608, 28, "put");
+    mw_Name_2B_C99_2E_put();
+    WORD_ATOM(608, 32, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46823,60 +46794,62 @@ static void mb_c99_word_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(607, 37, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(608, 37, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_word_exit_21__1);
 }
 
 static void mb_c99_word_def_21__1 (void) {
-    WORD_ENTER(mb_c99_word_def_21__1, "c99-word-def! block", "src/mirth/codegen.mth", 612, 14);
+    WORD_ENTER(mb_c99_word_def_21__1, "c99-word-def! block", "src/mirth/codegen.mth", 613, 14);
     mw_prim_drop();
-    WORD_ATOM(612, 14, "dup");
+    WORD_ATOM(613, 14, "dup");
     mw_prim_dup();
-    WORD_ATOM(612, 18, "name");
+    WORD_ATOM(613, 18, "name");
     mw_Word_2E_name();
-    WORD_ATOM(612, 23, ".w");
-    mw_Name_2B_C99_2E_w();
-    WORD_ATOM(612, 26, "");
+    WORD_ATOM(613, 23, "sig");
+    mw_Name_2B_C99_2E_sig();
+    WORD_ATOM(613, 27, "put");
+    mw_Str_2B_C99_2E_put();
+    WORD_ATOM(613, 31, "");
     {
         static bool vready = false;
         static VAL v;
         if (! vready) {
-            v = mkstr("{", 1);
+            v = mkstr(" {", 2);
             vready = true;
         }
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(612, 30, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(613, 36, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_word_def_21__1);
 }
 
 static void mb_c99_word_def_21__2 (void) {
-    WORD_ENTER(mb_c99_word_def_21__2, "c99-word-def! block", "src/mirth/codegen.mth", 614, 9);
+    WORD_ENTER(mb_c99_word_def_21__2, "c99-word-def! block", "src/mirth/codegen.mth", 615, 9);
     mw_prim_drop();
-    WORD_ATOM(614, 9, "dup");
-    mw_prim_dup();
-    WORD_ATOM(614, 13, "c99-word-enter!");
-    mw_c99_word_enter_21_();
     WORD_ATOM(615, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(615, 13, "arrow");
-    mw_Word_2E_arrow();
-    WORD_ATOM(615, 19, "c99-arrow!");
-    mw_c99_arrow_21_();
+    WORD_ATOM(615, 13, "c99-word-enter!");
+    mw_c99_word_enter_21_();
     WORD_ATOM(616, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(616, 13, "c99-word-exit!");
+    WORD_ATOM(616, 13, "arrow");
+    mw_Word_2E_arrow();
+    WORD_ATOM(616, 19, "c99-arrow!");
+    mw_c99_arrow_21_();
+    WORD_ATOM(617, 9, "dup");
+    mw_prim_dup();
+    WORD_ATOM(617, 13, "c99-word-exit!");
     mw_c99_word_exit_21_();
     WORD_EXIT(mb_c99_word_def_21__2);
 }
 
 static void mb_c99_word_def_21__3 (void) {
-    WORD_ENTER(mb_c99_word_def_21__3, "c99-word-def! block", "src/mirth/codegen.mth", 618, 14);
+    WORD_ENTER(mb_c99_word_def_21__3, "c99-word-def! block", "src/mirth/codegen.mth", 619, 14);
     mw_prim_drop();
-    WORD_ATOM(618, 14, "");
+    WORD_ATOM(619, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -46887,8 +46860,8 @@ static void mb_c99_word_def_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(618, 18, ".");
-    mw_Str_2B_C99_2E_();
+    WORD_ATOM(619, 18, "put");
+    mw_Str_2B_C99_2E_put();
     WORD_EXIT(mb_c99_word_def_21__3);
 }
 

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -4481,6 +4481,11 @@ static void mb_c99_prim_21__19 (void);
 static void mb_c99_prim_21__20 (void);
 static void mb_c99_prim_21__21 (void);
 static void mb_c99_prim_21__22 (void);
+static void mb_c99_prim_21__23 (void);
+static void mb_c99_prim_21__27 (void);
+static void mb_c99_prim_21__28 (void);
+static void mb_c99_prim_21__29 (void);
+static void mb_c99_prim_21__30 (void);
 static void mb_c99_match_21__3 (void);
 static void mb_c99_match_21__5 (void);
 static void mb_c99_match_21__7 (void);
@@ -14850,21 +14855,13 @@ static void mw_need_prim (void){
                     break;
             
 }            break;
-        case 5LL:
+        case 13LL:
             mw_prim_drop();
             WORD_ATOM(106, 9, "match");
             switch (get_top_data_tag()) {
-                case 2LL:
+                case 1LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    mw_prim_pack_uncons(); mw_prim_swap();
-                    WORD_ATOM(107, 19, "dip");
-                    {
-                        VAL d6 = pop_value();
-                        WORD_ATOM(107, 23, "need-arg-run");
-                        mw_need_arg_run();
-                        push_value(d6);
-                    }
-                    WORD_ATOM(107, 37, "need-arg-run");
+                    WORD_ATOM(107, 19, "need-arg-run");
                     mw_need_arg_run();
                     break;
                 default:
@@ -14873,7 +14870,7 @@ static void mw_need_prim (void){
                     break;
             
 }            break;
-        case 6LL:
+        case 5LL:
             mw_prim_drop();
             WORD_ATOM(111, 9, "match");
             switch (get_top_data_tag()) {
@@ -14896,20 +14893,43 @@ static void mw_need_prim (void){
                     break;
             
 }            break;
-        default:
-            WORD_ATOM(115, 10, "drop");
+        case 6LL:
             mw_prim_drop();
-            WORD_ATOM(115, 15, "need-args-push");
+            WORD_ATOM(116, 9, "match");
+            switch (get_top_data_tag()) {
+                case 2LL:
+                    mw_prim_pack_uncons(); mw_prim_drop();
+                    mw_prim_pack_uncons(); mw_prim_swap();
+                    WORD_ATOM(117, 19, "dip");
+                    {
+                        VAL d6 = pop_value();
+                        WORD_ATOM(117, 23, "need-arg-run");
+                        mw_need_arg_run();
+                        push_value(d6);
+                    }
+                    WORD_ATOM(117, 37, "need-arg-run");
+                    mw_need_arg_run();
+                    break;
+                default:
+                    WORD_ATOM(118, 18, "need-args-push");
+                    mw_need_args_push();
+                    break;
+            
+}            break;
+        default:
+            WORD_ATOM(120, 10, "drop");
+            mw_prim_drop();
+            WORD_ATOM(120, 15, "need-args-push");
             mw_need_args_push();
             break;
     
 }    WORD_EXIT(mw_need_prim);
 }
 static void mw_need_match (void){
-    WORD_ENTER(mw_need_match, "need-match", "src/mirth/codegen.mth", 117, 27);
-    WORD_ATOM(117, 27, "cases");
+    WORD_ENTER(mw_need_match, "need-match", "src/mirth/codegen.mth", 122, 27);
+    WORD_ATOM(122, 27, "cases");
     mw_Match_2E_cases();
-    WORD_ATOM(117, 33, "for");
+    WORD_ATOM(122, 33, "for");
     push_u64(0);
     push_fnptr(&mb_need_match_1);
     mw_prim_pack_cons();
@@ -14917,29 +14937,29 @@ static void mw_need_match (void){
     WORD_EXIT(mw_need_match);
 }
 static void mw_need_lambda (void){
-    WORD_ENTER(mw_need_lambda, "need-lambda", "src/mirth/codegen.mth", 118, 29);
-    WORD_ATOM(118, 29, "body");
+    WORD_ENTER(mw_need_lambda, "need-lambda", "src/mirth/codegen.mth", 123, 29);
+    WORD_ATOM(123, 29, "body");
     mw_Lambda_2E_body();
-    WORD_ATOM(118, 34, "need-arrow-run");
+    WORD_ATOM(123, 34, "need-arrow-run");
     mw_need_arrow_run();
     WORD_EXIT(mw_need_lambda);
 }
 static void mw_need_block_push (void){
-    WORD_ENTER(mw_need_block_push, "need-block-push", "src/mirth/codegen.mth", 121, 5);
-    WORD_ATOM(121, 5, "dup");
+    WORD_ENTER(mw_need_block_push, "need-block-push", "src/mirth/codegen.mth", 126, 5);
+    WORD_ATOM(126, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(121, 9, "block-to-run-var");
+    WORD_ATOM(126, 9, "block-to-run-var");
     mw_block_to_run_var();
-    WORD_ATOM(121, 26, "match");
+    WORD_ATOM(126, 26, "match");
     switch (get_top_data_tag()) {
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(122, 17, "drop2");
+            WORD_ATOM(127, 17, "drop2");
             mw_drop2();
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(123, 17, "need-block");
+            WORD_ATOM(128, 17, "need-block");
             mw_need_block();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -14947,54 +14967,54 @@ static void mw_need_block_push (void){
 }    WORD_EXIT(mw_need_block_push);
 }
 static void mw_need_block_run (void){
-    WORD_ENTER(mw_need_block_run, "need-block-run", "src/mirth/codegen.mth", 125, 31);
-    WORD_ATOM(125, 31, "arrow");
+    WORD_ENTER(mw_need_block_run, "need-block-run", "src/mirth/codegen.mth", 130, 31);
+    WORD_ATOM(130, 31, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(125, 37, "need-arrow-run");
+    WORD_ATOM(130, 37, "need-arrow-run");
     mw_need_arrow_run();
     WORD_EXIT(mw_need_block_run);
 }
 static void mw_codegen_full_3F_ (void){
-    WORD_ENTER(mw_codegen_full_3F_, "codegen-full?", "src/mirth/codegen.mth", 128, 5);
-    WORD_ATOM(128, 5, "codegen-length");
+    WORD_ENTER(mw_codegen_full_3F_, "codegen-full?", "src/mirth/codegen.mth", 133, 5);
+    WORD_ATOM(133, 5, "codegen-length");
     mw_codegen_length();
-    WORD_ATOM(128, 20, "@");
+    WORD_ATOM(133, 20, "@");
     mw_prim_mut_get();
-    WORD_ATOM(128, 22, "");
+    WORD_ATOM(133, 22, "");
     push_i64(4LL);
-    WORD_ATOM(128, 24, "+");
+    WORD_ATOM(133, 24, "+");
     mw_prim_int_add();
-    WORD_ATOM(128, 26, "CODEGEN_BUF_SIZE");
+    WORD_ATOM(133, 26, "CODEGEN_BUF_SIZE");
     mw_CODEGEN_5F_BUF_5F_SIZE();
-    WORD_ATOM(128, 43, ">=");
+    WORD_ATOM(133, 43, ">=");
     mw_Int_3E__3D_();
     WORD_EXIT(mw_codegen_full_3F_);
 }
 static void mw_codegen_flush_21_ (void){
-    WORD_ENTER(mw_codegen_flush_21_, "codegen-flush!", "src/mirth/codegen.mth", 131, 5);
-    WORD_ATOM(131, 5, "codegen-length");
+    WORD_ENTER(mw_codegen_flush_21_, "codegen-flush!", "src/mirth/codegen.mth", 136, 5);
+    WORD_ATOM(136, 5, "codegen-length");
     mw_codegen_length();
-    WORD_ATOM(131, 20, "@");
+    WORD_ATOM(136, 20, "@");
     mw_prim_mut_get();
-    WORD_ATOM(131, 22, "0>");
+    WORD_ATOM(136, 22, "0>");
     mw_0_3E_();
-    WORD_ATOM(131, 25, "if");
+    WORD_ATOM(136, 25, "if");
     if (pop_u64()) {
-        WORD_ATOM(132, 9, "codegen-file");
+        WORD_ATOM(137, 9, "codegen-file");
         mw_codegen_file();
-        WORD_ATOM(132, 22, "@");
+        WORD_ATOM(137, 22, "@");
         mw_prim_mut_get();
-        WORD_ATOM(132, 24, "File>Int");
+        WORD_ATOM(137, 24, "File>Int");
         mw_File_3E_Int();
-        WORD_ATOM(132, 33, "CODEGEN_BUF");
+        WORD_ATOM(137, 33, "CODEGEN_BUF");
         mw_CODEGEN_5F_BUF();
-        WORD_ATOM(132, 45, "codegen-length");
+        WORD_ATOM(137, 45, "codegen-length");
         mw_codegen_length();
-        WORD_ATOM(132, 60, "@");
+        WORD_ATOM(137, 60, "@");
         mw_prim_mut_get();
-        WORD_ATOM(133, 9, "posix-write!");
+        WORD_ATOM(138, 9, "posix-write!");
         mw_prim_posix_write();
-        WORD_ATOM(134, 9, "expect!");
+        WORD_ATOM(139, 9, "expect!");
         push_u64(0);
         push_fnptr(&mb_codegen_flush_21__2);
         mw_prim_pack_cons();
@@ -15002,7 +15022,7 @@ static void mw_codegen_flush_21_ (void){
         push_fnptr(&mb_codegen_flush_21__3);
         mw_prim_pack_cons();
         mw_expect_21_();
-        WORD_ATOM(135, 9, "expect!");
+        WORD_ATOM(140, 9, "expect!");
         push_u64(0);
         push_fnptr(&mb_codegen_flush_21__4);
         mw_prim_pack_cons();
@@ -15010,287 +15030,287 @@ static void mw_codegen_flush_21_ (void){
         push_fnptr(&mb_codegen_flush_21__5);
         mw_prim_pack_cons();
         mw_expect_21_();
-        WORD_ATOM(136, 9, "drop");
+        WORD_ATOM(141, 9, "drop");
         mw_prim_drop();
-        WORD_ATOM(137, 9, "");
+        WORD_ATOM(142, 9, "");
         push_i64(0LL);
-        WORD_ATOM(137, 11, "codegen-length");
+        WORD_ATOM(142, 11, "codegen-length");
         mw_codegen_length();
-        WORD_ATOM(137, 26, "!");
+        WORD_ATOM(142, 26, "!");
         mw_prim_mut_set();
     } else {
-        WORD_ATOM(138, 9, "id");
+        WORD_ATOM(143, 9, "id");
         mw_prim_id();
     }
     WORD_EXIT(mw_codegen_flush_21_);
 }
 static void mw__2E_b (void){
-    WORD_ENTER(mw__2E_b, ".b", "src/mirth/codegen.mth", 142, 5);
-    WORD_ATOM(142, 5, ">U8");
+    WORD_ENTER(mw__2E_b, ".b", "src/mirth/codegen.mth", 147, 5);
+    WORD_ATOM(147, 5, ">U8");
     mw_Byte_3E_U8();
-    WORD_ATOM(143, 5, "codegen-full?");
+    WORD_ATOM(148, 5, "codegen-full?");
     mw_codegen_full_3F_();
-    WORD_ATOM(143, 19, "if");
+    WORD_ATOM(148, 19, "if");
     if (pop_u64()) {
-        WORD_ATOM(143, 22, "codegen-flush!");
+        WORD_ATOM(148, 22, "codegen-flush!");
         mw_codegen_flush_21_();
     } else {
-        WORD_ATOM(143, 38, "id");
+        WORD_ATOM(148, 38, "id");
         mw_prim_id();
     }
-    WORD_ATOM(144, 5, "codegen-length");
+    WORD_ATOM(149, 5, "codegen-length");
     mw_codegen_length();
-    WORD_ATOM(144, 20, "modify");
+    WORD_ATOM(149, 20, "modify");
     push_u64(0);
     push_fnptr(&mb__2E_b_3);
     mw_prim_pack_cons();
     mw_modify();
-    WORD_ATOM(145, 5, "CODEGEN_BUF");
+    WORD_ATOM(150, 5, "CODEGEN_BUF");
     mw_CODEGEN_5F_BUF();
-    WORD_ATOM(145, 17, "!!U8");
+    WORD_ATOM(150, 17, "!!U8");
     mw_Ptr_21__21_U8();
     WORD_EXIT(mw__2E_b);
 }
 static void mw__2E_ (void){
-    WORD_ENTER(mw__2E_, ".", "src/mirth/codegen.mth", 148, 5);
-    WORD_ATOM(148, 5, "dup");
+    WORD_ENTER(mw__2E_, ".", "src/mirth/codegen.mth", 153, 5);
+    WORD_ATOM(153, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(148, 9, "prim-str-base");
+    WORD_ATOM(153, 9, "prim-str-base");
     mw_prim_str_base();
-    WORD_ATOM(148, 23, "over");
+    WORD_ATOM(153, 23, "over");
     mw_over();
-    WORD_ATOM(148, 28, "num-bytes");
+    WORD_ATOM(153, 28, "num-bytes");
     mw_prim_str_num_bytes();
-    WORD_ATOM(149, 5, "dup");
+    WORD_ATOM(154, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(149, 9, "codegen-length");
+    WORD_ATOM(154, 9, "codegen-length");
     mw_codegen_length();
-    WORD_ATOM(149, 24, "@");
+    WORD_ATOM(154, 24, "@");
     mw_prim_mut_get();
-    WORD_ATOM(149, 26, "+");
+    WORD_ATOM(154, 26, "+");
     mw_prim_int_add();
-    WORD_ATOM(149, 28, "CODEGEN_BUF_SIZE");
+    WORD_ATOM(154, 28, "CODEGEN_BUF_SIZE");
     mw_CODEGEN_5F_BUF_5F_SIZE();
-    WORD_ATOM(149, 45, ">");
+    WORD_ATOM(154, 45, ">");
     mw_Int_3E_();
-    WORD_ATOM(149, 47, "if");
+    WORD_ATOM(154, 47, "if");
     if (pop_u64()) {
-        WORD_ATOM(150, 9, "codegen-flush!");
+        WORD_ATOM(155, 9, "codegen-flush!");
         mw_codegen_flush_21_();
-        WORD_ATOM(151, 9, "while");
+        WORD_ATOM(156, 9, "while");
         while(1) {
-            WORD_ATOM(151, 15, "dup");
+            WORD_ATOM(156, 15, "dup");
             mw_prim_dup();
-            WORD_ATOM(151, 19, "CODEGEN_BUF_SIZE");
+            WORD_ATOM(156, 19, "CODEGEN_BUF_SIZE");
             mw_CODEGEN_5F_BUF_5F_SIZE();
-            WORD_ATOM(151, 36, ">");
+            WORD_ATOM(156, 36, ">");
             mw_Int_3E_();
             if (! pop_u64()) break;
-            WORD_ATOM(152, 13, "over");
+            WORD_ATOM(157, 13, "over");
             mw_over();
-            WORD_ATOM(152, 18, "CODEGEN_BUF_SIZE");
+            WORD_ATOM(157, 18, "CODEGEN_BUF_SIZE");
             mw_CODEGEN_5F_BUF_5F_SIZE();
-            WORD_ATOM(152, 35, "CODEGEN_BUF");
+            WORD_ATOM(157, 35, "CODEGEN_BUF");
             mw_CODEGEN_5F_BUF();
-            WORD_ATOM(152, 47, "prim-ptr-copy");
+            WORD_ATOM(157, 47, "prim-ptr-copy");
             mw_prim_ptr_copy();
-            WORD_ATOM(153, 13, "CODEGEN_BUF_SIZE");
+            WORD_ATOM(158, 13, "CODEGEN_BUF_SIZE");
             mw_CODEGEN_5F_BUF_5F_SIZE();
-            WORD_ATOM(153, 30, "codegen-length");
+            WORD_ATOM(158, 30, "codegen-length");
             mw_codegen_length();
-            WORD_ATOM(153, 45, "!");
+            WORD_ATOM(158, 45, "!");
             mw_prim_mut_set();
-            WORD_ATOM(154, 13, "codegen-flush!");
+            WORD_ATOM(159, 13, "codegen-flush!");
             mw_codegen_flush_21_();
-            WORD_ATOM(155, 13, "dip");
+            WORD_ATOM(160, 13, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(155, 17, "CODEGEN_BUF_SIZE");
+                WORD_ATOM(160, 17, "CODEGEN_BUF_SIZE");
                 mw_CODEGEN_5F_BUF_5F_SIZE();
-                WORD_ATOM(155, 34, "swap");
+                WORD_ATOM(160, 34, "swap");
                 mw_prim_swap();
-                WORD_ATOM(155, 39, ".offset-unsafe");
+                WORD_ATOM(160, 39, ".offset-unsafe");
                 mw_prim_ptr_add();
                 push_value(d4);
             }
-            WORD_ATOM(156, 13, "CODEGEN_BUF_SIZE");
+            WORD_ATOM(161, 13, "CODEGEN_BUF_SIZE");
             mw_CODEGEN_5F_BUF_5F_SIZE();
-            WORD_ATOM(156, 30, "-");
+            WORD_ATOM(161, 30, "-");
             mw_prim_int_sub();
         }
-        WORD_ATOM(158, 9, "dup");
+        WORD_ATOM(163, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(158, 13, "codegen-length");
+        WORD_ATOM(163, 13, "codegen-length");
         mw_codegen_length();
-        WORD_ATOM(158, 28, "!");
+        WORD_ATOM(163, 28, "!");
         mw_prim_mut_set();
-        WORD_ATOM(158, 30, "CODEGEN_BUF");
+        WORD_ATOM(163, 30, "CODEGEN_BUF");
         mw_CODEGEN_5F_BUF();
-        WORD_ATOM(158, 42, "prim-ptr-copy");
+        WORD_ATOM(163, 42, "prim-ptr-copy");
         mw_prim_ptr_copy();
     } else {
-        WORD_ATOM(160, 9, "sip");
+        WORD_ATOM(165, 9, "sip");
         push_u64(0);
         push_fnptr(&mb__2E__6);
         mw_prim_pack_cons();
         mw_sip();
-        WORD_ATOM(161, 9, "codegen-length");
+        WORD_ATOM(166, 9, "codegen-length");
         mw_codegen_length();
-        WORD_ATOM(161, 24, "modify");
+        WORD_ATOM(166, 24, "modify");
         push_u64(0);
         push_fnptr(&mb__2E__7);
         mw_prim_pack_cons();
         mw_modify();
     }
-    WORD_ATOM(162, 7, "drop");
+    WORD_ATOM(167, 7, "drop");
     mw_prim_drop();
     WORD_EXIT(mw__2E_);
 }
 static void mw_codegen_start_21_ (void){
-    WORD_ENTER(mw_codegen_start_21_, "codegen-start!", "src/mirth/codegen.mth", 165, 5);
-    WORD_ATOM(165, 5, "codegen-file");
+    WORD_ENTER(mw_codegen_start_21_, "codegen-start!", "src/mirth/codegen.mth", 170, 5);
+    WORD_ATOM(170, 5, "codegen-file");
     mw_codegen_file();
-    WORD_ATOM(165, 18, "!");
+    WORD_ATOM(170, 18, "!");
     mw_prim_mut_set();
-    WORD_ATOM(165, 20, "");
+    WORD_ATOM(170, 20, "");
     push_i64(0LL);
-    WORD_ATOM(165, 22, "codegen-length");
+    WORD_ATOM(170, 22, "codegen-length");
     mw_codegen_length();
-    WORD_ATOM(165, 37, "!");
+    WORD_ATOM(170, 37, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_codegen_start_21_);
 }
 static void mw_codegen_end_21_ (void){
-    WORD_ENTER(mw_codegen_end_21_, "codegen-end!", "src/mirth/codegen.mth", 168, 5);
-    WORD_ATOM(168, 5, "codegen-flush!");
+    WORD_ENTER(mw_codegen_end_21_, "codegen-end!", "src/mirth/codegen.mth", 173, 5);
+    WORD_ATOM(173, 5, "codegen-flush!");
     mw_codegen_flush_21_();
-    WORD_ATOM(169, 5, "codegen-file");
+    WORD_ATOM(174, 5, "codegen-file");
     mw_codegen_file();
-    WORD_ATOM(169, 18, "@");
+    WORD_ATOM(174, 18, "@");
     mw_prim_mut_get();
-    WORD_ATOM(169, 20, "close-file!");
+    WORD_ATOM(174, 20, "close-file!");
     mw_close_file_21_();
-    WORD_ATOM(170, 5, "STDOUT");
+    WORD_ATOM(175, 5, "STDOUT");
     mw_STDOUT();
-    WORD_ATOM(170, 12, "codegen-file");
+    WORD_ATOM(175, 12, "codegen-file");
     mw_codegen_file();
-    WORD_ATOM(170, 25, "!");
+    WORD_ATOM(175, 25, "!");
     mw_prim_mut_set();
-    WORD_ATOM(171, 5, "");
+    WORD_ATOM(176, 5, "");
     push_i64(0LL);
-    WORD_ATOM(171, 7, "codegen-length");
+    WORD_ATOM(176, 7, "codegen-length");
     mw_codegen_length();
-    WORD_ATOM(171, 22, "!");
+    WORD_ATOM(176, 22, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_codegen_end_21_);
 }
 static void mw_run_output_c99_21_ (void){
-    WORD_ENTER(mw_run_output_c99_21_, "run-output-c99!", "src/mirth/codegen.mth", 174, 5);
-    WORD_ATOM(174, 5, "num-errors");
+    WORD_ENTER(mw_run_output_c99_21_, "run-output-c99!", "src/mirth/codegen.mth", 179, 5);
+    WORD_ATOM(179, 5, "num-errors");
     mw_num_errors();
-    WORD_ATOM(174, 16, "@");
+    WORD_ATOM(179, 16, "@");
     mw_prim_mut_get();
-    WORD_ATOM(174, 18, "0>");
+    WORD_ATOM(179, 18, "0>");
     mw_0_3E_();
-    WORD_ATOM(174, 21, "if");
+    WORD_ATOM(179, 21, "if");
     if (pop_u64()) {
-        WORD_ATOM(175, 9, "drop2");
+        WORD_ATOM(180, 9, "drop2");
         mw_drop2();
     } else {
-        WORD_ATOM(177, 9, "reset-needs!");
+        WORD_ATOM(182, 9, "reset-needs!");
         mw_reset_needs_21_();
-        WORD_ATOM(178, 9, "over");
+        WORD_ATOM(183, 9, "over");
         mw_over();
-        WORD_ATOM(178, 14, "determine-arrow-needs!");
+        WORD_ATOM(183, 14, "determine-arrow-needs!");
         mw_determine_arrow_needs_21_();
-        WORD_ATOM(180, 9, "");
+        WORD_ATOM(185, 9, "");
         push_i64(0LL);
-        WORD_ATOM(180, 11, "c99-depth");
+        WORD_ATOM(185, 11, "c99-depth");
         mw_c99_depth();
-        WORD_ATOM(180, 21, "!");
+        WORD_ATOM(185, 21, "!");
         mw_prim_mut_set();
-        WORD_ATOM(181, 9, "to-output-path");
+        WORD_ATOM(186, 9, "to-output-path");
         mw_Path_2E_to_output_path();
-        WORD_ATOM(181, 24, ">Str");
+        WORD_ATOM(186, 24, ">Str");
         mw_Path_3E_Str();
-        WORD_ATOM(182, 9, "create-file!");
+        WORD_ATOM(187, 9, "create-file!");
         mw_create_file_21_();
-        WORD_ATOM(182, 22, "codegen-start!");
+        WORD_ATOM(187, 22, "codegen-start!");
         mw_codegen_start_21_();
-        WORD_ATOM(183, 9, "c99-header!");
+        WORD_ATOM(188, 9, "c99-header!");
         mw_c99_header_21_();
-        WORD_ATOM(184, 9, "c99-tags!");
+        WORD_ATOM(189, 9, "c99-tags!");
         mw_c99_tags_21_();
-        WORD_ATOM(185, 9, "c99-buffers!");
+        WORD_ATOM(190, 9, "c99-buffers!");
         mw_c99_buffers_21_();
-        WORD_ATOM(186, 9, "c99-variables!");
+        WORD_ATOM(191, 9, "c99-variables!");
         mw_c99_variables_21_();
-        WORD_ATOM(187, 9, "c99-externals!");
+        WORD_ATOM(192, 9, "c99-externals!");
         mw_c99_externals_21_();
-        WORD_ATOM(188, 9, "c99-word-sigs!");
+        WORD_ATOM(193, 9, "c99-word-sigs!");
         mw_c99_word_sigs_21_();
-        WORD_ATOM(189, 9, "c99-block-sigs!");
+        WORD_ATOM(194, 9, "c99-block-sigs!");
         mw_c99_block_sigs_21_();
-        WORD_ATOM(190, 9, "c99-field-sigs!");
+        WORD_ATOM(195, 9, "c99-field-sigs!");
         mw_c99_field_sigs_21_();
-        WORD_ATOM(191, 9, "c99-main!");
+        WORD_ATOM(196, 9, "c99-main!");
         mw_c99_main_21_();
-        WORD_ATOM(192, 9, "c99-field-defs!");
+        WORD_ATOM(197, 9, "c99-field-defs!");
         mw_c99_field_defs_21_();
-        WORD_ATOM(193, 9, "c99-word-defs!");
+        WORD_ATOM(198, 9, "c99-word-defs!");
         mw_c99_word_defs_21_();
-        WORD_ATOM(194, 9, "c99-block-defs!");
+        WORD_ATOM(199, 9, "c99-block-defs!");
         mw_c99_block_defs_21_();
-        WORD_ATOM(195, 9, "codegen-end!");
+        WORD_ATOM(200, 9, "codegen-end!");
         mw_codegen_end_21_();
     }
     WORD_EXIT(mw_run_output_c99_21_);
 }
 static void mw__2E_lf (void){
-    WORD_ENTER(mw__2E_lf, ".lf", "src/mirth/codegen.mth", 200, 14);
-    WORD_ATOM(200, 14, "BLF");
+    WORD_ENTER(mw__2E_lf, ".lf", "src/mirth/codegen.mth", 205, 14);
+    WORD_ATOM(205, 14, "BLF");
     mw_BLF();
-    WORD_ATOM(200, 18, ".b");
+    WORD_ATOM(205, 18, ".b");
     mw__2E_b();
     WORD_EXIT(mw__2E_lf);
 }
 static void mw__3B_ (void){
-    WORD_ENTER(mw__3B_, ";", "src/mirth/codegen.mth", 201, 16);
-    WORD_ATOM(201, 16, ".");
+    WORD_ENTER(mw__3B_, ";", "src/mirth/codegen.mth", 206, 16);
+    WORD_ATOM(206, 16, ".");
     mw__2E_();
-    WORD_ATOM(201, 18, ".lf");
+    WORD_ATOM(206, 18, ".lf");
     mw__2E_lf();
     WORD_EXIT(mw__3B_);
 }
 static void mw__3B__3B_ (void){
-    WORD_ENTER(mw__3B__3B_, ";;", "src/mirth/codegen.mth", 202, 17);
-    WORD_ATOM(202, 17, ".");
+    WORD_ENTER(mw__3B__3B_, ";;", "src/mirth/codegen.mth", 207, 17);
+    WORD_ATOM(207, 17, ".");
     mw__2E_();
-    WORD_ATOM(202, 19, ".lf");
+    WORD_ATOM(207, 19, ".lf");
     mw__2E_lf();
-    WORD_ATOM(202, 23, ".lf");
+    WORD_ATOM(207, 23, ".lf");
     mw__2E_lf();
     WORD_EXIT(mw__3B__3B_);
 }
 static void mw__2E_n (void){
-    WORD_ENTER(mw__2E_n, ".n", "src/mirth/codegen.mth", 203, 17);
-    WORD_ATOM(203, 17, "int-to-str");
+    WORD_ENTER(mw__2E_n, ".n", "src/mirth/codegen.mth", 208, 17);
+    WORD_ATOM(208, 17, "int-to-str");
     mw_prim_int_to_str();
-    WORD_ATOM(203, 28, ".");
+    WORD_ATOM(208, 28, ".");
     mw__2E_();
     WORD_EXIT(mw__2E_n);
 }
 static void mw__2E_name (void){
-    WORD_ENTER(mw__2E_name, ".name", "src/mirth/codegen.mth", 204, 21);
-    WORD_ATOM(204, 21, "mangled");
+    WORD_ENTER(mw__2E_name, ".name", "src/mirth/codegen.mth", 209, 21);
+    WORD_ATOM(209, 21, "mangled");
     mw_Name_2E_mangled();
-    WORD_ATOM(204, 29, ".");
+    WORD_ATOM(209, 29, ".");
     mw__2E_();
     WORD_EXIT(mw__2E_name);
 }
 static void mw__2E_w (void){
-    WORD_ENTER(mw__2E_w, ".w", "src/mirth/codegen.mth", 206, 18);
-    WORD_ATOM(206, 18, "");
+    WORD_ENTER(mw__2E_w, ".w", "src/mirth/codegen.mth", 211, 18);
+    WORD_ATOM(211, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -15301,11 +15321,11 @@ static void mw__2E_w (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(206, 36, ".");
+    WORD_ATOM(211, 36, ".");
     mw__2E_();
-    WORD_ATOM(206, 38, ".name");
+    WORD_ATOM(211, 38, ".name");
     mw__2E_name();
-    WORD_ATOM(206, 44, "");
+    WORD_ATOM(211, 44, "");
     {
         static bool vready = false;
         static VAL v;
@@ -15316,13 +15336,13 @@ static void mw__2E_w (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(206, 54, ".");
+    WORD_ATOM(211, 54, ".");
     mw__2E_();
     WORD_EXIT(mw__2E_w);
 }
 static void mw_c99_header_21_ (void){
-    WORD_ENTER(mw_c99_header_21_, "c99-header!", "src/mirth/codegen.mth", 211, 22);
-    WORD_ATOM(211, 22, "c99-header-str");
+    WORD_ENTER(mw_c99_header_21_, "c99-header!", "src/mirth/codegen.mth", 216, 22);
+    WORD_ATOM(216, 22, "c99-header-str");
     {
         static bool vready = false;
         static VAL v;
@@ -16552,32 +16572,32 @@ static uint8_t b[] = {                47,42,32,77,73,82,84,72,32,72,69,65,68,69,
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(211, 37, ".");
+    WORD_ATOM(216, 37, ".");
     mw__2E_();
-    WORD_ATOM(211, 39, ".lf");
+    WORD_ATOM(216, 39, ".lf");
     mw__2E_lf();
     WORD_EXIT(mw_c99_header_21_);
 }
 static void mw_c99_buffers_21_ (void){
-    WORD_ENTER(mw_c99_buffers_21_, "c99-buffers!", "src/mirth/codegen.mth", 213, 23);
-    WORD_ATOM(213, 23, "Buffer.for");
+    WORD_ENTER(mw_c99_buffers_21_, "c99-buffers!", "src/mirth/codegen.mth", 218, 23);
+    WORD_ATOM(218, 23, "Buffer.for");
     push_u64(0);
     push_fnptr(&mb_c99_buffers_21__1);
     mw_prim_pack_cons();
     mw_Buffer_2E_for();
-    WORD_ATOM(213, 47, ".lf");
+    WORD_ATOM(218, 47, ".lf");
     mw__2E_lf();
     WORD_EXIT(mw_c99_buffers_21_);
 }
 static void mw_c99_buffer_21_ (void){
-    WORD_ENTER(mw_c99_buffer_21_, "c99-buffer!", "src/mirth/codegen.mth", 215, 5);
-    WORD_ATOM(215, 5, "dup");
+    WORD_ENTER(mw_c99_buffer_21_, "c99-buffer!", "src/mirth/codegen.mth", 220, 5);
+    WORD_ATOM(220, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(215, 9, "name");
+    WORD_ATOM(220, 9, "name");
     mw_Buffer_2E_name();
-    WORD_ATOM(215, 14, ".w");
+    WORD_ATOM(220, 14, ".w");
     mw__2E_w();
-    WORD_ATOM(215, 17, "");
+    WORD_ATOM(220, 17, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16588,9 +16608,9 @@ static void mw_c99_buffer_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(215, 22, ";");
+    WORD_ATOM(220, 22, ";");
     mw__3B_();
-    WORD_ATOM(216, 5, "");
+    WORD_ATOM(221, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16601,15 +16621,15 @@ static void mw_c99_buffer_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(216, 29, ".");
+    WORD_ATOM(221, 29, ".");
     mw__2E_();
-    WORD_ATOM(216, 31, "dup");
+    WORD_ATOM(221, 31, "dup");
     mw_prim_dup();
-    WORD_ATOM(216, 35, "size");
+    WORD_ATOM(221, 35, "size");
     mw_Buffer_2E_size();
-    WORD_ATOM(216, 40, ".n");
+    WORD_ATOM(221, 40, ".n");
     mw__2E_n();
-    WORD_ATOM(216, 43, "");
+    WORD_ATOM(221, 43, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16620,9 +16640,9 @@ static void mw_c99_buffer_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(216, 54, ";");
+    WORD_ATOM(221, 54, ";");
     mw__3B_();
-    WORD_ATOM(217, 5, "");
+    WORD_ATOM(222, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16633,9 +16653,9 @@ static void mw_c99_buffer_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(217, 25, ";");
+    WORD_ATOM(222, 25, ";");
     mw__3B_();
-    WORD_ATOM(218, 5, "");
+    WORD_ATOM(223, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16646,26 +16666,26 @@ static void mw_c99_buffer_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(218, 9, ";");
+    WORD_ATOM(223, 9, ";");
     mw__3B_();
-    WORD_ATOM(219, 5, "drop");
+    WORD_ATOM(224, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_buffer_21_);
 }
 static void mw_c99_variables_21_ (void){
-    WORD_ENTER(mw_c99_variables_21_, "c99-variables!", "src/mirth/codegen.mth", 221, 25);
-    WORD_ATOM(221, 25, "Variable.for");
+    WORD_ENTER(mw_c99_variables_21_, "c99-variables!", "src/mirth/codegen.mth", 226, 25);
+    WORD_ATOM(226, 25, "Variable.for");
     push_u64(0);
     push_fnptr(&mb_c99_variables_21__1);
     mw_prim_pack_cons();
     mw_Variable_2E_for();
-    WORD_ATOM(221, 53, ".lf");
+    WORD_ATOM(226, 53, ".lf");
     mw__2E_lf();
     WORD_EXIT(mw_c99_variables_21_);
 }
 static void mw_c99_variable_21_ (void){
-    WORD_ENTER(mw_c99_variable_21_, "c99-variable!", "src/mirth/codegen.mth", 223, 5);
-    WORD_ATOM(223, 5, "");
+    WORD_ENTER(mw_c99_variable_21_, "c99-variable!", "src/mirth/codegen.mth", 228, 5);
+    WORD_ATOM(228, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16676,13 +16696,13 @@ static void mw_c99_variable_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(223, 16, ".");
+    WORD_ATOM(228, 16, ".");
     mw__2E_();
-    WORD_ATOM(223, 18, "name");
+    WORD_ATOM(228, 18, "name");
     mw_Variable_2E_name();
-    WORD_ATOM(223, 23, ".name");
+    WORD_ATOM(228, 23, ".name");
     mw__2E_name();
-    WORD_ATOM(223, 29, "");
+    WORD_ATOM(228, 29, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16693,9 +16713,9 @@ static void mw_c99_variable_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(223, 36, ";");
+    WORD_ATOM(228, 36, ";");
     mw__3B_();
-    WORD_ATOM(224, 5, "");
+    WORD_ATOM(229, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16706,9 +16726,9 @@ static void mw_c99_variable_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(224, 31, ";");
+    WORD_ATOM(229, 31, ";");
     mw__3B_();
-    WORD_ATOM(225, 5, "");
+    WORD_ATOM(230, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16719,9 +16739,9 @@ static void mw_c99_variable_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(225, 25, ";");
+    WORD_ATOM(230, 25, ";");
     mw__3B_();
-    WORD_ATOM(226, 5, "");
+    WORD_ATOM(231, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16732,30 +16752,30 @@ static void mw_c99_variable_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(226, 9, ";");
+    WORD_ATOM(231, 9, ";");
     mw__3B_();
     WORD_EXIT(mw_c99_variable_21_);
 }
 static void mw_c99_tags_21_ (void){
-    WORD_ENTER(mw_c99_tags_21_, "c99-tags!", "src/mirth/codegen.mth", 228, 20);
-    WORD_ATOM(228, 20, "Tag.for");
+    WORD_ENTER(mw_c99_tags_21_, "c99-tags!", "src/mirth/codegen.mth", 233, 20);
+    WORD_ATOM(233, 20, "Tag.for");
     push_u64(0);
     push_fnptr(&mb_c99_tags_21__1);
     mw_prim_pack_cons();
     mw_Tag_2E_for();
-    WORD_ATOM(228, 38, ".lf");
+    WORD_ATOM(233, 38, ".lf");
     mw__2E_lf();
     WORD_EXIT(mw_c99_tags_21_);
 }
 static void mw_c99_tag_21_ (void){
-    WORD_ENTER(mw_c99_tag_21_, "c99-tag!", "src/mirth/codegen.mth", 230, 5);
-    WORD_ATOM(230, 5, "dup");
+    WORD_ENTER(mw_c99_tag_21_, "c99-tag!", "src/mirth/codegen.mth", 235, 5);
+    WORD_ATOM(235, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(230, 9, "name");
+    WORD_ATOM(235, 9, "name");
     mw_Tag_2E_name();
-    WORD_ATOM(230, 14, ".w");
+    WORD_ATOM(235, 14, ".w");
     mw__2E_w();
-    WORD_ATOM(230, 17, "");
+    WORD_ATOM(235, 17, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16766,26 +16786,26 @@ static void mw_c99_tag_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(230, 22, ";");
+    WORD_ATOM(235, 22, ";");
     mw__3B_();
-    WORD_ATOM(231, 5, "dup");
+    WORD_ATOM(236, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(231, 9, "is-transparent?");
+    WORD_ATOM(236, 9, "is-transparent?");
     mw_Tag_2E_is_transparent_3F_();
-    WORD_ATOM(231, 25, "if");
+    WORD_ATOM(236, 25, "if");
     if (pop_u64()) {
-        WORD_ATOM(232, 9, "drop");
+        WORD_ATOM(237, 9, "drop");
         mw_prim_drop();
     } else {
-        WORD_ATOM(233, 9, "dup");
+        WORD_ATOM(238, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(233, 13, "num-inputs");
+        WORD_ATOM(238, 13, "num-inputs");
         mw_Tag_2E_num_inputs();
-        WORD_ATOM(233, 24, "0=");
+        WORD_ATOM(238, 24, "0=");
         mw_0_3D_();
-        WORD_ATOM(233, 27, "if");
+        WORD_ATOM(238, 27, "if");
         if (pop_u64()) {
-            WORD_ATOM(234, 13, "");
+            WORD_ATOM(239, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -16796,13 +16816,13 @@ static void mw_c99_tag_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(234, 29, ".");
+            WORD_ATOM(239, 29, ".");
             mw__2E_();
-            WORD_ATOM(234, 31, "value");
+            WORD_ATOM(239, 31, "value");
             mw_Tag_2E_value();
-            WORD_ATOM(234, 37, ".n");
+            WORD_ATOM(239, 37, ".n");
             mw__2E_n();
-            WORD_ATOM(234, 40, "");
+            WORD_ATOM(239, 40, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -16813,10 +16833,10 @@ static void mw_c99_tag_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(234, 47, ";");
+            WORD_ATOM(239, 47, ";");
             mw__3B_();
         } else {
-            WORD_ATOM(236, 13, "");
+            WORD_ATOM(241, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -16827,20 +16847,20 @@ static void mw_c99_tag_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(236, 42, ";");
+            WORD_ATOM(241, 42, ";");
             mw__3B_();
-            WORD_ATOM(237, 13, "dup");
+            WORD_ATOM(242, 13, "dup");
             mw_prim_dup();
-            WORD_ATOM(237, 17, "num-inputs");
+            WORD_ATOM(242, 17, "num-inputs");
             mw_Tag_2E_num_inputs();
-            WORD_ATOM(237, 28, "1-");
+            WORD_ATOM(242, 28, "1-");
             mw_prim_int_pred();
-            WORD_ATOM(237, 31, "repeat");
+            WORD_ATOM(242, 31, "repeat");
             push_u64(0);
             push_fnptr(&mb_c99_tag_21__5);
             mw_prim_pack_cons();
             mw_repeat();
-            WORD_ATOM(238, 13, "");
+            WORD_ATOM(243, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -16851,13 +16871,13 @@ static void mw_c99_tag_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(238, 36, ".");
+            WORD_ATOM(243, 36, ".");
             mw__2E_();
-            WORD_ATOM(238, 38, "value");
+            WORD_ATOM(243, 38, "value");
             mw_Tag_2E_value();
-            WORD_ATOM(238, 44, ".n");
+            WORD_ATOM(243, 44, ".n");
             mw__2E_n();
-            WORD_ATOM(238, 47, "");
+            WORD_ATOM(243, 47, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -16868,9 +16888,9 @@ static void mw_c99_tag_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(238, 54, ";");
+            WORD_ATOM(243, 54, ";");
             mw__3B_();
-            WORD_ATOM(239, 13, "");
+            WORD_ATOM(244, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -16881,9 +16901,9 @@ static void mw_c99_tag_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(239, 43, ";");
+            WORD_ATOM(244, 43, ";");
             mw__3B_();
-            WORD_ATOM(240, 13, "");
+            WORD_ATOM(245, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -16894,11 +16914,11 @@ static void mw_c99_tag_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(240, 36, ";");
+            WORD_ATOM(245, 36, ";");
             mw__3B_();
         }
     }
-    WORD_ATOM(243, 5, "");
+    WORD_ATOM(248, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16909,38 +16929,38 @@ static void mw_c99_tag_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(243, 9, ";");
+    WORD_ATOM(248, 9, ";");
     mw__3B_();
     WORD_EXIT(mw_c99_tag_21_);
 }
 static void mw_c99_externals_21_ (void){
-    WORD_ENTER(mw_c99_externals_21_, "c99-externals!", "src/mirth/codegen.mth", 246, 5);
-    WORD_ATOM(246, 5, "External.for");
+    WORD_ENTER(mw_c99_externals_21_, "c99-externals!", "src/mirth/codegen.mth", 251, 5);
+    WORD_ATOM(251, 5, "External.for");
     push_u64(0);
     push_fnptr(&mb_c99_externals_21__1);
     mw_prim_pack_cons();
     mw_External_2E_for();
-    WORD_ATOM(246, 33, ".lf");
+    WORD_ATOM(251, 33, ".lf");
     mw__2E_lf();
     WORD_EXIT(mw_c99_externals_21_);
 }
 static void mw_c99_external_21_ (void){
-    WORD_ENTER(mw_c99_external_21_, "c99-external!", "src/mirth/codegen.mth", 249, 5);
-    WORD_ATOM(249, 5, "dup");
+    WORD_ENTER(mw_c99_external_21_, "c99-external!", "src/mirth/codegen.mth", 254, 5);
+    WORD_ATOM(254, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(249, 9, "sig");
+    WORD_ATOM(254, 9, "sig");
     mw_External_2E_sig();
-    WORD_ATOM(249, 13, "sig-arity");
+    WORD_ATOM(254, 13, "sig-arity");
     mw_Token_2E_sig_arity();
-    WORD_ATOM(250, 5, "dup");
+    WORD_ATOM(255, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(250, 9, "");
+    WORD_ATOM(255, 9, "");
     push_i64(2LL);
-    WORD_ATOM(250, 11, ">=");
+    WORD_ATOM(255, 11, ">=");
     mw_Int_3E__3D_();
-    WORD_ATOM(250, 14, "if");
+    WORD_ATOM(255, 14, "if");
     if (pop_u64()) {
-        WORD_ATOM(251, 9, "");
+        WORD_ATOM(256, 9, "");
         {
             static bool vready = false;
             static VAL v;
@@ -16951,18 +16971,18 @@ static void mw_c99_external_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(251, 62, "panic!");
+        WORD_ATOM(256, 62, "panic!");
         mw_prim_panic();
     } else {
-        WORD_ATOM(253, 9, "dup");
+        WORD_ATOM(258, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(253, 13, "");
+        WORD_ATOM(258, 13, "");
         push_i64(1LL);
-        WORD_ATOM(253, 15, ">=");
+        WORD_ATOM(258, 15, ">=");
         mw_Int_3E__3D_();
-        WORD_ATOM(253, 18, "if");
+        WORD_ATOM(258, 18, "if");
         if (pop_u64()) {
-            WORD_ATOM(254, 13, "");
+            WORD_ATOM(259, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -16973,10 +16993,10 @@ static void mw_c99_external_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(254, 24, ".");
+            WORD_ATOM(259, 24, ".");
             mw__2E_();
         } else {
-            WORD_ATOM(255, 13, "");
+            WORD_ATOM(260, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -16987,16 +17007,16 @@ static void mw_c99_external_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(255, 21, ".");
+            WORD_ATOM(260, 21, ".");
             mw__2E_();
         }
     }
-    WORD_ATOM(259, 5, "dip2");
+    WORD_ATOM(264, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_c99_external_21__5);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(261, 5, "");
+    WORD_ATOM(266, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -17007,17 +17027,17 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(261, 10, ".");
+    WORD_ATOM(266, 10, ".");
     mw__2E_();
-    WORD_ATOM(262, 5, "over");
+    WORD_ATOM(267, 5, "over");
     mw_over();
-    WORD_ATOM(262, 10, "dup");
+    WORD_ATOM(267, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(262, 14, "0>");
+    WORD_ATOM(267, 14, "0>");
     mw_0_3E_();
-    WORD_ATOM(262, 17, "if");
+    WORD_ATOM(267, 17, "if");
     if (pop_u64()) {
-        WORD_ATOM(262, 20, "");
+        WORD_ATOM(267, 20, "");
         {
             static bool vready = false;
             static VAL v;
@@ -17028,19 +17048,19 @@ static void mw_c99_external_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(262, 30, ".");
+        WORD_ATOM(267, 30, ".");
         mw__2E_();
-        WORD_ATOM(262, 32, "1-");
+        WORD_ATOM(267, 32, "1-");
         mw_prim_int_pred();
-        WORD_ATOM(262, 35, "repeat");
+        WORD_ATOM(267, 35, "repeat");
         push_u64(0);
         push_fnptr(&mb_c99_external_21__7);
         mw_prim_pack_cons();
         mw_repeat();
     } else {
-        WORD_ATOM(262, 58, "drop");
+        WORD_ATOM(267, 58, "drop");
         mw_prim_drop();
-        WORD_ATOM(262, 63, "");
+        WORD_ATOM(267, 63, "");
         {
             static bool vready = false;
             static VAL v;
@@ -17051,10 +17071,10 @@ static void mw_c99_external_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(262, 70, ".");
+        WORD_ATOM(267, 70, ".");
         mw__2E_();
     }
-    WORD_ATOM(263, 5, "");
+    WORD_ATOM(268, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -17065,9 +17085,9 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(263, 10, ";");
+    WORD_ATOM(268, 10, ";");
     mw__3B_();
-    WORD_ATOM(265, 5, "");
+    WORD_ATOM(270, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -17078,14 +17098,14 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(265, 23, ".");
+    WORD_ATOM(270, 23, ".");
     mw__2E_();
-    WORD_ATOM(265, 25, "dip2");
+    WORD_ATOM(270, 25, "dip2");
     push_u64(0);
     push_fnptr(&mb_c99_external_21__9);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(265, 46, "");
+    WORD_ATOM(270, 46, "");
     {
         static bool vready = false;
         static VAL v;
@@ -17096,22 +17116,22 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(265, 58, ";");
+    WORD_ATOM(270, 58, ";");
     mw__3B_();
-    WORD_ATOM(266, 5, "over");
+    WORD_ATOM(271, 5, "over");
     mw_over();
-    WORD_ATOM(266, 10, "countdown");
+    WORD_ATOM(271, 10, "countdown");
     push_u64(0);
     push_fnptr(&mb_c99_external_21__10);
     mw_prim_pack_cons();
     mw_countdown();
-    WORD_ATOM(267, 5, "dup");
+    WORD_ATOM(272, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(267, 9, "0>");
+    WORD_ATOM(272, 9, "0>");
     mw_0_3E_();
-    WORD_ATOM(267, 12, "if");
+    WORD_ATOM(272, 12, "if");
     if (pop_u64()) {
-        WORD_ATOM(267, 15, "");
+        WORD_ATOM(272, 15, "");
         {
             static bool vready = false;
             static VAL v;
@@ -17123,7 +17143,7 @@ static void mw_c99_external_21_ (void){
             incref(v);
         }
     } else {
-        WORD_ATOM(267, 32, "");
+        WORD_ATOM(272, 32, "");
         {
             static bool vready = false;
             static VAL v;
@@ -17135,14 +17155,14 @@ static void mw_c99_external_21_ (void){
             incref(v);
         }
     }
-    WORD_ATOM(267, 40, ".");
+    WORD_ATOM(272, 40, ".");
     mw__2E_();
-    WORD_ATOM(268, 5, "dip2");
+    WORD_ATOM(273, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_c99_external_21__13);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(269, 5, "");
+    WORD_ATOM(274, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -17153,29 +17173,29 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(269, 9, ".");
+    WORD_ATOM(274, 9, ".");
     mw__2E_();
-    WORD_ATOM(270, 5, "dip");
+    WORD_ATOM(275, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(270, 9, "dup");
+        WORD_ATOM(275, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(270, 13, "0>");
+        WORD_ATOM(275, 13, "0>");
         mw_0_3E_();
-        WORD_ATOM(270, 16, "if");
+        WORD_ATOM(275, 16, "if");
         if (pop_u64()) {
-            WORD_ATOM(271, 9, "dup");
+            WORD_ATOM(276, 9, "dup");
             mw_prim_dup();
-            WORD_ATOM(271, 13, "1-");
+            WORD_ATOM(276, 13, "1-");
             mw_prim_int_pred();
-            WORD_ATOM(271, 16, "dup");
+            WORD_ATOM(276, 16, "dup");
             mw_prim_dup();
-            WORD_ATOM(271, 20, "count");
+            WORD_ATOM(276, 20, "count");
             push_u64(0);
             push_fnptr(&mb_c99_external_21__16);
             mw_prim_pack_cons();
             mw_count();
-            WORD_ATOM(271, 43, "");
+            WORD_ATOM(276, 43, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -17186,17 +17206,17 @@ static void mw_c99_external_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(271, 47, ".");
+            WORD_ATOM(276, 47, ".");
             mw__2E_();
-            WORD_ATOM(271, 49, ".n");
+            WORD_ATOM(276, 49, ".n");
             mw__2E_n();
         } else {
-            WORD_ATOM(272, 9, "id");
+            WORD_ATOM(277, 9, "id");
             mw_prim_id();
         }
         push_value(d2);
     }
-    WORD_ATOM(274, 5, "");
+    WORD_ATOM(279, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -17207,15 +17227,15 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(274, 9, ".");
+    WORD_ATOM(279, 9, ".");
     mw__2E_();
-    WORD_ATOM(275, 5, "dup");
+    WORD_ATOM(280, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(275, 9, "0>");
+    WORD_ATOM(280, 9, "0>");
     mw_0_3E_();
-    WORD_ATOM(275, 12, "if");
+    WORD_ATOM(280, 12, "if");
     if (pop_u64()) {
-        WORD_ATOM(275, 15, "");
+        WORD_ATOM(280, 15, "");
         {
             static bool vready = false;
             static VAL v;
@@ -17227,7 +17247,7 @@ static void mw_c99_external_21_ (void){
             incref(v);
         }
     } else {
-        WORD_ATOM(275, 21, "");
+        WORD_ATOM(280, 21, "");
         {
             static bool vready = false;
             static VAL v;
@@ -17239,9 +17259,9 @@ static void mw_c99_external_21_ (void){
             incref(v);
         }
     }
-    WORD_ATOM(275, 26, ";");
+    WORD_ATOM(280, 26, ";");
     mw__3B_();
-    WORD_ATOM(276, 5, "");
+    WORD_ATOM(281, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -17252,20 +17272,20 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(276, 9, ";");
+    WORD_ATOM(281, 9, ";");
     mw__3B_();
-    WORD_ATOM(277, 5, "drop3");
+    WORD_ATOM(282, 5, "drop3");
     mw_drop3();
     WORD_EXIT(mw_c99_external_21_);
 }
 static void mw_c99_nest (void){
-    WORD_ENTER(mw_c99_nest, "c99-nest", "src/mirth/codegen.mth", 280, 5);
-    WORD_ATOM(280, 5, "c99-depth");
+    WORD_ENTER(mw_c99_nest, "c99-nest", "src/mirth/codegen.mth", 285, 5);
+    WORD_ATOM(285, 5, "c99-depth");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(280, 5, "c99-depth");
+        WORD_ATOM(285, 5, "c99-depth");
         mw_c99_depth();
-        WORD_ATOM(280, 15, "modify");
+        WORD_ATOM(285, 15, "modify");
         push_u64(0);
         incref(var_f);
         push_value(var_f);
@@ -17273,12 +17293,12 @@ static void mw_c99_nest (void){
         push_fnptr(&mb_c99_nest_2);
         mw_prim_pack_cons();
         mw_modify();
-        WORD_ATOM(281, 5, "f");
+        WORD_ATOM(286, 5, "f");
         incref(var_f);
         run_value(var_f);
-        WORD_ATOM(282, 5, "c99-depth");
+        WORD_ATOM(287, 5, "c99-depth");
         mw_c99_depth();
-        WORD_ATOM(282, 15, "modify");
+        WORD_ATOM(287, 15, "modify");
         push_u64(0);
         incref(var_f);
         push_value(var_f);
@@ -17291,12 +17311,12 @@ static void mw_c99_nest (void){
     WORD_EXIT(mw_c99_nest);
 }
 static void mw_c99_indent (void){
-    WORD_ENTER(mw_c99_indent, "c99-indent", "src/mirth/codegen.mth", 284, 21);
-    WORD_ATOM(284, 21, "c99-depth");
+    WORD_ENTER(mw_c99_indent, "c99-indent", "src/mirth/codegen.mth", 289, 21);
+    WORD_ATOM(289, 21, "c99-depth");
     mw_c99_depth();
-    WORD_ATOM(284, 31, "@");
+    WORD_ATOM(289, 31, "@");
     mw_prim_mut_get();
-    WORD_ATOM(284, 33, "repeat");
+    WORD_ATOM(289, 33, "repeat");
     push_u64(0);
     push_fnptr(&mb_c99_indent_1);
     mw_prim_pack_cons();
@@ -17304,31 +17324,31 @@ static void mw_c99_indent (void){
     WORD_EXIT(mw_c99_indent);
 }
 static void mw_c99_line (void){
-    WORD_ENTER(mw_c99_line, "c99-line", "src/mirth/codegen.mth", 285, 39);
-    WORD_ATOM(285, 39, "c99-indent");
+    WORD_ENTER(mw_c99_line, "c99-line", "src/mirth/codegen.mth", 290, 39);
+    WORD_ATOM(290, 39, "c99-indent");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(285, 39, "c99-indent");
+        WORD_ATOM(290, 39, "c99-indent");
         mw_c99_indent();
-        WORD_ATOM(285, 50, "f");
+        WORD_ATOM(290, 50, "f");
         incref(var_f);
         run_value(var_f);
-        WORD_ATOM(285, 52, ".lf");
+        WORD_ATOM(290, 52, ".lf");
         mw__2E_lf();
         decref(var_f);
     }
     WORD_EXIT(mw_c99_line);
 }
 static void mw_c99_call_21_ (void){
-    WORD_ENTER(mw_c99_call_21_, "c99-call!", "src/mirth/codegen.mth", 288, 5);
-    WORD_ATOM(288, 5, "dip");
+    WORD_ENTER(mw_c99_call_21_, "c99-call!", "src/mirth/codegen.mth", 293, 5);
+    WORD_ATOM(293, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(288, 9, "c99-args-push!");
+        WORD_ATOM(293, 9, "c99-args-push!");
         mw_c99_args_push_21_();
         push_value(d2);
     }
-    WORD_ATOM(289, 5, "c99-line");
+    WORD_ATOM(294, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_call_21__2);
     mw_prim_pack_cons();
@@ -17336,10 +17356,10 @@ static void mw_c99_call_21_ (void){
     WORD_EXIT(mw_c99_call_21_);
 }
 static void mw_c99_arrow_21_ (void){
-    WORD_ENTER(mw_c99_arrow_21_, "c99-arrow!", "src/mirth/codegen.mth", 291, 27);
-    WORD_ATOM(291, 27, "atoms");
+    WORD_ENTER(mw_c99_arrow_21_, "c99-arrow!", "src/mirth/codegen.mth", 296, 27);
+    WORD_ATOM(296, 27, "atoms");
     mw_Arrow_2E_atoms();
-    WORD_ATOM(291, 33, "for");
+    WORD_ATOM(296, 33, "for");
     push_u64(0);
     push_fnptr(&mb_c99_arrow_21__1);
     mw_prim_pack_cons();
@@ -17347,126 +17367,126 @@ static void mw_c99_arrow_21_ (void){
     WORD_EXIT(mw_c99_arrow_21_);
 }
 static void mw_c99_atom_21_ (void){
-    WORD_ENTER(mw_c99_atom_21_, "c99-atom!", "src/mirth/codegen.mth", 293, 5);
-    WORD_ATOM(293, 5, "c99-line");
+    WORD_ENTER(mw_c99_atom_21_, "c99-atom!", "src/mirth/codegen.mth", 298, 5);
+    WORD_ATOM(298, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_atom_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(298, 5, "sip");
+    WORD_ATOM(303, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_c99_atom_21__4);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(298, 15, "op");
+    WORD_ATOM(303, 15, "op");
     mw_Atom_2E_op();
-    WORD_ATOM(299, 5, "c99-args-op!");
+    WORD_ATOM(304, 5, "c99-args-op!");
     mw_c99_args_op_21_();
     WORD_EXIT(mw_c99_atom_21_);
 }
 static void mw_c99_args_op_21_ (void){
-    WORD_ENTER(mw_c99_args_op_21_, "c99-args-op!", "src/mirth/codegen.mth", 302, 5);
-    WORD_ATOM(302, 5, "OP_NONE");
+    WORD_ENTER(mw_c99_args_op_21_, "c99-args-op!", "src/mirth/codegen.mth", 307, 5);
+    WORD_ATOM(307, 5, "OP_NONE");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(302, 20, "drop");
+            WORD_ATOM(307, 20, "drop");
             mw_prim_drop();
             break;
         case 8LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(303, 20, "nip");
+            WORD_ATOM(308, 20, "nip");
             mw_nip();
-            WORD_ATOM(303, 24, "c99-int!");
+            WORD_ATOM(308, 24, "c99-int!");
             mw_c99_int_21_();
             break;
         case 9LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(304, 20, "nip");
+            WORD_ATOM(309, 20, "nip");
             mw_nip();
-            WORD_ATOM(304, 24, "c99-str!");
+            WORD_ATOM(309, 24, "c99-str!");
             mw_c99_str_21_();
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(305, 20, "nip");
+            WORD_ATOM(310, 20, "nip");
             mw_nip();
-            WORD_ATOM(305, 24, "c99-constant!");
+            WORD_ATOM(310, 24, "c99-constant!");
             mw_c99_constant_21_();
             break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(306, 20, "name");
+            WORD_ATOM(311, 20, "name");
             mw_Word_2E_name();
-            WORD_ATOM(306, 25, "c99-call!");
+            WORD_ATOM(311, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(307, 20, "name");
+            WORD_ATOM(312, 20, "name");
             mw_External_2E_name();
-            WORD_ATOM(307, 25, "c99-call!");
+            WORD_ATOM(312, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(308, 20, "name");
+            WORD_ATOM(313, 20, "name");
             mw_Buffer_2E_name();
-            WORD_ATOM(308, 25, "c99-call!");
+            WORD_ATOM(313, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(309, 20, "name");
+            WORD_ATOM(314, 20, "name");
             mw_Variable_2E_name();
-            WORD_ATOM(309, 25, "c99-call!");
+            WORD_ATOM(314, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 7LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(310, 20, "name");
+            WORD_ATOM(315, 20, "name");
             mw_Field_2E_name();
-            WORD_ATOM(310, 25, "c99-call!");
+            WORD_ATOM(315, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 10LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(311, 20, "name");
+            WORD_ATOM(316, 20, "name");
             mw_Tag_2E_name();
-            WORD_ATOM(311, 25, "c99-call!");
+            WORD_ATOM(316, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(312, 20, "c99-prim!");
+            WORD_ATOM(317, 20, "c99-prim!");
             mw_c99_prim_21_();
             break;
         case 11LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(313, 20, "nip");
+            WORD_ATOM(318, 20, "nip");
             mw_nip();
-            WORD_ATOM(313, 24, "c99-match!");
+            WORD_ATOM(318, 24, "c99-match!");
             mw_c99_match_21_();
             break;
         case 12LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(314, 20, "nip");
+            WORD_ATOM(319, 20, "nip");
             mw_nip();
-            WORD_ATOM(314, 24, "c99-lambda!");
+            WORD_ATOM(319, 24, "c99-lambda!");
             mw_c99_lambda_21_();
             break;
         case 13LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(315, 20, "nip");
+            WORD_ATOM(320, 20, "nip");
             mw_nip();
-            WORD_ATOM(315, 24, "c99-var!");
+            WORD_ATOM(320, 24, "c99-var!");
             mw_c99_var_21_();
             break;
         case 14LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(316, 20, "nip");
+            WORD_ATOM(321, 20, "nip");
             mw_nip();
-            WORD_ATOM(316, 24, "c99-block-push!");
+            WORD_ATOM(321, 24, "c99-block-push!");
             mw_c99_block_push_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -17474,8 +17494,8 @@ static void mw_c99_args_op_21_ (void){
 }    WORD_EXIT(mw_c99_args_op_21_);
 }
 static void mw_c99_int_21_ (void){
-    WORD_ENTER(mw_c99_int_21_, "c99-int!", "src/mirth/codegen.mth", 319, 5);
-    WORD_ATOM(319, 5, "c99-line");
+    WORD_ENTER(mw_c99_int_21_, "c99-int!", "src/mirth/codegen.mth", 324, 5);
+    WORD_ATOM(324, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_int_21__1);
     mw_prim_pack_cons();
@@ -17483,29 +17503,29 @@ static void mw_c99_int_21_ (void){
     WORD_EXIT(mw_c99_int_21_);
 }
 static void mw_c99_str_21_ (void){
-    WORD_ENTER(mw_c99_str_21_, "c99-str!", "src/mirth/codegen.mth", 322, 5);
-    WORD_ATOM(322, 5, "c99-line");
+    WORD_ENTER(mw_c99_str_21_, "c99-str!", "src/mirth/codegen.mth", 327, 5);
+    WORD_ATOM(327, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(323, 5, "c99-nest");
+    WORD_ATOM(328, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(346, 5, "c99-line");
+    WORD_ATOM(351, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__20);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(347, 5, "drop");
+    WORD_ATOM(352, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_str_21_);
 }
 static void mw__2E_str (void){
-    WORD_ENTER(mw__2E_str, ".str", "src/mirth/codegen.mth", 349, 19);
-    WORD_ATOM(349, 19, "");
+    WORD_ENTER(mw__2E_str, ".str", "src/mirth/codegen.mth", 354, 19);
+    WORD_ATOM(354, 19, "");
     {
         static bool vready = false;
         static VAL v;
@@ -17516,14 +17536,14 @@ static void mw__2E_str (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(349, 24, ".");
+    WORD_ATOM(354, 24, ".");
     mw__2E_();
-    WORD_ATOM(349, 26, "str-bytes-for");
+    WORD_ATOM(354, 26, "str-bytes-for");
     push_u64(0);
     push_fnptr(&mb__2E_str_1);
     mw_prim_pack_cons();
     mw_str_bytes_for();
-    WORD_ATOM(349, 58, "");
+    WORD_ATOM(354, 58, "");
     {
         static bool vready = false;
         static VAL v;
@@ -17534,17 +17554,17 @@ static void mw__2E_str (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(349, 63, ".");
+    WORD_ATOM(354, 63, ".");
     mw__2E_();
     WORD_EXIT(mw__2E_str);
 }
 static void mw_c99_string_byte_21_ (void){
-    WORD_ENTER(mw_c99_string_byte_21_, "c99-string-byte!", "src/mirth/codegen.mth", 352, 5);
-    WORD_ATOM(352, 5, "B'\\'");
+    WORD_ENTER(mw_c99_string_byte_21_, "c99-string-byte!", "src/mirth/codegen.mth", 357, 5);
+    WORD_ATOM(357, 5, "B'\\'");
     switch (get_top_data_tag()) {
         case 92LL:
             mw_prim_drop();
-            WORD_ATOM(352, 13, "");
+            WORD_ATOM(357, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -17555,12 +17575,12 @@ static void mw_c99_string_byte_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(352, 20, ".");
+            WORD_ATOM(357, 20, ".");
             mw__2E_();
             break;
         case 34LL:
             mw_prim_drop();
-            WORD_ATOM(353, 15, "");
+            WORD_ATOM(358, 15, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -17571,12 +17591,12 @@ static void mw_c99_string_byte_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(353, 22, ".");
+            WORD_ATOM(358, 22, ".");
             mw__2E_();
             break;
         case 9LL:
             mw_prim_drop();
-            WORD_ATOM(354, 12, "");
+            WORD_ATOM(359, 12, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -17587,12 +17607,12 @@ static void mw_c99_string_byte_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(354, 18, ".");
+            WORD_ATOM(359, 18, ".");
             mw__2E_();
             break;
         case 10LL:
             mw_prim_drop();
-            WORD_ATOM(355, 12, "");
+            WORD_ATOM(360, 12, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -17603,12 +17623,12 @@ static void mw_c99_string_byte_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(355, 18, ".");
+            WORD_ATOM(360, 18, ".");
             mw__2E_();
             break;
         case 13LL:
             mw_prim_drop();
-            WORD_ATOM(356, 12, "");
+            WORD_ATOM(361, 12, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -17619,24 +17639,24 @@ static void mw_c99_string_byte_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(356, 18, ".");
+            WORD_ATOM(361, 18, ".");
             mw__2E_();
             break;
         default:
-            WORD_ATOM(358, 9, "dup");
+            WORD_ATOM(363, 9, "dup");
             mw_prim_dup();
-            WORD_ATOM(358, 13, "BSPACE");
+            WORD_ATOM(363, 13, "BSPACE");
             mw_BSPACE();
-            WORD_ATOM(358, 20, "B'~'");
+            WORD_ATOM(363, 20, "B'~'");
             mw_B_27__7E__27_();
-            WORD_ATOM(358, 25, "in-range");
+            WORD_ATOM(363, 25, "in-range");
             mw_Byte_2E_in_range();
-            WORD_ATOM(358, 34, "if");
+            WORD_ATOM(363, 34, "if");
             if (pop_u64()) {
-                WORD_ATOM(359, 13, ".b");
+                WORD_ATOM(364, 13, ".b");
                 mw__2E_b();
             } else {
-                WORD_ATOM(360, 13, "");
+                WORD_ATOM(365, 13, "");
                 {
                     static bool vready = false;
                     static VAL v;
@@ -17647,18 +17667,18 @@ static void mw_c99_string_byte_21_ (void){
                     push_value(v);
                     incref(v);
                 }
-                WORD_ATOM(360, 19, ".");
+                WORD_ATOM(365, 19, ".");
                 mw__2E_();
-                WORD_ATOM(360, 21, "to-hexdigits");
+                WORD_ATOM(365, 21, "to-hexdigits");
                 mw_Byte_2E_to_hexdigits();
-                WORD_ATOM(360, 34, "dip");
+                WORD_ATOM(365, 34, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(360, 38, ".b");
+                    WORD_ATOM(365, 38, ".b");
                     mw__2E_b();
                     push_value(d5);
                 }
-                WORD_ATOM(360, 42, ".b");
+                WORD_ATOM(365, 42, ".b");
                 mw__2E_b();
             }
             break;
@@ -17666,30 +17686,30 @@ static void mw_c99_string_byte_21_ (void){
 }    WORD_EXIT(mw_c99_string_byte_21_);
 }
 static void mw_c99_constant_21_ (void){
-    WORD_ENTER(mw_c99_constant_21_, "c99-constant!", "src/mirth/codegen.mth", 365, 5);
-    WORD_ATOM(365, 5, "value");
+    WORD_ENTER(mw_c99_constant_21_, "c99-constant!", "src/mirth/codegen.mth", 370, 5);
+    WORD_ATOM(370, 5, "value");
     mw_Constant_2E_value();
-    WORD_ATOM(365, 11, "c99-value!");
+    WORD_ATOM(370, 11, "c99-value!");
     mw_c99_value_21_();
     WORD_EXIT(mw_c99_constant_21_);
 }
 static void mw_c99_value_21_ (void){
-    WORD_ENTER(mw_c99_value_21_, "c99-value!", "src/mirth/codegen.mth", 368, 5);
-    WORD_ATOM(368, 5, "VALUE_INT");
+    WORD_ENTER(mw_c99_value_21_, "c99-value!", "src/mirth/codegen.mth", 373, 5);
+    WORD_ATOM(373, 5, "VALUE_INT");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(368, 18, "c99-int!");
+            WORD_ATOM(373, 18, "c99-int!");
             mw_c99_int_21_();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(369, 18, "c99-str!");
+            WORD_ATOM(374, 18, "c99-str!");
             mw_c99_str_21_();
             break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(370, 20, "c99-block-push!");
+            WORD_ATOM(375, 20, "c99-block-push!");
             mw_c99_block_push_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -17697,129 +17717,159 @@ static void mw_c99_value_21_ (void){
 }    WORD_EXIT(mw_c99_value_21_);
 }
 static void mw_c99_prim_21_ (void){
-    WORD_ENTER(mw_c99_prim_21_, "c99-prim!", "src/mirth/codegen.mth", 373, 5);
-    WORD_ATOM(373, 5, "PRIM_CORE_DIP");
+    WORD_ENTER(mw_c99_prim_21_, "c99-prim!", "src/mirth/codegen.mth", 378, 5);
+    WORD_ATOM(378, 5, "PRIM_CORE_DIP");
     switch (get_top_data_tag()) {
         case 4LL:
             mw_prim_drop();
-            WORD_ATOM(374, 9, "match");
+            WORD_ATOM(379, 9, "match");
             switch (get_top_data_tag()) {
                 case 1LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(376, 17, "c99-line");
+                    WORD_ATOM(381, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__3);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(377, 17, "c99-nest");
+                    WORD_ATOM(382, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__4);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(382, 17, "c99-line");
+                    WORD_ATOM(387, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__7);
                     mw_prim_pack_cons();
                     mw_c99_line();
                     break;
                 default:
-                    WORD_ATOM(384, 17, "PRIM_CORE_DIP");
+                    WORD_ATOM(389, 17, "PRIM_CORE_DIP");
                     mw_PRIM_5F_CORE_5F_DIP();
-                    WORD_ATOM(384, 31, "c99-prim-default!");
+                    WORD_ATOM(389, 31, "c99-prim-default!");
                     mw_c99_prim_default_21_();
                     break;
             
 }            break;
-        case 5LL:
+        case 13LL:
             mw_prim_drop();
-            WORD_ATOM(388, 9, "match");
+            WORD_ATOM(393, 9, "match");
             switch (get_top_data_tag()) {
-                case 2LL:
+                case 1LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    mw_prim_pack_uncons(); mw_prim_swap();
-                    WORD_ATOM(390, 17, "c99-line");
+                    WORD_ATOM(395, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__11);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(391, 17, "c99-nest");
+                    WORD_ATOM(396, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__12);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(392, 17, "c99-line");
-                    push_u64(0);
-                    push_fnptr(&mb_c99_prim_21__13);
-                    mw_prim_pack_cons();
-                    mw_c99_line();
-                    WORD_ATOM(393, 17, "c99-nest");
-                    push_u64(0);
-                    push_fnptr(&mb_c99_prim_21__14);
-                    mw_prim_pack_cons();
-                    mw_c99_nest();
-                    WORD_ATOM(394, 17, "c99-line");
+                    WORD_ATOM(401, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__15);
                     mw_prim_pack_cons();
                     mw_c99_line();
                     break;
                 default:
-                    WORD_ATOM(396, 17, "PRIM_CORE_IF");
+                    WORD_ATOM(403, 17, "PRIM_CORE_RDIP");
+                    mw_PRIM_5F_CORE_5F_RDIP();
+                    WORD_ATOM(403, 32, "c99-prim-default!");
+                    mw_c99_prim_default_21_();
+                    break;
+            
+}            break;
+        case 5LL:
+            mw_prim_drop();
+            WORD_ATOM(407, 9, "match");
+            switch (get_top_data_tag()) {
+                case 2LL:
+                    mw_prim_pack_uncons(); mw_prim_drop();
+                    mw_prim_pack_uncons(); mw_prim_swap();
+                    WORD_ATOM(409, 17, "c99-line");
+                    push_u64(0);
+                    push_fnptr(&mb_c99_prim_21__19);
+                    mw_prim_pack_cons();
+                    mw_c99_line();
+                    WORD_ATOM(410, 17, "c99-nest");
+                    push_u64(0);
+                    push_fnptr(&mb_c99_prim_21__20);
+                    mw_prim_pack_cons();
+                    mw_c99_nest();
+                    WORD_ATOM(411, 17, "c99-line");
+                    push_u64(0);
+                    push_fnptr(&mb_c99_prim_21__21);
+                    mw_prim_pack_cons();
+                    mw_c99_line();
+                    WORD_ATOM(412, 17, "c99-nest");
+                    push_u64(0);
+                    push_fnptr(&mb_c99_prim_21__22);
+                    mw_prim_pack_cons();
+                    mw_c99_nest();
+                    WORD_ATOM(413, 17, "c99-line");
+                    push_u64(0);
+                    push_fnptr(&mb_c99_prim_21__23);
+                    mw_prim_pack_cons();
+                    mw_c99_line();
+                    break;
+                default:
+                    WORD_ATOM(415, 17, "PRIM_CORE_IF");
                     mw_PRIM_5F_CORE_5F_IF();
-                    WORD_ATOM(396, 30, "c99-prim-default!");
+                    WORD_ATOM(415, 30, "c99-prim-default!");
                     mw_c99_prim_default_21_();
                     break;
             
 }            break;
         case 6LL:
             mw_prim_drop();
-            WORD_ATOM(400, 9, "match");
+            WORD_ATOM(419, 9, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
                     mw_prim_pack_uncons(); mw_prim_swap();
-                    WORD_ATOM(402, 17, "c99-line");
+                    WORD_ATOM(421, 17, "c99-line");
                     push_u64(0);
-                    push_fnptr(&mb_c99_prim_21__19);
+                    push_fnptr(&mb_c99_prim_21__27);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(403, 17, "c99-nest");
+                    WORD_ATOM(422, 17, "c99-nest");
                     push_u64(0);
-                    push_fnptr(&mb_c99_prim_21__20);
+                    push_fnptr(&mb_c99_prim_21__28);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(408, 17, "c99-line");
+                    WORD_ATOM(427, 17, "c99-line");
                     push_u64(0);
-                    push_fnptr(&mb_c99_prim_21__22);
+                    push_fnptr(&mb_c99_prim_21__30);
                     mw_prim_pack_cons();
                     mw_c99_line();
                     break;
                 default:
-                    WORD_ATOM(411, 17, "PRIM_CORE_WHILE");
+                    WORD_ATOM(430, 17, "PRIM_CORE_WHILE");
                     mw_PRIM_5F_CORE_5F_WHILE();
-                    WORD_ATOM(411, 33, "c99-prim-default!");
+                    WORD_ATOM(430, 33, "c99-prim-default!");
                     mw_c99_prim_default_21_();
                     break;
             
 }            break;
         default:
-            WORD_ATOM(414, 10, "c99-prim-default!");
+            WORD_ATOM(433, 10, "c99-prim-default!");
             mw_c99_prim_default_21_();
             break;
     
 }    WORD_EXIT(mw_c99_prim_21_);
 }
 static void mw_c99_prim_default_21_ (void){
-    WORD_ENTER(mw_c99_prim_default_21_, "c99-prim-default!", "src/mirth/codegen.mth", 417, 5);
-    WORD_ATOM(417, 5, "name");
+    WORD_ENTER(mw_c99_prim_default_21_, "c99-prim-default!", "src/mirth/codegen.mth", 436, 5);
+    WORD_ATOM(436, 5, "name");
     mw_Prim_2E_name();
-    WORD_ATOM(417, 10, "c99-call!");
+    WORD_ATOM(436, 10, "c99-call!");
     mw_c99_call_21_();
     WORD_EXIT(mw_c99_prim_default_21_);
 }
 static void mw_c99_args_push_21_ (void){
-    WORD_ENTER(mw_c99_args_push_21_, "c99-args-push!", "src/mirth/codegen.mth", 420, 5);
-    WORD_ATOM(420, 5, "for");
+    WORD_ENTER(mw_c99_args_push_21_, "c99-args-push!", "src/mirth/codegen.mth", 439, 5);
+    WORD_ATOM(439, 5, "for");
     push_u64(0);
     push_fnptr(&mb_c99_args_push_21__1);
     mw_prim_pack_cons();
@@ -17827,30 +17877,30 @@ static void mw_c99_args_push_21_ (void){
     WORD_EXIT(mw_c99_args_push_21_);
 }
 static void mw_c99_arg_push_21_ (void){
-    WORD_ENTER(mw_c99_arg_push_21_, "c99-arg-push!", "src/mirth/codegen.mth", 423, 5);
-    WORD_ATOM(423, 5, "ARG_BLOCK");
-    WORD_ATOM(423, 18, "c99-block-push!");
+    WORD_ENTER(mw_c99_arg_push_21_, "c99-arg-push!", "src/mirth/codegen.mth", 442, 5);
+    WORD_ATOM(442, 5, "ARG_BLOCK");
+    WORD_ATOM(442, 18, "c99-block-push!");
     mw_c99_block_push_21_();
     WORD_EXIT(mw_c99_arg_push_21_);
 }
 static void mw_c99_arg_run_21_ (void){
-    WORD_ENTER(mw_c99_arg_run_21_, "c99-arg-run!", "src/mirth/codegen.mth", 426, 5);
-    WORD_ATOM(426, 5, "ARG_BLOCK");
-    WORD_ATOM(426, 18, "c99-block-run!");
+    WORD_ENTER(mw_c99_arg_run_21_, "c99-arg-run!", "src/mirth/codegen.mth", 445, 5);
+    WORD_ATOM(445, 5, "ARG_BLOCK");
+    WORD_ATOM(445, 18, "c99-block-run!");
     mw_c99_block_run_21_();
     WORD_EXIT(mw_c99_arg_run_21_);
 }
 static void mw_c99_block_run_21_ (void){
-    WORD_ENTER(mw_c99_block_run_21_, "c99-block-run!", "src/mirth/codegen.mth", 429, 5);
-    WORD_ATOM(429, 5, "arrow");
+    WORD_ENTER(mw_c99_block_run_21_, "c99-block-run!", "src/mirth/codegen.mth", 448, 5);
+    WORD_ATOM(448, 5, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(429, 11, "c99-arrow!");
+    WORD_ATOM(448, 11, "c99-arrow!");
     mw_c99_arrow_21_();
     WORD_EXIT(mw_c99_block_run_21_);
 }
 static void mw__2E_var (void){
-    WORD_ENTER(mw__2E_var, ".var", "src/mirth/codegen.mth", 431, 19);
-    WORD_ATOM(431, 19, "");
+    WORD_ENTER(mw__2E_var, ".var", "src/mirth/codegen.mth", 450, 19);
+    WORD_ATOM(450, 19, "");
     {
         static bool vready = false;
         static VAL v;
@@ -17861,32 +17911,32 @@ static void mw__2E_var (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(431, 26, ".");
+    WORD_ATOM(450, 26, ".");
     mw__2E_();
-    WORD_ATOM(431, 28, "name");
+    WORD_ATOM(450, 28, "name");
     mw_Var_2E_name();
-    WORD_ATOM(431, 33, ".name");
+    WORD_ATOM(450, 33, ".name");
     mw__2E_name();
     WORD_EXIT(mw__2E_var);
 }
 static void mw__2E_param (void){
-    WORD_ENTER(mw__2E_param, ".param", "src/mirth/codegen.mth", 432, 23);
-    WORD_ATOM(432, 23, ">Var");
+    WORD_ENTER(mw__2E_param, ".param", "src/mirth/codegen.mth", 451, 23);
+    WORD_ATOM(451, 23, ">Var");
     mw_Param_3E_Var();
-    WORD_ATOM(432, 28, ".var");
+    WORD_ATOM(451, 28, ".var");
     mw__2E_var();
     WORD_EXIT(mw__2E_param);
 }
 static void mw_c99_pack_ctx_21_ (void){
-    WORD_ENTER(mw_c99_pack_ctx_21_, "c99-pack-ctx!", "src/mirth/codegen.mth", 435, 5);
-    WORD_ATOM(435, 5, "c99-line");
+    WORD_ENTER(mw_c99_pack_ctx_21_, "c99-pack-ctx!", "src/mirth/codegen.mth", 454, 5);
+    WORD_ATOM(454, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_pack_ctx_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(436, 5, "physical-vars");
+    WORD_ATOM(455, 5, "physical-vars");
     mw_Ctx_2E_physical_vars();
-    WORD_ATOM(436, 19, "for");
+    WORD_ATOM(455, 19, "for");
     push_u64(0);
     push_fnptr(&mb_c99_pack_ctx_21__2);
     mw_prim_pack_cons();
@@ -17894,15 +17944,15 @@ static void mw_c99_pack_ctx_21_ (void){
     WORD_EXIT(mw_c99_pack_ctx_21_);
 }
 static void mw_c99_unpack_ctx_21_ (void){
-    WORD_ENTER(mw_c99_unpack_ctx_21_, "c99-unpack-ctx!", "src/mirth/codegen.mth", 442, 5);
-    WORD_ATOM(442, 5, "physical-vars");
+    WORD_ENTER(mw_c99_unpack_ctx_21_, "c99-unpack-ctx!", "src/mirth/codegen.mth", 461, 5);
+    WORD_ATOM(461, 5, "physical-vars");
     mw_Ctx_2E_physical_vars();
-    WORD_ATOM(442, 19, "reverse-for");
+    WORD_ATOM(461, 19, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_c99_unpack_ctx_21__1);
     mw_prim_pack_cons();
     mw_List_2E_reverse_for();
-    WORD_ATOM(446, 5, "c99-line");
+    WORD_ATOM(465, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_unpack_ctx_21__4);
     mw_prim_pack_cons();
@@ -17910,10 +17960,10 @@ static void mw_c99_unpack_ctx_21_ (void){
     WORD_EXIT(mw_c99_unpack_ctx_21_);
 }
 static void mw_c99_decref_ctx_21_ (void){
-    WORD_ENTER(mw_c99_decref_ctx_21_, "c99-decref-ctx!", "src/mirth/codegen.mth", 449, 5);
-    WORD_ATOM(449, 5, "physical-vars");
+    WORD_ENTER(mw_c99_decref_ctx_21_, "c99-decref-ctx!", "src/mirth/codegen.mth", 468, 5);
+    WORD_ATOM(468, 5, "physical-vars");
     mw_Ctx_2E_physical_vars();
-    WORD_ATOM(449, 19, "reverse-for");
+    WORD_ATOM(468, 19, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_c99_decref_ctx_21__1);
     mw_prim_pack_cons();
@@ -17921,34 +17971,34 @@ static void mw_c99_decref_ctx_21_ (void){
     WORD_EXIT(mw_c99_decref_ctx_21_);
 }
 static void mw_c99_block_push_21_ (void){
-    WORD_ENTER(mw_c99_block_push_21_, "c99-block-push!", "src/mirth/codegen.mth", 454, 5);
-    WORD_ATOM(454, 5, "dup");
+    WORD_ENTER(mw_c99_block_push_21_, "c99-block-push!", "src/mirth/codegen.mth", 473, 5);
+    WORD_ATOM(473, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(454, 9, "block-to-run-var");
+    WORD_ATOM(473, 9, "block-to-run-var");
     mw_block_to_run_var();
-    WORD_ATOM(454, 26, "match");
+    WORD_ATOM(473, 26, "match");
     switch (get_top_data_tag()) {
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(455, 17, "nip");
+            WORD_ATOM(474, 17, "nip");
             mw_nip();
-            WORD_ATOM(455, 21, "c99-var-push!");
+            WORD_ATOM(474, 21, "c99-var-push!");
             mw_c99_var_push_21_();
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(457, 13, "dup");
+            WORD_ATOM(476, 13, "dup");
             mw_prim_dup();
-            WORD_ATOM(457, 17, "ctx");
+            WORD_ATOM(476, 17, "ctx");
             mw_Block_2E_ctx();
-            WORD_ATOM(457, 21, "c99-pack-ctx!");
+            WORD_ATOM(476, 21, "c99-pack-ctx!");
             mw_c99_pack_ctx_21_();
-            WORD_ATOM(458, 13, "c99-line");
+            WORD_ATOM(477, 13, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_block_push_21__3);
             mw_prim_pack_cons();
             mw_c99_line();
-            WORD_ATOM(459, 13, "c99-line");
+            WORD_ATOM(478, 13, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_block_push_21__4);
             mw_prim_pack_cons();
@@ -17959,66 +18009,66 @@ static void mw_c99_block_push_21_ (void){
 }    WORD_EXIT(mw_c99_block_push_21_);
 }
 static void mw_c99_var_21_ (void){
-    WORD_ENTER(mw_c99_var_21_, "c99-var!", "src/mirth/codegen.mth", 463, 5);
-    WORD_ATOM(463, 5, "dup");
+    WORD_ENTER(mw_c99_var_21_, "c99-var!", "src/mirth/codegen.mth", 482, 5);
+    WORD_ATOM(482, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(463, 9, "auto-run?");
+    WORD_ATOM(482, 9, "auto-run?");
     mw_Var_2E_auto_run_3F_();
-    WORD_ATOM(463, 19, "if");
+    WORD_ATOM(482, 19, "if");
     if (pop_u64()) {
-        WORD_ATOM(463, 22, "c99-var-run!");
+        WORD_ATOM(482, 22, "c99-var-run!");
         mw_c99_var_run_21_();
     } else {
-        WORD_ATOM(463, 36, "c99-var-push!");
+        WORD_ATOM(482, 36, "c99-var-push!");
         mw_c99_var_push_21_();
     }
     WORD_EXIT(mw_c99_var_21_);
 }
 static void mw_c99_var_run_21_ (void){
-    WORD_ENTER(mw_c99_var_run_21_, "c99-var-run!", "src/mirth/codegen.mth", 466, 5);
-    WORD_ATOM(466, 5, "c99-line");
+    WORD_ENTER(mw_c99_var_run_21_, "c99-var-run!", "src/mirth/codegen.mth", 485, 5);
+    WORD_ATOM(485, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_var_run_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(467, 5, "c99-line");
+    WORD_ATOM(486, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_var_run_21__2);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(468, 5, "drop");
+    WORD_ATOM(487, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_var_run_21_);
 }
 static void mw_c99_var_push_21_ (void){
-    WORD_ENTER(mw_c99_var_push_21_, "c99-var-push!", "src/mirth/codegen.mth", 471, 5);
-    WORD_ATOM(471, 5, "c99-line");
+    WORD_ENTER(mw_c99_var_push_21_, "c99-var-push!", "src/mirth/codegen.mth", 490, 5);
+    WORD_ATOM(490, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_var_push_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(472, 5, "c99-line");
+    WORD_ATOM(491, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_var_push_21__2);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(473, 5, "drop");
+    WORD_ATOM(492, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_var_push_21_);
 }
 static void mw_c99_lambda_21_ (void){
-    WORD_ENTER(mw_c99_lambda_21_, "c99-lambda!", "src/mirth/codegen.mth", 476, 5);
-    WORD_ATOM(476, 5, "c99-line");
+    WORD_ENTER(mw_c99_lambda_21_, "c99-lambda!", "src/mirth/codegen.mth", 495, 5);
+    WORD_ATOM(495, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(477, 5, "c99-nest");
+    WORD_ATOM(496, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(486, 5, "c99-line");
+    WORD_ATOM(505, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__7);
     mw_prim_pack_cons();
@@ -18026,73 +18076,73 @@ static void mw_c99_lambda_21_ (void){
     WORD_EXIT(mw_c99_lambda_21_);
 }
 static void mw_c99_match_21_ (void){
-    WORD_ENTER(mw_c99_match_21_, "c99-match!", "src/mirth/codegen.mth", 489, 5);
-    WORD_ATOM(489, 5, "dup");
+    WORD_ENTER(mw_c99_match_21_, "c99-match!", "src/mirth/codegen.mth", 508, 5);
+    WORD_ATOM(508, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(489, 9, "is-transparent?");
+    WORD_ATOM(508, 9, "is-transparent?");
     mw_Match_2E_is_transparent_3F_();
-    WORD_ATOM(489, 25, "if");
+    WORD_ATOM(508, 25, "if");
     if (pop_u64()) {
-        WORD_ATOM(490, 9, "cases");
+        WORD_ATOM(509, 9, "cases");
         mw_Match_2E_cases();
-        WORD_ATOM(490, 15, "first");
+        WORD_ATOM(509, 15, "first");
         mw_first();
-        WORD_ATOM(490, 21, "unwrap");
+        WORD_ATOM(509, 21, "unwrap");
         mw_Maybe_2E_unwrap();
-        WORD_ATOM(490, 28, "body");
+        WORD_ATOM(509, 28, "body");
         mw_Case_2E_body();
-        WORD_ATOM(490, 33, "c99-arrow!");
+        WORD_ATOM(509, 33, "c99-arrow!");
         mw_c99_arrow_21_();
     } else {
-        WORD_ATOM(492, 9, "dup");
+        WORD_ATOM(511, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(492, 13, "scrutinee-data?");
+        WORD_ATOM(511, 13, "scrutinee-data?");
         mw_Match_2E_scrutinee_data_3F_();
-        WORD_ATOM(493, 9, "unwrap-or");
+        WORD_ATOM(512, 9, "unwrap-or");
         push_u64(0);
         push_fnptr(&mb_c99_match_21__3);
         mw_prim_pack_cons();
         mw_Maybe_2E_unwrap_or();
-        WORD_ATOM(494, 9, "is-resource?");
+        WORD_ATOM(513, 9, "is-resource?");
         mw_Data_2E_is_resource_3F_();
-        WORD_ATOM(494, 22, "if");
+        WORD_ATOM(513, 22, "if");
         if (pop_u64()) {
-            WORD_ATOM(495, 13, "c99-line");
+            WORD_ATOM(514, 13, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_match_21__5);
             mw_prim_pack_cons();
             mw_c99_line();
         } else {
-            WORD_ATOM(496, 13, "c99-line");
+            WORD_ATOM(515, 13, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_match_21__7);
             mw_prim_pack_cons();
             mw_c99_line();
         }
-        WORD_ATOM(498, 9, "c99-nest");
+        WORD_ATOM(517, 9, "c99-nest");
         push_u64(0);
         push_fnptr(&mb_c99_match_21__8);
         mw_prim_pack_cons();
         mw_c99_nest();
-        WORD_ATOM(504, 9, "c99-line");
+        WORD_ATOM(523, 9, "c99-line");
         push_u64(0);
         push_fnptr(&mb_c99_match_21__12);
         mw_prim_pack_cons();
         mw_c99_line();
-        WORD_ATOM(504, 22, ".");
+        WORD_ATOM(523, 22, ".");
         mw__2E_();
     }
     WORD_EXIT(mw_c99_match_21_);
 }
 static void mw_c99_case_21_ (void){
-    WORD_ENTER(mw_c99_case_21_, "c99-case!", "src/mirth/codegen.mth", 508, 5);
-    WORD_ATOM(508, 5, "dup");
+    WORD_ENTER(mw_c99_case_21_, "c99-case!", "src/mirth/codegen.mth", 527, 5);
+    WORD_ATOM(527, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(508, 9, "pattern");
+    WORD_ATOM(527, 9, "pattern");
     mw_Case_2E_pattern();
-    WORD_ATOM(508, 17, "c99-pattern!");
+    WORD_ATOM(527, 17, "c99-pattern!");
     mw_c99_pattern_21_();
-    WORD_ATOM(509, 5, "c99-nest");
+    WORD_ATOM(528, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_case_21__1);
     mw_prim_pack_cons();
@@ -18100,12 +18150,12 @@ static void mw_c99_case_21_ (void){
     WORD_EXIT(mw_c99_case_21_);
 }
 static void mw_c99_pattern_21_ (void){
-    WORD_ENTER(mw_c99_pattern_21_, "c99-pattern!", "src/mirth/codegen.mth", 515, 5);
-    WORD_ATOM(515, 5, "PATTERN_UNDERSCORE");
+    WORD_ENTER(mw_c99_pattern_21_, "c99-pattern!", "src/mirth/codegen.mth", 534, 5);
+    WORD_ATOM(534, 5, "PATTERN_UNDERSCORE");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(516, 9, "c99-line");
+            WORD_ATOM(535, 9, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_pattern_21__2);
             mw_prim_pack_cons();
@@ -18113,12 +18163,12 @@ static void mw_c99_pattern_21_ (void){
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(519, 9, "c99-line");
+            WORD_ATOM(538, 9, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_pattern_21__4);
             mw_prim_pack_cons();
             mw_c99_line();
-            WORD_ATOM(520, 9, "c99-nest");
+            WORD_ATOM(539, 9, "c99-nest");
             push_u64(0);
             push_fnptr(&mb_c99_pattern_21__5);
             mw_prim_pack_cons();
@@ -18129,19 +18179,19 @@ static void mw_c99_pattern_21_ (void){
 }    WORD_EXIT(mw_c99_pattern_21_);
 }
 static void mw_c99_word_sigs_21_ (void){
-    WORD_ENTER(mw_c99_word_sigs_21_, "c99-word-sigs!", "src/mirth/codegen.mth", 529, 25);
-    WORD_ATOM(529, 25, "for-needed-words");
+    WORD_ENTER(mw_c99_word_sigs_21_, "c99-word-sigs!", "src/mirth/codegen.mth", 548, 25);
+    WORD_ATOM(548, 25, "for-needed-words");
     push_u64(0);
     push_fnptr(&mb_c99_word_sigs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_words();
-    WORD_ATOM(529, 57, ".lf");
+    WORD_ATOM(548, 57, ".lf");
     mw__2E_lf();
     WORD_EXIT(mw_c99_word_sigs_21_);
 }
 static void mw_c99_word_sig_21_ (void){
-    WORD_ENTER(mw_c99_word_sig_21_, "c99-word-sig!", "src/mirth/codegen.mth", 531, 5);
-    WORD_ATOM(531, 5, "c99-line");
+    WORD_ENTER(mw_c99_word_sig_21_, "c99-word-sig!", "src/mirth/codegen.mth", 550, 5);
+    WORD_ATOM(550, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_sig_21__1);
     mw_prim_pack_cons();
@@ -18149,19 +18199,19 @@ static void mw_c99_word_sig_21_ (void){
     WORD_EXIT(mw_c99_word_sig_21_);
 }
 static void mw_c99_block_sigs_21_ (void){
-    WORD_ENTER(mw_c99_block_sigs_21_, "c99-block-sigs!", "src/mirth/codegen.mth", 533, 26);
-    WORD_ATOM(533, 26, "for-needed-blocks");
+    WORD_ENTER(mw_c99_block_sigs_21_, "c99-block-sigs!", "src/mirth/codegen.mth", 552, 26);
+    WORD_ATOM(552, 26, "for-needed-blocks");
     push_u64(0);
     push_fnptr(&mb_c99_block_sigs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_blocks();
-    WORD_ATOM(533, 60, ".lf");
+    WORD_ATOM(552, 60, ".lf");
     mw__2E_lf();
     WORD_EXIT(mw_c99_block_sigs_21_);
 }
 static void mw_c99_block_sig_21_ (void){
-    WORD_ENTER(mw_c99_block_sig_21_, "c99-block-sig!", "src/mirth/codegen.mth", 535, 5);
-    WORD_ATOM(535, 5, "c99-line");
+    WORD_ENTER(mw_c99_block_sig_21_, "c99-block-sig!", "src/mirth/codegen.mth", 554, 5);
+    WORD_ATOM(554, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_sig_21__1);
     mw_prim_pack_cons();
@@ -18169,19 +18219,19 @@ static void mw_c99_block_sig_21_ (void){
     WORD_EXIT(mw_c99_block_sig_21_);
 }
 static void mw_c99_field_sigs_21_ (void){
-    WORD_ENTER(mw_c99_field_sigs_21_, "c99-field-sigs!", "src/mirth/codegen.mth", 537, 26);
-    WORD_ATOM(537, 26, "Field.for");
+    WORD_ENTER(mw_c99_field_sigs_21_, "c99-field-sigs!", "src/mirth/codegen.mth", 556, 26);
+    WORD_ATOM(556, 26, "Field.for");
     push_u64(0);
     push_fnptr(&mb_c99_field_sigs_21__1);
     mw_prim_pack_cons();
     mw_Field_2E_for();
-    WORD_ATOM(537, 52, ".lf");
+    WORD_ATOM(556, 52, ".lf");
     mw__2E_lf();
     WORD_EXIT(mw_c99_field_sigs_21_);
 }
 static void mw_c99_field_sig_21_ (void){
-    WORD_ENTER(mw_c99_field_sig_21_, "c99-field-sig!", "src/mirth/codegen.mth", 539, 5);
-    WORD_ATOM(539, 5, "c99-line");
+    WORD_ENTER(mw_c99_field_sig_21_, "c99-field-sig!", "src/mirth/codegen.mth", 558, 5);
+    WORD_ATOM(558, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_field_sig_21__1);
     mw_prim_pack_cons();
@@ -18189,19 +18239,19 @@ static void mw_c99_field_sig_21_ (void){
     WORD_EXIT(mw_c99_field_sig_21_);
 }
 static void mw_c99_block_enter_21_ (void){
-    WORD_ENTER(mw_c99_block_enter_21_, "c99-block-enter!", "src/mirth/codegen.mth", 542, 5);
-    WORD_ATOM(542, 5, "c99-line");
+    WORD_ENTER(mw_c99_block_enter_21_, "c99-block-enter!", "src/mirth/codegen.mth", 561, 5);
+    WORD_ATOM(561, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_enter_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(551, 5, "drop");
+    WORD_ATOM(570, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_block_enter_21_);
 }
 static void mw_c99_block_exit_21_ (void){
-    WORD_ENTER(mw_c99_block_exit_21_, "c99-block-exit!", "src/mirth/codegen.mth", 554, 5);
-    WORD_ATOM(554, 5, "c99-line");
+    WORD_ENTER(mw_c99_block_exit_21_, "c99-block-exit!", "src/mirth/codegen.mth", 573, 5);
+    WORD_ATOM(573, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_exit_21__1);
     mw_prim_pack_cons();
@@ -18209,40 +18259,40 @@ static void mw_c99_block_exit_21_ (void){
     WORD_EXIT(mw_c99_block_exit_21_);
 }
 static void mw_c99_block_defs_21_ (void){
-    WORD_ENTER(mw_c99_block_defs_21_, "c99-block-defs!", "src/mirth/codegen.mth", 556, 26);
-    WORD_ATOM(556, 26, "for-needed-blocks");
+    WORD_ENTER(mw_c99_block_defs_21_, "c99-block-defs!", "src/mirth/codegen.mth", 575, 26);
+    WORD_ATOM(575, 26, "for-needed-blocks");
     push_u64(0);
     push_fnptr(&mb_c99_block_defs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_blocks();
-    WORD_ATOM(556, 60, ".lf");
+    WORD_ATOM(575, 60, ".lf");
     mw__2E_lf();
     WORD_EXIT(mw_c99_block_defs_21_);
 }
 static void mw_c99_block_def_21_ (void){
-    WORD_ENTER(mw_c99_block_def_21_, "c99-block-def!", "src/mirth/codegen.mth", 558, 5);
-    WORD_ATOM(558, 5, "c99-line");
+    WORD_ENTER(mw_c99_block_def_21_, "c99-block-def!", "src/mirth/codegen.mth", 577, 5);
+    WORD_ATOM(577, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_def_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(559, 5, "c99-nest");
+    WORD_ATOM(578, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_block_def_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(567, 5, "c99-line");
+    WORD_ATOM(586, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_def_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(567, 21, ".lf");
+    WORD_ATOM(586, 21, ".lf");
     mw__2E_lf();
     WORD_EXIT(mw_c99_block_def_21_);
 }
 static void mw__2E_block (void){
-    WORD_ENTER(mw__2E_block, ".block", "src/mirth/codegen.mth", 570, 5);
-    WORD_ATOM(570, 5, "");
+    WORD_ENTER(mw__2E_block, ".block", "src/mirth/codegen.mth", 589, 5);
+    WORD_ATOM(589, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18253,34 +18303,34 @@ static void mw__2E_block (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(570, 11, ".");
+    WORD_ATOM(589, 11, ".");
     mw__2E_();
-    WORD_ATOM(571, 5, "dup");
+    WORD_ATOM(590, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(571, 9, "arrow");
+    WORD_ATOM(590, 9, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(571, 15, "dup");
+    WORD_ATOM(590, 15, "dup");
     mw_prim_dup();
-    WORD_ATOM(571, 19, "home");
+    WORD_ATOM(590, 19, "home");
     mw_Arrow_2E_home();
-    WORD_ATOM(571, 24, "match");
+    WORD_ATOM(590, 24, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(572, 17, "drop");
+            WORD_ATOM(591, 17, "drop");
             mw_prim_drop();
-            WORD_ATOM(572, 22, "Block.id");
+            WORD_ATOM(591, 22, "Block.id");
             mw_Block_2E_id();
-            WORD_ATOM(572, 31, ".n");
+            WORD_ATOM(591, 31, ".n");
             mw__2E_n();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(574, 13, "name");
+            WORD_ATOM(593, 13, "name");
             mw_Word_2E_name();
-            WORD_ATOM(574, 18, ".name");
+            WORD_ATOM(593, 18, ".name");
             mw__2E_name();
-            WORD_ATOM(574, 24, "");
+            WORD_ATOM(593, 24, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -18291,13 +18341,13 @@ static void mw__2E_block (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(574, 28, ".");
+            WORD_ATOM(593, 28, ".");
             mw__2E_();
-            WORD_ATOM(575, 13, "homeidx");
+            WORD_ATOM(594, 13, "homeidx");
             mw_Arrow_2E_homeidx();
-            WORD_ATOM(575, 21, ".n");
+            WORD_ATOM(594, 21, ".n");
             mw__2E_n();
-            WORD_ATOM(575, 24, "drop");
+            WORD_ATOM(594, 24, "drop");
             mw_prim_drop();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -18305,73 +18355,73 @@ static void mw__2E_block (void){
 }    WORD_EXIT(mw__2E_block);
 }
 static void mw_c99_word_enter_21_ (void){
-    WORD_ENTER(mw_c99_word_enter_21_, "c99-word-enter!", "src/mirth/codegen.mth", 579, 5);
-    WORD_ATOM(579, 5, "c99-line");
+    WORD_ENTER(mw_c99_word_enter_21_, "c99-word-enter!", "src/mirth/codegen.mth", 598, 5);
+    WORD_ATOM(598, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_enter_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(585, 5, "drop");
+    WORD_ATOM(604, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_word_enter_21_);
 }
 static void mw_c99_word_exit_21_ (void){
-    WORD_ENTER(mw_c99_word_exit_21_, "c99-word-exit!", "src/mirth/codegen.mth", 588, 5);
-    WORD_ATOM(588, 5, "c99-line");
+    WORD_ENTER(mw_c99_word_exit_21_, "c99-word-exit!", "src/mirth/codegen.mth", 607, 5);
+    WORD_ATOM(607, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_exit_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(590, 5, "drop");
+    WORD_ATOM(609, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_word_exit_21_);
 }
 static void mw_c99_word_defs_21_ (void){
-    WORD_ENTER(mw_c99_word_defs_21_, "c99-word-defs!", "src/mirth/codegen.mth", 592, 25);
-    WORD_ATOM(592, 25, "for-needed-words");
+    WORD_ENTER(mw_c99_word_defs_21_, "c99-word-defs!", "src/mirth/codegen.mth", 611, 25);
+    WORD_ATOM(611, 25, "for-needed-words");
     push_u64(0);
     push_fnptr(&mb_c99_word_defs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_words();
-    WORD_ATOM(592, 57, ".lf");
+    WORD_ATOM(611, 57, ".lf");
     mw__2E_lf();
     WORD_EXIT(mw_c99_word_defs_21_);
 }
 static void mw_c99_word_def_21_ (void){
-    WORD_ENTER(mw_c99_word_def_21_, "c99-word-def!", "src/mirth/codegen.mth", 594, 5);
-    WORD_ATOM(594, 5, "c99-line");
+    WORD_ENTER(mw_c99_word_def_21_, "c99-word-def!", "src/mirth/codegen.mth", 613, 5);
+    WORD_ATOM(613, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_def_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(595, 5, "c99-nest");
+    WORD_ATOM(614, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_word_def_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(600, 5, "c99-line");
+    WORD_ATOM(619, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_def_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(601, 5, "drop");
+    WORD_ATOM(620, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_word_def_21_);
 }
 static void mw_c99_field_defs_21_ (void){
-    WORD_ENTER(mw_c99_field_defs_21_, "c99-field-defs!", "src/mirth/codegen.mth", 603, 26);
-    WORD_ATOM(603, 26, "Field.for");
+    WORD_ENTER(mw_c99_field_defs_21_, "c99-field-defs!", "src/mirth/codegen.mth", 622, 26);
+    WORD_ATOM(622, 26, "Field.for");
     push_u64(0);
     push_fnptr(&mb_c99_field_defs_21__1);
     mw_prim_pack_cons();
     mw_Field_2E_for();
-    WORD_ATOM(603, 52, ".lf");
+    WORD_ATOM(622, 52, ".lf");
     mw__2E_lf();
     WORD_EXIT(mw_c99_field_defs_21_);
 }
 static void mw_c99_field_def_21_ (void){
-    WORD_ENTER(mw_c99_field_def_21_, "c99-field-def!", "src/mirth/codegen.mth", 605, 5);
-    WORD_ATOM(605, 5, "");
+    WORD_ENTER(mw_c99_field_def_21_, "c99-field-def!", "src/mirth/codegen.mth", 624, 5);
+    WORD_ATOM(624, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18382,15 +18432,15 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(605, 29, ".");
+    WORD_ATOM(624, 29, ".");
     mw__2E_();
-    WORD_ATOM(605, 31, "dup");
+    WORD_ATOM(624, 31, "dup");
     mw_prim_dup();
-    WORD_ATOM(605, 35, "name");
+    WORD_ATOM(624, 35, "name");
     mw_Field_2E_name();
-    WORD_ATOM(605, 40, ".name");
+    WORD_ATOM(624, 40, ".name");
     mw__2E_name();
-    WORD_ATOM(605, 46, "");
+    WORD_ATOM(624, 46, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18401,9 +18451,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(605, 62, ";");
+    WORD_ATOM(624, 62, ";");
     mw__3B_();
-    WORD_ATOM(606, 5, "");
+    WORD_ATOM(625, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18414,9 +18464,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(606, 37, ";");
+    WORD_ATOM(625, 37, ";");
     mw__3B_();
-    WORD_ATOM(607, 5, "");
+    WORD_ATOM(626, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18427,13 +18477,13 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(607, 23, ".");
+    WORD_ATOM(626, 23, ".");
     mw__2E_();
-    WORD_ATOM(607, 25, "TABLE_MAX_SIZE");
+    WORD_ATOM(626, 25, "TABLE_MAX_SIZE");
     mw_TABLE_5F_MAX_5F_SIZE();
-    WORD_ATOM(607, 40, ".n");
+    WORD_ATOM(626, 40, ".n");
     mw__2E_n();
-    WORD_ATOM(607, 43, "");
+    WORD_ATOM(626, 43, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18444,9 +18494,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(607, 47, ";");
+    WORD_ATOM(626, 47, ";");
     mw__3B_();
-    WORD_ATOM(608, 5, "");
+    WORD_ATOM(627, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18457,9 +18507,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(608, 50, ";");
+    WORD_ATOM(627, 50, ";");
     mw__3B_();
-    WORD_ATOM(609, 5, "");
+    WORD_ATOM(628, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18470,9 +18520,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(609, 70, ";");
+    WORD_ATOM(628, 70, ";");
     mw__3B_();
-    WORD_ATOM(610, 5, "");
+    WORD_ATOM(629, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18483,9 +18533,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(610, 23, ";");
+    WORD_ATOM(629, 23, ";");
     mw__3B_();
-    WORD_ATOM(611, 5, "");
+    WORD_ATOM(630, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18496,15 +18546,15 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(611, 9, ";;");
+    WORD_ATOM(630, 9, ";;");
     mw__3B__3B_();
-    WORD_ATOM(614, 5, "dup");
+    WORD_ATOM(633, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(614, 9, "name");
+    WORD_ATOM(633, 9, "name");
     mw_Field_2E_name();
-    WORD_ATOM(614, 14, ".w");
+    WORD_ATOM(633, 14, ".w");
     mw__2E_w();
-    WORD_ATOM(614, 17, "");
+    WORD_ATOM(633, 17, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18515,9 +18565,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(614, 21, ";");
+    WORD_ATOM(633, 21, ";");
     mw__3B_();
-    WORD_ATOM(615, 5, "");
+    WORD_ATOM(634, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18528,9 +18578,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(615, 45, ";");
+    WORD_ATOM(634, 45, ";");
     mw__3B_();
-    WORD_ATOM(616, 5, "");
+    WORD_ATOM(635, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18541,15 +18591,15 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(616, 30, ".");
+    WORD_ATOM(635, 30, ".");
     mw__2E_();
-    WORD_ATOM(616, 32, "dup");
+    WORD_ATOM(635, 32, "dup");
     mw_prim_dup();
-    WORD_ATOM(616, 36, "name");
+    WORD_ATOM(635, 36, "name");
     mw_Field_2E_name();
-    WORD_ATOM(616, 41, ".name");
+    WORD_ATOM(635, 41, ".name");
     mw__2E_name();
-    WORD_ATOM(616, 47, "");
+    WORD_ATOM(635, 47, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18560,9 +18610,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(616, 58, ";");
+    WORD_ATOM(635, 58, ";");
     mw__3B_();
-    WORD_ATOM(617, 5, "");
+    WORD_ATOM(636, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18573,9 +18623,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(617, 24, ";");
+    WORD_ATOM(636, 24, ";");
     mw__3B_();
-    WORD_ATOM(618, 5, "");
+    WORD_ATOM(637, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18586,25 +18636,25 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(618, 9, ";;");
+    WORD_ATOM(637, 9, ";;");
     mw__3B__3B_();
-    WORD_ATOM(620, 5, "drop");
+    WORD_ATOM(639, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_field_def_21_);
 }
 static void mw_c99_main_21_ (void){
-    WORD_ENTER(mw_c99_main_21_, "c99-main!", "src/mirth/codegen.mth", 623, 5);
-    WORD_ATOM(623, 5, "c99-line");
+    WORD_ENTER(mw_c99_main_21_, "c99-main!", "src/mirth/codegen.mth", 642, 5);
+    WORD_ATOM(642, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(624, 5, "c99-nest");
+    WORD_ATOM(643, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(637, 5, "c99-line");
+    WORD_ATOM(656, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__8);
     mw_prim_pack_cons();
@@ -19786,7 +19836,7 @@ static void mw_atom_accepts_args_3F_ (void){
             mw_prim_pack_uncons(); mw_prim_drop();
             WORD_ATOM(282, 13, "match");
             switch (get_top_data_tag()) {
-                case 9LL:
+                case 4LL:
                     mw_prim_drop();
                     WORD_ATOM(283, 34, "dup");
                     mw_prim_dup();
@@ -19799,17 +19849,17 @@ static void mw_atom_accepts_args_3F_ (void){
                     WORD_ATOM(283, 49, "<");
                     mw_prim_int_lt();
                     break;
-                case 4LL:
+                case 13LL:
                     mw_prim_drop();
-                    WORD_ATOM(284, 34, "dup");
+                    WORD_ATOM(284, 35, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(284, 38, "args");
+                    WORD_ATOM(284, 39, "args");
                     mw_Atom_2E_args();
-                    WORD_ATOM(284, 43, "len");
+                    WORD_ATOM(284, 44, "len");
                     mw_List_2E_len();
-                    WORD_ATOM(284, 47, "");
+                    WORD_ATOM(284, 48, "");
                     push_i64(1LL);
-                    WORD_ATOM(284, 49, "<");
+                    WORD_ATOM(284, 50, "<");
                     mw_prim_int_lt();
                     break;
                 case 5LL:
@@ -39759,29 +39809,29 @@ static void mb_need_args_push_1 (void) {
 }
 
 static void mb_need_match_1 (void) {
-    WORD_ENTER(mb_need_match_1, "need-match block", "src/mirth/codegen.mth", 117, 37);
+    WORD_ENTER(mb_need_match_1, "need-match block", "src/mirth/codegen.mth", 122, 37);
     mw_prim_drop();
-    WORD_ATOM(117, 37, "body");
+    WORD_ATOM(122, 37, "body");
     mw_Case_2E_body();
-    WORD_ATOM(117, 42, "need-arrow-run");
+    WORD_ATOM(122, 42, "need-arrow-run");
     mw_need_arrow_run();
     WORD_EXIT(mb_need_match_1);
 }
 
 static void mb_codegen_flush_21__2 (void) {
-    WORD_ENTER(mb_codegen_flush_21__2, "codegen-flush! block", "src/mirth/codegen.mth", 134, 17);
+    WORD_ENTER(mb_codegen_flush_21__2, "codegen-flush! block", "src/mirth/codegen.mth", 139, 17);
     mw_prim_drop();
-    WORD_ATOM(134, 17, "dup");
+    WORD_ATOM(139, 17, "dup");
     mw_prim_dup();
-    WORD_ATOM(134, 21, "0>");
+    WORD_ATOM(139, 21, "0>");
     mw_0_3E_();
     WORD_EXIT(mb_codegen_flush_21__2);
 }
 
 static void mb_codegen_flush_21__3 (void) {
-    WORD_ENTER(mb_codegen_flush_21__3, "codegen-flush! block", "src/mirth/codegen.mth", 134, 25);
+    WORD_ENTER(mb_codegen_flush_21__3, "codegen-flush! block", "src/mirth/codegen.mth", 139, 25);
     mw_prim_drop();
-    WORD_ATOM(134, 25, "");
+    WORD_ATOM(139, 25, "");
     {
         static bool vready = false;
         static VAL v;
@@ -39796,23 +39846,23 @@ static void mb_codegen_flush_21__3 (void) {
 }
 
 static void mb_codegen_flush_21__4 (void) {
-    WORD_ENTER(mb_codegen_flush_21__4, "codegen-flush! block", "src/mirth/codegen.mth", 135, 17);
+    WORD_ENTER(mb_codegen_flush_21__4, "codegen-flush! block", "src/mirth/codegen.mth", 140, 17);
     mw_prim_drop();
-    WORD_ATOM(135, 17, "dup");
+    WORD_ATOM(140, 17, "dup");
     mw_prim_dup();
-    WORD_ATOM(135, 21, "codegen-length");
+    WORD_ATOM(140, 21, "codegen-length");
     mw_codegen_length();
-    WORD_ATOM(135, 36, "@");
+    WORD_ATOM(140, 36, "@");
     mw_prim_mut_get();
-    WORD_ATOM(135, 38, "=");
+    WORD_ATOM(140, 38, "=");
     mw_prim_int_eq();
     WORD_EXIT(mb_codegen_flush_21__4);
 }
 
 static void mb_codegen_flush_21__5 (void) {
-    WORD_ENTER(mb_codegen_flush_21__5, "codegen-flush! block", "src/mirth/codegen.mth", 135, 41);
+    WORD_ENTER(mb_codegen_flush_21__5, "codegen-flush! block", "src/mirth/codegen.mth", 140, 41);
     mw_prim_drop();
-    WORD_ATOM(135, 41, "");
+    WORD_ATOM(140, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -39827,99 +39877,99 @@ static void mb_codegen_flush_21__5 (void) {
 }
 
 static void mb__2E_b_3 (void) {
-    WORD_ENTER(mb__2E_b_3, ".b block", "src/mirth/codegen.mth", 144, 27);
+    WORD_ENTER(mb__2E_b_3, ".b block", "src/mirth/codegen.mth", 149, 27);
     mw_prim_drop();
-    WORD_ATOM(144, 27, "dup");
+    WORD_ATOM(149, 27, "dup");
     mw_prim_dup();
-    WORD_ATOM(144, 31, "1+");
+    WORD_ATOM(149, 31, "1+");
     mw_prim_int_succ();
     WORD_EXIT(mb__2E_b_3);
 }
 
 static void mb__2E__6 (void) {
-    WORD_ENTER(mb__2E__6, ". block", "src/mirth/codegen.mth", 160, 13);
+    WORD_ENTER(mb__2E__6, ". block", "src/mirth/codegen.mth", 165, 13);
     mw_prim_drop();
-    WORD_ATOM(160, 13, "codegen-length");
+    WORD_ATOM(165, 13, "codegen-length");
     mw_codegen_length();
-    WORD_ATOM(160, 28, "@");
+    WORD_ATOM(165, 28, "@");
     mw_prim_mut_get();
-    WORD_ATOM(160, 30, "CODEGEN_BUF");
+    WORD_ATOM(165, 30, "CODEGEN_BUF");
     mw_CODEGEN_5F_BUF();
-    WORD_ATOM(160, 42, ".offset-unsafe");
+    WORD_ATOM(165, 42, ".offset-unsafe");
     mw_prim_ptr_add();
-    WORD_ATOM(160, 57, "prim-ptr-copy");
+    WORD_ATOM(165, 57, "prim-ptr-copy");
     mw_prim_ptr_copy();
     WORD_EXIT(mb__2E__6);
 }
 
 static void mb__2E__7 (void) {
-    WORD_ENTER(mb__2E__7, ". block", "src/mirth/codegen.mth", 161, 31);
+    WORD_ENTER(mb__2E__7, ". block", "src/mirth/codegen.mth", 166, 31);
     mw_prim_drop();
-    WORD_ATOM(161, 31, "+");
+    WORD_ATOM(166, 31, "+");
     mw_prim_int_add();
     WORD_EXIT(mb__2E__7);
 }
 
 static void mb_c99_tags_21__1 (void) {
-    WORD_ENTER(mb_c99_tags_21__1, "c99-tags! block", "src/mirth/codegen.mth", 228, 28);
+    WORD_ENTER(mb_c99_tags_21__1, "c99-tags! block", "src/mirth/codegen.mth", 233, 28);
     mw_prim_drop();
-    WORD_ATOM(228, 28, "c99-tag!");
+    WORD_ATOM(233, 28, "c99-tag!");
     mw_c99_tag_21_();
     WORD_EXIT(mb_c99_tags_21__1);
 }
 
 static void mb_c99_buffers_21__1 (void) {
-    WORD_ENTER(mb_c99_buffers_21__1, "c99-buffers! block", "src/mirth/codegen.mth", 213, 34);
+    WORD_ENTER(mb_c99_buffers_21__1, "c99-buffers! block", "src/mirth/codegen.mth", 218, 34);
     mw_prim_drop();
-    WORD_ATOM(213, 34, "c99-buffer!");
+    WORD_ATOM(218, 34, "c99-buffer!");
     mw_c99_buffer_21_();
     WORD_EXIT(mb_c99_buffers_21__1);
 }
 
 static void mb_c99_variables_21__1 (void) {
-    WORD_ENTER(mb_c99_variables_21__1, "c99-variables! block", "src/mirth/codegen.mth", 221, 38);
+    WORD_ENTER(mb_c99_variables_21__1, "c99-variables! block", "src/mirth/codegen.mth", 226, 38);
     mw_prim_drop();
-    WORD_ATOM(221, 38, "c99-variable!");
+    WORD_ATOM(226, 38, "c99-variable!");
     mw_c99_variable_21_();
     WORD_EXIT(mb_c99_variables_21__1);
 }
 
 static void mb_c99_externals_21__1 (void) {
-    WORD_ENTER(mb_c99_externals_21__1, "c99-externals! block", "src/mirth/codegen.mth", 246, 18);
+    WORD_ENTER(mb_c99_externals_21__1, "c99-externals! block", "src/mirth/codegen.mth", 251, 18);
     mw_prim_drop();
-    WORD_ATOM(246, 18, "c99-external!");
+    WORD_ATOM(251, 18, "c99-external!");
     mw_c99_external_21_();
     WORD_EXIT(mb_c99_externals_21__1);
 }
 
 static void mb_c99_word_sigs_21__1 (void) {
-    WORD_ENTER(mb_c99_word_sigs_21__1, "c99-word-sigs! block", "src/mirth/codegen.mth", 529, 42);
+    WORD_ENTER(mb_c99_word_sigs_21__1, "c99-word-sigs! block", "src/mirth/codegen.mth", 548, 42);
     mw_prim_drop();
-    WORD_ATOM(529, 42, "c99-word-sig!");
+    WORD_ATOM(548, 42, "c99-word-sig!");
     mw_c99_word_sig_21_();
     WORD_EXIT(mb_c99_word_sigs_21__1);
 }
 
 static void mb_c99_block_sigs_21__1 (void) {
-    WORD_ENTER(mb_c99_block_sigs_21__1, "c99-block-sigs! block", "src/mirth/codegen.mth", 533, 44);
+    WORD_ENTER(mb_c99_block_sigs_21__1, "c99-block-sigs! block", "src/mirth/codegen.mth", 552, 44);
     mw_prim_drop();
-    WORD_ATOM(533, 44, "c99-block-sig!");
+    WORD_ATOM(552, 44, "c99-block-sig!");
     mw_c99_block_sig_21_();
     WORD_EXIT(mb_c99_block_sigs_21__1);
 }
 
 static void mb_c99_field_sigs_21__1 (void) {
-    WORD_ENTER(mb_c99_field_sigs_21__1, "c99-field-sigs! block", "src/mirth/codegen.mth", 537, 36);
+    WORD_ENTER(mb_c99_field_sigs_21__1, "c99-field-sigs! block", "src/mirth/codegen.mth", 556, 36);
     mw_prim_drop();
-    WORD_ATOM(537, 36, "c99-field-sig!");
+    WORD_ATOM(556, 36, "c99-field-sig!");
     mw_c99_field_sig_21_();
     WORD_EXIT(mb_c99_field_sigs_21__1);
 }
 
 static void mb_c99_main_21__1 (void) {
-    WORD_ENTER(mb_c99_main_21__1, "c99-main! block", "src/mirth/codegen.mth", 623, 14);
+    WORD_ENTER(mb_c99_main_21__1, "c99-main! block", "src/mirth/codegen.mth", 642, 14);
     mw_prim_drop();
-    WORD_ATOM(623, 14, "");
+    WORD_ATOM(642, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -39930,37 +39980,37 @@ static void mb_c99_main_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(623, 51, ".");
+    WORD_ATOM(642, 51, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_main_21__1);
 }
 
 static void mb_c99_main_21__2 (void) {
-    WORD_ENTER(mb_c99_main_21__2, "c99-main! block", "src/mirth/codegen.mth", 625, 9);
+    WORD_ENTER(mb_c99_main_21__2, "c99-main! block", "src/mirth/codegen.mth", 644, 9);
     mw_prim_drop();
-    WORD_ATOM(625, 9, "c99-line");
+    WORD_ATOM(644, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(626, 9, "c99-line");
+    WORD_ATOM(645, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__4);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(627, 9, "c99-line");
+    WORD_ATOM(646, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__5);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(633, 9, "c99-arrow!");
+    WORD_ATOM(652, 9, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(634, 9, "c99-line");
+    WORD_ATOM(653, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__6);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(635, 9, "c99-line");
+    WORD_ATOM(654, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__7);
     mw_prim_pack_cons();
@@ -39969,9 +40019,9 @@ static void mb_c99_main_21__2 (void) {
 }
 
 static void mb_c99_main_21__3 (void) {
-    WORD_ENTER(mb_c99_main_21__3, "c99-main! block", "src/mirth/codegen.mth", 625, 18);
+    WORD_ENTER(mb_c99_main_21__3, "c99-main! block", "src/mirth/codegen.mth", 644, 18);
     mw_prim_drop();
-    WORD_ATOM(625, 18, "");
+    WORD_ATOM(644, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -39982,15 +40032,15 @@ static void mb_c99_main_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(625, 40, ".");
+    WORD_ATOM(644, 40, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_main_21__3);
 }
 
 static void mb_c99_main_21__4 (void) {
-    WORD_ENTER(mb_c99_main_21__4, "c99-main! block", "src/mirth/codegen.mth", 626, 18);
+    WORD_ENTER(mb_c99_main_21__4, "c99-main! block", "src/mirth/codegen.mth", 645, 18);
     mw_prim_drop();
-    WORD_ATOM(626, 18, "");
+    WORD_ATOM(645, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40001,15 +40051,15 @@ static void mb_c99_main_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(626, 40, ".");
+    WORD_ATOM(645, 40, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_main_21__4);
 }
 
 static void mb_c99_main_21__5 (void) {
-    WORD_ENTER(mb_c99_main_21__5, "c99-main! block", "src/mirth/codegen.mth", 627, 18);
+    WORD_ENTER(mb_c99_main_21__5, "c99-main! block", "src/mirth/codegen.mth", 646, 18);
     mw_prim_drop();
-    WORD_ATOM(627, 18, "");
+    WORD_ATOM(646, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40020,9 +40070,9 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(627, 32, ".");
+    WORD_ATOM(646, 32, ".");
     mw__2E_();
-    WORD_ATOM(628, 13, "");
+    WORD_ATOM(647, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40033,9 +40083,9 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(628, 34, ".");
+    WORD_ATOM(647, 34, ".");
     mw__2E_();
-    WORD_ATOM(629, 13, "");
+    WORD_ATOM(648, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40046,21 +40096,21 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(629, 28, ".");
+    WORD_ATOM(648, 28, ".");
     mw__2E_();
-    WORD_ATOM(630, 13, "dup");
+    WORD_ATOM(649, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(630, 17, "token-start");
+    WORD_ATOM(649, 17, "token-start");
     mw_Arrow_2E_token_start();
-    WORD_ATOM(630, 29, ".module");
+    WORD_ATOM(649, 29, ".module");
     mw_Token_2E_module();
-    WORD_ATOM(630, 37, "source-path");
+    WORD_ATOM(649, 37, "source-path");
     mw_Module_2E_source_path();
-    WORD_ATOM(630, 49, ">Str");
+    WORD_ATOM(649, 49, ">Str");
     mw_Path_3E_Str();
-    WORD_ATOM(630, 54, ".str");
+    WORD_ATOM(649, 54, ".str");
     mw__2E_str();
-    WORD_ATOM(630, 59, "");
+    WORD_ATOM(649, 59, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40071,19 +40121,19 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(630, 64, ".");
+    WORD_ATOM(649, 64, ".");
     mw__2E_();
-    WORD_ATOM(631, 13, "dup");
+    WORD_ATOM(650, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(631, 17, "token-start");
+    WORD_ATOM(650, 17, "token-start");
     mw_Arrow_2E_token_start();
-    WORD_ATOM(631, 29, "row");
+    WORD_ATOM(650, 29, "row");
     mw_Token_2E_row();
-    WORD_ATOM(631, 33, ">Int");
+    WORD_ATOM(650, 33, ">Int");
     mw_Row_3E_Int();
-    WORD_ATOM(631, 38, ".n");
+    WORD_ATOM(650, 38, ".n");
     mw__2E_n();
-    WORD_ATOM(631, 41, "");
+    WORD_ATOM(650, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40094,19 +40144,19 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(631, 46, ".");
+    WORD_ATOM(650, 46, ".");
     mw__2E_();
-    WORD_ATOM(632, 13, "dup");
+    WORD_ATOM(651, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(632, 17, "token-start");
+    WORD_ATOM(651, 17, "token-start");
     mw_Arrow_2E_token_start();
-    WORD_ATOM(632, 29, "col");
+    WORD_ATOM(651, 29, "col");
     mw_Token_2E_col();
-    WORD_ATOM(632, 33, ">Int");
+    WORD_ATOM(651, 33, ">Int");
     mw_Col_3E_Int();
-    WORD_ATOM(632, 38, ".n");
+    WORD_ATOM(651, 38, ".n");
     mw__2E_n();
-    WORD_ATOM(632, 41, "");
+    WORD_ATOM(651, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40117,15 +40167,15 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(632, 46, ".");
+    WORD_ATOM(651, 46, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_main_21__5);
 }
 
 static void mb_c99_main_21__6 (void) {
-    WORD_ENTER(mb_c99_main_21__6, "c99-main! block", "src/mirth/codegen.mth", 634, 18);
+    WORD_ENTER(mb_c99_main_21__6, "c99-main! block", "src/mirth/codegen.mth", 653, 18);
     mw_prim_drop();
-    WORD_ATOM(634, 18, "");
+    WORD_ATOM(653, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40136,15 +40186,15 @@ static void mb_c99_main_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(634, 49, ".");
+    WORD_ATOM(653, 49, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_main_21__6);
 }
 
 static void mb_c99_main_21__7 (void) {
-    WORD_ENTER(mb_c99_main_21__7, "c99-main! block", "src/mirth/codegen.mth", 635, 18);
+    WORD_ENTER(mb_c99_main_21__7, "c99-main! block", "src/mirth/codegen.mth", 654, 18);
     mw_prim_drop();
-    WORD_ATOM(635, 18, "");
+    WORD_ATOM(654, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40155,15 +40205,15 @@ static void mb_c99_main_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(635, 30, ".");
+    WORD_ATOM(654, 30, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_main_21__7);
 }
 
 static void mb_c99_main_21__8 (void) {
-    WORD_ENTER(mb_c99_main_21__8, "c99-main! block", "src/mirth/codegen.mth", 637, 14);
+    WORD_ENTER(mb_c99_main_21__8, "c99-main! block", "src/mirth/codegen.mth", 656, 14);
     mw_prim_drop();
-    WORD_ATOM(637, 14, "");
+    WORD_ATOM(656, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40174,39 +40224,39 @@ static void mb_c99_main_21__8 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(637, 18, ".");
+    WORD_ATOM(656, 18, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_main_21__8);
 }
 
 static void mb_c99_field_defs_21__1 (void) {
-    WORD_ENTER(mb_c99_field_defs_21__1, "c99-field-defs! block", "src/mirth/codegen.mth", 603, 36);
+    WORD_ENTER(mb_c99_field_defs_21__1, "c99-field-defs! block", "src/mirth/codegen.mth", 622, 36);
     mw_prim_drop();
-    WORD_ATOM(603, 36, "c99-field-def!");
+    WORD_ATOM(622, 36, "c99-field-def!");
     mw_c99_field_def_21_();
     WORD_EXIT(mb_c99_field_defs_21__1);
 }
 
 static void mb_c99_word_defs_21__1 (void) {
-    WORD_ENTER(mb_c99_word_defs_21__1, "c99-word-defs! block", "src/mirth/codegen.mth", 592, 42);
+    WORD_ENTER(mb_c99_word_defs_21__1, "c99-word-defs! block", "src/mirth/codegen.mth", 611, 42);
     mw_prim_drop();
-    WORD_ATOM(592, 42, "c99-word-def!");
+    WORD_ATOM(611, 42, "c99-word-def!");
     mw_c99_word_def_21_();
     WORD_EXIT(mb_c99_word_defs_21__1);
 }
 
 static void mb_c99_block_defs_21__1 (void) {
-    WORD_ENTER(mb_c99_block_defs_21__1, "c99-block-defs! block", "src/mirth/codegen.mth", 556, 44);
+    WORD_ENTER(mb_c99_block_defs_21__1, "c99-block-defs! block", "src/mirth/codegen.mth", 575, 44);
     mw_prim_drop();
-    WORD_ATOM(556, 44, "c99-block-def!");
+    WORD_ATOM(575, 44, "c99-block-def!");
     mw_c99_block_def_21_();
     WORD_EXIT(mb_c99_block_defs_21__1);
 }
 
 static void mb_c99_tag_21__5 (void) {
-    WORD_ENTER(mb_c99_tag_21__5, "c99-tag! block", "src/mirth/codegen.mth", 237, 38);
+    WORD_ENTER(mb_c99_tag_21__5, "c99-tag! block", "src/mirth/codegen.mth", 242, 38);
     mw_prim_drop();
-    WORD_ATOM(237, 38, "");
+    WORD_ATOM(242, 38, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40217,29 +40267,29 @@ static void mb_c99_tag_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(237, 76, ";");
+    WORD_ATOM(242, 76, ";");
     mw__3B_();
     WORD_EXIT(mb_c99_tag_21__5);
 }
 
 static void mb_c99_external_21__5 (void) {
-    WORD_ENTER(mb_c99_external_21__5, "c99-external! block", "src/mirth/codegen.mth", 259, 10);
+    WORD_ENTER(mb_c99_external_21__5, "c99-external! block", "src/mirth/codegen.mth", 264, 10);
     mw_prim_drop();
-    WORD_ATOM(259, 10, "dup");
+    WORD_ATOM(264, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(259, 14, "name");
+    WORD_ATOM(264, 14, "name");
     mw_External_2E_name();
-    WORD_ATOM(259, 19, ">Str");
+    WORD_ATOM(264, 19, ">Str");
     mw_Name_3E_Str();
-    WORD_ATOM(259, 24, ".");
+    WORD_ATOM(264, 24, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_external_21__5);
 }
 
 static void mb_c99_external_21__7 (void) {
-    WORD_ENTER(mb_c99_external_21__7, "c99-external! block", "src/mirth/codegen.mth", 262, 42);
+    WORD_ENTER(mb_c99_external_21__7, "c99-external! block", "src/mirth/codegen.mth", 267, 42);
     mw_prim_drop();
-    WORD_ATOM(262, 42, "");
+    WORD_ATOM(267, 42, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40250,27 +40300,27 @@ static void mb_c99_external_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(262, 54, ".");
+    WORD_ATOM(267, 54, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_external_21__7);
 }
 
 static void mb_c99_external_21__9 (void) {
-    WORD_ENTER(mb_c99_external_21__9, "c99-external! block", "src/mirth/codegen.mth", 265, 30);
+    WORD_ENTER(mb_c99_external_21__9, "c99-external! block", "src/mirth/codegen.mth", 270, 30);
     mw_prim_drop();
-    WORD_ATOM(265, 30, "dup");
+    WORD_ATOM(270, 30, "dup");
     mw_prim_dup();
-    WORD_ATOM(265, 34, "name");
+    WORD_ATOM(270, 34, "name");
     mw_External_2E_name();
-    WORD_ATOM(265, 39, ".name");
+    WORD_ATOM(270, 39, ".name");
     mw__2E_name();
     WORD_EXIT(mb_c99_external_21__9);
 }
 
 static void mb_c99_external_21__10 (void) {
-    WORD_ENTER(mb_c99_external_21__10, "c99-external! block", "src/mirth/codegen.mth", 266, 20);
+    WORD_ENTER(mb_c99_external_21__10, "c99-external! block", "src/mirth/codegen.mth", 271, 20);
     mw_prim_drop();
-    WORD_ATOM(266, 20, "");
+    WORD_ATOM(271, 20, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40281,11 +40331,11 @@ static void mb_c99_external_21__10 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(266, 36, ".");
+    WORD_ATOM(271, 36, ".");
     mw__2E_();
-    WORD_ATOM(266, 38, ".n");
+    WORD_ATOM(271, 38, ".n");
     mw__2E_n();
-    WORD_ATOM(266, 41, "");
+    WORD_ATOM(271, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40296,29 +40346,29 @@ static void mb_c99_external_21__10 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(266, 57, ";");
+    WORD_ATOM(271, 57, ";");
     mw__3B_();
     WORD_EXIT(mb_c99_external_21__10);
 }
 
 static void mb_c99_external_21__13 (void) {
-    WORD_ENTER(mb_c99_external_21__13, "c99-external! block", "src/mirth/codegen.mth", 268, 10);
+    WORD_ENTER(mb_c99_external_21__13, "c99-external! block", "src/mirth/codegen.mth", 273, 10);
     mw_prim_drop();
-    WORD_ATOM(268, 10, "dup");
+    WORD_ATOM(273, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(268, 14, "name");
+    WORD_ATOM(273, 14, "name");
     mw_External_2E_name();
-    WORD_ATOM(268, 19, ">Str");
+    WORD_ATOM(273, 19, ">Str");
     mw_Name_3E_Str();
-    WORD_ATOM(268, 24, ".");
+    WORD_ATOM(273, 24, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_external_21__13);
 }
 
 static void mb_c99_external_21__16 (void) {
-    WORD_ENTER(mb_c99_external_21__16, "c99-external! block", "src/mirth/codegen.mth", 271, 26);
+    WORD_ENTER(mb_c99_external_21__16, "c99-external! block", "src/mirth/codegen.mth", 276, 26);
     mw_prim_drop();
-    WORD_ATOM(271, 26, "");
+    WORD_ATOM(276, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40329,11 +40379,11 @@ static void mb_c99_external_21__16 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(271, 30, ".");
+    WORD_ATOM(276, 30, ".");
     mw__2E_();
-    WORD_ATOM(271, 32, ".n");
+    WORD_ATOM(276, 32, ".n");
     mw__2E_n();
-    WORD_ATOM(271, 35, "");
+    WORD_ATOM(276, 35, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40344,37 +40394,37 @@ static void mb_c99_external_21__16 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(271, 40, ".");
+    WORD_ATOM(276, 40, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_external_21__16);
 }
 
 static void mb_c99_nest_2 (void) {
-    WORD_ENTER(mb_c99_nest_2, "c99-nest block", "src/mirth/codegen.mth", 280, 22);
+    WORD_ENTER(mb_c99_nest_2, "c99-nest block", "src/mirth/codegen.mth", 285, 22);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(280, 22, "1+");
+    WORD_ATOM(285, 22, "1+");
     mw_prim_int_succ();
     decref(var_f);
     WORD_EXIT(mb_c99_nest_2);
 }
 
 static void mb_c99_nest_3 (void) {
-    WORD_ENTER(mb_c99_nest_3, "c99-nest block", "src/mirth/codegen.mth", 282, 22);
+    WORD_ENTER(mb_c99_nest_3, "c99-nest block", "src/mirth/codegen.mth", 287, 22);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(282, 22, "1-");
+    WORD_ATOM(287, 22, "1-");
     mw_prim_int_pred();
     decref(var_f);
     WORD_EXIT(mb_c99_nest_3);
 }
 
 static void mb_c99_indent_1 (void) {
-    WORD_ENTER(mb_c99_indent_1, "c99-indent block", "src/mirth/codegen.mth", 284, 40);
+    WORD_ENTER(mb_c99_indent_1, "c99-indent block", "src/mirth/codegen.mth", 289, 40);
     mw_prim_drop();
-    WORD_ATOM(284, 40, "");
+    WORD_ATOM(289, 40, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40385,15 +40435,15 @@ static void mb_c99_indent_1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(284, 47, ".");
+    WORD_ATOM(289, 47, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_indent_1);
 }
 
 static void mb_c99_call_21__2 (void) {
-    WORD_ENTER(mb_c99_call_21__2, "c99-call! block", "src/mirth/codegen.mth", 289, 14);
+    WORD_ENTER(mb_c99_call_21__2, "c99-call! block", "src/mirth/codegen.mth", 294, 14);
     mw_prim_drop();
-    WORD_ATOM(289, 14, "");
+    WORD_ATOM(294, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40404,11 +40454,11 @@ static void mb_c99_call_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(289, 20, ".");
+    WORD_ATOM(294, 20, ".");
     mw__2E_();
-    WORD_ATOM(289, 22, ".name");
+    WORD_ATOM(294, 22, ".name");
     mw__2E_name();
-    WORD_ATOM(289, 28, "");
+    WORD_ATOM(294, 28, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40419,31 +40469,31 @@ static void mb_c99_call_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(289, 34, ".");
+    WORD_ATOM(294, 34, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_call_21__2);
 }
 
 static void mb_c99_args_push_21__1 (void) {
-    WORD_ENTER(mb_c99_args_push_21__1, "c99-args-push! block", "src/mirth/codegen.mth", 420, 9);
+    WORD_ENTER(mb_c99_args_push_21__1, "c99-args-push! block", "src/mirth/codegen.mth", 439, 9);
     mw_prim_drop();
-    WORD_ATOM(420, 9, "c99-arg-push!");
+    WORD_ATOM(439, 9, "c99-arg-push!");
     mw_c99_arg_push_21_();
     WORD_EXIT(mb_c99_args_push_21__1);
 }
 
 static void mb_c99_arrow_21__1 (void) {
-    WORD_ENTER(mb_c99_arrow_21__1, "c99-arrow! block", "src/mirth/codegen.mth", 291, 37);
+    WORD_ENTER(mb_c99_arrow_21__1, "c99-arrow! block", "src/mirth/codegen.mth", 296, 37);
     mw_prim_drop();
-    WORD_ATOM(291, 37, "c99-atom!");
+    WORD_ATOM(296, 37, "c99-atom!");
     mw_c99_atom_21_();
     WORD_EXIT(mb_c99_arrow_21__1);
 }
 
 static void mb_c99_atom_21__1 (void) {
-    WORD_ENTER(mb_c99_atom_21__1, "c99-atom! block", "src/mirth/codegen.mth", 293, 14);
+    WORD_ENTER(mb_c99_atom_21__1, "c99-atom! block", "src/mirth/codegen.mth", 298, 14);
     mw_prim_drop();
-    WORD_ATOM(293, 14, "");
+    WORD_ATOM(298, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40454,19 +40504,19 @@ static void mb_c99_atom_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(293, 27, ".");
+    WORD_ATOM(298, 27, ".");
     mw__2E_();
-    WORD_ATOM(294, 9, "dup");
+    WORD_ATOM(299, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(294, 13, "token");
+    WORD_ATOM(299, 13, "token");
     mw_Atom_2E_token();
-    WORD_ATOM(294, 19, "row");
+    WORD_ATOM(299, 19, "row");
     mw_Token_2E_row();
-    WORD_ATOM(294, 23, ">Int");
+    WORD_ATOM(299, 23, ">Int");
     mw_Row_3E_Int();
-    WORD_ATOM(294, 28, ".n");
+    WORD_ATOM(299, 28, ".n");
     mw__2E_n();
-    WORD_ATOM(294, 31, "");
+    WORD_ATOM(299, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40477,19 +40527,19 @@ static void mb_c99_atom_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(294, 36, ".");
+    WORD_ATOM(299, 36, ".");
     mw__2E_();
-    WORD_ATOM(295, 9, "dup");
+    WORD_ATOM(300, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(295, 13, "token");
+    WORD_ATOM(300, 13, "token");
     mw_Atom_2E_token();
-    WORD_ATOM(295, 19, "col");
+    WORD_ATOM(300, 19, "col");
     mw_Token_2E_col();
-    WORD_ATOM(295, 23, ">Int");
+    WORD_ATOM(300, 23, ">Int");
     mw_Col_3E_Int();
-    WORD_ATOM(295, 28, ".n");
+    WORD_ATOM(300, 28, ".n");
     mw__2E_n();
-    WORD_ATOM(295, 31, "");
+    WORD_ATOM(300, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40500,15 +40550,15 @@ static void mb_c99_atom_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(295, 36, ".");
+    WORD_ATOM(300, 36, ".");
     mw__2E_();
-    WORD_ATOM(296, 9, "dup");
+    WORD_ATOM(301, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(296, 13, "token");
+    WORD_ATOM(301, 13, "token");
     mw_Atom_2E_token();
-    WORD_ATOM(296, 19, "name?");
+    WORD_ATOM(301, 19, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(296, 25, "if-some");
+    WORD_ATOM(301, 25, "if-some");
     push_u64(0);
     push_fnptr(&mb_c99_atom_21__2);
     mw_prim_pack_cons();
@@ -40516,9 +40566,9 @@ static void mb_c99_atom_21__1 (void) {
     push_fnptr(&mb_c99_atom_21__3);
     mw_prim_pack_cons();
     mw_Maybe_2E_if_some();
-    WORD_ATOM(296, 43, ".str");
+    WORD_ATOM(301, 43, ".str");
     mw__2E_str();
-    WORD_ATOM(297, 9, "");
+    WORD_ATOM(302, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40529,23 +40579,23 @@ static void mb_c99_atom_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(297, 14, ".");
+    WORD_ATOM(302, 14, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_atom_21__1);
 }
 
 static void mb_c99_atom_21__2 (void) {
-    WORD_ENTER(mb_c99_atom_21__2, "c99-atom! block", "src/mirth/codegen.mth", 296, 33);
+    WORD_ENTER(mb_c99_atom_21__2, "c99-atom! block", "src/mirth/codegen.mth", 301, 33);
     mw_prim_drop();
-    WORD_ATOM(296, 33, ">Str");
+    WORD_ATOM(301, 33, ">Str");
     mw_Name_3E_Str();
     WORD_EXIT(mb_c99_atom_21__2);
 }
 
 static void mb_c99_atom_21__3 (void) {
-    WORD_ENTER(mb_c99_atom_21__3, "c99-atom! block", "src/mirth/codegen.mth", 296, 39);
+    WORD_ENTER(mb_c99_atom_21__3, "c99-atom! block", "src/mirth/codegen.mth", 301, 39);
     mw_prim_drop();
-    WORD_ATOM(296, 39, "");
+    WORD_ATOM(301, 39, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40560,25 +40610,25 @@ static void mb_c99_atom_21__3 (void) {
 }
 
 static void mb_c99_atom_21__4 (void) {
-    WORD_ENTER(mb_c99_atom_21__4, "c99-atom! block", "src/mirth/codegen.mth", 298, 9);
+    WORD_ENTER(mb_c99_atom_21__4, "c99-atom! block", "src/mirth/codegen.mth", 303, 9);
     mw_prim_drop();
-    WORD_ATOM(298, 9, "args");
+    WORD_ATOM(303, 9, "args");
     mw_Atom_2E_args();
     WORD_EXIT(mb_c99_atom_21__4);
 }
 
 static void mb__2E_str_1 (void) {
-    WORD_ENTER(mb__2E_str_1, ".str block", "src/mirth/codegen.mth", 349, 40);
+    WORD_ENTER(mb__2E_str_1, ".str block", "src/mirth/codegen.mth", 354, 40);
     mw_prim_drop();
-    WORD_ATOM(349, 40, "c99-string-byte!");
+    WORD_ATOM(354, 40, "c99-string-byte!");
     mw_c99_string_byte_21_();
     WORD_EXIT(mb__2E_str_1);
 }
 
 static void mb_c99_int_21__1 (void) {
-    WORD_ENTER(mb_c99_int_21__1, "c99-int! block", "src/mirth/codegen.mth", 319, 14);
+    WORD_ENTER(mb_c99_int_21__1, "c99-int! block", "src/mirth/codegen.mth", 324, 14);
     mw_prim_drop();
-    WORD_ATOM(319, 14, "");
+    WORD_ATOM(324, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40589,11 +40639,11 @@ static void mb_c99_int_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(319, 26, ".");
+    WORD_ATOM(324, 26, ".");
     mw__2E_();
-    WORD_ATOM(319, 28, ".n");
+    WORD_ATOM(324, 28, ".n");
     mw__2E_n();
-    WORD_ATOM(319, 31, "");
+    WORD_ATOM(324, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40604,15 +40654,15 @@ static void mb_c99_int_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(319, 38, ".");
+    WORD_ATOM(324, 38, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_int_21__1);
 }
 
 static void mb_c99_str_21__1 (void) {
-    WORD_ENTER(mb_c99_str_21__1, "c99-str! block", "src/mirth/codegen.mth", 322, 14);
+    WORD_ENTER(mb_c99_str_21__1, "c99-str! block", "src/mirth/codegen.mth", 327, 14);
     mw_prim_drop();
-    WORD_ATOM(322, 14, "");
+    WORD_ATOM(327, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40623,45 +40673,45 @@ static void mb_c99_str_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(322, 18, ".");
+    WORD_ATOM(327, 18, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_str_21__1);
 }
 
 static void mb_c99_str_21__2 (void) {
-    WORD_ENTER(mb_c99_str_21__2, "c99-str! block", "src/mirth/codegen.mth", 324, 9);
+    WORD_ENTER(mb_c99_str_21__2, "c99-str! block", "src/mirth/codegen.mth", 329, 9);
     mw_prim_drop();
-    WORD_ATOM(324, 9, "c99-line");
+    WORD_ATOM(329, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(325, 9, "c99-line");
+    WORD_ATOM(330, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__4);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(326, 9, "c99-line");
+    WORD_ATOM(331, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__5);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(327, 9, "c99-nest");
+    WORD_ATOM(332, 9, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__6);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(342, 9, "c99-line");
+    WORD_ATOM(347, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__17);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(343, 9, "c99-line");
+    WORD_ATOM(348, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__18);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(344, 9, "c99-line");
+    WORD_ATOM(349, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__19);
     mw_prim_pack_cons();
@@ -40670,9 +40720,9 @@ static void mb_c99_str_21__2 (void) {
 }
 
 static void mb_c99_str_21__3 (void) {
-    WORD_ENTER(mb_c99_str_21__3, "c99-str! block", "src/mirth/codegen.mth", 324, 18);
+    WORD_ENTER(mb_c99_str_21__3, "c99-str! block", "src/mirth/codegen.mth", 329, 18);
     mw_prim_drop();
-    WORD_ATOM(324, 18, "");
+    WORD_ATOM(329, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40683,15 +40733,15 @@ static void mb_c99_str_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(324, 48, ".");
+    WORD_ATOM(329, 48, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_str_21__3);
 }
 
 static void mb_c99_str_21__4 (void) {
-    WORD_ENTER(mb_c99_str_21__4, "c99-str! block", "src/mirth/codegen.mth", 325, 18);
+    WORD_ENTER(mb_c99_str_21__4, "c99-str! block", "src/mirth/codegen.mth", 330, 18);
     mw_prim_drop();
-    WORD_ATOM(325, 18, "");
+    WORD_ATOM(330, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40702,15 +40752,15 @@ static void mb_c99_str_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(325, 34, ".");
+    WORD_ATOM(330, 34, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_str_21__4);
 }
 
 static void mb_c99_str_21__5 (void) {
-    WORD_ENTER(mb_c99_str_21__5, "c99-str! block", "src/mirth/codegen.mth", 326, 18);
+    WORD_ENTER(mb_c99_str_21__5, "c99-str! block", "src/mirth/codegen.mth", 331, 18);
     mw_prim_drop();
-    WORD_ATOM(326, 18, "");
+    WORD_ATOM(331, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40721,25 +40771,25 @@ static void mb_c99_str_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(326, 36, ".");
+    WORD_ATOM(331, 36, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_str_21__5);
 }
 
 static void mb_c99_str_21__6 (void) {
-    WORD_ENTER(mb_c99_str_21__6, "c99-str! block", "src/mirth/codegen.mth", 328, 13);
+    WORD_ENTER(mb_c99_str_21__6, "c99-str! block", "src/mirth/codegen.mth", 333, 13);
     mw_prim_drop();
-    WORD_ATOM(328, 13, "dup");
+    WORD_ATOM(333, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(328, 17, "num-bytes");
+    WORD_ATOM(333, 17, "num-bytes");
     mw_prim_str_num_bytes();
-    WORD_ATOM(328, 27, "");
+    WORD_ATOM(333, 27, "");
     push_i64(4090LL);
-    WORD_ATOM(328, 32, ">");
+    WORD_ATOM(333, 32, ">");
     mw_Int_3E_();
-    WORD_ATOM(328, 34, "if");
+    WORD_ATOM(333, 34, "if");
     if (pop_u64()) {
-        WORD_ATOM(329, 17, "");
+        WORD_ATOM(334, 17, "");
         {
             static bool vready = false;
             static VAL v;
@@ -40750,31 +40800,31 @@ static void mb_c99_str_21__6 (void) {
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(329, 42, ".");
+        WORD_ATOM(334, 42, ".");
         mw__2E_();
-        WORD_ATOM(330, 17, "c99-nest");
+        WORD_ATOM(335, 17, "c99-nest");
         push_u64(0);
         push_fnptr(&mb_c99_str_21__8);
         mw_prim_pack_cons();
         mw_c99_nest();
-        WORD_ATOM(336, 17, "c99-line");
+        WORD_ATOM(341, 17, "c99-line");
         push_u64(0);
         push_fnptr(&mb_c99_str_21__12);
         mw_prim_pack_cons();
         mw_c99_line();
-        WORD_ATOM(337, 17, "c99-line");
+        WORD_ATOM(342, 17, "c99-line");
         push_u64(0);
         push_fnptr(&mb_c99_str_21__13);
         mw_prim_pack_cons();
         mw_c99_line();
     } else {
-        WORD_ATOM(338, 17, "c99-line");
+        WORD_ATOM(343, 17, "c99-line");
         push_u64(0);
         push_fnptr(&mb_c99_str_21__15);
         mw_prim_pack_cons();
         mw_c99_line();
     }
-    WORD_ATOM(340, 13, "c99-line");
+    WORD_ATOM(345, 13, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__16);
     mw_prim_pack_cons();
@@ -40783,32 +40833,32 @@ static void mb_c99_str_21__6 (void) {
 }
 
 static void mb_c99_str_21__8 (void) {
-    WORD_ENTER(mb_c99_str_21__8, "c99-str! block", "src/mirth/codegen.mth", 331, 21);
+    WORD_ENTER(mb_c99_str_21__8, "c99-str! block", "src/mirth/codegen.mth", 336, 21);
     mw_prim_drop();
-    WORD_ATOM(331, 21, "c99-indent");
+    WORD_ATOM(336, 21, "c99-indent");
     mw_c99_indent();
-    WORD_ATOM(331, 32, "dup");
+    WORD_ATOM(336, 32, "dup");
     mw_prim_dup();
-    WORD_ATOM(331, 36, "str-bytes-for");
+    WORD_ATOM(336, 36, "str-bytes-for");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__9);
     mw_prim_pack_cons();
     mw_str_bytes_for();
-    WORD_ATOM(334, 23, ".lf");
+    WORD_ATOM(339, 23, ".lf");
     mw__2E_lf();
     WORD_EXIT(mb_c99_str_21__8);
 }
 
 static void mb_c99_str_21__9 (void) {
-    WORD_ENTER(mb_c99_str_21__9, "c99-str! block", "src/mirth/codegen.mth", 332, 25);
+    WORD_ENTER(mb_c99_str_21__9, "c99-str! block", "src/mirth/codegen.mth", 337, 25);
     mw_prim_drop();
-    WORD_ATOM(332, 25, ">Int");
+    WORD_ATOM(337, 25, ">Int");
     mw_Byte_3E_Int();
-    WORD_ATOM(332, 30, "dup");
+    WORD_ATOM(337, 30, "dup");
     mw_prim_dup();
-    WORD_ATOM(332, 34, ".n");
+    WORD_ATOM(337, 34, ".n");
     mw__2E_n();
-    WORD_ATOM(332, 37, "");
+    WORD_ATOM(337, 37, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40819,29 +40869,29 @@ static void mb_c99_str_21__9 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(332, 41, ".");
+    WORD_ATOM(337, 41, ".");
     mw__2E_();
-    WORD_ATOM(333, 25, "");
+    WORD_ATOM(338, 25, "");
     push_i64(10LL);
-    WORD_ATOM(333, 28, "=");
+    WORD_ATOM(338, 28, "=");
     mw_prim_int_eq();
-    WORD_ATOM(333, 30, "if");
+    WORD_ATOM(338, 30, "if");
     if (pop_u64()) {
-        WORD_ATOM(333, 33, ".lf");
+        WORD_ATOM(338, 33, ".lf");
         mw__2E_lf();
-        WORD_ATOM(333, 37, "c99-indent");
+        WORD_ATOM(338, 37, "c99-indent");
         mw_c99_indent();
     } else {
-        WORD_ATOM(333, 49, "id");
+        WORD_ATOM(338, 49, "id");
         mw_prim_id();
     }
     WORD_EXIT(mb_c99_str_21__9);
 }
 
 static void mb_c99_str_21__12 (void) {
-    WORD_ENTER(mb_c99_str_21__12, "c99-str! block", "src/mirth/codegen.mth", 336, 26);
+    WORD_ENTER(mb_c99_str_21__12, "c99-str! block", "src/mirth/codegen.mth", 341, 26);
     mw_prim_drop();
-    WORD_ATOM(336, 26, "");
+    WORD_ATOM(341, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40852,15 +40902,15 @@ static void mb_c99_str_21__12 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(336, 31, ".");
+    WORD_ATOM(341, 31, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_str_21__12);
 }
 
 static void mb_c99_str_21__13 (void) {
-    WORD_ENTER(mb_c99_str_21__13, "c99-str! block", "src/mirth/codegen.mth", 337, 26);
+    WORD_ENTER(mb_c99_str_21__13, "c99-str! block", "src/mirth/codegen.mth", 342, 26);
     mw_prim_drop();
-    WORD_ATOM(337, 26, "");
+    WORD_ATOM(342, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40871,15 +40921,15 @@ static void mb_c99_str_21__13 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(337, 49, ".");
+    WORD_ATOM(342, 49, ".");
     mw__2E_();
-    WORD_ATOM(337, 51, "dup");
+    WORD_ATOM(342, 51, "dup");
     mw_prim_dup();
-    WORD_ATOM(337, 55, "num-bytes");
+    WORD_ATOM(342, 55, "num-bytes");
     mw_prim_str_num_bytes();
-    WORD_ATOM(337, 65, ".n");
+    WORD_ATOM(342, 65, ".n");
     mw__2E_n();
-    WORD_ATOM(337, 68, "");
+    WORD_ATOM(342, 68, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40890,15 +40940,15 @@ static void mb_c99_str_21__13 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(337, 73, ".");
+    WORD_ATOM(342, 73, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_str_21__13);
 }
 
 static void mb_c99_str_21__15 (void) {
-    WORD_ENTER(mb_c99_str_21__15, "c99-str! block", "src/mirth/codegen.mth", 338, 26);
+    WORD_ENTER(mb_c99_str_21__15, "c99-str! block", "src/mirth/codegen.mth", 343, 26);
     mw_prim_drop();
-    WORD_ATOM(338, 26, "");
+    WORD_ATOM(343, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40909,13 +40959,13 @@ static void mb_c99_str_21__15 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(338, 39, ".");
+    WORD_ATOM(343, 39, ".");
     mw__2E_();
-    WORD_ATOM(338, 41, "dup");
+    WORD_ATOM(343, 41, "dup");
     mw_prim_dup();
-    WORD_ATOM(338, 45, ".str");
+    WORD_ATOM(343, 45, ".str");
     mw__2E_str();
-    WORD_ATOM(338, 50, "");
+    WORD_ATOM(343, 50, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40926,15 +40976,15 @@ static void mb_c99_str_21__15 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(338, 55, ".");
+    WORD_ATOM(343, 55, ".");
     mw__2E_();
-    WORD_ATOM(338, 57, "dup");
+    WORD_ATOM(343, 57, "dup");
     mw_prim_dup();
-    WORD_ATOM(338, 61, "num-bytes");
+    WORD_ATOM(343, 61, "num-bytes");
     mw_prim_str_num_bytes();
-    WORD_ATOM(338, 71, ".n");
+    WORD_ATOM(343, 71, ".n");
     mw__2E_n();
-    WORD_ATOM(338, 74, "");
+    WORD_ATOM(343, 74, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40945,15 +40995,15 @@ static void mb_c99_str_21__15 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(338, 79, ".");
+    WORD_ATOM(343, 79, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_str_21__15);
 }
 
 static void mb_c99_str_21__16 (void) {
-    WORD_ENTER(mb_c99_str_21__16, "c99-str! block", "src/mirth/codegen.mth", 340, 22);
+    WORD_ENTER(mb_c99_str_21__16, "c99-str! block", "src/mirth/codegen.mth", 345, 22);
     mw_prim_drop();
-    WORD_ATOM(340, 22, "");
+    WORD_ATOM(345, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40964,15 +41014,15 @@ static void mb_c99_str_21__16 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(340, 39, ".");
+    WORD_ATOM(345, 39, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_str_21__16);
 }
 
 static void mb_c99_str_21__17 (void) {
-    WORD_ENTER(mb_c99_str_21__17, "c99-str! block", "src/mirth/codegen.mth", 342, 18);
+    WORD_ENTER(mb_c99_str_21__17, "c99-str! block", "src/mirth/codegen.mth", 347, 18);
     mw_prim_drop();
-    WORD_ATOM(342, 18, "");
+    WORD_ATOM(347, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40983,15 +41033,15 @@ static void mb_c99_str_21__17 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(342, 22, ".");
+    WORD_ATOM(347, 22, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_str_21__17);
 }
 
 static void mb_c99_str_21__18 (void) {
-    WORD_ENTER(mb_c99_str_21__18, "c99-str! block", "src/mirth/codegen.mth", 343, 18);
+    WORD_ENTER(mb_c99_str_21__18, "c99-str! block", "src/mirth/codegen.mth", 348, 18);
     mw_prim_drop();
-    WORD_ATOM(343, 18, "");
+    WORD_ATOM(348, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41002,15 +41052,15 @@ static void mb_c99_str_21__18 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(343, 35, ".");
+    WORD_ATOM(348, 35, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_str_21__18);
 }
 
 static void mb_c99_str_21__19 (void) {
-    WORD_ENTER(mb_c99_str_21__19, "c99-str! block", "src/mirth/codegen.mth", 344, 18);
+    WORD_ENTER(mb_c99_str_21__19, "c99-str! block", "src/mirth/codegen.mth", 349, 18);
     mw_prim_drop();
-    WORD_ATOM(344, 18, "");
+    WORD_ATOM(349, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41021,15 +41071,15 @@ static void mb_c99_str_21__19 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(344, 31, ".");
+    WORD_ATOM(349, 31, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_str_21__19);
 }
 
 static void mb_c99_str_21__20 (void) {
-    WORD_ENTER(mb_c99_str_21__20, "c99-str! block", "src/mirth/codegen.mth", 346, 14);
+    WORD_ENTER(mb_c99_str_21__20, "c99-str! block", "src/mirth/codegen.mth", 351, 14);
     mw_prim_drop();
-    WORD_ATOM(346, 14, "");
+    WORD_ATOM(351, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41040,15 +41090,15 @@ static void mb_c99_str_21__20 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(346, 18, ".");
+    WORD_ATOM(351, 18, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_str_21__20);
 }
 
 static void mb_c99_prim_21__3 (void) {
-    WORD_ENTER(mb_c99_prim_21__3, "c99-prim! block", "src/mirth/codegen.mth", 376, 26);
+    WORD_ENTER(mb_c99_prim_21__3, "c99-prim! block", "src/mirth/codegen.mth", 381, 26);
     mw_prim_drop();
-    WORD_ATOM(376, 26, "");
+    WORD_ATOM(381, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41059,22 +41109,22 @@ static void mb_c99_prim_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(376, 30, ".");
+    WORD_ATOM(381, 30, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_prim_21__3);
 }
 
 static void mb_c99_prim_21__4 (void) {
-    WORD_ENTER(mb_c99_prim_21__4, "c99-prim! block", "src/mirth/codegen.mth", 378, 21);
+    WORD_ENTER(mb_c99_prim_21__4, "c99-prim! block", "src/mirth/codegen.mth", 383, 21);
     mw_prim_drop();
-    WORD_ATOM(378, 21, "c99-line");
+    WORD_ATOM(383, 21, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_prim_21__5);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(379, 21, "c99-arg-run!");
+    WORD_ATOM(384, 21, "c99-arg-run!");
     mw_c99_arg_run_21_();
-    WORD_ATOM(380, 21, "c99-line");
+    WORD_ATOM(385, 21, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_prim_21__6);
     mw_prim_pack_cons();
@@ -41083,9 +41133,9 @@ static void mb_c99_prim_21__4 (void) {
 }
 
 static void mb_c99_prim_21__5 (void) {
-    WORD_ENTER(mb_c99_prim_21__5, "c99-prim! block", "src/mirth/codegen.mth", 378, 30);
+    WORD_ENTER(mb_c99_prim_21__5, "c99-prim! block", "src/mirth/codegen.mth", 383, 30);
     mw_prim_drop();
-    WORD_ATOM(378, 30, "");
+    WORD_ATOM(383, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41096,15 +41146,15 @@ static void mb_c99_prim_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(378, 38, ".");
+    WORD_ATOM(383, 38, ".");
     mw__2E_();
-    WORD_ATOM(378, 40, "c99-depth");
+    WORD_ATOM(383, 40, "c99-depth");
     mw_c99_depth();
-    WORD_ATOM(378, 50, "@");
+    WORD_ATOM(383, 50, "@");
     mw_prim_mut_get();
-    WORD_ATOM(378, 52, ".n");
+    WORD_ATOM(383, 52, ".n");
     mw__2E_n();
-    WORD_ATOM(378, 55, "");
+    WORD_ATOM(383, 55, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41115,15 +41165,15 @@ static void mb_c99_prim_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(378, 73, ".");
+    WORD_ATOM(383, 73, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_prim_21__5);
 }
 
 static void mb_c99_prim_21__6 (void) {
-    WORD_ENTER(mb_c99_prim_21__6, "c99-prim! block", "src/mirth/codegen.mth", 380, 30);
+    WORD_ENTER(mb_c99_prim_21__6, "c99-prim! block", "src/mirth/codegen.mth", 385, 30);
     mw_prim_drop();
-    WORD_ATOM(380, 30, "");
+    WORD_ATOM(385, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41134,15 +41184,15 @@ static void mb_c99_prim_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(380, 45, ".");
+    WORD_ATOM(385, 45, ".");
     mw__2E_();
-    WORD_ATOM(380, 47, "c99-depth");
+    WORD_ATOM(385, 47, "c99-depth");
     mw_c99_depth();
-    WORD_ATOM(380, 57, "@");
+    WORD_ATOM(385, 57, "@");
     mw_prim_mut_get();
-    WORD_ATOM(380, 59, ".n");
+    WORD_ATOM(385, 59, ".n");
     mw__2E_n();
-    WORD_ATOM(380, 62, "");
+    WORD_ATOM(385, 62, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41153,15 +41203,15 @@ static void mb_c99_prim_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(380, 67, ".");
+    WORD_ATOM(385, 67, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_prim_21__6);
 }
 
 static void mb_c99_prim_21__7 (void) {
-    WORD_ENTER(mb_c99_prim_21__7, "c99-prim! block", "src/mirth/codegen.mth", 382, 26);
+    WORD_ENTER(mb_c99_prim_21__7, "c99-prim! block", "src/mirth/codegen.mth", 387, 26);
     mw_prim_drop();
-    WORD_ATOM(382, 26, "");
+    WORD_ATOM(387, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41172,15 +41222,147 @@ static void mb_c99_prim_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(382, 30, ".");
+    WORD_ATOM(387, 30, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_prim_21__7);
 }
 
 static void mb_c99_prim_21__11 (void) {
-    WORD_ENTER(mb_c99_prim_21__11, "c99-prim! block", "src/mirth/codegen.mth", 390, 26);
+    WORD_ENTER(mb_c99_prim_21__11, "c99-prim! block", "src/mirth/codegen.mth", 395, 26);
     mw_prim_drop();
-    WORD_ATOM(390, 26, "");
+    WORD_ATOM(395, 26, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("{", 1);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(395, 30, ".");
+    mw__2E_();
+    WORD_EXIT(mb_c99_prim_21__11);
+}
+
+static void mb_c99_prim_21__12 (void) {
+    WORD_ENTER(mb_c99_prim_21__12, "c99-prim! block", "src/mirth/codegen.mth", 397, 21);
+    mw_prim_drop();
+    WORD_ATOM(397, 21, "c99-line");
+    push_u64(0);
+    push_fnptr(&mb_c99_prim_21__13);
+    mw_prim_pack_cons();
+    mw_c99_line();
+    WORD_ATOM(398, 21, "c99-arg-run!");
+    mw_c99_arg_run_21_();
+    WORD_ATOM(399, 21, "c99-line");
+    push_u64(0);
+    push_fnptr(&mb_c99_prim_21__14);
+    mw_prim_pack_cons();
+    mw_c99_line();
+    WORD_EXIT(mb_c99_prim_21__12);
+}
+
+static void mb_c99_prim_21__13 (void) {
+    WORD_ENTER(mb_c99_prim_21__13, "c99-prim! block", "src/mirth/codegen.mth", 397, 30);
+    mw_prim_drop();
+    WORD_ATOM(397, 30, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("VAL d", 5);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(397, 38, ".");
+    mw__2E_();
+    WORD_ATOM(397, 40, "c99-depth");
+    mw_c99_depth();
+    WORD_ATOM(397, 50, "@");
+    mw_prim_mut_get();
+    WORD_ATOM(397, 52, ".n");
+    mw__2E_n();
+    WORD_ATOM(397, 55, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr(" = pop_resource();", 18);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(397, 76, ".");
+    mw__2E_();
+    WORD_EXIT(mb_c99_prim_21__13);
+}
+
+static void mb_c99_prim_21__14 (void) {
+    WORD_ENTER(mb_c99_prim_21__14, "c99-prim! block", "src/mirth/codegen.mth", 399, 30);
+    mw_prim_drop();
+    WORD_ATOM(399, 30, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("push_resource(d", 15);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(399, 48, ".");
+    mw__2E_();
+    WORD_ATOM(399, 50, "c99-depth");
+    mw_c99_depth();
+    WORD_ATOM(399, 60, "@");
+    mw_prim_mut_get();
+    WORD_ATOM(399, 62, ".n");
+    mw__2E_n();
+    WORD_ATOM(399, 65, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr(");", 2);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(399, 70, ".");
+    mw__2E_();
+    WORD_EXIT(mb_c99_prim_21__14);
+}
+
+static void mb_c99_prim_21__15 (void) {
+    WORD_ENTER(mb_c99_prim_21__15, "c99-prim! block", "src/mirth/codegen.mth", 401, 26);
+    mw_prim_drop();
+    WORD_ATOM(401, 26, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("}", 1);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(401, 30, ".");
+    mw__2E_();
+    WORD_EXIT(mb_c99_prim_21__15);
+}
+
+static void mb_c99_prim_21__19 (void) {
+    WORD_ENTER(mb_c99_prim_21__19, "c99-prim! block", "src/mirth/codegen.mth", 409, 26);
+    mw_prim_drop();
+    WORD_ATOM(409, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41191,25 +41373,25 @@ static void mb_c99_prim_21__11 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(390, 45, ".");
+    WORD_ATOM(409, 45, ".");
     mw__2E_();
-    WORD_EXIT(mb_c99_prim_21__11);
+    WORD_EXIT(mb_c99_prim_21__19);
 }
 
-static void mb_c99_prim_21__12 (void) {
-    WORD_ENTER(mb_c99_prim_21__12, "c99-prim! block", "src/mirth/codegen.mth", 391, 26);
+static void mb_c99_prim_21__20 (void) {
+    WORD_ENTER(mb_c99_prim_21__20, "c99-prim! block", "src/mirth/codegen.mth", 410, 26);
     mw_prim_drop();
-    WORD_ATOM(391, 26, "swap");
+    WORD_ATOM(410, 26, "swap");
     mw_prim_swap();
-    WORD_ATOM(391, 31, "c99-arg-run!");
+    WORD_ATOM(410, 31, "c99-arg-run!");
     mw_c99_arg_run_21_();
-    WORD_EXIT(mb_c99_prim_21__12);
+    WORD_EXIT(mb_c99_prim_21__20);
 }
 
-static void mb_c99_prim_21__13 (void) {
-    WORD_ENTER(mb_c99_prim_21__13, "c99-prim! block", "src/mirth/codegen.mth", 392, 26);
+static void mb_c99_prim_21__21 (void) {
+    WORD_ENTER(mb_c99_prim_21__21, "c99-prim! block", "src/mirth/codegen.mth", 411, 26);
     mw_prim_drop();
-    WORD_ATOM(392, 26, "");
+    WORD_ATOM(411, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41220,23 +41402,23 @@ static void mb_c99_prim_21__13 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(392, 37, ".");
+    WORD_ATOM(411, 37, ".");
     mw__2E_();
-    WORD_EXIT(mb_c99_prim_21__13);
+    WORD_EXIT(mb_c99_prim_21__21);
 }
 
-static void mb_c99_prim_21__14 (void) {
-    WORD_ENTER(mb_c99_prim_21__14, "c99-prim! block", "src/mirth/codegen.mth", 393, 26);
+static void mb_c99_prim_21__22 (void) {
+    WORD_ENTER(mb_c99_prim_21__22, "c99-prim! block", "src/mirth/codegen.mth", 412, 26);
     mw_prim_drop();
-    WORD_ATOM(393, 26, "c99-arg-run!");
+    WORD_ATOM(412, 26, "c99-arg-run!");
     mw_c99_arg_run_21_();
-    WORD_EXIT(mb_c99_prim_21__14);
+    WORD_EXIT(mb_c99_prim_21__22);
 }
 
-static void mb_c99_prim_21__15 (void) {
-    WORD_ENTER(mb_c99_prim_21__15, "c99-prim! block", "src/mirth/codegen.mth", 394, 26);
+static void mb_c99_prim_21__23 (void) {
+    WORD_ENTER(mb_c99_prim_21__23, "c99-prim! block", "src/mirth/codegen.mth", 413, 26);
     mw_prim_drop();
-    WORD_ATOM(394, 26, "");
+    WORD_ATOM(413, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41247,15 +41429,15 @@ static void mb_c99_prim_21__15 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(394, 30, ".");
+    WORD_ATOM(413, 30, ".");
     mw__2E_();
-    WORD_EXIT(mb_c99_prim_21__15);
+    WORD_EXIT(mb_c99_prim_21__23);
 }
 
-static void mb_c99_prim_21__19 (void) {
-    WORD_ENTER(mb_c99_prim_21__19, "c99-prim! block", "src/mirth/codegen.mth", 402, 26);
+static void mb_c99_prim_21__27 (void) {
+    WORD_ENTER(mb_c99_prim_21__27, "c99-prim! block", "src/mirth/codegen.mth", 421, 26);
     mw_prim_drop();
-    WORD_ATOM(402, 26, "");
+    WORD_ATOM(421, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41266,32 +41448,32 @@ static void mb_c99_prim_21__19 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(402, 39, ".");
+    WORD_ATOM(421, 39, ".");
     mw__2E_();
-    WORD_EXIT(mb_c99_prim_21__19);
+    WORD_EXIT(mb_c99_prim_21__27);
 }
 
-static void mb_c99_prim_21__20 (void) {
-    WORD_ENTER(mb_c99_prim_21__20, "c99-prim! block", "src/mirth/codegen.mth", 404, 21);
+static void mb_c99_prim_21__28 (void) {
+    WORD_ENTER(mb_c99_prim_21__28, "c99-prim! block", "src/mirth/codegen.mth", 423, 21);
     mw_prim_drop();
-    WORD_ATOM(404, 21, "swap");
+    WORD_ATOM(423, 21, "swap");
     mw_prim_swap();
-    WORD_ATOM(404, 26, "c99-arg-run!");
+    WORD_ATOM(423, 26, "c99-arg-run!");
     mw_c99_arg_run_21_();
-    WORD_ATOM(405, 21, "c99-line");
+    WORD_ATOM(424, 21, "c99-line");
     push_u64(0);
-    push_fnptr(&mb_c99_prim_21__21);
+    push_fnptr(&mb_c99_prim_21__29);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(406, 21, "c99-arg-run!");
+    WORD_ATOM(425, 21, "c99-arg-run!");
     mw_c99_arg_run_21_();
-    WORD_EXIT(mb_c99_prim_21__20);
+    WORD_EXIT(mb_c99_prim_21__28);
 }
 
-static void mb_c99_prim_21__21 (void) {
-    WORD_ENTER(mb_c99_prim_21__21, "c99-prim! block", "src/mirth/codegen.mth", 405, 30);
+static void mb_c99_prim_21__29 (void) {
+    WORD_ENTER(mb_c99_prim_21__29, "c99-prim! block", "src/mirth/codegen.mth", 424, 30);
     mw_prim_drop();
-    WORD_ATOM(405, 30, "");
+    WORD_ATOM(424, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41302,15 +41484,15 @@ static void mb_c99_prim_21__21 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(405, 56, ".");
+    WORD_ATOM(424, 56, ".");
     mw__2E_();
-    WORD_EXIT(mb_c99_prim_21__21);
+    WORD_EXIT(mb_c99_prim_21__29);
 }
 
-static void mb_c99_prim_21__22 (void) {
-    WORD_ENTER(mb_c99_prim_21__22, "c99-prim! block", "src/mirth/codegen.mth", 408, 26);
+static void mb_c99_prim_21__30 (void) {
+    WORD_ENTER(mb_c99_prim_21__30, "c99-prim! block", "src/mirth/codegen.mth", 427, 26);
     mw_prim_drop();
-    WORD_ATOM(408, 26, "");
+    WORD_ATOM(427, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41321,17 +41503,17 @@ static void mb_c99_prim_21__22 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(408, 30, ".");
+    WORD_ATOM(427, 30, ".");
     mw__2E_();
-    WORD_EXIT(mb_c99_prim_21__22);
+    WORD_EXIT(mb_c99_prim_21__30);
 }
 
 static void mb_c99_match_21__3 (void) {
-    WORD_ENTER(mb_c99_match_21__3, "c99-match! block", "src/mirth/codegen.mth", 493, 19);
+    WORD_ENTER(mb_c99_match_21__3, "c99-match! block", "src/mirth/codegen.mth", 512, 19);
     mw_prim_drop();
-    WORD_ATOM(493, 19, "token");
+    WORD_ATOM(512, 19, "token");
     mw_Match_2E_token();
-    WORD_ATOM(493, 25, "");
+    WORD_ATOM(512, 25, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41342,15 +41524,15 @@ static void mb_c99_match_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(493, 71, "emit-fatal-error!");
+    WORD_ATOM(512, 71, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_c99_match_21__3);
 }
 
 static void mb_c99_match_21__5 (void) {
-    WORD_ENTER(mb_c99_match_21__5, "c99-match! block", "src/mirth/codegen.mth", 495, 22);
+    WORD_ENTER(mb_c99_match_21__5, "c99-match! block", "src/mirth/codegen.mth", 514, 22);
     mw_prim_drop();
-    WORD_ATOM(495, 22, "");
+    WORD_ATOM(514, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41361,15 +41543,15 @@ static void mb_c99_match_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(495, 63, ".");
+    WORD_ATOM(514, 63, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_match_21__5);
 }
 
 static void mb_c99_match_21__7 (void) {
-    WORD_ENTER(mb_c99_match_21__7, "c99-match! block", "src/mirth/codegen.mth", 496, 22);
+    WORD_ENTER(mb_c99_match_21__7, "c99-match! block", "src/mirth/codegen.mth", 515, 22);
     mw_prim_drop();
-    WORD_ATOM(496, 22, "");
+    WORD_ATOM(515, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41380,26 +41562,26 @@ static void mb_c99_match_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(496, 54, ".");
+    WORD_ATOM(515, 54, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_match_21__7);
 }
 
 static void mb_c99_match_21__8 (void) {
-    WORD_ENTER(mb_c99_match_21__8, "c99-match! block", "src/mirth/codegen.mth", 499, 13);
+    WORD_ENTER(mb_c99_match_21__8, "c99-match! block", "src/mirth/codegen.mth", 518, 13);
     mw_prim_drop();
-    WORD_ATOM(499, 13, "dup");
+    WORD_ATOM(518, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(499, 17, "cases");
+    WORD_ATOM(518, 17, "cases");
     mw_Match_2E_cases();
-    WORD_ATOM(499, 23, "for");
+    WORD_ATOM(518, 23, "for");
     push_u64(0);
     push_fnptr(&mb_c99_match_21__9);
     mw_prim_pack_cons();
     mw_List_2E_for();
-    WORD_ATOM(500, 13, "has-default-case?");
+    WORD_ATOM(519, 13, "has-default-case?");
     mw_Match_2E_has_default_case_3F_();
-    WORD_ATOM(500, 31, "else");
+    WORD_ATOM(519, 31, "else");
     push_u64(0);
     push_fnptr(&mb_c99_match_21__10);
     mw_prim_pack_cons();
@@ -41408,17 +41590,17 @@ static void mb_c99_match_21__8 (void) {
 }
 
 static void mb_c99_match_21__9 (void) {
-    WORD_ENTER(mb_c99_match_21__9, "c99-match! block", "src/mirth/codegen.mth", 499, 27);
+    WORD_ENTER(mb_c99_match_21__9, "c99-match! block", "src/mirth/codegen.mth", 518, 27);
     mw_prim_drop();
-    WORD_ATOM(499, 27, "c99-case!");
+    WORD_ATOM(518, 27, "c99-case!");
     mw_c99_case_21_();
     WORD_EXIT(mb_c99_match_21__9);
 }
 
 static void mb_c99_match_21__10 (void) {
-    WORD_ENTER(mb_c99_match_21__10, "c99-match! block", "src/mirth/codegen.mth", 501, 17);
+    WORD_ENTER(mb_c99_match_21__10, "c99-match! block", "src/mirth/codegen.mth", 520, 17);
     mw_prim_drop();
-    WORD_ATOM(501, 17, "c99-line");
+    WORD_ATOM(520, 17, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_match_21__11);
     mw_prim_pack_cons();
@@ -41427,9 +41609,9 @@ static void mb_c99_match_21__10 (void) {
 }
 
 static void mb_c99_match_21__11 (void) {
-    WORD_ENTER(mb_c99_match_21__11, "c99-match! block", "src/mirth/codegen.mth", 501, 26);
+    WORD_ENTER(mb_c99_match_21__11, "c99-match! block", "src/mirth/codegen.mth", 520, 26);
     mw_prim_drop();
-    WORD_ATOM(501, 26, "");
+    WORD_ATOM(520, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41440,15 +41622,15 @@ static void mb_c99_match_21__11 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(501, 118, ".");
+    WORD_ATOM(520, 118, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_match_21__11);
 }
 
 static void mb_c99_match_21__12 (void) {
-    WORD_ENTER(mb_c99_match_21__12, "c99-match! block", "src/mirth/codegen.mth", 504, 18);
+    WORD_ENTER(mb_c99_match_21__12, "c99-match! block", "src/mirth/codegen.mth", 523, 18);
     mw_prim_drop();
-    WORD_ATOM(504, 18, "");
+    WORD_ATOM(523, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41463,9 +41645,9 @@ static void mb_c99_match_21__12 (void) {
 }
 
 static void mb_c99_lambda_21__1 (void) {
-    WORD_ENTER(mb_c99_lambda_21__1, "c99-lambda! block", "src/mirth/codegen.mth", 476, 14);
+    WORD_ENTER(mb_c99_lambda_21__1, "c99-lambda! block", "src/mirth/codegen.mth", 495, 14);
     mw_prim_drop();
-    WORD_ATOM(476, 14, "");
+    WORD_ATOM(495, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41476,32 +41658,32 @@ static void mb_c99_lambda_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(476, 18, ".");
+    WORD_ATOM(495, 18, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_lambda_21__1);
 }
 
 static void mb_c99_lambda_21__2 (void) {
-    WORD_ENTER(mb_c99_lambda_21__2, "c99-lambda! block", "src/mirth/codegen.mth", 478, 9);
+    WORD_ENTER(mb_c99_lambda_21__2, "c99-lambda! block", "src/mirth/codegen.mth", 497, 9);
     mw_prim_drop();
-    WORD_ATOM(478, 9, "dup");
+    WORD_ATOM(497, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(478, 13, "params");
+    WORD_ATOM(497, 13, "params");
     mw_Lambda_2E_params();
-    WORD_ATOM(478, 20, "reverse-for");
+    WORD_ATOM(497, 20, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__3);
     mw_prim_pack_cons();
     mw_List_2E_reverse_for();
-    WORD_ATOM(481, 9, "dup");
+    WORD_ATOM(500, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(481, 13, "body");
+    WORD_ATOM(500, 13, "body");
     mw_Lambda_2E_body();
-    WORD_ATOM(481, 18, "c99-arrow!");
+    WORD_ATOM(500, 18, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(482, 9, "params");
+    WORD_ATOM(501, 9, "params");
     mw_Lambda_2E_params();
-    WORD_ATOM(482, 16, "reverse-for");
+    WORD_ATOM(501, 16, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__5);
     mw_prim_pack_cons();
@@ -41510,9 +41692,9 @@ static void mb_c99_lambda_21__2 (void) {
 }
 
 static void mb_c99_lambda_21__3 (void) {
-    WORD_ENTER(mb_c99_lambda_21__3, "c99-lambda! block", "src/mirth/codegen.mth", 479, 13);
+    WORD_ENTER(mb_c99_lambda_21__3, "c99-lambda! block", "src/mirth/codegen.mth", 498, 13);
     mw_prim_drop();
-    WORD_ATOM(479, 13, "c99-line");
+    WORD_ATOM(498, 13, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__4);
     mw_prim_pack_cons();
@@ -41521,9 +41703,9 @@ static void mb_c99_lambda_21__3 (void) {
 }
 
 static void mb_c99_lambda_21__4 (void) {
-    WORD_ENTER(mb_c99_lambda_21__4, "c99-lambda! block", "src/mirth/codegen.mth", 479, 22);
+    WORD_ENTER(mb_c99_lambda_21__4, "c99-lambda! block", "src/mirth/codegen.mth", 498, 22);
     mw_prim_drop();
-    WORD_ATOM(479, 22, "");
+    WORD_ATOM(498, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41534,11 +41716,11 @@ static void mb_c99_lambda_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(479, 29, ".");
+    WORD_ATOM(498, 29, ".");
     mw__2E_();
-    WORD_ATOM(479, 31, ".param");
+    WORD_ATOM(498, 31, ".param");
     mw__2E_param();
-    WORD_ATOM(479, 38, "");
+    WORD_ATOM(498, 38, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41549,15 +41731,15 @@ static void mb_c99_lambda_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(479, 56, ".");
+    WORD_ATOM(498, 56, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_lambda_21__4);
 }
 
 static void mb_c99_lambda_21__5 (void) {
-    WORD_ENTER(mb_c99_lambda_21__5, "c99-lambda! block", "src/mirth/codegen.mth", 483, 13);
+    WORD_ENTER(mb_c99_lambda_21__5, "c99-lambda! block", "src/mirth/codegen.mth", 502, 13);
     mw_prim_drop();
-    WORD_ATOM(483, 13, "c99-line");
+    WORD_ATOM(502, 13, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__6);
     mw_prim_pack_cons();
@@ -41566,9 +41748,9 @@ static void mb_c99_lambda_21__5 (void) {
 }
 
 static void mb_c99_lambda_21__6 (void) {
-    WORD_ENTER(mb_c99_lambda_21__6, "c99-lambda! block", "src/mirth/codegen.mth", 483, 22);
+    WORD_ENTER(mb_c99_lambda_21__6, "c99-lambda! block", "src/mirth/codegen.mth", 502, 22);
     mw_prim_drop();
-    WORD_ATOM(483, 22, "");
+    WORD_ATOM(502, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41579,11 +41761,11 @@ static void mb_c99_lambda_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(483, 32, ".");
+    WORD_ATOM(502, 32, ".");
     mw__2E_();
-    WORD_ATOM(483, 34, ".param");
+    WORD_ATOM(502, 34, ".param");
     mw__2E_param();
-    WORD_ATOM(483, 41, "");
+    WORD_ATOM(502, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41594,15 +41776,15 @@ static void mb_c99_lambda_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(483, 46, ".");
+    WORD_ATOM(502, 46, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_lambda_21__6);
 }
 
 static void mb_c99_lambda_21__7 (void) {
-    WORD_ENTER(mb_c99_lambda_21__7, "c99-lambda! block", "src/mirth/codegen.mth", 486, 14);
+    WORD_ENTER(mb_c99_lambda_21__7, "c99-lambda! block", "src/mirth/codegen.mth", 505, 14);
     mw_prim_drop();
-    WORD_ATOM(486, 14, "");
+    WORD_ATOM(505, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41613,15 +41795,15 @@ static void mb_c99_lambda_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(486, 18, ".");
+    WORD_ATOM(505, 18, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_lambda_21__7);
 }
 
 static void mb_c99_block_push_21__3 (void) {
-    WORD_ENTER(mb_c99_block_push_21__3, "c99-block-push! block", "src/mirth/codegen.mth", 458, 22);
+    WORD_ENTER(mb_c99_block_push_21__3, "c99-block-push! block", "src/mirth/codegen.mth", 477, 22);
     mw_prim_drop();
-    WORD_ATOM(458, 22, "");
+    WORD_ATOM(477, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41632,11 +41814,11 @@ static void mb_c99_block_push_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(458, 37, ".");
+    WORD_ATOM(477, 37, ".");
     mw__2E_();
-    WORD_ATOM(458, 39, ".block");
+    WORD_ATOM(477, 39, ".block");
     mw__2E_block();
-    WORD_ATOM(458, 46, "");
+    WORD_ATOM(477, 46, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41647,15 +41829,15 @@ static void mb_c99_block_push_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(458, 51, ".");
+    WORD_ATOM(477, 51, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_block_push_21__3);
 }
 
 static void mb_c99_block_push_21__4 (void) {
-    WORD_ENTER(mb_c99_block_push_21__4, "c99-block-push! block", "src/mirth/codegen.mth", 459, 22);
+    WORD_ENTER(mb_c99_block_push_21__4, "c99-block-push! block", "src/mirth/codegen.mth", 478, 22);
     mw_prim_drop();
-    WORD_ATOM(459, 22, "");
+    WORD_ATOM(478, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41666,15 +41848,15 @@ static void mb_c99_block_push_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(459, 45, ".");
+    WORD_ATOM(478, 45, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_block_push_21__4);
 }
 
 static void mb_c99_pack_ctx_21__1 (void) {
-    WORD_ENTER(mb_c99_pack_ctx_21__1, "c99-pack-ctx! block", "src/mirth/codegen.mth", 435, 14);
+    WORD_ENTER(mb_c99_pack_ctx_21__1, "c99-pack-ctx! block", "src/mirth/codegen.mth", 454, 14);
     mw_prim_drop();
-    WORD_ATOM(435, 14, "");
+    WORD_ATOM(454, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41685,17 +41867,17 @@ static void mb_c99_pack_ctx_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(435, 29, ".");
+    WORD_ATOM(454, 29, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_pack_ctx_21__1);
 }
 
 static void mb_c99_pack_ctx_21__2 (void) {
-    WORD_ENTER(mb_c99_pack_ctx_21__2, "c99-pack-ctx! block", "src/mirth/codegen.mth", 437, 9);
+    WORD_ENTER(mb_c99_pack_ctx_21__2, "c99-pack-ctx! block", "src/mirth/codegen.mth", 456, 9);
     mw_prim_drop();
-    WORD_ATOM(437, 9, "c99-var-push!");
+    WORD_ATOM(456, 9, "c99-var-push!");
     mw_c99_var_push_21_();
-    WORD_ATOM(438, 9, "c99-line");
+    WORD_ATOM(457, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_pack_ctx_21__3);
     mw_prim_pack_cons();
@@ -41704,9 +41886,9 @@ static void mb_c99_pack_ctx_21__2 (void) {
 }
 
 static void mb_c99_pack_ctx_21__3 (void) {
-    WORD_ENTER(mb_c99_pack_ctx_21__3, "c99-pack-ctx! block", "src/mirth/codegen.mth", 438, 18);
+    WORD_ENTER(mb_c99_pack_ctx_21__3, "c99-pack-ctx! block", "src/mirth/codegen.mth", 457, 18);
     mw_prim_drop();
-    WORD_ATOM(438, 18, "");
+    WORD_ATOM(457, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41717,15 +41899,15 @@ static void mb_c99_pack_ctx_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(438, 41, ".");
+    WORD_ATOM(457, 41, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_pack_ctx_21__3);
 }
 
 static void mb_c99_var_push_21__1 (void) {
-    WORD_ENTER(mb_c99_var_push_21__1, "c99-var-push! block", "src/mirth/codegen.mth", 471, 14);
+    WORD_ENTER(mb_c99_var_push_21__1, "c99-var-push! block", "src/mirth/codegen.mth", 490, 14);
     mw_prim_drop();
-    WORD_ATOM(471, 14, "");
+    WORD_ATOM(490, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41736,13 +41918,13 @@ static void mb_c99_var_push_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(471, 24, ".");
+    WORD_ATOM(490, 24, ".");
     mw__2E_();
-    WORD_ATOM(471, 26, "dup");
+    WORD_ATOM(490, 26, "dup");
     mw_prim_dup();
-    WORD_ATOM(471, 30, ".var");
+    WORD_ATOM(490, 30, ".var");
     mw__2E_var();
-    WORD_ATOM(471, 35, "");
+    WORD_ATOM(490, 35, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41753,15 +41935,15 @@ static void mb_c99_var_push_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(471, 40, ".");
+    WORD_ATOM(490, 40, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_var_push_21__1);
 }
 
 static void mb_c99_var_push_21__2 (void) {
-    WORD_ENTER(mb_c99_var_push_21__2, "c99-var-push! block", "src/mirth/codegen.mth", 472, 14);
+    WORD_ENTER(mb_c99_var_push_21__2, "c99-var-push! block", "src/mirth/codegen.mth", 491, 14);
     mw_prim_drop();
-    WORD_ATOM(472, 14, "");
+    WORD_ATOM(491, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41772,13 +41954,13 @@ static void mb_c99_var_push_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(472, 28, ".");
+    WORD_ATOM(491, 28, ".");
     mw__2E_();
-    WORD_ATOM(472, 30, "dup");
+    WORD_ATOM(491, 30, "dup");
     mw_prim_dup();
-    WORD_ATOM(472, 34, ".var");
+    WORD_ATOM(491, 34, ".var");
     mw__2E_var();
-    WORD_ATOM(472, 39, "");
+    WORD_ATOM(491, 39, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41789,20 +41971,20 @@ static void mb_c99_var_push_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(472, 44, ".");
+    WORD_ATOM(491, 44, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_var_push_21__2);
 }
 
 static void mb_c99_unpack_ctx_21__1 (void) {
-    WORD_ENTER(mb_c99_unpack_ctx_21__1, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 443, 9);
+    WORD_ENTER(mb_c99_unpack_ctx_21__1, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 462, 9);
     mw_prim_drop();
-    WORD_ATOM(443, 9, "c99-line");
+    WORD_ATOM(462, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_unpack_ctx_21__2);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(444, 9, "c99-line");
+    WORD_ATOM(463, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_unpack_ctx_21__3);
     mw_prim_pack_cons();
@@ -41811,9 +41993,9 @@ static void mb_c99_unpack_ctx_21__1 (void) {
 }
 
 static void mb_c99_unpack_ctx_21__2 (void) {
-    WORD_ENTER(mb_c99_unpack_ctx_21__2, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 443, 18);
+    WORD_ENTER(mb_c99_unpack_ctx_21__2, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 462, 18);
     mw_prim_drop();
-    WORD_ATOM(443, 18, "");
+    WORD_ATOM(462, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41824,15 +42006,15 @@ static void mb_c99_unpack_ctx_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(443, 43, ".");
+    WORD_ATOM(462, 43, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_unpack_ctx_21__2);
 }
 
 static void mb_c99_unpack_ctx_21__3 (void) {
-    WORD_ENTER(mb_c99_unpack_ctx_21__3, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 444, 18);
+    WORD_ENTER(mb_c99_unpack_ctx_21__3, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 463, 18);
     mw_prim_drop();
-    WORD_ATOM(444, 18, "");
+    WORD_ATOM(463, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41843,11 +42025,11 @@ static void mb_c99_unpack_ctx_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(444, 25, ".");
+    WORD_ATOM(463, 25, ".");
     mw__2E_();
-    WORD_ATOM(444, 27, ".var");
+    WORD_ATOM(463, 27, ".var");
     mw__2E_var();
-    WORD_ATOM(444, 32, "");
+    WORD_ATOM(463, 32, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41858,15 +42040,15 @@ static void mb_c99_unpack_ctx_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(444, 50, ".");
+    WORD_ATOM(463, 50, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_unpack_ctx_21__3);
 }
 
 static void mb_c99_unpack_ctx_21__4 (void) {
-    WORD_ENTER(mb_c99_unpack_ctx_21__4, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 446, 14);
+    WORD_ENTER(mb_c99_unpack_ctx_21__4, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 465, 14);
     mw_prim_drop();
-    WORD_ATOM(446, 14, "");
+    WORD_ATOM(465, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41877,15 +42059,15 @@ static void mb_c99_unpack_ctx_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(446, 32, ".");
+    WORD_ATOM(465, 32, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_unpack_ctx_21__4);
 }
 
 static void mb_c99_decref_ctx_21__1 (void) {
-    WORD_ENTER(mb_c99_decref_ctx_21__1, "c99-decref-ctx! block", "src/mirth/codegen.mth", 450, 9);
+    WORD_ENTER(mb_c99_decref_ctx_21__1, "c99-decref-ctx! block", "src/mirth/codegen.mth", 469, 9);
     mw_prim_drop();
-    WORD_ATOM(450, 9, "c99-line");
+    WORD_ATOM(469, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_decref_ctx_21__2);
     mw_prim_pack_cons();
@@ -41894,9 +42076,9 @@ static void mb_c99_decref_ctx_21__1 (void) {
 }
 
 static void mb_c99_decref_ctx_21__2 (void) {
-    WORD_ENTER(mb_c99_decref_ctx_21__2, "c99-decref-ctx! block", "src/mirth/codegen.mth", 450, 18);
+    WORD_ENTER(mb_c99_decref_ctx_21__2, "c99-decref-ctx! block", "src/mirth/codegen.mth", 469, 18);
     mw_prim_drop();
-    WORD_ATOM(450, 18, "");
+    WORD_ATOM(469, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41907,11 +42089,11 @@ static void mb_c99_decref_ctx_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(450, 28, ".");
+    WORD_ATOM(469, 28, ".");
     mw__2E_();
-    WORD_ATOM(450, 30, ".var");
+    WORD_ATOM(469, 30, ".var");
     mw__2E_var();
-    WORD_ATOM(450, 35, "");
+    WORD_ATOM(469, 35, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41922,15 +42104,15 @@ static void mb_c99_decref_ctx_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(450, 40, ".");
+    WORD_ATOM(469, 40, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_decref_ctx_21__2);
 }
 
 static void mb_c99_var_run_21__1 (void) {
-    WORD_ENTER(mb_c99_var_run_21__1, "c99-var-run! block", "src/mirth/codegen.mth", 466, 14);
+    WORD_ENTER(mb_c99_var_run_21__1, "c99-var-run! block", "src/mirth/codegen.mth", 485, 14);
     mw_prim_drop();
-    WORD_ATOM(466, 14, "");
+    WORD_ATOM(485, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41941,13 +42123,13 @@ static void mb_c99_var_run_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(466, 24, ".");
+    WORD_ATOM(485, 24, ".");
     mw__2E_();
-    WORD_ATOM(466, 26, "dup");
+    WORD_ATOM(485, 26, "dup");
     mw_prim_dup();
-    WORD_ATOM(466, 30, ".var");
+    WORD_ATOM(485, 30, ".var");
     mw__2E_var();
-    WORD_ATOM(466, 35, "");
+    WORD_ATOM(485, 35, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41958,15 +42140,15 @@ static void mb_c99_var_run_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(466, 40, ".");
+    WORD_ATOM(485, 40, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_var_run_21__1);
 }
 
 static void mb_c99_var_run_21__2 (void) {
-    WORD_ENTER(mb_c99_var_run_21__2, "c99-var-run! block", "src/mirth/codegen.mth", 467, 14);
+    WORD_ENTER(mb_c99_var_run_21__2, "c99-var-run! block", "src/mirth/codegen.mth", 486, 14);
     mw_prim_drop();
-    WORD_ATOM(467, 14, "");
+    WORD_ATOM(486, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41977,13 +42159,13 @@ static void mb_c99_var_run_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(467, 27, ".");
+    WORD_ATOM(486, 27, ".");
     mw__2E_();
-    WORD_ATOM(467, 29, "dup");
+    WORD_ATOM(486, 29, "dup");
     mw_prim_dup();
-    WORD_ATOM(467, 33, ".var");
+    WORD_ATOM(486, 33, ".var");
     mw__2E_var();
-    WORD_ATOM(467, 38, "");
+    WORD_ATOM(486, 38, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41994,19 +42176,19 @@ static void mb_c99_var_run_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(467, 43, ".");
+    WORD_ATOM(486, 43, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_var_run_21__2);
 }
 
 static void mb_c99_case_21__1 (void) {
-    WORD_ENTER(mb_c99_case_21__1, "c99-case! block", "src/mirth/codegen.mth", 510, 9);
+    WORD_ENTER(mb_c99_case_21__1, "c99-case! block", "src/mirth/codegen.mth", 529, 9);
     mw_prim_drop();
-    WORD_ATOM(510, 9, "body");
+    WORD_ATOM(529, 9, "body");
     mw_Case_2E_body();
-    WORD_ATOM(510, 14, "c99-arrow!");
+    WORD_ATOM(529, 14, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(511, 9, "c99-line");
+    WORD_ATOM(530, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_case_21__2);
     mw_prim_pack_cons();
@@ -42015,9 +42197,9 @@ static void mb_c99_case_21__1 (void) {
 }
 
 static void mb_c99_case_21__2 (void) {
-    WORD_ENTER(mb_c99_case_21__2, "c99-case! block", "src/mirth/codegen.mth", 511, 18);
+    WORD_ENTER(mb_c99_case_21__2, "c99-case! block", "src/mirth/codegen.mth", 530, 18);
     mw_prim_drop();
-    WORD_ATOM(511, 18, "");
+    WORD_ATOM(530, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42028,15 +42210,15 @@ static void mb_c99_case_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(511, 27, ".");
+    WORD_ATOM(530, 27, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_case_21__2);
 }
 
 static void mb_c99_pattern_21__2 (void) {
-    WORD_ENTER(mb_c99_pattern_21__2, "c99-pattern! block", "src/mirth/codegen.mth", 516, 18);
+    WORD_ENTER(mb_c99_pattern_21__2, "c99-pattern! block", "src/mirth/codegen.mth", 535, 18);
     mw_prim_drop();
-    WORD_ATOM(516, 18, "");
+    WORD_ATOM(535, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42047,15 +42229,15 @@ static void mb_c99_pattern_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(516, 29, ".");
+    WORD_ATOM(535, 29, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_pattern_21__2);
 }
 
 static void mb_c99_pattern_21__4 (void) {
-    WORD_ENTER(mb_c99_pattern_21__4, "c99-pattern! block", "src/mirth/codegen.mth", 519, 18);
+    WORD_ENTER(mb_c99_pattern_21__4, "c99-pattern! block", "src/mirth/codegen.mth", 538, 18);
     mw_prim_drop();
-    WORD_ATOM(519, 18, "");
+    WORD_ATOM(538, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42066,15 +42248,15 @@ static void mb_c99_pattern_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(519, 26, ".");
+    WORD_ATOM(538, 26, ".");
     mw__2E_();
-    WORD_ATOM(519, 28, "dup");
+    WORD_ATOM(538, 28, "dup");
     mw_prim_dup();
-    WORD_ATOM(519, 32, "value");
+    WORD_ATOM(538, 32, "value");
     mw_Tag_2E_value();
-    WORD_ATOM(519, 38, ".n");
+    WORD_ATOM(538, 38, ".n");
     mw__2E_n();
-    WORD_ATOM(519, 41, "");
+    WORD_ATOM(538, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42085,38 +42267,38 @@ static void mb_c99_pattern_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(519, 47, ".");
+    WORD_ATOM(538, 47, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_pattern_21__4);
 }
 
 static void mb_c99_pattern_21__5 (void) {
-    WORD_ENTER(mb_c99_pattern_21__5, "c99-pattern! block", "src/mirth/codegen.mth", 521, 13);
+    WORD_ENTER(mb_c99_pattern_21__5, "c99-pattern! block", "src/mirth/codegen.mth", 540, 13);
     mw_prim_drop();
-    WORD_ATOM(521, 13, "num-inputs");
+    WORD_ATOM(540, 13, "num-inputs");
     mw_Tag_2E_num_inputs();
-    WORD_ATOM(521, 24, "dup");
+    WORD_ATOM(540, 24, "dup");
     mw_prim_dup();
-    WORD_ATOM(521, 28, "0>");
+    WORD_ATOM(540, 28, "0>");
     mw_0_3E_();
-    WORD_ATOM(521, 31, "if");
+    WORD_ATOM(540, 31, "if");
     if (pop_u64()) {
-        WORD_ATOM(522, 17, "c99-line");
+        WORD_ATOM(541, 17, "c99-line");
         push_u64(0);
         push_fnptr(&mb_c99_pattern_21__7);
         mw_prim_pack_cons();
         mw_c99_line();
-        WORD_ATOM(523, 17, "1-");
+        WORD_ATOM(542, 17, "1-");
         mw_prim_int_pred();
-        WORD_ATOM(523, 20, "repeat");
+        WORD_ATOM(542, 20, "repeat");
         push_u64(0);
         push_fnptr(&mb_c99_pattern_21__8);
         mw_prim_pack_cons();
         mw_repeat();
     } else {
-        WORD_ATOM(524, 17, "drop");
+        WORD_ATOM(543, 17, "drop");
         mw_prim_drop();
-        WORD_ATOM(524, 22, "c99-line");
+        WORD_ATOM(543, 22, "c99-line");
         push_u64(0);
         push_fnptr(&mb_c99_pattern_21__11);
         mw_prim_pack_cons();
@@ -42126,9 +42308,9 @@ static void mb_c99_pattern_21__5 (void) {
 }
 
 static void mb_c99_pattern_21__7 (void) {
-    WORD_ENTER(mb_c99_pattern_21__7, "c99-pattern! block", "src/mirth/codegen.mth", 522, 26);
+    WORD_ENTER(mb_c99_pattern_21__7, "c99-pattern! block", "src/mirth/codegen.mth", 541, 26);
     mw_prim_drop();
-    WORD_ATOM(522, 26, "");
+    WORD_ATOM(541, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42139,15 +42321,15 @@ static void mb_c99_pattern_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(522, 67, ".");
+    WORD_ATOM(541, 67, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_pattern_21__7);
 }
 
 static void mb_c99_pattern_21__8 (void) {
-    WORD_ENTER(mb_c99_pattern_21__8, "c99-pattern! block", "src/mirth/codegen.mth", 523, 27);
+    WORD_ENTER(mb_c99_pattern_21__8, "c99-pattern! block", "src/mirth/codegen.mth", 542, 27);
     mw_prim_drop();
-    WORD_ATOM(523, 27, "c99-line");
+    WORD_ATOM(542, 27, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_pattern_21__9);
     mw_prim_pack_cons();
@@ -42156,9 +42338,9 @@ static void mb_c99_pattern_21__8 (void) {
 }
 
 static void mb_c99_pattern_21__9 (void) {
-    WORD_ENTER(mb_c99_pattern_21__9, "c99-pattern! block", "src/mirth/codegen.mth", 523, 36);
+    WORD_ENTER(mb_c99_pattern_21__9, "c99-pattern! block", "src/mirth/codegen.mth", 542, 36);
     mw_prim_drop();
-    WORD_ATOM(523, 36, "");
+    WORD_ATOM(542, 36, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42169,15 +42351,15 @@ static void mb_c99_pattern_21__9 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(523, 77, ".");
+    WORD_ATOM(542, 77, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_pattern_21__9);
 }
 
 static void mb_c99_pattern_21__11 (void) {
-    WORD_ENTER(mb_c99_pattern_21__11, "c99-pattern! block", "src/mirth/codegen.mth", 524, 31);
+    WORD_ENTER(mb_c99_pattern_21__11, "c99-pattern! block", "src/mirth/codegen.mth", 543, 31);
     mw_prim_drop();
-    WORD_ATOM(524, 31, "");
+    WORD_ATOM(543, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42188,15 +42370,15 @@ static void mb_c99_pattern_21__11 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(524, 49, ".");
+    WORD_ATOM(543, 49, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_pattern_21__11);
 }
 
 static void mb_c99_word_sig_21__1 (void) {
-    WORD_ENTER(mb_c99_word_sig_21__1, "c99-word-sig! block", "src/mirth/codegen.mth", 531, 14);
+    WORD_ENTER(mb_c99_word_sig_21__1, "c99-word-sig! block", "src/mirth/codegen.mth", 550, 14);
     mw_prim_drop();
-    WORD_ATOM(531, 14, "");
+    WORD_ATOM(550, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42207,13 +42389,13 @@ static void mb_c99_word_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(531, 32, ".");
+    WORD_ATOM(550, 32, ".");
     mw__2E_();
-    WORD_ATOM(531, 34, "name");
+    WORD_ATOM(550, 34, "name");
     mw_Word_2E_name();
-    WORD_ATOM(531, 39, ".name");
+    WORD_ATOM(550, 39, ".name");
     mw__2E_name();
-    WORD_ATOM(531, 45, "");
+    WORD_ATOM(550, 45, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42224,15 +42406,15 @@ static void mb_c99_word_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(531, 56, ".");
+    WORD_ATOM(550, 56, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_word_sig_21__1);
 }
 
 static void mb_c99_block_sig_21__1 (void) {
-    WORD_ENTER(mb_c99_block_sig_21__1, "c99-block-sig! block", "src/mirth/codegen.mth", 535, 14);
+    WORD_ENTER(mb_c99_block_sig_21__1, "c99-block-sig! block", "src/mirth/codegen.mth", 554, 14);
     mw_prim_drop();
-    WORD_ATOM(535, 14, "");
+    WORD_ATOM(554, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42243,11 +42425,11 @@ static void mb_c99_block_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(535, 29, ".");
+    WORD_ATOM(554, 29, ".");
     mw__2E_();
-    WORD_ATOM(535, 31, ".block");
+    WORD_ATOM(554, 31, ".block");
     mw__2E_block();
-    WORD_ATOM(535, 38, "");
+    WORD_ATOM(554, 38, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42258,15 +42440,15 @@ static void mb_c99_block_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(535, 49, ".");
+    WORD_ATOM(554, 49, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_block_sig_21__1);
 }
 
 static void mb_c99_field_sig_21__1 (void) {
-    WORD_ENTER(mb_c99_field_sig_21__1, "c99-field-sig! block", "src/mirth/codegen.mth", 539, 14);
+    WORD_ENTER(mb_c99_field_sig_21__1, "c99-field-sig! block", "src/mirth/codegen.mth", 558, 14);
     mw_prim_drop();
-    WORD_ATOM(539, 14, "");
+    WORD_ATOM(558, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42277,13 +42459,13 @@ static void mb_c99_field_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(539, 32, ".");
+    WORD_ATOM(558, 32, ".");
     mw__2E_();
-    WORD_ATOM(539, 34, "name");
+    WORD_ATOM(558, 34, "name");
     mw_Field_2E_name();
-    WORD_ATOM(539, 39, ".name");
+    WORD_ATOM(558, 39, ".name");
     mw__2E_name();
-    WORD_ATOM(539, 45, "");
+    WORD_ATOM(558, 45, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42294,15 +42476,15 @@ static void mb_c99_field_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(539, 56, ".");
+    WORD_ATOM(558, 56, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_field_sig_21__1);
 }
 
 static void mb_c99_block_enter_21__1 (void) {
-    WORD_ENTER(mb_c99_block_enter_21__1, "c99-block-enter! block", "src/mirth/codegen.mth", 542, 14);
+    WORD_ENTER(mb_c99_block_enter_21__1, "c99-block-enter! block", "src/mirth/codegen.mth", 561, 14);
     mw_prim_drop();
-    WORD_ATOM(542, 14, "");
+    WORD_ATOM(561, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42313,13 +42495,13 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(542, 28, ".");
+    WORD_ATOM(561, 28, ".");
     mw__2E_();
-    WORD_ATOM(543, 9, "dup");
+    WORD_ATOM(562, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(543, 13, ".block");
+    WORD_ATOM(562, 13, ".block");
     mw__2E_block();
-    WORD_ATOM(543, 20, "");
+    WORD_ATOM(562, 20, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42330,19 +42512,19 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(543, 25, ".");
+    WORD_ATOM(562, 25, ".");
     mw__2E_();
-    WORD_ATOM(544, 9, "dup");
+    WORD_ATOM(563, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(544, 13, "arrow");
+    WORD_ATOM(563, 13, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(544, 19, "home");
+    WORD_ATOM(563, 19, "home");
     mw_Arrow_2E_home();
-    WORD_ATOM(544, 24, "match");
+    WORD_ATOM(563, 24, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(545, 21, "");
+            WORD_ATOM(564, 21, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -42356,11 +42538,11 @@ static void mb_c99_block_enter_21__1 (void) {
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(546, 21, "name");
+            WORD_ATOM(565, 21, "name");
             mw_Word_2E_name();
-            WORD_ATOM(546, 26, ">Str");
+            WORD_ATOM(565, 26, ">Str");
             mw_Name_3E_Str();
-            WORD_ATOM(546, 31, "");
+            WORD_ATOM(565, 31, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -42371,14 +42553,14 @@ static void mb_c99_block_enter_21__1 (void) {
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(546, 40, "cat");
+            WORD_ATOM(565, 40, "cat");
             mw_prim_str_cat();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
     
-}    WORD_ATOM(547, 11, ".str");
+}    WORD_ATOM(566, 11, ".str");
     mw__2E_str();
-    WORD_ATOM(547, 16, "");
+    WORD_ATOM(566, 16, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42389,21 +42571,21 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(547, 21, ".");
+    WORD_ATOM(566, 21, ".");
     mw__2E_();
-    WORD_ATOM(548, 9, "dup");
+    WORD_ATOM(567, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(548, 13, "token");
+    WORD_ATOM(567, 13, "token");
     mw_Block_2E_token();
-    WORD_ATOM(548, 19, ".module");
+    WORD_ATOM(567, 19, ".module");
     mw_Token_2E_module();
-    WORD_ATOM(548, 27, "source-path");
+    WORD_ATOM(567, 27, "source-path");
     mw_Module_2E_source_path();
-    WORD_ATOM(548, 39, ">Str");
+    WORD_ATOM(567, 39, ">Str");
     mw_Path_3E_Str();
-    WORD_ATOM(548, 44, ".str");
+    WORD_ATOM(567, 44, ".str");
     mw__2E_str();
-    WORD_ATOM(548, 49, "");
+    WORD_ATOM(567, 49, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42414,19 +42596,19 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(548, 54, ".");
+    WORD_ATOM(567, 54, ".");
     mw__2E_();
-    WORD_ATOM(549, 9, "dup");
+    WORD_ATOM(568, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(549, 13, "token");
+    WORD_ATOM(568, 13, "token");
     mw_Block_2E_token();
-    WORD_ATOM(549, 19, "row");
+    WORD_ATOM(568, 19, "row");
     mw_Token_2E_row();
-    WORD_ATOM(549, 23, ">Int");
+    WORD_ATOM(568, 23, ">Int");
     mw_Row_3E_Int();
-    WORD_ATOM(549, 28, ".n");
+    WORD_ATOM(568, 28, ".n");
     mw__2E_n();
-    WORD_ATOM(549, 31, "");
+    WORD_ATOM(568, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42437,19 +42619,19 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(549, 36, ".");
+    WORD_ATOM(568, 36, ".");
     mw__2E_();
-    WORD_ATOM(550, 9, "dup");
+    WORD_ATOM(569, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(550, 13, "token");
+    WORD_ATOM(569, 13, "token");
     mw_Block_2E_token();
-    WORD_ATOM(550, 19, "col");
+    WORD_ATOM(569, 19, "col");
     mw_Token_2E_col();
-    WORD_ATOM(550, 23, ">Int");
+    WORD_ATOM(569, 23, ">Int");
     mw_Col_3E_Int();
-    WORD_ATOM(550, 28, ".n");
+    WORD_ATOM(569, 28, ".n");
     mw__2E_n();
-    WORD_ATOM(550, 31, "");
+    WORD_ATOM(569, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42460,15 +42642,15 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(550, 36, ".");
+    WORD_ATOM(569, 36, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_block_enter_21__1);
 }
 
 static void mb_c99_block_exit_21__1 (void) {
-    WORD_ENTER(mb_c99_block_exit_21__1, "c99-block-exit! block", "src/mirth/codegen.mth", 554, 14);
+    WORD_ENTER(mb_c99_block_exit_21__1, "c99-block-exit! block", "src/mirth/codegen.mth", 573, 14);
     mw_prim_drop();
-    WORD_ATOM(554, 14, "");
+    WORD_ATOM(573, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42479,11 +42661,11 @@ static void mb_c99_block_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(554, 27, ".");
+    WORD_ATOM(573, 27, ".");
     mw__2E_();
-    WORD_ATOM(554, 29, ".block");
+    WORD_ATOM(573, 29, ".block");
     mw__2E_block();
-    WORD_ATOM(554, 36, "");
+    WORD_ATOM(573, 36, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42494,15 +42676,15 @@ static void mb_c99_block_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(554, 41, ".");
+    WORD_ATOM(573, 41, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_block_exit_21__1);
 }
 
 static void mb_c99_block_def_21__1 (void) {
-    WORD_ENTER(mb_c99_block_def_21__1, "c99-block-def! block", "src/mirth/codegen.mth", 558, 14);
+    WORD_ENTER(mb_c99_block_def_21__1, "c99-block-def! block", "src/mirth/codegen.mth", 577, 14);
     mw_prim_drop();
-    WORD_ATOM(558, 14, "");
+    WORD_ATOM(577, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42513,13 +42695,13 @@ static void mb_c99_block_def_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(558, 29, ".");
+    WORD_ATOM(577, 29, ".");
     mw__2E_();
-    WORD_ATOM(558, 31, "dup");
+    WORD_ATOM(577, 31, "dup");
     mw_prim_dup();
-    WORD_ATOM(558, 35, ".block");
+    WORD_ATOM(577, 35, ".block");
     mw__2E_block();
-    WORD_ATOM(558, 42, "");
+    WORD_ATOM(577, 42, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42530,45 +42712,45 @@ static void mb_c99_block_def_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(558, 54, ".");
+    WORD_ATOM(577, 54, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_block_def_21__1);
 }
 
 static void mb_c99_block_def_21__2 (void) {
-    WORD_ENTER(mb_c99_block_def_21__2, "c99-block-def! block", "src/mirth/codegen.mth", 560, 9);
+    WORD_ENTER(mb_c99_block_def_21__2, "c99-block-def! block", "src/mirth/codegen.mth", 579, 9);
     mw_prim_drop();
-    WORD_ATOM(560, 9, "dup");
+    WORD_ATOM(579, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(560, 13, "c99-block-enter!");
+    WORD_ATOM(579, 13, "c99-block-enter!");
     mw_c99_block_enter_21_();
-    WORD_ATOM(561, 9, "dup");
+    WORD_ATOM(580, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(561, 13, "arrow");
+    WORD_ATOM(580, 13, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(562, 9, "dup");
+    WORD_ATOM(581, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(562, 13, "ctx");
+    WORD_ATOM(581, 13, "ctx");
     mw_Arrow_2E_ctx();
-    WORD_ATOM(562, 17, "c99-unpack-ctx!");
+    WORD_ATOM(581, 17, "c99-unpack-ctx!");
     mw_c99_unpack_ctx_21_();
-    WORD_ATOM(563, 9, "dup");
+    WORD_ATOM(582, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(563, 13, "c99-arrow!");
+    WORD_ATOM(582, 13, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(564, 9, "ctx");
+    WORD_ATOM(583, 9, "ctx");
     mw_Arrow_2E_ctx();
-    WORD_ATOM(564, 13, "c99-decref-ctx!");
+    WORD_ATOM(583, 13, "c99-decref-ctx!");
     mw_c99_decref_ctx_21_();
-    WORD_ATOM(565, 9, "c99-block-exit!");
+    WORD_ATOM(584, 9, "c99-block-exit!");
     mw_c99_block_exit_21_();
     WORD_EXIT(mb_c99_block_def_21__2);
 }
 
 static void mb_c99_block_def_21__3 (void) {
-    WORD_ENTER(mb_c99_block_def_21__3, "c99-block-def! block", "src/mirth/codegen.mth", 567, 14);
+    WORD_ENTER(mb_c99_block_def_21__3, "c99-block-def! block", "src/mirth/codegen.mth", 586, 14);
     mw_prim_drop();
-    WORD_ATOM(567, 14, "");
+    WORD_ATOM(586, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42579,15 +42761,15 @@ static void mb_c99_block_def_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(567, 18, ".");
+    WORD_ATOM(586, 18, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_block_def_21__3);
 }
 
 static void mb_c99_word_enter_21__1 (void) {
-    WORD_ENTER(mb_c99_word_enter_21__1, "c99-word-enter! block", "src/mirth/codegen.mth", 579, 14);
+    WORD_ENTER(mb_c99_word_enter_21__1, "c99-word-enter! block", "src/mirth/codegen.mth", 598, 14);
     mw_prim_drop();
-    WORD_ATOM(579, 14, "");
+    WORD_ATOM(598, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42598,9 +42780,9 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(579, 28, ".");
+    WORD_ATOM(598, 28, ".");
     mw__2E_();
-    WORD_ATOM(580, 9, "");
+    WORD_ATOM(599, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42611,15 +42793,15 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(580, 15, ".");
+    WORD_ATOM(599, 15, ".");
     mw__2E_();
-    WORD_ATOM(580, 17, "dup");
+    WORD_ATOM(599, 17, "dup");
     mw_prim_dup();
-    WORD_ATOM(580, 21, "name");
+    WORD_ATOM(599, 21, "name");
     mw_Word_2E_name();
-    WORD_ATOM(580, 26, ".name");
+    WORD_ATOM(599, 26, ".name");
     mw__2E_name();
-    WORD_ATOM(580, 32, "");
+    WORD_ATOM(599, 32, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42630,17 +42812,17 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(580, 37, ".");
+    WORD_ATOM(599, 37, ".");
     mw__2E_();
-    WORD_ATOM(581, 9, "dup");
+    WORD_ATOM(600, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(581, 13, "name");
+    WORD_ATOM(600, 13, "name");
     mw_Word_2E_name();
-    WORD_ATOM(581, 18, ">Str");
+    WORD_ATOM(600, 18, ">Str");
     mw_Name_3E_Str();
-    WORD_ATOM(581, 23, ".str");
+    WORD_ATOM(600, 23, ".str");
     mw__2E_str();
-    WORD_ATOM(581, 28, "");
+    WORD_ATOM(600, 28, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42651,21 +42833,21 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(581, 33, ".");
+    WORD_ATOM(600, 33, ".");
     mw__2E_();
-    WORD_ATOM(582, 9, "dup");
+    WORD_ATOM(601, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(582, 13, "body");
+    WORD_ATOM(601, 13, "body");
     mw_Word_2E_body();
-    WORD_ATOM(582, 18, ".module");
+    WORD_ATOM(601, 18, ".module");
     mw_Token_2E_module();
-    WORD_ATOM(582, 26, "source-path");
+    WORD_ATOM(601, 26, "source-path");
     mw_Module_2E_source_path();
-    WORD_ATOM(582, 38, ">Str");
+    WORD_ATOM(601, 38, ">Str");
     mw_Path_3E_Str();
-    WORD_ATOM(582, 43, ".str");
+    WORD_ATOM(601, 43, ".str");
     mw__2E_str();
-    WORD_ATOM(582, 48, "");
+    WORD_ATOM(601, 48, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42676,19 +42858,19 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(582, 53, ".");
+    WORD_ATOM(601, 53, ".");
     mw__2E_();
-    WORD_ATOM(583, 9, "dup");
+    WORD_ATOM(602, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(583, 13, "body");
+    WORD_ATOM(602, 13, "body");
     mw_Word_2E_body();
-    WORD_ATOM(583, 18, "row");
+    WORD_ATOM(602, 18, "row");
     mw_Token_2E_row();
-    WORD_ATOM(583, 22, ">Int");
+    WORD_ATOM(602, 22, ">Int");
     mw_Row_3E_Int();
-    WORD_ATOM(583, 27, ".n");
+    WORD_ATOM(602, 27, ".n");
     mw__2E_n();
-    WORD_ATOM(583, 30, "");
+    WORD_ATOM(602, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42699,19 +42881,19 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(583, 35, ".");
+    WORD_ATOM(602, 35, ".");
     mw__2E_();
-    WORD_ATOM(584, 9, "dup");
+    WORD_ATOM(603, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(584, 13, "body");
+    WORD_ATOM(603, 13, "body");
     mw_Word_2E_body();
-    WORD_ATOM(584, 18, "col");
+    WORD_ATOM(603, 18, "col");
     mw_Token_2E_col();
-    WORD_ATOM(584, 22, ">Int");
+    WORD_ATOM(603, 22, ">Int");
     mw_Col_3E_Int();
-    WORD_ATOM(584, 27, ".n");
+    WORD_ATOM(603, 27, ".n");
     mw__2E_n();
-    WORD_ATOM(584, 30, "");
+    WORD_ATOM(603, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42722,15 +42904,15 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(584, 35, ".");
+    WORD_ATOM(603, 35, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_word_enter_21__1);
 }
 
 static void mb_c99_word_exit_21__1 (void) {
-    WORD_ENTER(mb_c99_word_exit_21__1, "c99-word-exit! block", "src/mirth/codegen.mth", 588, 14);
+    WORD_ENTER(mb_c99_word_exit_21__1, "c99-word-exit! block", "src/mirth/codegen.mth", 607, 14);
     mw_prim_drop();
-    WORD_ATOM(588, 14, "");
+    WORD_ATOM(607, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42741,9 +42923,9 @@ static void mb_c99_word_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(588, 27, ".");
+    WORD_ATOM(607, 27, ".");
     mw__2E_();
-    WORD_ATOM(589, 9, "");
+    WORD_ATOM(608, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42754,15 +42936,15 @@ static void mb_c99_word_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(589, 15, ".");
+    WORD_ATOM(608, 15, ".");
     mw__2E_();
-    WORD_ATOM(589, 17, "dup");
+    WORD_ATOM(608, 17, "dup");
     mw_prim_dup();
-    WORD_ATOM(589, 21, "name");
+    WORD_ATOM(608, 21, "name");
     mw_Word_2E_name();
-    WORD_ATOM(589, 26, ".name");
+    WORD_ATOM(608, 26, ".name");
     mw__2E_name();
-    WORD_ATOM(589, 32, "");
+    WORD_ATOM(608, 32, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42773,21 +42955,21 @@ static void mb_c99_word_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(589, 37, ".");
+    WORD_ATOM(608, 37, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_word_exit_21__1);
 }
 
 static void mb_c99_word_def_21__1 (void) {
-    WORD_ENTER(mb_c99_word_def_21__1, "c99-word-def! block", "src/mirth/codegen.mth", 594, 14);
+    WORD_ENTER(mb_c99_word_def_21__1, "c99-word-def! block", "src/mirth/codegen.mth", 613, 14);
     mw_prim_drop();
-    WORD_ATOM(594, 14, "dup");
+    WORD_ATOM(613, 14, "dup");
     mw_prim_dup();
-    WORD_ATOM(594, 18, "name");
+    WORD_ATOM(613, 18, "name");
     mw_Word_2E_name();
-    WORD_ATOM(594, 23, ".w");
+    WORD_ATOM(613, 23, ".w");
     mw__2E_w();
-    WORD_ATOM(594, 26, "");
+    WORD_ATOM(613, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42798,35 +42980,35 @@ static void mb_c99_word_def_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(594, 30, ".");
+    WORD_ATOM(613, 30, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_word_def_21__1);
 }
 
 static void mb_c99_word_def_21__2 (void) {
-    WORD_ENTER(mb_c99_word_def_21__2, "c99-word-def! block", "src/mirth/codegen.mth", 596, 9);
+    WORD_ENTER(mb_c99_word_def_21__2, "c99-word-def! block", "src/mirth/codegen.mth", 615, 9);
     mw_prim_drop();
-    WORD_ATOM(596, 9, "dup");
+    WORD_ATOM(615, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(596, 13, "c99-word-enter!");
+    WORD_ATOM(615, 13, "c99-word-enter!");
     mw_c99_word_enter_21_();
-    WORD_ATOM(597, 9, "dup");
+    WORD_ATOM(616, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(597, 13, "arrow");
+    WORD_ATOM(616, 13, "arrow");
     mw_Word_2E_arrow();
-    WORD_ATOM(597, 19, "c99-arrow!");
+    WORD_ATOM(616, 19, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(598, 9, "dup");
+    WORD_ATOM(617, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(598, 13, "c99-word-exit!");
+    WORD_ATOM(617, 13, "c99-word-exit!");
     mw_c99_word_exit_21_();
     WORD_EXIT(mb_c99_word_def_21__2);
 }
 
 static void mb_c99_word_def_21__3 (void) {
-    WORD_ENTER(mb_c99_word_def_21__3, "c99-word-def! block", "src/mirth/codegen.mth", 600, 14);
+    WORD_ENTER(mb_c99_word_def_21__3, "c99-word-def! block", "src/mirth/codegen.mth", 619, 14);
     mw_prim_drop();
-    WORD_ATOM(600, 14, "");
+    WORD_ATOM(619, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42837,7 +43019,7 @@ static void mb_c99_word_def_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(600, 18, ".");
+    WORD_ATOM(619, 18, ".");
     mw__2E_();
     WORD_EXIT(mb_c99_word_def_21__3);
 }

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -2099,6 +2099,22 @@ static void mw_Str_3E_Path (void) {
 }
 static void mw_FILE (void) {
 }
+static void mw_IO_unsafe (void) {
+    push_u64(0LL);
+}
+static void mw_OUT_5F_STR (void) {
+    VAL car = pop_value();
+    VAL tag = MKU64(0LL);
+    car = mkcons(car, tag);
+    push_value(car);
+}
+static void mw_OUT_5F_FILE (void) {
+    VAL car = pop_value();
+    car = mkcons(car, pop_value());
+    VAL tag = MKU64(1LL);
+    car = mkcons(car, tag);
+    push_value(car);
+}
 static void mw_LAZY_5F_READY (void) {
     VAL car = pop_value();
     VAL tag = MKU64(0LL);
@@ -3183,7 +3199,9 @@ static void mw_List_2E_find (void);
 static void mw_List_2B__2E_find (void);
 static void mw_List_2E_reverse_find (void);
 static void mw_List_2E_any (void);
+static void mw_List_2E_all (void);
 static void mw_collect_while (void);
+static void mw_Maybe_2E_none_3F_ (void);
 static void mw_Maybe_2E_some_3F_ (void);
 static void mw_Maybe_3E_Bool (void);
 static void mw_Maybe_2E_if (void);
@@ -3406,7 +3424,6 @@ static void mw_Case_2E_mid (void);
 static void mw_Case_2E_body (void);
 static void mw_Match_2E_is_exhaustive_3F_ (void);
 static void mw_Match_2E_has_default_case_3F_ (void);
-static void mw_Match_2E_scrutinee_3F_ (void);
 static void mw_Match_2E_scrutinee_data_3F_ (void);
 static void mw_Match_2E_is_transparent_3F_ (void);
 static void mw_Match_2E_add_case_21_ (void);
@@ -3790,7 +3807,6 @@ static void mw_T5 (void);
 static void mw_T6 (void);
 static void mw_Type_2E_morphism_3F_ (void);
 static void mw_Type_2E_prim_3F_ (void);
-static void mw_Type_2E_data_3F_ (void);
 static void mw_Type_3D_meta (void);
 static void mw_Type_2E_is_physical_3F_ (void);
 static void mw_TYPE_5F_TYPE (void);
@@ -3825,7 +3841,6 @@ static void mw_Type_2E_freshen2 (void);
 static void mw_MetaVar_2E_freshen (void);
 static void mw_Var_2E_freshen (void);
 static void mw_Type_2E_arity (void);
-static void mw_type_head (void);
 static void mw_MetaVar_2E_id (void);
 static void mw_MetaVar_2E_alloc_21_ (void);
 static void mw_MetaVar_2E_type_3F_ (void);
@@ -4081,6 +4096,7 @@ static void mb_first_1 (void);
 static void mb_last_1 (void);
 static void mb_List_2B__2E_filter_5 (void);
 static void mb_List_2B__2E_filter_10 (void);
+static void mb_List_2E_all_2 (void);
 static void mb_Str_2E_write_21__1 (void);
 static void mb_slice_write_21__1 (void);
 static void mb_slice_write_21__3 (void);
@@ -4203,8 +4219,6 @@ static void mb_Type_2E_tycon_name_5 (void);
 static void mb_Type_2E_tycon_name_6 (void);
 static void mb_PrimType_3D__1 (void);
 static void mb_TT_1 (void);
-static void mb_type_head_2 (void);
-static void mb_type_head_3 (void);
 static void mb_Type_2E_is_physical_3F__2 (void);
 static void mb_Type_2E_is_physical_3F__3 (void);
 static void mb_Type_2E_unify_failed_21__2 (void);
@@ -4265,8 +4279,13 @@ static void mb_Tag_3D__1 (void);
 static void mb_Match_2E_is_exhaustive_3F__1 (void);
 static void mb_Match_2E_has_default_case_3F__1 (void);
 static void mb_Match_2E_scrutinee_data_3F__1 (void);
-static void mb_Match_2E_is_transparent_3F__1 (void);
-static void mb_Match_2E_is_transparent_3F__2 (void);
+static void mb_Match_2E_scrutinee_data_3F__2 (void);
+static void mb_Match_2E_scrutinee_data_3F__3 (void);
+static void mb_Match_2E_scrutinee_data_3F__4 (void);
+static void mb_Match_2E_scrutinee_data_3F__11 (void);
+static void mb_Match_2E_scrutinee_data_3F__5 (void);
+static void mb_Match_2E_scrutinee_data_3F__6 (void);
+static void mb_Match_2E_scrutinee_data_3F__8 (void);
 static void mb_Match_2E_add_case_21__3 (void);
 static void mb_Match_2E_case_redundant_3F__1 (void);
 static void mb_Case_2E_covers_3F__1 (void);
@@ -4331,6 +4350,7 @@ static void mb_elab_module_decl_21__2 (void);
 static void mb_elab_module_decl_21__3 (void);
 static void mb_elab_data_header_21__1 (void);
 static void mb_elab_data_header_21__2 (void);
+static void mb_elab_data_header_21__3 (void);
 static void mb_elab_data_tag_21__1 (void);
 static void mb_elab_data_tag_21__2 (void);
 static void mb_elab_data_tag_21__9 (void);
@@ -7934,6 +7954,25 @@ static void mw_List_2E_any (void){
     }
     WORD_EXIT(mw_List_2E_any);
 }
+static void mw_List_2E_all (void){
+    WORD_ENTER(mw_List_2E_all, "List.all", "src/data/list.mth", 322, 5);
+    WORD_ATOM(322, 5, "find");
+    {
+        VAL var_f = pop_value();
+        WORD_ATOM(322, 5, "find");
+        push_u64(0);
+        incref(var_f);
+        push_value(var_f);
+        mw_prim_pack_cons();
+        push_fnptr(&mb_List_2E_all_2);
+        mw_prim_pack_cons();
+        mw_List_2E_find();
+        WORD_ATOM(322, 17, "none?");
+        mw_Maybe_2E_none_3F_();
+        decref(var_f);
+    }
+    WORD_EXIT(mw_List_2E_all);
+}
 static void mw_collect_while (void){
     WORD_ENTER(mw_collect_while, "collect-while", "src/data/list.mth", 334, 5);
     WORD_ATOM(334, 5, "L0");
@@ -7972,6 +8011,14 @@ static void mw_collect_while (void){
         decref(var_f);
     }
     WORD_EXIT(mw_collect_while);
+}
+static void mw_Maybe_2E_none_3F_ (void){
+    WORD_ENTER(mw_Maybe_2E_none_3F_, "Maybe.none?", "src/data/maybe.mth", 8, 36);
+    WORD_ATOM(8, 36, ">Bool");
+    mw_Maybe_3E_Bool();
+    WORD_ATOM(8, 42, "not");
+    mw_Bool_2E_not();
+    WORD_EXIT(mw_Maybe_2E_none_3F_);
 }
 static void mw_Maybe_2E_some_3F_ (void){
     WORD_ENTER(mw_Maybe_2E_some_3F_, "Maybe.some?", "src/data/maybe.mth", 9, 36);
@@ -11731,10 +11778,10 @@ static void mw_Data_2E_is_transparent_3F_ (void){
 }    WORD_EXIT(mw_Data_2E_is_transparent_3F_);
 }
 static void mw_Tag_2E_num_inputs_from_sig (void){
-    WORD_ENTER(mw_Tag_2E_num_inputs_from_sig, "Tag.num-inputs-from-sig", "src/mirth/data/data.mth", 130, 5);
-    WORD_ATOM(130, 5, "sig?");
+    WORD_ENTER(mw_Tag_2E_num_inputs_from_sig, "Tag.num-inputs-from-sig", "src/mirth/data/data.mth", 133, 5);
+    WORD_ATOM(133, 5, "sig?");
     mw_Tag_2E_sig_3F_();
-    WORD_ATOM(130, 10, "if-some");
+    WORD_ATOM(133, 10, "if-some");
     push_u64(0);
     push_fnptr(&mb_Tag_2E_num_inputs_from_sig_1);
     mw_prim_pack_cons();
@@ -11745,21 +11792,21 @@ static void mw_Tag_2E_num_inputs_from_sig (void){
     WORD_EXIT(mw_Tag_2E_num_inputs_from_sig);
 }
 static void mw_Tag_2E_is_transparent_3F_ (void){
-    WORD_ENTER(mw_Tag_2E_is_transparent_3F_, "Tag.is-transparent?", "src/mirth/data/data.mth", 133, 5);
-    WORD_ATOM(133, 5, ".data");
+    WORD_ENTER(mw_Tag_2E_is_transparent_3F_, "Tag.is-transparent?", "src/mirth/data/data.mth", 136, 5);
+    WORD_ATOM(136, 5, ".data");
     mw_Tag_2E_data();
-    WORD_ATOM(133, 11, "is-transparent?");
+    WORD_ATOM(136, 11, "is-transparent?");
     mw_Data_2E_is_transparent_3F_();
     WORD_EXIT(mw_Tag_2E_is_transparent_3F_);
 }
 static void mw_Tag_3D_ (void){
-    WORD_ENTER(mw_Tag_3D_, "Tag=", "src/mirth/data/data.mth", 135, 28);
-    WORD_ATOM(135, 28, "both");
+    WORD_ENTER(mw_Tag_3D_, "Tag=", "src/mirth/data/data.mth", 138, 28);
+    WORD_ATOM(138, 28, "both");
     push_u64(0);
     push_fnptr(&mb_Tag_3D__1);
     mw_prim_pack_cons();
     mw_both();
-    WORD_ATOM(135, 38, "=");
+    WORD_ATOM(138, 38, "=");
     mw_prim_int_eq();
     WORD_EXIT(mw_Tag_3D_);
 }
@@ -11910,67 +11957,103 @@ static void mw_Match_2E_is_exhaustive_3F_ (void){
     push_fnptr(&mb_Match_2E_is_exhaustive_3F__1);
     mw_prim_pack_cons();
     mw_Bool_2E_or();
-    WORD_ATOM(51, 7, "nip");
+    WORD_ATOM(53, 7, "nip");
     mw_nip();
     WORD_EXIT(mw_Match_2E_is_exhaustive_3F_);
 }
 static void mw_Match_2E_has_default_case_3F_ (void){
-    WORD_ENTER(mw_Match_2E_has_default_case_3F_, "Match.has-default-case?", "src/mirth/data/match.mth", 54, 5);
-    WORD_ATOM(54, 5, "cases");
+    WORD_ENTER(mw_Match_2E_has_default_case_3F_, "Match.has-default-case?", "src/mirth/data/match.mth", 56, 5);
+    WORD_ATOM(56, 5, "cases");
     mw_Match_2E_cases();
-    WORD_ATOM(54, 11, "any");
+    WORD_ATOM(56, 11, "any");
     push_u64(0);
     push_fnptr(&mb_Match_2E_has_default_case_3F__1);
     mw_prim_pack_cons();
     mw_List_2E_any();
     WORD_EXIT(mw_Match_2E_has_default_case_3F_);
 }
-static void mw_Match_2E_scrutinee_3F_ (void){
-    WORD_ENTER(mw_Match_2E_scrutinee_3F_, "Match.scrutinee?", "src/mirth/data/match.mth", 58, 5);
-    WORD_ATOM(58, 5, "dom");
-    mw_Match_2E_dom();
-    WORD_ATOM(58, 9, "top-type");
-    mw_StackType_2E_top_type();
-    WORD_EXIT(mw_Match_2E_scrutinee_3F_);
-}
 static void mw_Match_2E_scrutinee_data_3F_ (void){
-    WORD_ENTER(mw_Match_2E_scrutinee_data_3F_, "Match.scrutinee-data?", "src/mirth/data/match.mth", 62, 5);
-    WORD_ATOM(62, 5, "scrutinee?");
-    mw_Match_2E_scrutinee_3F_();
-    WORD_ATOM(62, 16, "bind");
+    WORD_ENTER(mw_Match_2E_scrutinee_data_3F_, "Match.scrutinee-data?", "src/mirth/data/match.mth", 61, 5);
+    WORD_ATOM(61, 5, "cases");
+    mw_Match_2E_cases();
+    WORD_ATOM(61, 11, "filter");
     push_u64(0);
     push_fnptr(&mb_Match_2E_scrutinee_data_3F__1);
     mw_prim_pack_cons();
+    mw_List_2E_filter();
+    WORD_ATOM(61, 44, "dup");
+    mw_prim_dup();
+    WORD_ATOM(62, 5, "first");
+    mw_first();
+    WORD_ATOM(62, 11, "bind");
+    push_u64(0);
+    push_fnptr(&mb_Match_2E_scrutinee_data_3F__2);
+    mw_prim_pack_cons();
     mw_Maybe_2E_bind();
+    WORD_ATOM(62, 30, "map");
+    push_u64(0);
+    push_fnptr(&mb_Match_2E_scrutinee_data_3F__3);
+    mw_prim_pack_cons();
+    mw_Maybe_2E_map();
+    WORD_ATOM(62, 41, "if-some");
+    push_u64(0);
+    push_fnptr(&mb_Match_2E_scrutinee_data_3F__4);
+    mw_prim_pack_cons();
+    push_u64(0);
+    push_fnptr(&mb_Match_2E_scrutinee_data_3F__11);
+    mw_prim_pack_cons();
+    mw_Maybe_2E_if_some();
     WORD_EXIT(mw_Match_2E_scrutinee_data_3F_);
 }
 static void mw_Match_2E_is_transparent_3F_ (void){
-    WORD_ENTER(mw_Match_2E_is_transparent_3F_, "Match.is-transparent?", "src/mirth/data/match.mth", 65, 5);
-    WORD_ATOM(65, 5, "scrutinee-data?");
-    mw_Match_2E_scrutinee_data_3F_();
-    WORD_ATOM(65, 21, "if-some");
-    push_u64(0);
-    push_fnptr(&mb_Match_2E_is_transparent_3F__1);
-    mw_prim_pack_cons();
-    push_u64(0);
-    push_fnptr(&mb_Match_2E_is_transparent_3F__2);
-    mw_prim_pack_cons();
-    mw_Maybe_2E_if_some();
-    WORD_EXIT(mw_Match_2E_is_transparent_3F_);
+    WORD_ENTER(mw_Match_2E_is_transparent_3F_, "Match.is-transparent?", "src/mirth/data/match.mth", 71, 5);
+    WORD_ATOM(71, 5, "cases");
+    mw_Match_2E_cases();
+    WORD_ATOM(71, 11, "match");
+    switch (get_top_data_tag()) {
+        case 1LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(72, 15, "pattern");
+            mw_Case_2E_pattern();
+            WORD_ATOM(72, 23, "match");
+            switch (get_top_data_tag()) {
+                case 1LL:
+                    mw_prim_pack_uncons(); mw_prim_drop();
+                    WORD_ATOM(73, 28, ".data");
+                    mw_Tag_2E_data();
+                    WORD_ATOM(73, 34, "is-transparent?");
+                    mw_Data_2E_is_transparent_3F_();
+                    break;
+                case 0LL:
+                    mw_prim_drop();
+                    WORD_ATOM(74, 35, "T");
+                    mw_T();
+                    break;
+                default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
+            
+}            break;
+        default:
+            WORD_ATOM(76, 14, "drop");
+            mw_prim_drop();
+            WORD_ATOM(76, 19, "F");
+            mw_F();
+            break;
+    
+}    WORD_EXIT(mw_Match_2E_is_transparent_3F_);
 }
 static void mw_Match_2E_add_case_21_ (void){
-    WORD_ENTER(mw_Match_2E_add_case_21_, "Match.add-case!", "src/mirth/data/match.mth", 68, 5);
-    WORD_ATOM(68, 5, "dup2");
+    WORD_ENTER(mw_Match_2E_add_case_21_, "Match.add-case!", "src/mirth/data/match.mth", 80, 5);
+    WORD_ATOM(80, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(68, 10, "case-redundant?");
+    WORD_ATOM(80, 10, "case-redundant?");
     mw_Match_2E_case_redundant_3F_();
-    WORD_ATOM(68, 26, "if");
+    WORD_ATOM(80, 26, "if");
     if (pop_u64()) {
-        WORD_ATOM(69, 9, "drop");
+        WORD_ATOM(81, 9, "drop");
         mw_prim_drop();
-        WORD_ATOM(69, 14, "token");
+        WORD_ATOM(81, 14, "token");
         mw_Case_2E_token();
-        WORD_ATOM(69, 20, "");
+        WORD_ATOM(81, 20, "");
         {
             static bool vready = false;
             static VAL v;
@@ -11981,94 +12064,94 @@ static void mw_Match_2E_add_case_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(69, 43, "emit-error!");
+        WORD_ATOM(81, 43, "emit-error!");
         mw_emit_error_21_();
     } else {
-        WORD_ATOM(70, 9, "sip");
+        WORD_ATOM(82, 9, "sip");
         push_u64(0);
         push_fnptr(&mb_Match_2E_add_case_21__3);
         mw_prim_pack_cons();
         mw_sip();
-        WORD_ATOM(70, 30, "~cases");
+        WORD_ATOM(82, 30, "~cases");
         mw_Match_7E_cases();
-        WORD_ATOM(70, 37, "!");
+        WORD_ATOM(82, 37, "!");
         mw_prim_mut_set();
     }
     WORD_EXIT(mw_Match_2E_add_case_21_);
 }
 static void mw_Match_2E_case_redundant_3F_ (void){
-    WORD_ENTER(mw_Match_2E_case_redundant_3F_, "Match.case-redundant?", "src/mirth/data/match.mth", 74, 5);
-    WORD_ATOM(74, 5, "cases");
+    WORD_ENTER(mw_Match_2E_case_redundant_3F_, "Match.case-redundant?", "src/mirth/data/match.mth", 86, 5);
+    WORD_ATOM(86, 5, "cases");
     mw_Match_2E_cases();
-    WORD_ATOM(74, 11, "any");
+    WORD_ATOM(86, 11, "any");
     push_u64(0);
     push_fnptr(&mb_Match_2E_case_redundant_3F__1);
     mw_prim_pack_cons();
     mw_List_2E_any();
-    WORD_ATOM(74, 29, "nip");
+    WORD_ATOM(86, 29, "nip");
     mw_nip();
     WORD_EXIT(mw_Match_2E_case_redundant_3F_);
 }
 static void mw_Case_2E_covers_3F_ (void){
-    WORD_ENTER(mw_Case_2E_covers_3F_, "Case.covers?", "src/mirth/data/match.mth", 81, 38);
-    WORD_ATOM(81, 38, "both");
+    WORD_ENTER(mw_Case_2E_covers_3F_, "Case.covers?", "src/mirth/data/match.mth", 93, 38);
+    WORD_ATOM(93, 38, "both");
     push_u64(0);
     push_fnptr(&mb_Case_2E_covers_3F__1);
     mw_prim_pack_cons();
     mw_both();
-    WORD_ATOM(81, 52, "covers?");
+    WORD_ATOM(93, 52, "covers?");
     mw_Pattern_2E_covers_3F_();
     WORD_EXIT(mw_Case_2E_covers_3F_);
 }
 static void mw_Case_2E_is_default_case_3F_ (void){
-    WORD_ENTER(mw_Case_2E_is_default_case_3F_, "Case.is-default-case?", "src/mirth/data/match.mth", 84, 42);
-    WORD_ATOM(84, 42, "pattern");
+    WORD_ENTER(mw_Case_2E_is_default_case_3F_, "Case.is-default-case?", "src/mirth/data/match.mth", 96, 42);
+    WORD_ATOM(96, 42, "pattern");
     mw_Case_2E_pattern();
-    WORD_ATOM(84, 50, "underscore?");
+    WORD_ATOM(96, 50, "underscore?");
     mw_Pattern_2E_underscore_3F_();
     WORD_EXIT(mw_Case_2E_is_default_case_3F_);
 }
 static void mw_Pattern_2E_underscore_3F_ (void){
-    WORD_ENTER(mw_Pattern_2E_underscore_3F_, "Pattern.underscore?", "src/mirth/data/match.mth", 94, 43);
-    WORD_ATOM(94, 43, "PATTERN_UNDERSCORE");
+    WORD_ENTER(mw_Pattern_2E_underscore_3F_, "Pattern.underscore?", "src/mirth/data/match.mth", 106, 43);
+    WORD_ATOM(106, 43, "PATTERN_UNDERSCORE");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(94, 65, "T");
+            WORD_ATOM(106, 65, "T");
             mw_T();
             break;
         default:
-            WORD_ATOM(94, 73, "drop");
+            WORD_ATOM(106, 73, "drop");
             mw_prim_drop();
-            WORD_ATOM(94, 78, "F");
+            WORD_ATOM(106, 78, "F");
             mw_F();
             break;
     
 }    WORD_EXIT(mw_Pattern_2E_underscore_3F_);
 }
 static void mw_Pattern_2E_tag_3F_ (void){
-    WORD_ENTER(mw_Pattern_2E_tag_3F_, "Pattern.tag?", "src/mirth/data/match.mth", 95, 42);
-    WORD_ATOM(95, 42, "PATTERN_TAG");
+    WORD_ENTER(mw_Pattern_2E_tag_3F_, "Pattern.tag?", "src/mirth/data/match.mth", 107, 42);
+    WORD_ATOM(107, 42, "PATTERN_TAG");
     switch (get_top_data_tag()) {
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(95, 57, "SOME");
+            WORD_ATOM(107, 57, "SOME");
             mw_SOME();
             break;
         default:
-            WORD_ATOM(95, 68, "drop");
+            WORD_ATOM(107, 68, "drop");
             mw_prim_drop();
-            WORD_ATOM(95, 73, "NONE");
+            WORD_ATOM(107, 73, "NONE");
             mw_NONE();
             break;
     
 }    WORD_EXIT(mw_Pattern_2E_tag_3F_);
 }
 static void mw_Pattern_2E_tag_3D_ (void){
-    WORD_ENTER(mw_Pattern_2E_tag_3D_, "Pattern.tag=", "src/mirth/data/match.mth", 96, 40);
-    WORD_ATOM(96, 40, "tag?");
+    WORD_ENTER(mw_Pattern_2E_tag_3D_, "Pattern.tag=", "src/mirth/data/match.mth", 108, 40);
+    WORD_ATOM(108, 40, "tag?");
     mw_Pattern_2E_tag_3F_();
-    WORD_ATOM(96, 45, "if-some");
+    WORD_ATOM(108, 45, "if-some");
     push_u64(0);
     push_fnptr(&mb_Pattern_2E_tag_3D__1);
     mw_prim_pack_cons();
@@ -12079,21 +12162,21 @@ static void mw_Pattern_2E_tag_3D_ (void){
     WORD_EXIT(mw_Pattern_2E_tag_3D_);
 }
 static void mw_Pattern_2E_covers_3F_ (void){
-    WORD_ENTER(mw_Pattern_2E_covers_3F_, "Pattern.covers?", "src/mirth/data/match.mth", 104, 5);
-    WORD_ATOM(104, 5, "PATTERN_UNDERSCORE");
+    WORD_ENTER(mw_Pattern_2E_covers_3F_, "Pattern.covers?", "src/mirth/data/match.mth", 116, 5);
+    WORD_ATOM(116, 5, "PATTERN_UNDERSCORE");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(104, 27, "drop");
+            WORD_ATOM(116, 27, "drop");
             mw_prim_drop();
-            WORD_ATOM(104, 32, "T");
+            WORD_ATOM(116, 32, "T");
             mw_T();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(105, 20, "swap");
+            WORD_ATOM(117, 20, "swap");
             mw_prim_swap();
-            WORD_ATOM(105, 25, "tag=");
+            WORD_ATOM(117, 25, "tag=");
             mw_Pattern_2E_tag_3D_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -21954,9 +22037,14 @@ static void mw_elab_data_header_21_ (void){
     mw_prim_dup();
     WORD_ATOM(821, 9, "sig-type-con?");
     mw_Token_2E_sig_type_con_3F_();
-    WORD_ATOM(821, 23, "else");
+    WORD_ATOM(821, 23, "or");
     push_u64(0);
     push_fnptr(&mb_elab_data_header_21__1);
+    mw_prim_pack_cons();
+    mw_Bool_2E_or();
+    WORD_ATOM(821, 49, "else");
+    push_u64(0);
+    push_fnptr(&mb_elab_data_header_21__2);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
     WORD_ATOM(822, 5, "dup2");
@@ -21969,7 +22057,7 @@ static void mw_elab_data_header_21_ (void){
     mw_name_undefined_3F_();
     WORD_ATOM(822, 39, "else");
     push_u64(0);
-    push_fnptr(&mb_elab_data_header_21__2);
+    push_fnptr(&mb_elab_data_header_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
     WORD_ATOM(823, 5, "over");
@@ -24603,26 +24691,6 @@ static void mw_Type_2E_prim_3F_ (void){
     
 }    WORD_EXIT(mw_Type_2E_prim_3F_);
 }
-static void mw_Type_2E_data_3F_ (void){
-    WORD_ENTER(mw_Type_2E_data_3F_, "Type.data?", "src/mirth/data/type.mth", 129, 5);
-    WORD_ATOM(129, 5, "type-head");
-    mw_type_head();
-    WORD_ATOM(129, 15, "match");
-    switch (get_top_data_tag()) {
-        case 7LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(129, 30, "SOME");
-            mw_SOME();
-            break;
-        default:
-            WORD_ATOM(129, 41, "drop");
-            mw_prim_drop();
-            WORD_ATOM(129, 46, "NONE");
-            mw_NONE();
-            break;
-    
-}    WORD_EXIT(mw_Type_2E_data_3F_);
-}
 static void mw_Type_3D_meta (void){
     WORD_ENTER(mw_Type_3D_meta, "Type=meta", "src/mirth/data/type.mth", 138, 5);
     WORD_ATOM(138, 5, "TMeta");
@@ -26320,36 +26388,6 @@ static void mw_Type_2E_arity (void){
             break;
     
 }    WORD_EXIT(mw_Type_2E_arity);
-}
-static void mw_type_head (void){
-    WORD_ENTER(mw_type_head, "type-head", "src/mirth/data/type.mth", 445, 5);
-    WORD_ATOM(445, 5, "TMeta");
-    switch (get_top_data_tag()) {
-        case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(445, 14, "expand-if");
-            push_u64(0);
-            push_fnptr(&mb_type_head_2);
-            mw_prim_pack_cons();
-            push_u64(0);
-            push_fnptr(&mb_type_head_3);
-            mw_prim_pack_cons();
-            mw_MetaVar_2E_expand_if();
-            break;
-        case 10LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(446, 13, "drop");
-            mw_prim_drop();
-            WORD_ATOM(446, 18, "type-head");
-            mw_type_head();
-            break;
-        default:
-            WORD_ATOM(447, 10, "id");
-            mw_prim_id();
-            break;
-    
-}    WORD_EXIT(mw_type_head);
 }
 static void mw_MetaVar_2E_id (void){
     WORD_ENTER(mw_MetaVar_2E_id, "MetaVar.id", "src/mirth/data/type.mth", 469, 7);
@@ -34765,6 +34803,20 @@ static void mb_List_2B__2E_filter_10 (void) {
     WORD_EXIT(mb_List_2B__2E_filter_10);
 }
 
+static void mb_List_2E_all_2 (void) {
+    WORD_ENTER(mb_List_2E_all_2, "List.all block", "src/data/list.mth", 322, 10);
+    mw_prim_pack_uncons();
+    VAL var_f = pop_value();
+    mw_prim_drop();
+    WORD_ATOM(322, 10, "f");
+    incref(var_f);
+    run_value(var_f);
+    WORD_ATOM(322, 12, "not");
+    mw_Bool_2E_not();
+    decref(var_f);
+    WORD_EXIT(mb_List_2E_all_2);
+}
+
 static void mb_Str_2E_write_21__1 (void) {
     WORD_ENTER(mb_Str_2E_write_21__1, "Str.write! block", "src/platform/posix.mth", 15, 19);
     mw_prim_drop();
@@ -36430,22 +36482,6 @@ static void mb_TT_1 (void) {
     WORD_EXIT(mb_TT_1);
 }
 
-static void mb_type_head_2 (void) {
-    WORD_ENTER(mb_type_head_2, "type-head block", "src/mirth/data/type.mth", 445, 24);
-    mw_prim_drop();
-    WORD_ATOM(445, 24, "type-head");
-    mw_type_head();
-    WORD_EXIT(mb_type_head_2);
-}
-
-static void mb_type_head_3 (void) {
-    WORD_ENTER(mb_type_head_3, "type-head block", "src/mirth/data/type.mth", 445, 35);
-    mw_prim_drop();
-    WORD_ATOM(445, 35, "TMeta");
-    mw_TMeta();
-    WORD_EXIT(mb_type_head_3);
-}
-
 static void mb_Type_2E_is_physical_3F__2 (void) {
     WORD_ENTER(mb_Type_2E_is_physical_3F__2, "Type.is-physical? block", "src/mirth/data/type.mth", 142, 24);
     mw_prim_drop();
@@ -37115,25 +37151,25 @@ static void mb_Data_3D__1 (void) {
 }
 
 static void mb_Tag_2E_num_inputs_from_sig_1 (void) {
-    WORD_ENTER(mb_Tag_2E_num_inputs_from_sig_1, "Tag.num-inputs-from-sig block", "src/mirth/data/data.mth", 130, 18);
+    WORD_ENTER(mb_Tag_2E_num_inputs_from_sig_1, "Tag.num-inputs-from-sig block", "src/mirth/data/data.mth", 133, 18);
     mw_prim_drop();
-    WORD_ATOM(130, 18, "run-length");
+    WORD_ATOM(133, 18, "run-length");
     mw_Token_2E_run_length();
     WORD_EXIT(mb_Tag_2E_num_inputs_from_sig_1);
 }
 
 static void mb_Tag_2E_num_inputs_from_sig_2 (void) {
-    WORD_ENTER(mb_Tag_2E_num_inputs_from_sig_2, "Tag.num-inputs-from-sig block", "src/mirth/data/data.mth", 130, 30);
+    WORD_ENTER(mb_Tag_2E_num_inputs_from_sig_2, "Tag.num-inputs-from-sig block", "src/mirth/data/data.mth", 133, 30);
     mw_prim_drop();
-    WORD_ATOM(130, 30, "");
+    WORD_ATOM(133, 30, "");
     push_i64(0LL);
     WORD_EXIT(mb_Tag_2E_num_inputs_from_sig_2);
 }
 
 static void mb_Tag_3D__1 (void) {
-    WORD_ENTER(mb_Tag_3D__1, "Tag= block", "src/mirth/data/data.mth", 135, 33);
+    WORD_ENTER(mb_Tag_3D__1, "Tag= block", "src/mirth/data/data.mth", 138, 33);
     mw_prim_drop();
-    WORD_ATOM(135, 33, ".id");
+    WORD_ATOM(138, 33, ".id");
     mw_Tag_2E_id();
     WORD_EXIT(mb_Tag_3D__1);
 }
@@ -37162,8 +37198,14 @@ static void mb_Match_2E_is_exhaustive_3F__1 (void) {
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(49, 17, "T");
-            mw_T();
+            WORD_ATOM(49, 17, "dup");
+            mw_prim_dup();
+            WORD_ATOM(49, 21, "cases");
+            mw_Match_2E_cases();
+            WORD_ATOM(49, 27, "len");
+            mw_List_2E_len();
+            WORD_ATOM(49, 31, "0>");
+            mw_0_3E_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
     
@@ -37171,83 +37213,167 @@ static void mb_Match_2E_is_exhaustive_3F__1 (void) {
 }
 
 static void mb_Match_2E_has_default_case_3F__1 (void) {
-    WORD_ENTER(mb_Match_2E_has_default_case_3F__1, "Match.has-default-case? block", "src/mirth/data/match.mth", 54, 15);
+    WORD_ENTER(mb_Match_2E_has_default_case_3F__1, "Match.has-default-case? block", "src/mirth/data/match.mth", 56, 15);
     mw_prim_drop();
-    WORD_ATOM(54, 15, "dup");
+    WORD_ATOM(56, 15, "dup");
     mw_prim_dup();
-    WORD_ATOM(54, 19, "is-default-case?");
+    WORD_ATOM(56, 19, "is-default-case?");
     mw_Case_2E_is_default_case_3F_();
     WORD_EXIT(mb_Match_2E_has_default_case_3F__1);
 }
 
 static void mb_Match_2E_scrutinee_data_3F__1 (void) {
-    WORD_ENTER(mb_Match_2E_scrutinee_data_3F__1, "Match.scrutinee-data? block", "src/mirth/data/match.mth", 62, 21);
+    WORD_ENTER(mb_Match_2E_scrutinee_data_3F__1, "Match.scrutinee-data? block", "src/mirth/data/match.mth", 61, 18);
     mw_prim_drop();
-    WORD_ATOM(62, 21, "data?");
-    mw_Type_2E_data_3F_();
+    WORD_ATOM(61, 18, "dup");
+    mw_prim_dup();
+    WORD_ATOM(61, 22, "is-default-case?");
+    mw_Case_2E_is_default_case_3F_();
+    WORD_ATOM(61, 39, "not");
+    mw_Bool_2E_not();
     WORD_EXIT(mb_Match_2E_scrutinee_data_3F__1);
 }
 
-static void mb_Match_2E_is_transparent_3F__1 (void) {
-    WORD_ENTER(mb_Match_2E_is_transparent_3F__1, "Match.is-transparent? block", "src/mirth/data/match.mth", 65, 29);
+static void mb_Match_2E_scrutinee_data_3F__2 (void) {
+    WORD_ENTER(mb_Match_2E_scrutinee_data_3F__2, "Match.scrutinee-data? block", "src/mirth/data/match.mth", 62, 16);
     mw_prim_drop();
-    WORD_ATOM(65, 29, "is-transparent?");
-    mw_Data_2E_is_transparent_3F_();
-    WORD_EXIT(mb_Match_2E_is_transparent_3F__1);
+    WORD_ATOM(62, 16, "pattern");
+    mw_Case_2E_pattern();
+    WORD_ATOM(62, 24, "tag?");
+    mw_Pattern_2E_tag_3F_();
+    WORD_EXIT(mb_Match_2E_scrutinee_data_3F__2);
 }
 
-static void mb_Match_2E_is_transparent_3F__2 (void) {
-    WORD_ENTER(mb_Match_2E_is_transparent_3F__2, "Match.is-transparent? block", "src/mirth/data/match.mth", 65, 46);
+static void mb_Match_2E_scrutinee_data_3F__3 (void) {
+    WORD_ENTER(mb_Match_2E_scrutinee_data_3F__3, "Match.scrutinee-data? block", "src/mirth/data/match.mth", 62, 34);
     mw_prim_drop();
-    WORD_ATOM(65, 46, "F");
+    WORD_ATOM(62, 34, ".data");
+    mw_Tag_2E_data();
+    WORD_EXIT(mb_Match_2E_scrutinee_data_3F__3);
+}
+
+static void mb_Match_2E_scrutinee_data_3F__4 (void) {
+    WORD_ENTER(mb_Match_2E_scrutinee_data_3F__4, "Match.scrutinee-data? block", "src/mirth/data/match.mth", 63, 9);
+    mw_prim_drop();
+    WORD_ATOM(63, 9, "swap");
+    mw_prim_swap();
+    WORD_ATOM(63, 14, "all");
+    push_u64(0);
+    push_fnptr(&mb_Match_2E_scrutinee_data_3F__5);
+    mw_prim_pack_cons();
+    mw_List_2E_all();
+    WORD_ATOM(63, 66, "if");
+    if (pop_u64()) {
+        WORD_ATOM(64, 13, "SOME");
+        mw_SOME();
+    } else {
+        WORD_ATOM(65, 13, "drop");
+        mw_prim_drop();
+        WORD_ATOM(65, 18, "NONE");
+        mw_NONE();
+    }
+    WORD_EXIT(mb_Match_2E_scrutinee_data_3F__4);
+}
+
+static void mb_Match_2E_scrutinee_data_3F__11 (void) {
+    WORD_ENTER(mb_Match_2E_scrutinee_data_3F__11, "Match.scrutinee-data? block", "src/mirth/data/match.mth", 67, 9);
+    mw_prim_drop();
+    WORD_ATOM(67, 9, "drop");
+    mw_prim_drop();
+    WORD_ATOM(67, 14, "NONE");
+    mw_NONE();
+    WORD_EXIT(mb_Match_2E_scrutinee_data_3F__11);
+}
+
+static void mb_Match_2E_scrutinee_data_3F__5 (void) {
+    WORD_ENTER(mb_Match_2E_scrutinee_data_3F__5, "Match.scrutinee-data? block", "src/mirth/data/match.mth", 63, 18);
+    mw_prim_drop();
+    WORD_ATOM(63, 18, "dup");
+    mw_prim_dup();
+    WORD_ATOM(63, 22, "pattern");
+    mw_Case_2E_pattern();
+    WORD_ATOM(63, 30, "tag?");
+    mw_Pattern_2E_tag_3F_();
+    WORD_ATOM(63, 35, "if-some");
+    push_u64(0);
+    push_fnptr(&mb_Match_2E_scrutinee_data_3F__6);
+    mw_prim_pack_cons();
+    push_u64(0);
+    push_fnptr(&mb_Match_2E_scrutinee_data_3F__8);
+    mw_prim_pack_cons();
+    mw_Maybe_2E_if_some();
+    WORD_EXIT(mb_Match_2E_scrutinee_data_3F__5);
+}
+
+static void mb_Match_2E_scrutinee_data_3F__6 (void) {
+    WORD_ENTER(mb_Match_2E_scrutinee_data_3F__6, "Match.scrutinee-data? block", "src/mirth/data/match.mth", 63, 43);
+    mw_prim_drop();
+    WORD_ATOM(63, 43, "dip");
+    {
+        VAL d2 = pop_value();
+        WORD_ATOM(63, 47, "over");
+        mw_over();
+        push_value(d2);
+    }
+    WORD_ATOM(63, 53, ".data");
+    mw_Tag_2E_data();
+    WORD_ATOM(63, 59, "=");
+    mw_Data_3D_();
+    WORD_EXIT(mb_Match_2E_scrutinee_data_3F__6);
+}
+
+static void mb_Match_2E_scrutinee_data_3F__8 (void) {
+    WORD_ENTER(mb_Match_2E_scrutinee_data_3F__8, "Match.scrutinee-data? block", "src/mirth/data/match.mth", 63, 62);
+    mw_prim_drop();
+    WORD_ATOM(63, 62, "F");
     mw_F();
-    WORD_EXIT(mb_Match_2E_is_transparent_3F__2);
+    WORD_EXIT(mb_Match_2E_scrutinee_data_3F__8);
 }
 
 static void mb_Match_2E_add_case_21__3 (void) {
-    WORD_ENTER(mb_Match_2E_add_case_21__3, "Match.add-case! block", "src/mirth/data/match.mth", 70, 13);
+    WORD_ENTER(mb_Match_2E_add_case_21__3, "Match.add-case! block", "src/mirth/data/match.mth", 82, 13);
     mw_prim_drop();
-    WORD_ATOM(70, 13, "cases");
+    WORD_ATOM(82, 13, "cases");
     mw_Match_2E_cases();
-    WORD_ATOM(70, 19, "swap");
+    WORD_ATOM(82, 19, "swap");
     mw_prim_swap();
-    WORD_ATOM(70, 24, "snoc");
+    WORD_ATOM(82, 24, "snoc");
     mw_snoc();
     WORD_EXIT(mb_Match_2E_add_case_21__3);
 }
 
 static void mb_Match_2E_case_redundant_3F__1 (void) {
-    WORD_ENTER(mb_Match_2E_case_redundant_3F__1, "Match.case-redundant? block", "src/mirth/data/match.mth", 74, 15);
+    WORD_ENTER(mb_Match_2E_case_redundant_3F__1, "Match.case-redundant? block", "src/mirth/data/match.mth", 86, 15);
     mw_prim_drop();
-    WORD_ATOM(74, 15, "dup2");
+    WORD_ATOM(86, 15, "dup2");
     mw_dup2();
-    WORD_ATOM(74, 20, "covers?");
+    WORD_ATOM(86, 20, "covers?");
     mw_Case_2E_covers_3F_();
     WORD_EXIT(mb_Match_2E_case_redundant_3F__1);
 }
 
 static void mb_Case_2E_covers_3F__1 (void) {
-    WORD_ENTER(mb_Case_2E_covers_3F__1, "Case.covers? block", "src/mirth/data/match.mth", 81, 43);
+    WORD_ENTER(mb_Case_2E_covers_3F__1, "Case.covers? block", "src/mirth/data/match.mth", 93, 43);
     mw_prim_drop();
-    WORD_ATOM(81, 43, "pattern");
+    WORD_ATOM(93, 43, "pattern");
     mw_Case_2E_pattern();
     WORD_EXIT(mb_Case_2E_covers_3F__1);
 }
 
 static void mb_Pattern_2E_tag_3D__1 (void) {
-    WORD_ENTER(mb_Pattern_2E_tag_3D__1, "Pattern.tag= block", "src/mirth/data/match.mth", 96, 53);
+    WORD_ENTER(mb_Pattern_2E_tag_3D__1, "Pattern.tag= block", "src/mirth/data/match.mth", 108, 53);
     mw_prim_drop();
-    WORD_ATOM(96, 53, "=");
+    WORD_ATOM(108, 53, "=");
     mw_Tag_3D_();
     WORD_EXIT(mb_Pattern_2E_tag_3D__1);
 }
 
 static void mb_Pattern_2E_tag_3D__2 (void) {
-    WORD_ENTER(mb_Pattern_2E_tag_3D__2, "Pattern.tag= block", "src/mirth/data/match.mth", 96, 56);
+    WORD_ENTER(mb_Pattern_2E_tag_3D__2, "Pattern.tag= block", "src/mirth/data/match.mth", 108, 56);
     mw_prim_drop();
-    WORD_ATOM(96, 56, "drop");
+    WORD_ATOM(108, 56, "drop");
     mw_prim_drop();
-    WORD_ATOM(96, 61, "F");
+    WORD_ATOM(108, 61, "F");
     mw_F();
     WORD_EXIT(mb_Pattern_2E_tag_3D__2);
 }
@@ -38403,9 +38529,19 @@ static void mb_elab_module_decl_21__3 (void) {
 }
 
 static void mb_elab_data_header_21__1 (void) {
-    WORD_ENTER(mb_elab_data_header_21__1, "elab-data-header! block", "src/mirth/elab.mth", 821, 28);
+    WORD_ENTER(mb_elab_data_header_21__1, "elab-data-header! block", "src/mirth/elab.mth", 821, 26);
     mw_prim_drop();
-    WORD_ATOM(821, 28, "");
+    WORD_ATOM(821, 26, "dup");
+    mw_prim_dup();
+    WORD_ATOM(821, 30, "sig-resource-con?");
+    mw_Token_2E_sig_resource_con_3F_();
+    WORD_EXIT(mb_elab_data_header_21__1);
+}
+
+static void mb_elab_data_header_21__2 (void) {
+    WORD_ENTER(mb_elab_data_header_21__2, "elab-data-header! block", "src/mirth/elab.mth", 821, 54);
+    mw_prim_drop();
+    WORD_ATOM(821, 54, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38416,13 +38552,13 @@ static void mb_elab_data_header_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(821, 50, "emit-fatal-error!");
+    WORD_ATOM(821, 76, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
-    WORD_EXIT(mb_elab_data_header_21__1);
+    WORD_EXIT(mb_elab_data_header_21__2);
 }
 
-static void mb_elab_data_header_21__2 (void) {
-    WORD_ENTER(mb_elab_data_header_21__2, "elab-data-header! block", "src/mirth/elab.mth", 822, 44);
+static void mb_elab_data_header_21__3 (void) {
+    WORD_ENTER(mb_elab_data_header_21__3, "elab-data-header! block", "src/mirth/elab.mth", 822, 44);
     mw_prim_drop();
     WORD_ATOM(822, 44, "drop2");
     mw_drop2();
@@ -38439,7 +38575,7 @@ static void mb_elab_data_header_21__2 (void) {
     }
     WORD_ATOM(822, 79, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
-    WORD_EXIT(mb_elab_data_header_21__2);
+    WORD_EXIT(mb_elab_data_header_21__3);
 }
 
 static void mb_elab_data_tag_21__1 (void) {

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -2103,22 +2103,6 @@ static void mw_Str_3E_Path (void) {
 }
 static void mw_FILE (void) {
 }
-static void mw_IO_unsafe (void) {
-    push_u64(0LL);
-}
-static void mw_OUT_5F_STR (void) {
-    VAL car = pop_value();
-    VAL tag = MKU64(0LL);
-    car = mkcons(car, tag);
-    push_value(car);
-}
-static void mw_OUT_5F_FILE (void) {
-    VAL car = pop_value();
-    car = mkcons(car, pop_value());
-    VAL tag = MKU64(1LL);
-    car = mkcons(car, tag);
-    push_value(car);
-}
 static void mw_LAZY_5F_READY (void) {
     VAL car = pop_value();
     VAL tag = MKU64(0LL);
@@ -2401,6 +2385,9 @@ static void mw_PRIM_5F_TYPE_5F_PTR (void) {
 }
 static void mw_PRIM_5F_TYPE_5F_STR (void) {
     push_u64(5LL);
+}
+static void mw_PRIM_5F_TYPE_5F__2B_PLATFORM (void) {
+    push_u64(6LL);
 }
 static void mw_GAMMA (void) {
 }
@@ -3183,22 +3170,24 @@ static void mw_List_2E_cat_2B_ (void);
 static void mw_List_2B__2E_cat_2B_ (void);
 static void mw_List_2B__2E_cat_aux (void);
 static void mw_List_2B__2E_rebalance (void);
-static void mw_split_half_left (void);
-static void mw_split_half_right (void);
-static void mw_first (void);
-static void mw_last (void);
-static void mw_first_2B_ (void);
-static void mw_last_2B_ (void);
-static void mw_reverse (void);
-static void mw_reverse_2B_ (void);
+static void mw_List_2B__2E_split_half_left (void);
+static void mw_List_2B__2E_split_half_right (void);
+static void mw_List_2E_first (void);
+static void mw_List_2E_last (void);
+static void mw_List_2B__2E_first (void);
+static void mw_List_2B__2E_last (void);
+static void mw_List_2E_reverse (void);
+static void mw_List_2B__2E_reverse (void);
 static void mw_List_2E_map (void);
-static void mw_map_2B_ (void);
+static void mw_List_2B__2E_map (void);
 static void mw_List_2E_for (void);
 static void mw_List_2B__2E_for (void);
 static void mw_List_2E_reverse_for (void);
 static void mw_List_2B__2E_reverse_for (void);
 static void mw_List_2E_filter (void);
 static void mw_List_2B__2E_filter (void);
+static void mw_List_2E_filter_some (void);
+static void mw_List_2B__2E_filter_some (void);
 static void mw_List_2E_find (void);
 static void mw_List_2B__2E_find (void);
 static void mw_List_2E_reverse_find (void);
@@ -3218,6 +3207,7 @@ static void mw_Maybe_2E_unwrap_or (void);
 static void mw_Maybe_2E_map (void);
 static void mw_Maybe_2E_bind (void);
 static void mw_Maybe_2E_for (void);
+static void mw_Maybe_2E_filter (void);
 static void mw_while_some (void);
 static void mw_Bool_26__26_ (void);
 static void mw_Bool_7C__7C_ (void);
@@ -3304,8 +3294,6 @@ static void mw_Byte_2E_to_hexdigits (void);
 static void mw_one_hexdigit_byte (void);
 static void mw_Byte_2E_is_name_byte (void);
 static void mw_Byte_2E_is_sign (void);
-static void mw_Byte_2E_is_upper_or_underscore (void);
-static void mw_Byte_2E_is_overload_trigger (void);
 static void mw_Str_2E_is_empty (void);
 static void mw_STR_5F_BUF_5F_SIZE (void);
 static void mw_build_str_21_ (void);
@@ -3325,6 +3313,7 @@ static void mw_with_str_data (void);
 static void mw_str_buf_push_ptr_21_ (void);
 static void mw_str_buf_21_ (void);
 static void mw_str_bytes_for (void);
+static void mw_Str_2E_first_byte (void);
 static void mw_Path_3E_Str (void);
 static void mw_Path_3D_ (void);
 static void mw_init_paths_21_ (void);
@@ -3701,6 +3690,11 @@ static void mw_elab_block_at_21_ (void);
 static void mw_elab_args_21_ (void);
 static void mw_elab_no_args_21_ (void);
 static void mw_elab_atom_name_21_ (void);
+static void mw_elab_needs_dot (void);
+static void mw_elab_combine_prefix (void);
+static void mw_elab_combine_prefixes (void);
+static void mw_elab_word_search (void);
+static void mw_elab_name_candidates (void);
 static void mw_elab_relativize_name_21_ (void);
 static void mw_elab_check_name_visible_21_ (void);
 static void mw_elab_module_is_visible (void);
@@ -3820,6 +3814,8 @@ static void mw_TYPE_5F_RESOURCE (void);
 static void mw_TYPE_5F_INT (void);
 static void mw_TYPE_5F_PTR (void);
 static void mw_TYPE_5F_STR (void);
+static void mw_TYPE_5F__2B_PLATFORM (void);
+static void mw_RESOURCE_5F__2B_PLATFORM (void);
 static void mw_Type_2E_expand (void);
 static void mw_Gamma_2E_token (void);
 static void mw_Type_2E_unify_failed_21_ (void);
@@ -3873,6 +3869,8 @@ static void mw_StackType_2E_split3 (void);
 static void mw_StackType_2E_base (void);
 static void mw_StackType_2E_top_type (void);
 static void mw_StackType_2E_top_tycon_name (void);
+static void mw_StackType_2E_top_resource (void);
+static void mw_StackType_2E_top_resource_name (void);
 static void mw_StackType_2E_has_meta_3F_ (void);
 static void mw_StackType_2E_unify_failed_21_ (void);
 static void mw_StackType_2E_unify_21_ (void);
@@ -4005,6 +4003,7 @@ static void mw_Def_3E_Module_3F_ (void);
 static void mw_Def_2E_none_3F_ (void);
 static void mw_Def_2E_prim_3F_ (void);
 static void mw_Def_2E_typecheck_21_ (void);
+static void mw_Def_2E_callable_3F_ (void);
 static void mw_Name_2E_id (void);
 static void mw_Name_2E_from_id (void);
 static void mw_Name_2E_for (void);
@@ -4036,8 +4035,6 @@ static void mw_Name_2E_could_be_stack_var (void);
 static void mw_Name_2E_could_be_resource_var (void);
 static void mw_Name_2E_could_be_resource_con (void);
 static void mw_Name_2E_mangle_compute_21_ (void);
-static void mw_Name_2E_could_be_relative (void);
-static void mw_Name_2E_to_overload_suffix (void);
 static void mw_name_undefined_3F_ (void);
 static void mw_name_defined_3F_ (void);
 static void mw_Module_2E_id (void);
@@ -4097,10 +4094,15 @@ static void mb_assert_21__3 (void);
 static void mb_List_2E_cat_1 (void);
 static void mb_List_2B__2E_cat_1 (void);
 static void mb_List_2E_cat_2B__1 (void);
-static void mb_first_1 (void);
-static void mb_last_1 (void);
+static void mb_List_2E_first_1 (void);
+static void mb_List_2E_last_1 (void);
 static void mb_List_2B__2E_filter_5 (void);
 static void mb_List_2B__2E_filter_10 (void);
+static void mb_List_2E_filter_some_2 (void);
+static void mb_List_2E_filter_some_4 (void);
+static void mb_List_2B__2E_filter_some_5 (void);
+static void mb_List_2B__2E_filter_some_11 (void);
+static void mb_List_2B__2E_filter_some_12 (void);
 static void mb_List_2E_all_2 (void);
 static void mb_Str_2E_write_21__1 (void);
 static void mb_slice_write_21__1 (void);
@@ -4123,6 +4125,7 @@ static void mb_str_buf_push_str_21__1 (void);
 static void mb_str_buf_push_ptr_21__1 (void);
 static void mb_str_bytes_for_2 (void);
 static void mb_str_bytes_for_3 (void);
+static void mb_Str_2E_first_byte_1 (void);
 static void mb_Int_3E_Byte_1 (void);
 static void mb_Int_3E_Byte_2 (void);
 static void mb_Byte_3D__1 (void);
@@ -4243,6 +4246,7 @@ static void mb_MetaVar_2E_expand_2 (void);
 static void mb_MetaVar_3D__1 (void);
 static void mb_Resource_2E_unify_21__1 (void);
 static void mb_StackType_2E_top_tycon_name_1 (void);
+static void mb_StackType_2E_top_resource_name_1 (void);
 static void mb_StackType_2E_unify_failed_21__1 (void);
 static void mb_StackType_2E_unify_21__30 (void);
 static void mb_StackType_2E_unify_21__34 (void);
@@ -4327,9 +4331,18 @@ static void mb_elab_arrow_fwd_21__1 (void);
 static void mb_elab_atoms_21__3 (void);
 static void mb_elab_args_21__1 (void);
 static void mb_elab_relativize_name_21__1 (void);
-static void mb_elab_relativize_name_21__3 (void);
-static void mb_elab_relativize_name_21__4 (void);
+static void mb_elab_relativize_name_21__2 (void);
 static void mb_elab_check_name_visible_21__1 (void);
+static void mb_elab_needs_dot_1 (void);
+static void mb_elab_needs_dot_2 (void);
+static void mb_elab_combine_prefix_1 (void);
+static void mb_elab_combine_prefixes_1 (void);
+static void mb_elab_combine_prefixes_3 (void);
+static void mb_elab_combine_prefixes_2 (void);
+static void mb_elab_word_search_1 (void);
+static void mb_elab_name_candidates_1 (void);
+static void mb_elab_name_candidates_2 (void);
+static void mb_elab_name_candidates_3 (void);
 static void mb_elab_match_exhaustive_21__1 (void);
 static void mb_elab_lambda_params_21__5 (void);
 static void mb_elab_lambda_params_21__9 (void);
@@ -6768,7 +6781,7 @@ static void mw_List_2B__2E_rebalance (void){
         {
             VAL d3 = pop_value();
             WORD_ATOM(142, 19, "split-half-left");
-            mw_split_half_left();
+            mw_List_2B__2E_split_half_left();
             push_value(d3);
         }
         WORD_ATOM(142, 36, "cat");
@@ -6790,7 +6803,7 @@ static void mw_List_2B__2E_rebalance (void){
         WORD_ATOM(143, 20, "if");
         if (pop_u64()) {
             WORD_ATOM(144, 13, "split-half-right");
-            mw_split_half_right();
+            mw_List_2B__2E_split_half_right();
             WORD_ATOM(144, 30, "dip");
             {
                 VAL d4 = pop_value();
@@ -6807,8 +6820,8 @@ static void mw_List_2B__2E_rebalance (void){
     }
     WORD_EXIT(mw_List_2B__2E_rebalance);
 }
-static void mw_split_half_left (void){
-    WORD_ENTER(mw_split_half_left, "split-half-left", "src/data/list.mth", 150, 5);
+static void mw_List_2B__2E_split_half_left (void){
+    WORD_ENTER(mw_List_2B__2E_split_half_left, "List+.split-half-left", "src/data/list.mth", 150, 5);
     WORD_ATOM(150, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
@@ -6861,10 +6874,10 @@ static void mw_split_half_left (void){
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
     
-}    WORD_EXIT(mw_split_half_left);
+}    WORD_EXIT(mw_List_2B__2E_split_half_left);
 }
-static void mw_split_half_right (void){
-    WORD_ENTER(mw_split_half_right, "split-half-right", "src/data/list.mth", 156, 5);
+static void mw_List_2B__2E_split_half_right (void){
+    WORD_ENTER(mw_List_2B__2E_split_half_right, "List+.split-half-right", "src/data/list.mth", 156, 5);
     WORD_ATOM(156, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
@@ -6922,32 +6935,32 @@ static void mw_split_half_right (void){
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
     
-}    WORD_EXIT(mw_split_half_right);
+}    WORD_EXIT(mw_List_2B__2E_split_half_right);
 }
-static void mw_first (void){
-    WORD_ENTER(mw_first, "first", "src/data/list.mth", 168, 33);
-    WORD_ATOM(168, 33, "List>List+");
+static void mw_List_2E_first (void){
+    WORD_ENTER(mw_List_2E_first, "List.first", "src/data/list.mth", 168, 38);
+    WORD_ATOM(168, 38, "List>List+");
     mw_List_3E_List_2B_();
-    WORD_ATOM(168, 44, "map");
+    WORD_ATOM(168, 49, "map");
     push_u64(0);
-    push_fnptr(&mb_first_1);
+    push_fnptr(&mb_List_2E_first_1);
     mw_prim_pack_cons();
     mw_Maybe_2E_map();
-    WORD_EXIT(mw_first);
+    WORD_EXIT(mw_List_2E_first);
 }
-static void mw_last (void){
-    WORD_ENTER(mw_last, "last", "src/data/list.mth", 169, 32);
-    WORD_ATOM(169, 32, "List>List+");
+static void mw_List_2E_last (void){
+    WORD_ENTER(mw_List_2E_last, "List.last", "src/data/list.mth", 169, 37);
+    WORD_ATOM(169, 37, "List>List+");
     mw_List_3E_List_2B_();
-    WORD_ATOM(169, 43, "map");
+    WORD_ATOM(169, 48, "map");
     push_u64(0);
-    push_fnptr(&mb_last_1);
+    push_fnptr(&mb_List_2E_last_1);
     mw_prim_pack_cons();
     mw_Maybe_2E_map();
-    WORD_EXIT(mw_last);
+    WORD_EXIT(mw_List_2E_last);
 }
-static void mw_first_2B_ (void){
-    WORD_ENTER(mw_first_2B_, "first+", "src/data/list.mth", 173, 5);
+static void mw_List_2B__2E_first (void){
+    WORD_ENTER(mw_List_2B__2E_first, "List+.first", "src/data/list.mth", 173, 5);
     WORD_ATOM(173, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
@@ -6974,15 +6987,15 @@ static void mw_first_2B_ (void){
             mw_prim_pack_uncons(); mw_prim_swap();
             WORD_ATOM(176, 14, "drop2");
             mw_drop2();
-            WORD_ATOM(176, 20, "first+");
-            mw_first_2B_();
+            WORD_ATOM(176, 20, "first");
+            mw_List_2B__2E_first();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
     
-}    WORD_EXIT(mw_first_2B_);
+}    WORD_EXIT(mw_List_2B__2E_first);
 }
-static void mw_last_2B_ (void){
-    WORD_ENTER(mw_last_2B_, "last+", "src/data/list.mth", 179, 5);
+static void mw_List_2B__2E_last (void){
+    WORD_ENTER(mw_List_2B__2E_last, "List+.last", "src/data/list.mth", 179, 5);
     WORD_ATOM(179, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
@@ -7021,15 +7034,15 @@ static void mw_last_2B_ (void){
             mw_prim_drop();
             WORD_ATOM(182, 19, "nip");
             mw_nip();
-            WORD_ATOM(182, 23, "last+");
-            mw_last_2B_();
+            WORD_ATOM(182, 23, "last");
+            mw_List_2B__2E_last();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
     
-}    WORD_EXIT(mw_last_2B_);
+}    WORD_EXIT(mw_List_2B__2E_last);
 }
-static void mw_reverse (void){
-    WORD_ENTER(mw_reverse, "reverse", "src/data/list.mth", 192, 5);
+static void mw_List_2E_reverse (void){
+    WORD_ENTER(mw_List_2E_reverse, "List.reverse", "src/data/list.mth", 192, 5);
     WORD_ATOM(192, 5, "L0");
     switch (get_top_data_tag()) {
         case 0LL:
@@ -7068,23 +7081,23 @@ static void mw_reverse (void){
             WORD_ATOM(196, 13, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(196, 17, "reverse+");
-                mw_reverse_2B_();
-                WORD_ATOM(196, 26, "swap");
+                WORD_ATOM(196, 17, "reverse");
+                mw_List_2B__2E_reverse();
+                WORD_ATOM(196, 25, "swap");
                 mw_prim_swap();
-                WORD_ATOM(196, 31, "reverse+");
-                mw_reverse_2B_();
+                WORD_ATOM(196, 30, "reverse");
+                mw_List_2B__2E_reverse();
                 push_value(d4);
             }
-            WORD_ATOM(196, 41, "LCAT");
+            WORD_ATOM(196, 39, "LCAT");
             mw_LCAT();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
     
-}    WORD_EXIT(mw_reverse);
+}    WORD_EXIT(mw_List_2E_reverse);
 }
-static void mw_reverse_2B_ (void){
-    WORD_ENTER(mw_reverse_2B_, "reverse+", "src/data/list.mth", 200, 5);
+static void mw_List_2B__2E_reverse (void){
+    WORD_ENTER(mw_List_2B__2E_reverse, "List+.reverse", "src/data/list.mth", 200, 5);
     WORD_ATOM(200, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
@@ -7118,20 +7131,20 @@ static void mw_reverse_2B_ (void){
             WORD_ATOM(203, 14, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(203, 18, "reverse+");
-                mw_reverse_2B_();
-                WORD_ATOM(203, 27, "swap");
+                WORD_ATOM(203, 18, "reverse");
+                mw_List_2B__2E_reverse();
+                WORD_ATOM(203, 26, "swap");
                 mw_prim_swap();
-                WORD_ATOM(203, 32, "reverse+");
-                mw_reverse_2B_();
+                WORD_ATOM(203, 31, "reverse");
+                mw_List_2B__2E_reverse();
                 push_value(d4);
             }
-            WORD_ATOM(203, 42, "LCAT+");
+            WORD_ATOM(203, 40, "LCAT+");
             mw_LCAT_2B_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
     
-}    WORD_EXIT(mw_reverse_2B_);
+}    WORD_EXIT(mw_List_2B__2E_reverse);
 }
 static void mw_List_2E_map (void){
     WORD_ENTER(mw_List_2E_map, "List.map", "src/data/list.mth", 207, 5);
@@ -7241,28 +7254,28 @@ static void mw_List_2E_map (void){
                     WORD_ATOM(211, 17, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(211, 21, "map+");
+                        WORD_ATOM(211, 21, "map");
                         incref(var_f);
                         push_value(var_f);
-                        mw_map_2B_();
+                        mw_List_2B__2E_map();
                         push_value(d6);
                     }
-                    WORD_ATOM(211, 30, "swap");
+                    WORD_ATOM(211, 29, "swap");
                     mw_prim_swap();
-                    WORD_ATOM(211, 35, "dip");
+                    WORD_ATOM(211, 34, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(211, 39, "map+");
+                        WORD_ATOM(211, 38, "map");
                         incref(var_f);
                         push_value(var_f);
-                        mw_map_2B_();
+                        mw_List_2B__2E_map();
                         push_value(d6);
                     }
-                    WORD_ATOM(211, 48, "swap");
+                    WORD_ATOM(211, 46, "swap");
                     mw_prim_swap();
                     push_value(d5);
                 }
-                WORD_ATOM(211, 54, "LCAT");
+                WORD_ATOM(211, 52, "LCAT");
                 mw_LCAT();
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -7271,8 +7284,8 @@ static void mw_List_2E_map (void){
     }
     WORD_EXIT(mw_List_2E_map);
 }
-static void mw_map_2B_ (void){
-    WORD_ENTER(mw_map_2B_, "map+", "src/data/list.mth", 215, 5);
+static void mw_List_2B__2E_map (void){
+    WORD_ENTER(mw_List_2B__2E_map, "List+.map", "src/data/list.mth", 215, 5);
     WORD_ATOM(215, 5, "L1+");
     {
         VAL var_f = pop_value();
@@ -7374,35 +7387,35 @@ static void mw_map_2B_ (void){
                     WORD_ATOM(218, 18, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(218, 22, "map+");
+                        WORD_ATOM(218, 22, "map");
                         incref(var_f);
                         push_value(var_f);
-                        mw_map_2B_();
+                        mw_List_2B__2E_map();
                         push_value(d6);
                     }
-                    WORD_ATOM(218, 31, "swap");
+                    WORD_ATOM(218, 30, "swap");
                     mw_prim_swap();
-                    WORD_ATOM(218, 36, "dip");
+                    WORD_ATOM(218, 35, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(218, 40, "map+");
+                        WORD_ATOM(218, 39, "map");
                         incref(var_f);
                         push_value(var_f);
-                        mw_map_2B_();
+                        mw_List_2B__2E_map();
                         push_value(d6);
                     }
-                    WORD_ATOM(218, 49, "swap");
+                    WORD_ATOM(218, 47, "swap");
                     mw_prim_swap();
                     push_value(d5);
                 }
-                WORD_ATOM(218, 55, "LCAT+");
+                WORD_ATOM(218, 53, "LCAT+");
                 mw_LCAT_2B_();
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
         
 }        decref(var_f);
     }
-    WORD_EXIT(mw_map_2B_);
+    WORD_EXIT(mw_List_2B__2E_map);
 }
 static void mw_List_2E_for (void){
     WORD_ENTER(mw_List_2E_for, "List.for", "src/data/list.mth", 222, 5);
@@ -7833,23 +7846,117 @@ static void mw_List_2B__2E_filter (void){
     }
     WORD_EXIT(mw_List_2B__2E_filter);
 }
+static void mw_List_2E_filter_some (void){
+    WORD_ENTER(mw_List_2E_filter_some, "List.filter-some", "src/data/list.mth", 279, 5);
+    WORD_ATOM(279, 5, "List>List+");
+    {
+        VAL var_p = pop_value();
+        WORD_ATOM(279, 5, "List>List+");
+        mw_List_3E_List_2B_();
+        WORD_ATOM(279, 16, "if-some");
+        push_u64(0);
+        incref(var_p);
+        push_value(var_p);
+        mw_prim_pack_cons();
+        push_fnptr(&mb_List_2E_filter_some_2);
+        mw_prim_pack_cons();
+        push_u64(0);
+        incref(var_p);
+        push_value(var_p);
+        mw_prim_pack_cons();
+        push_fnptr(&mb_List_2E_filter_some_4);
+        mw_prim_pack_cons();
+        mw_Maybe_2E_if_some();
+        decref(var_p);
+    }
+    WORD_EXIT(mw_List_2E_filter_some);
+}
+static void mw_List_2B__2E_filter_some (void){
+    WORD_ENTER(mw_List_2B__2E_filter_some, "List+.filter-some", "src/data/list.mth", 282, 5);
+    WORD_ATOM(282, 5, "LCAT+");
+    {
+        VAL var_p = pop_value();
+        WORD_ATOM(282, 5, "LCAT+");
+        switch (get_top_data_tag()) {
+            case 3LL:
+                mw_prim_pack_uncons(); mw_prim_drop();
+                mw_prim_pack_uncons(); mw_prim_swap();
+                mw_prim_pack_uncons(); mw_prim_swap();
+                WORD_ATOM(282, 14, "drop");
+                mw_prim_drop();
+                WORD_ATOM(282, 19, "dip");
+                {
+                    VAL d5 = pop_value();
+                    WORD_ATOM(282, 23, "filter-some");
+                    incref(var_p);
+                    push_value(var_p);
+                    mw_List_2B__2E_filter_some();
+                    push_value(d5);
+                }
+                WORD_ATOM(282, 39, "dip'");
+                push_u64(0);
+                incref(var_p);
+                push_value(var_p);
+                mw_prim_pack_cons();
+                push_fnptr(&mb_List_2B__2E_filter_some_5);
+                mw_prim_pack_cons();
+                mw_dip_27_();
+                WORD_ATOM(282, 60, "cat");
+                mw_List_2E_cat();
+                break;
+            default:
+                WORD_ATOM(283, 10, "unsnoc");
+                mw_List_2B__2E_unsnoc();
+                WORD_ATOM(283, 17, "dip");
+                {
+                    VAL d5 = pop_value();
+                    WORD_ATOM(283, 21, "filter-some");
+                    incref(var_p);
+                    push_value(var_p);
+                    mw_List_2E_filter_some();
+                    push_value(d5);
+                }
+                WORD_ATOM(283, 37, "dip'");
+                incref(var_p);
+                push_value(var_p);
+                mw_dip_27_();
+                WORD_ATOM(283, 45, "if-some");
+                push_u64(0);
+                incref(var_p);
+                push_value(var_p);
+                mw_prim_pack_cons();
+                push_fnptr(&mb_List_2B__2E_filter_some_11);
+                mw_prim_pack_cons();
+                push_u64(0);
+                incref(var_p);
+                push_value(var_p);
+                mw_prim_pack_cons();
+                push_fnptr(&mb_List_2B__2E_filter_some_12);
+                mw_prim_pack_cons();
+                mw_Maybe_2E_if_some();
+                break;
+        
+}        decref(var_p);
+    }
+    WORD_EXIT(mw_List_2B__2E_filter_some);
+}
 static void mw_List_2E_find (void){
-    WORD_ENTER(mw_List_2E_find, "List.find", "src/data/list.mth", 280, 5);
-    WORD_ATOM(280, 5, "List>List+");
+    WORD_ENTER(mw_List_2E_find, "List.find", "src/data/list.mth", 287, 5);
+    WORD_ATOM(287, 5, "List>List+");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(280, 5, "List>List+");
+        WORD_ATOM(287, 5, "List>List+");
         mw_List_3E_List_2B_();
-        WORD_ATOM(280, 16, "match");
+        WORD_ATOM(287, 16, "match");
         switch (get_top_data_tag()) {
             case 0LL:
                 mw_prim_drop();
-                WORD_ATOM(281, 17, "NONE");
+                WORD_ATOM(288, 17, "NONE");
                 mw_NONE();
                 break;
             case 1LL:
                 mw_prim_pack_uncons(); mw_prim_drop();
-                WORD_ATOM(282, 17, "find");
+                WORD_ATOM(289, 17, "find");
                 incref(var_f);
                 push_value(var_f);
                 mw_List_2B__2E_find();
@@ -7861,41 +7968,41 @@ static void mw_List_2E_find (void){
     WORD_EXIT(mw_List_2E_find);
 }
 static void mw_List_2B__2E_find (void){
-    WORD_ENTER(mw_List_2B__2E_find, "List+.find", "src/data/list.mth", 287, 5);
-    WORD_ATOM(287, 5, "LCAT+");
+    WORD_ENTER(mw_List_2B__2E_find, "List+.find", "src/data/list.mth", 294, 5);
+    WORD_ATOM(294, 5, "LCAT+");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(287, 5, "LCAT+");
+        WORD_ATOM(294, 5, "LCAT+");
         switch (get_top_data_tag()) {
             case 3LL:
                 mw_prim_pack_uncons(); mw_prim_drop();
                 mw_prim_pack_uncons(); mw_prim_swap();
                 mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(288, 9, "drop");
+                WORD_ATOM(295, 9, "drop");
                 mw_prim_drop();
-                WORD_ATOM(288, 14, "dip");
+                WORD_ATOM(295, 14, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(288, 18, "find");
+                    WORD_ATOM(295, 18, "find");
                     incref(var_f);
                     push_value(var_f);
                     mw_List_2B__2E_find();
                     push_value(d5);
                 }
-                WORD_ATOM(288, 27, "swap");
+                WORD_ATOM(295, 27, "swap");
                 mw_prim_swap();
-                WORD_ATOM(289, 9, "match");
+                WORD_ATOM(296, 9, "match");
                 switch (get_top_data_tag()) {
                     case 1LL:
                         mw_prim_pack_uncons(); mw_prim_drop();
-                        WORD_ATOM(290, 21, "nip");
+                        WORD_ATOM(297, 21, "nip");
                         mw_nip();
-                        WORD_ATOM(290, 25, "SOME");
+                        WORD_ATOM(297, 25, "SOME");
                         mw_SOME();
                         break;
                     case 0LL:
                         mw_prim_drop();
-                        WORD_ATOM(291, 21, "find");
+                        WORD_ATOM(298, 21, "find");
                         incref(var_f);
                         push_value(var_f);
                         mw_List_2B__2E_find();
@@ -7904,28 +8011,28 @@ static void mw_List_2B__2E_find (void){
                 
 }                break;
             default:
-                WORD_ATOM(294, 9, "uncons");
+                WORD_ATOM(301, 9, "uncons");
                 mw_List_2B__2E_uncons();
-                WORD_ATOM(294, 16, "dip");
+                WORD_ATOM(301, 16, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(294, 20, "f");
+                    WORD_ATOM(301, 20, "f");
                     incref(var_f);
                     run_value(var_f);
                     push_value(d5);
                 }
-                WORD_ATOM(294, 23, "swap");
+                WORD_ATOM(301, 23, "swap");
                 mw_prim_swap();
-                WORD_ATOM(294, 28, "if");
+                WORD_ATOM(301, 28, "if");
                 if (pop_u64()) {
-                    WORD_ATOM(295, 13, "drop");
+                    WORD_ATOM(302, 13, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(295, 18, "SOME");
+                    WORD_ATOM(302, 18, "SOME");
                     mw_SOME();
                 } else {
-                    WORD_ATOM(296, 13, "nip");
+                    WORD_ATOM(303, 13, "nip");
                     mw_nip();
-                    WORD_ATOM(296, 17, "find");
+                    WORD_ATOM(303, 17, "find");
                     incref(var_f);
                     push_value(var_f);
                     mw_List_2E_find();
@@ -7937,13 +8044,13 @@ static void mw_List_2B__2E_find (void){
     WORD_EXIT(mw_List_2B__2E_find);
 }
 static void mw_List_2E_reverse_find (void){
-    WORD_ENTER(mw_List_2E_reverse_find, "List.reverse-find", "src/data/list.mth", 306, 5);
-    WORD_ATOM(306, 5, "reverse");
+    WORD_ENTER(mw_List_2E_reverse_find, "List.reverse-find", "src/data/list.mth", 313, 5);
+    WORD_ATOM(313, 5, "reverse");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(306, 5, "reverse");
-        mw_reverse();
-        WORD_ATOM(306, 13, "find");
+        WORD_ATOM(313, 5, "reverse");
+        mw_List_2E_reverse();
+        WORD_ATOM(313, 13, "find");
         incref(var_f);
         push_value(var_f);
         mw_List_2E_find();
@@ -7952,26 +8059,26 @@ static void mw_List_2E_reverse_find (void){
     WORD_EXIT(mw_List_2E_reverse_find);
 }
 static void mw_List_2E_any (void){
-    WORD_ENTER(mw_List_2E_any, "List.any", "src/data/list.mth", 314, 5);
-    WORD_ATOM(314, 5, "find");
+    WORD_ENTER(mw_List_2E_any, "List.any", "src/data/list.mth", 321, 5);
+    WORD_ATOM(321, 5, "find");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(314, 5, "find");
+        WORD_ATOM(321, 5, "find");
         incref(var_f);
         push_value(var_f);
         mw_List_2E_find();
-        WORD_ATOM(314, 13, "some?");
+        WORD_ATOM(321, 13, "some?");
         mw_Maybe_2E_some_3F_();
         decref(var_f);
     }
     WORD_EXIT(mw_List_2E_any);
 }
 static void mw_List_2E_all (void){
-    WORD_ENTER(mw_List_2E_all, "List.all", "src/data/list.mth", 322, 5);
-    WORD_ATOM(322, 5, "find");
+    WORD_ENTER(mw_List_2E_all, "List.all", "src/data/list.mth", 329, 5);
+    WORD_ATOM(329, 5, "find");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(322, 5, "find");
+        WORD_ATOM(329, 5, "find");
         push_u64(0);
         incref(var_f);
         push_value(var_f);
@@ -7979,44 +8086,44 @@ static void mw_List_2E_all (void){
         push_fnptr(&mb_List_2E_all_2);
         mw_prim_pack_cons();
         mw_List_2E_find();
-        WORD_ATOM(322, 17, "none?");
+        WORD_ATOM(329, 17, "none?");
         mw_Maybe_2E_none_3F_();
         decref(var_f);
     }
     WORD_EXIT(mw_List_2E_all);
 }
 static void mw_collect_while (void){
-    WORD_ENTER(mw_collect_while, "collect-while", "src/data/list.mth", 334, 5);
-    WORD_ATOM(334, 5, "L0");
+    WORD_ENTER(mw_collect_while, "collect-while", "src/data/list.mth", 341, 5);
+    WORD_ATOM(341, 5, "L0");
     {
         VAL var_g = pop_value();
         VAL var_f = pop_value();
-        WORD_ATOM(334, 5, "L0");
+        WORD_ATOM(341, 5, "L0");
         mw_L0();
-        WORD_ATOM(334, 8, "while");
+        WORD_ATOM(341, 8, "while");
         while(1) {
-            WORD_ATOM(334, 14, "dip");
+            WORD_ATOM(341, 14, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(334, 18, "f");
+                WORD_ATOM(341, 18, "f");
                 incref(var_f);
                 run_value(var_f);
                 push_value(d4);
             }
-            WORD_ATOM(334, 21, "swap");
+            WORD_ATOM(341, 21, "swap");
             mw_prim_swap();
             if (! pop_u64()) break;
-            WORD_ATOM(334, 27, "dip");
+            WORD_ATOM(341, 27, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(334, 31, "g");
+                WORD_ATOM(341, 31, "g");
                 incref(var_g);
                 run_value(var_g);
                 push_value(d4);
             }
-            WORD_ATOM(334, 34, "swap");
+            WORD_ATOM(341, 34, "swap");
             mw_prim_swap();
-            WORD_ATOM(334, 39, "snoc");
+            WORD_ATOM(341, 39, "snoc");
             mw_snoc();
         }
         decref(var_g);
@@ -8296,6 +8403,40 @@ static void mw_Maybe_2E_for (void){
 }        decref(var_f);
     }
     WORD_EXIT(mw_Maybe_2E_for);
+}
+static void mw_Maybe_2E_filter (void){
+    WORD_ENTER(mw_Maybe_2E_filter, "Maybe.filter", "src/data/maybe.mth", 65, 5);
+    WORD_ATOM(65, 5, "NONE");
+    {
+        VAL var_f = pop_value();
+        WORD_ATOM(65, 5, "NONE");
+        switch (get_top_data_tag()) {
+            case 0LL:
+                mw_prim_drop();
+                WORD_ATOM(65, 13, "NONE");
+                mw_NONE();
+                break;
+            case 1LL:
+                mw_prim_pack_uncons(); mw_prim_drop();
+                WORD_ATOM(66, 13, "f");
+                incref(var_f);
+                run_value(var_f);
+                WORD_ATOM(66, 15, "if");
+                if (pop_u64()) {
+                    WORD_ATOM(66, 18, "SOME");
+                    mw_SOME();
+                } else {
+                    WORD_ATOM(66, 24, "drop");
+                    mw_prim_drop();
+                    WORD_ATOM(66, 29, "NONE");
+                    mw_NONE();
+                }
+                break;
+            default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
+        
+}        decref(var_f);
+    }
+    WORD_EXIT(mw_Maybe_2E_filter);
 }
 static void mw_while_some (void){
     WORD_ENTER(mw_while_some, "while-some", "src/data/maybe.mth", 69, 5);
@@ -9751,30 +9892,6 @@ static void mw_Byte_2E_is_sign (void){
     
 }    WORD_EXIT(mw_Byte_2E_is_sign);
 }
-static void mw_Byte_2E_is_upper_or_underscore (void){
-    WORD_ENTER(mw_Byte_2E_is_upper_or_underscore, "Byte.is-upper-or-underscore", "src/data/byte.mth", 105, 5);
-    WORD_ATOM(105, 5, "B'_'");
-    switch (get_top_data_tag()) {
-        case 95LL:
-            mw_prim_drop();
-            WORD_ATOM(105, 13, "T");
-            mw_T();
-            break;
-        default:
-            WORD_ATOM(106, 10, "is-upper");
-            mw_Byte_2E_is_upper();
-            break;
-    
-}    WORD_EXIT(mw_Byte_2E_is_upper_or_underscore);
-}
-static void mw_Byte_2E_is_overload_trigger (void){
-    WORD_ENTER(mw_Byte_2E_is_overload_trigger, "Byte.is-overload-trigger", "src/data/byte.mth", 109, 5);
-    WORD_ATOM(109, 5, "is-upper-or-underscore");
-    mw_Byte_2E_is_upper_or_underscore();
-    WORD_ATOM(109, 28, "not");
-    mw_Bool_2E_not();
-    WORD_EXIT(mw_Byte_2E_is_overload_trigger);
-}
 static void mw_Str_2E_is_empty (void){
     WORD_ENTER(mw_Str_2E_is_empty, "Str.is-empty", "src/data/str.mth", 9, 32);
     WORD_ATOM(9, 32, "num-bytes");
@@ -10055,6 +10172,15 @@ static void mw_str_bytes_for (void){
         decref(var_f);
     }
     WORD_EXIT(mw_str_bytes_for);
+}
+static void mw_Str_2E_first_byte (void){
+    WORD_ENTER(mw_Str_2E_first_byte, "Str.first-byte", "src/data/str.mth", 101, 5);
+    WORD_ATOM(101, 5, "with-str-data");
+    push_u64(0);
+    push_fnptr(&mb_Str_2E_first_byte_1);
+    mw_prim_pack_cons();
+    mw_with_str_data();
+    WORD_EXIT(mw_Str_2E_first_byte);
 }
 static void mw_Path_3E_Str (void){
     WORD_ENTER(mw_Path_3E_Str, "Path>Str", "src/data/path.mth", 7, 28);
@@ -12004,7 +12130,7 @@ static void mw_Match_2E_scrutinee_data_3F_ (void){
     WORD_ATOM(61, 44, "dup");
     mw_prim_dup();
     WORD_ATOM(62, 5, "first");
-    mw_first();
+    mw_List_2E_first();
     WORD_ATOM(62, 11, "bind");
     push_u64(0);
     push_fnptr(&mb_Match_2E_scrutinee_data_3F__2);
@@ -18086,7 +18212,7 @@ static void mw_c99_match_21_ (void){
         WORD_ATOM(509, 9, "cases");
         mw_Match_2E_cases();
         WORD_ATOM(509, 15, "first");
-        mw_first();
+        mw_List_2E_first();
         WORD_ATOM(509, 21, "unwrap");
         mw_Maybe_2E_unwrap();
         WORD_ATOM(509, 28, "body");
@@ -18662,36 +18788,36 @@ static void mw_c99_main_21_ (void){
     WORD_EXIT(mw_c99_main_21_);
 }
 static void mw_type_elab_default (void){
-    WORD_ENTER(mw_type_elab_default, "type-elab-default", "src/mirth/elab.mth", 39, 34);
-    WORD_ATOM(39, 34, "F");
+    WORD_ENTER(mw_type_elab_default, "type-elab-default", "src/mirth/elab.mth", 40, 34);
+    WORD_ATOM(40, 34, "F");
     mw_F();
-    WORD_ATOM(39, 36, "CTX0");
+    WORD_ATOM(40, 36, "CTX0");
     mw_CTX0();
-    WORD_ATOM(39, 41, "TYPE_ELAB");
+    WORD_ATOM(40, 41, "TYPE_ELAB");
     mw_TYPE_5F_ELAB();
     WORD_EXIT(mw_type_elab_default);
 }
 static void mw_type_elab_stack_assertion (void){
-    WORD_ENTER(mw_type_elab_stack_assertion, "type-elab-stack-assertion", "src/mirth/elab.mth", 40, 49);
-    WORD_ATOM(40, 49, "dip");
+    WORD_ENTER(mw_type_elab_stack_assertion, "type-elab-stack-assertion", "src/mirth/elab.mth", 41, 49);
+    WORD_ATOM(41, 49, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(40, 53, "T");
+        WORD_ATOM(41, 53, "T");
         mw_T();
         push_value(d2);
     }
-    WORD_ATOM(40, 56, "TYPE_ELAB");
+    WORD_ATOM(41, 56, "TYPE_ELAB");
     mw_TYPE_5F_ELAB();
     WORD_EXIT(mw_type_elab_stack_assertion);
 }
 static void mw_type_elab_holes_allowed (void){
-    WORD_ENTER(mw_type_elab_holes_allowed, "type-elab-holes-allowed", "src/mirth/elab.mth", 41, 48);
-    WORD_ATOM(41, 48, "TYPE_ELAB");
+    WORD_ENTER(mw_type_elab_holes_allowed, "type-elab-holes-allowed", "src/mirth/elab.mth", 42, 48);
+    WORD_ATOM(42, 48, "TYPE_ELAB");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(41, 61, "drop");
+            WORD_ATOM(42, 61, "drop");
             mw_prim_drop();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -18699,13 +18825,13 @@ static void mw_type_elab_holes_allowed (void){
 }    WORD_EXIT(mw_type_elab_holes_allowed);
 }
 static void mw_type_elab_ctx (void){
-    WORD_ENTER(mw_type_elab_ctx, "type-elab-ctx", "src/mirth/elab.mth", 42, 37);
-    WORD_ATOM(42, 37, "TYPE_ELAB");
+    WORD_ENTER(mw_type_elab_ctx, "type-elab-ctx", "src/mirth/elab.mth", 43, 37);
+    WORD_ATOM(43, 37, "TYPE_ELAB");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(42, 50, "nip");
+            WORD_ATOM(43, 50, "nip");
             mw_nip();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -18713,27 +18839,27 @@ static void mw_type_elab_ctx (void){
 }    WORD_EXIT(mw_type_elab_ctx);
 }
 static void mw_type_elab_ctx_3F_ (void){
-    WORD_ENTER(mw_type_elab_ctx_3F_, "type-elab-ctx?", "src/mirth/elab.mth", 43, 47);
-    WORD_ATOM(43, 47, "dup");
+    WORD_ENTER(mw_type_elab_ctx_3F_, "type-elab-ctx?", "src/mirth/elab.mth", 44, 47);
+    WORD_ATOM(44, 47, "dup");
     mw_prim_dup();
-    WORD_ATOM(43, 51, "type-elab-ctx");
+    WORD_ATOM(44, 51, "type-elab-ctx");
     mw_type_elab_ctx();
     WORD_EXIT(mw_type_elab_ctx_3F_);
 }
 static void mw_type_elab_ctx_replace (void){
-    WORD_ENTER(mw_type_elab_ctx_replace, "type-elab-ctx-replace", "src/mirth/elab.mth", 45, 5);
-    WORD_ATOM(45, 5, "swap");
+    WORD_ENTER(mw_type_elab_ctx_replace, "type-elab-ctx-replace", "src/mirth/elab.mth", 46, 5);
+    WORD_ATOM(46, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(45, 10, "match");
+    WORD_ATOM(46, 10, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(45, 29, "drop");
+            WORD_ATOM(46, 29, "drop");
             mw_prim_drop();
-            WORD_ATOM(45, 34, "swap");
+            WORD_ATOM(46, 34, "swap");
             mw_prim_swap();
-            WORD_ATOM(45, 39, "TYPE_ELAB");
+            WORD_ATOM(46, 39, "TYPE_ELAB");
             mw_TYPE_5F_ELAB();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -18741,101 +18867,101 @@ static void mw_type_elab_ctx_replace (void){
 }    WORD_EXIT(mw_type_elab_ctx_replace);
 }
 static void mw_elab_type_sig_21_ (void){
-    WORD_ENTER(mw_elab_type_sig_21_, "elab-type-sig!", "src/mirth/elab.mth", 48, 5);
-    WORD_ATOM(48, 5, "dup");
+    WORD_ENTER(mw_elab_type_sig_21_, "elab-type-sig!", "src/mirth/elab.mth", 49, 5);
+    WORD_ATOM(49, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(48, 9, "run-end?");
+    WORD_ATOM(49, 9, "run-end?");
     mw_Token_2E_run_end_3F_();
-    WORD_ATOM(48, 18, "then");
+    WORD_ATOM(49, 18, "then");
     push_u64(0);
     push_fnptr(&mb_elab_type_sig_21__1);
     mw_prim_pack_cons();
     mw_Bool_2E_then();
-    WORD_ATOM(49, 5, "elab-type-sig-params!");
+    WORD_ATOM(50, 5, "elab-type-sig-params!");
     mw_elab_type_sig_params_21_();
-    WORD_ATOM(49, 27, "dip");
+    WORD_ATOM(50, 27, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(49, 31, "swap");
+        WORD_ATOM(50, 31, "swap");
         mw_prim_swap();
         push_value(d2);
     }
-    WORD_ATOM(50, 5, "elab-type-stack!");
+    WORD_ATOM(51, 5, "elab-type-stack!");
     mw_elab_type_stack_21_();
-    WORD_ATOM(50, 22, "dip");
+    WORD_ATOM(51, 22, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(50, 26, "swap");
+        WORD_ATOM(51, 26, "swap");
         mw_prim_swap();
         push_value(d2);
     }
-    WORD_ATOM(51, 5, "dup");
+    WORD_ATOM(52, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(51, 9, "sig-dashes?");
+    WORD_ATOM(52, 9, "sig-dashes?");
     mw_Token_2E_sig_dashes_3F_();
-    WORD_ATOM(51, 21, "if");
+    WORD_ATOM(52, 21, "if");
     if (pop_u64()) {
-        WORD_ATOM(52, 9, "next");
+        WORD_ATOM(53, 9, "next");
         mw_Token_2E_next();
-        WORD_ATOM(52, 14, "elab-type-stack!");
+        WORD_ATOM(53, 14, "elab-type-stack!");
         mw_elab_type_stack_21_();
-        WORD_ATOM(52, 31, "dip");
+        WORD_ATOM(53, 31, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(52, 35, "swap");
+            WORD_ATOM(53, 35, "swap");
             mw_prim_swap();
             push_value(d3);
         }
     } else {
-        WORD_ATOM(53, 9, "dip");
+        WORD_ATOM(54, 9, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(53, 13, "T0");
+            WORD_ATOM(54, 13, "T0");
             mw_T0();
-            WORD_ATOM(53, 16, "rotr");
+            WORD_ATOM(54, 16, "rotr");
             mw_rotr();
             push_value(d3);
         }
     }
-    WORD_ATOM(54, 5, "dup");
+    WORD_ATOM(55, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(54, 9, "run-end?");
+    WORD_ATOM(55, 9, "run-end?");
     mw_Token_2E_run_end_3F_();
-    WORD_ATOM(54, 18, "else");
+    WORD_ATOM(55, 18, "else");
     push_u64(0);
     push_fnptr(&mb_elab_type_sig_21__8);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(55, 5, "dip");
+    WORD_ATOM(56, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(55, 9, "rot4r");
+        WORD_ATOM(56, 9, "rot4r");
         mw_rot4r();
-        WORD_ATOM(55, 15, "dip");
+        WORD_ATOM(56, 15, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(55, 19, "swap");
+            WORD_ATOM(56, 19, "swap");
             mw_prim_swap();
-            WORD_ATOM(55, 24, "for");
+            WORD_ATOM(56, 24, "for");
             push_u64(0);
             push_fnptr(&mb_elab_type_sig_21__11);
             mw_prim_pack_cons();
             mw_List_2E_for();
             push_value(d3);
         }
-        WORD_ATOM(55, 33, "T->");
+        WORD_ATOM(56, 33, "T->");
         mw_T__3E_();
         push_value(d2);
     }
     WORD_EXIT(mw_elab_type_sig_21_);
 }
 static void mw_elab_type_sig_params_21_ (void){
-    WORD_ENTER(mw_elab_type_sig_params_21_, "elab-type-sig-params!", "src/mirth/elab.mth", 58, 5);
-    WORD_ATOM(58, 5, "dup");
+    WORD_ENTER(mw_elab_type_sig_params_21_, "elab-type-sig-params!", "src/mirth/elab.mth", 59, 5);
+    WORD_ATOM(59, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(58, 9, "lparen?");
+    WORD_ATOM(59, 9, "lparen?");
     mw_Token_2E_lparen_3F_();
-    WORD_ATOM(58, 17, ".if");
+    WORD_ATOM(59, 17, ".if");
     push_u64(0);
     push_fnptr(&mb_elab_type_sig_params_21__1);
     mw_prim_pack_cons();
@@ -18846,63 +18972,63 @@ static void mw_elab_type_sig_params_21_ (void){
     WORD_EXIT(mw_elab_type_sig_params_21_);
 }
 static void mw_elab_type_stack_21_ (void){
-    WORD_ENTER(mw_elab_type_stack_21_, "elab-type-stack!", "src/mirth/elab.mth", 68, 5);
-    WORD_ATOM(68, 5, "dup");
+    WORD_ENTER(mw_elab_type_stack_21_, "elab-type-stack!", "src/mirth/elab.mth", 69, 5);
+    WORD_ATOM(69, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(68, 9, "sig-stack-var?");
+    WORD_ATOM(69, 9, "sig-stack-var?");
     mw_Token_2E_sig_stack_var_3F_();
-    WORD_ATOM(68, 24, "if");
+    WORD_ATOM(69, 24, "if");
     if (pop_u64()) {
-        WORD_ATOM(69, 9, "elab-stack-var!");
+        WORD_ATOM(70, 9, "elab-stack-var!");
         mw_elab_stack_var_21_();
-        WORD_ATOM(69, 25, "dip");
+        WORD_ATOM(70, 25, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(69, 29, "STVar");
+            WORD_ATOM(70, 29, "STVar");
             mw_STVar();
             push_value(d3);
         }
     } else {
-        WORD_ATOM(70, 9, "dip");
+        WORD_ATOM(71, 9, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(70, 13, "T0");
+            WORD_ATOM(71, 13, "T0");
             mw_T0();
             push_value(d3);
         }
     }
-    WORD_ATOM(72, 5, "elab-type-stack-rest!");
+    WORD_ATOM(73, 5, "elab-type-stack-rest!");
     mw_elab_type_stack_rest_21_();
     WORD_EXIT(mw_elab_type_stack_21_);
 }
 static void mw_elab_type_stack_rest_21_ (void){
-    WORD_ENTER(mw_elab_type_stack_rest_21_, "elab-type-stack-rest!", "src/mirth/elab.mth", 75, 5);
-    WORD_ATOM(75, 5, "while");
+    WORD_ENTER(mw_elab_type_stack_rest_21_, "elab-type-stack-rest!", "src/mirth/elab.mth", 76, 5);
+    WORD_ATOM(76, 5, "while");
     while(1) {
-        WORD_ATOM(75, 11, "dup");
+        WORD_ATOM(76, 11, "dup");
         mw_prim_dup();
-        WORD_ATOM(75, 15, "sig-stack-end?");
+        WORD_ATOM(76, 15, "sig-stack-end?");
         mw_Token_2E_sig_stack_end_3F_();
-        WORD_ATOM(75, 30, "not");
+        WORD_ATOM(76, 30, "not");
         mw_Bool_2E_not();
         if (! pop_u64()) break;
-        WORD_ATOM(76, 9, "swap");
+        WORD_ATOM(77, 9, "swap");
         mw_prim_swap();
-        WORD_ATOM(76, 14, "dip");
+        WORD_ATOM(77, 14, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(76, 18, "elab-type-atom!");
+            WORD_ATOM(77, 18, "elab-type-atom!");
             mw_elab_type_atom_21_();
             push_value(d3);
         }
-        WORD_ATOM(76, 35, "swap");
+        WORD_ATOM(77, 35, "swap");
         mw_prim_swap();
-        WORD_ATOM(77, 9, "dip");
+        WORD_ATOM(78, 9, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(77, 13, "swap");
+            WORD_ATOM(78, 13, "swap");
             mw_prim_swap();
-            WORD_ATOM(77, 18, "T*+");
+            WORD_ATOM(78, 18, "T*+");
             mw_T_2A__2B_();
             push_value(d3);
         }
@@ -18910,23 +19036,23 @@ static void mw_elab_type_stack_rest_21_ (void){
     WORD_EXIT(mw_elab_type_stack_rest_21_);
 }
 static void mw_elab_type_arg_21_ (void){
-    WORD_ENTER(mw_elab_type_arg_21_, "elab-type-arg!", "src/mirth/elab.mth", 81, 5);
-    WORD_ATOM(81, 5, "elab-type-atom!");
+    WORD_ENTER(mw_elab_type_arg_21_, "elab-type-arg!", "src/mirth/elab.mth", 82, 5);
+    WORD_ATOM(82, 5, "elab-type-atom!");
     mw_elab_type_atom_21_();
-    WORD_ATOM(82, 5, "swap");
+    WORD_ATOM(83, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(82, 10, "match");
+    WORD_ATOM(83, 10, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(83, 17, "swap");
+            WORD_ATOM(84, 17, "swap");
             mw_prim_swap();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(84, 18, "drop");
+            WORD_ATOM(85, 18, "drop");
             mw_prim_drop();
-            WORD_ATOM(84, 23, "");
+            WORD_ATOM(85, 23, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -18937,21 +19063,21 @@ static void mw_elab_type_arg_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(84, 54, "emit-fatal-error!");
+            WORD_ATOM(85, 54, "emit-fatal-error!");
             mw_emit_fatal_error_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
     
-}    WORD_ATOM(86, 5, "dup");
+}    WORD_ATOM(87, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(86, 9, "arg-end?");
+    WORD_ATOM(87, 9, "arg-end?");
     mw_Token_2E_arg_end_3F_();
-    WORD_ATOM(86, 18, "if");
+    WORD_ATOM(87, 18, "if");
     if (pop_u64()) {
-        WORD_ATOM(87, 9, "id");
+        WORD_ATOM(88, 9, "id");
         mw_prim_id();
     } else {
-        WORD_ATOM(88, 9, "");
+        WORD_ATOM(89, 9, "");
         {
             static bool vready = false;
             static VAL v;
@@ -18962,120 +19088,120 @@ static void mw_elab_type_arg_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(88, 40, "emit-fatal-error!");
+        WORD_ATOM(89, 40, "emit-fatal-error!");
         mw_emit_fatal_error_21_();
     }
     WORD_EXIT(mw_elab_type_arg_21_);
 }
 static void mw_elab_type_atom_21_ (void){
-    WORD_ENTER(mw_elab_type_atom_21_, "elab-type-atom!", "src/mirth/elab.mth", 93, 5);
-    WORD_ATOM(93, 5, "dup");
+    WORD_ENTER(mw_elab_type_atom_21_, "elab-type-atom!", "src/mirth/elab.mth", 94, 5);
+    WORD_ATOM(94, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(93, 9, "sig-type-var?");
+    WORD_ATOM(94, 9, "sig-type-var?");
     mw_Token_2E_sig_type_var_3F_();
-    WORD_ATOM(93, 23, "if");
+    WORD_ATOM(94, 23, "if");
     if (pop_u64()) {
-        WORD_ATOM(94, 9, "elab-type-var!");
+        WORD_ATOM(95, 9, "elab-type-var!");
         mw_elab_type_var_21_();
-        WORD_ATOM(94, 24, "dip");
+        WORD_ATOM(95, 24, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(94, 28, "TVar");
+            WORD_ATOM(95, 28, "TVar");
             mw_TVar();
-            WORD_ATOM(94, 33, "LEFT");
+            WORD_ATOM(95, 33, "LEFT");
             mw_LEFT();
             push_value(d3);
         }
     } else {
-        WORD_ATOM(96, 5, "dup");
+        WORD_ATOM(97, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(96, 9, "sig-type-con?");
+        WORD_ATOM(97, 9, "sig-type-con?");
         mw_Token_2E_sig_type_con_3F_();
-        WORD_ATOM(96, 23, "if");
+        WORD_ATOM(97, 23, "if");
         if (pop_u64()) {
-            WORD_ATOM(97, 9, "elab-type-con!");
+            WORD_ATOM(98, 9, "elab-type-con!");
             mw_elab_type_con_21_();
-            WORD_ATOM(97, 24, "dip");
+            WORD_ATOM(98, 24, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(97, 28, "LEFT");
+                WORD_ATOM(98, 28, "LEFT");
                 mw_LEFT();
                 push_value(d4);
             }
         } else {
-            WORD_ATOM(99, 5, "dup");
+            WORD_ATOM(100, 5, "dup");
             mw_prim_dup();
-            WORD_ATOM(99, 9, "sig-resource-var?");
+            WORD_ATOM(100, 9, "sig-resource-var?");
             mw_Token_2E_sig_resource_var_3F_();
-            WORD_ATOM(99, 27, "if");
+            WORD_ATOM(100, 27, "if");
             if (pop_u64()) {
-                WORD_ATOM(100, 9, "elab-resource-var!");
+                WORD_ATOM(101, 9, "elab-resource-var!");
                 mw_elab_resource_var_21_();
-                WORD_ATOM(100, 28, "dip");
+                WORD_ATOM(101, 28, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(100, 32, "TVar");
+                    WORD_ATOM(101, 32, "TVar");
                     mw_TVar();
-                    WORD_ATOM(100, 37, "RESOURCE");
+                    WORD_ATOM(101, 37, "RESOURCE");
                     mw_RESOURCE();
-                    WORD_ATOM(100, 46, "RIGHT");
+                    WORD_ATOM(101, 46, "RIGHT");
                     mw_RIGHT();
                     push_value(d5);
                 }
             } else {
-                WORD_ATOM(102, 5, "dup");
+                WORD_ATOM(103, 5, "dup");
                 mw_prim_dup();
-                WORD_ATOM(102, 9, "sig-resource-con?");
+                WORD_ATOM(103, 9, "sig-resource-con?");
                 mw_Token_2E_sig_resource_con_3F_();
-                WORD_ATOM(102, 27, "if");
+                WORD_ATOM(103, 27, "if");
                 if (pop_u64()) {
-                    WORD_ATOM(103, 9, "elab-resource-con!");
+                    WORD_ATOM(104, 9, "elab-resource-con!");
                     mw_elab_resource_con_21_();
-                    WORD_ATOM(103, 28, "dip");
+                    WORD_ATOM(104, 28, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(103, 32, "RIGHT");
+                        WORD_ATOM(104, 32, "RIGHT");
                         mw_RIGHT();
                         push_value(d6);
                     }
                 } else {
-                    WORD_ATOM(105, 5, "dup");
+                    WORD_ATOM(106, 5, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(105, 9, "pat-underscore?");
+                    WORD_ATOM(106, 9, "pat-underscore?");
                     mw_Token_2E_pat_underscore_3F_();
-                    WORD_ATOM(105, 25, "if");
+                    WORD_ATOM(106, 25, "if");
                     if (pop_u64()) {
-                        WORD_ATOM(106, 9, "elab-type-dont-care!");
+                        WORD_ATOM(107, 9, "elab-type-dont-care!");
                         mw_elab_type_dont_care_21_();
-                        WORD_ATOM(106, 30, "dip");
+                        WORD_ATOM(107, 30, "dip");
                         {
                             VAL d7 = pop_value();
-                            WORD_ATOM(106, 34, "LEFT");
+                            WORD_ATOM(107, 34, "LEFT");
                             mw_LEFT();
                             push_value(d7);
                         }
                     } else {
-                        WORD_ATOM(108, 5, "dup");
+                        WORD_ATOM(109, 5, "dup");
                         mw_prim_dup();
-                        WORD_ATOM(108, 9, "sig-type-hole?");
+                        WORD_ATOM(109, 9, "sig-type-hole?");
                         mw_Token_2E_sig_type_hole_3F_();
-                        WORD_ATOM(108, 24, "if");
+                        WORD_ATOM(109, 24, "if");
                         if (pop_u64()) {
-                            WORD_ATOM(109, 9, "elab-type-hole!");
+                            WORD_ATOM(110, 9, "elab-type-hole!");
                             mw_elab_type_hole_21_();
-                            WORD_ATOM(109, 25, "dip");
+                            WORD_ATOM(110, 25, "dip");
                             {
                                 VAL d8 = pop_value();
-                                WORD_ATOM(109, 29, "LEFT");
+                                WORD_ATOM(110, 29, "LEFT");
                                 mw_LEFT();
                                 push_value(d8);
                             }
                         } else {
-                            WORD_ATOM(111, 5, "dup");
+                            WORD_ATOM(112, 5, "dup");
                             mw_prim_dup();
-                            WORD_ATOM(111, 9, "lsquare?");
+                            WORD_ATOM(112, 9, "lsquare?");
                             mw_Token_2E_lsquare_3F_();
-                            WORD_ATOM(111, 18, ".if");
+                            WORD_ATOM(112, 18, ".if");
                             push_u64(0);
                             push_fnptr(&mb_elab_type_atom_21__19);
                             mw_prim_pack_cons();
@@ -19092,71 +19218,71 @@ static void mw_elab_type_atom_21_ (void){
     WORD_EXIT(mw_elab_type_atom_21_);
 }
 static void mw_elab_stack_var_21_ (void){
-    WORD_ENTER(mw_elab_stack_var_21_, "elab-stack-var!", "src/mirth/elab.mth", 119, 5);
-    WORD_ATOM(119, 5, "TYPE_STACK");
+    WORD_ENTER(mw_elab_stack_var_21_, "elab-stack-var!", "src/mirth/elab.mth", 120, 5);
+    WORD_ATOM(120, 5, "TYPE_STACK");
     mw_TYPE_5F_STACK();
-    WORD_ATOM(119, 16, "elab-implicit-var!");
+    WORD_ATOM(120, 16, "elab-implicit-var!");
     mw_elab_implicit_var_21_();
     WORD_EXIT(mw_elab_stack_var_21_);
 }
 static void mw_elab_type_var_21_ (void){
-    WORD_ENTER(mw_elab_type_var_21_, "elab-type-var!", "src/mirth/elab.mth", 122, 5);
-    WORD_ATOM(122, 5, "TYPE_TYPE");
+    WORD_ENTER(mw_elab_type_var_21_, "elab-type-var!", "src/mirth/elab.mth", 123, 5);
+    WORD_ATOM(123, 5, "TYPE_TYPE");
     mw_TYPE_5F_TYPE();
-    WORD_ATOM(122, 15, "elab-implicit-var!");
+    WORD_ATOM(123, 15, "elab-implicit-var!");
     mw_elab_implicit_var_21_();
     WORD_EXIT(mw_elab_type_var_21_);
 }
 static void mw_elab_resource_var_21_ (void){
-    WORD_ENTER(mw_elab_resource_var_21_, "elab-resource-var!", "src/mirth/elab.mth", 125, 5);
-    WORD_ATOM(125, 5, "TYPE_RESOURCE");
+    WORD_ENTER(mw_elab_resource_var_21_, "elab-resource-var!", "src/mirth/elab.mth", 126, 5);
+    WORD_ATOM(126, 5, "TYPE_RESOURCE");
     mw_TYPE_5F_RESOURCE();
-    WORD_ATOM(125, 19, "elab-implicit-var!");
+    WORD_ATOM(126, 19, "elab-implicit-var!");
     mw_elab_implicit_var_21_();
     WORD_EXIT(mw_elab_resource_var_21_);
 }
 static void mw_elab_implicit_var_21_ (void){
-    WORD_ENTER(mw_elab_implicit_var_21_, "elab-implicit-var!", "src/mirth/elab.mth", 128, 5);
-    WORD_ATOM(128, 5, "dip2");
+    WORD_ENTER(mw_elab_implicit_var_21_, "elab-implicit-var!", "src/mirth/elab.mth", 129, 5);
+    WORD_ATOM(129, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_elab_implicit_var_21__1);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(128, 26, "over");
+    WORD_ATOM(129, 26, "over");
     mw_over();
-    WORD_ATOM(129, 5, "dip2");
+    WORD_ATOM(130, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_elab_implicit_var_21__2);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(130, 5, "rotl");
+    WORD_ATOM(131, 5, "rotl");
     mw_rotl();
-    WORD_ATOM(130, 10, "match");
+    WORD_ATOM(131, 10, "match");
     switch (get_top_data_tag()) {
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(132, 13, "rotr");
+            WORD_ATOM(133, 13, "rotr");
             mw_rotr();
-            WORD_ATOM(132, 18, "dip2");
+            WORD_ATOM(133, 18, "dip2");
             push_u64(0);
             push_fnptr(&mb_elab_implicit_var_21__4);
             mw_prim_pack_cons();
             mw_dip2();
-            WORD_ATOM(133, 13, "elab-type-unify!");
+            WORD_ATOM(134, 13, "elab-type-unify!");
             mw_elab_type_unify_21_();
-            WORD_ATOM(133, 30, "nip");
+            WORD_ATOM(134, 30, "nip");
             mw_nip();
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(135, 13, "dip");
+            WORD_ATOM(136, 13, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(136, 17, "swap");
+                WORD_ATOM(137, 17, "swap");
                 mw_prim_swap();
-                WORD_ATOM(136, 22, "Var.new!");
+                WORD_ATOM(137, 22, "Var.new!");
                 mw_Var_2E_new_21_();
-                WORD_ATOM(137, 17, "sip");
+                WORD_ATOM(138, 17, "sip");
                 push_u64(0);
                 push_fnptr(&mb_elab_implicit_var_21__7);
                 mw_prim_pack_cons();
@@ -19166,9 +19292,9 @@ static void mw_elab_implicit_var_21_ (void){
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
     
-}    WORD_ATOM(140, 5, "next");
+}    WORD_ATOM(141, 5, "next");
     mw_Token_2E_next();
-    WORD_ATOM(141, 5, "dip2");
+    WORD_ATOM(142, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_elab_implicit_var_21__8);
     mw_prim_pack_cons();
@@ -19176,16 +19302,16 @@ static void mw_elab_implicit_var_21_ (void){
     WORD_EXIT(mw_elab_implicit_var_21_);
 }
 static void mw_elab_type_con_21_ (void){
-    WORD_ENTER(mw_elab_type_con_21_, "elab-type-con!", "src/mirth/elab.mth", 144, 5);
-    WORD_ATOM(144, 5, "dup");
+    WORD_ENTER(mw_elab_type_con_21_, "elab-type-con!", "src/mirth/elab.mth", 145, 5);
+    WORD_ATOM(145, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(144, 9, "name?");
+    WORD_ATOM(145, 9, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(144, 15, "unwrap");
+    WORD_ATOM(145, 15, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(144, 22, ">Str");
+    WORD_ATOM(145, 22, ">Str");
     mw_Name_3E_Str();
-    WORD_ATOM(144, 27, "");
+    WORD_ATOM(145, 27, "");
     {
         static bool vready = false;
         static VAL v;
@@ -19196,57 +19322,57 @@ static void mw_elab_type_con_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(144, 33, "=");
+    WORD_ATOM(145, 33, "=");
     mw_Str_3D_();
-    WORD_ATOM(144, 35, "if");
+    WORD_ATOM(145, 35, "if");
     if (pop_u64()) {
-        WORD_ATOM(145, 9, "tuck");
+        WORD_ATOM(146, 9, "tuck");
         mw_tuck();
-        WORD_ATOM(145, 14, "args-1");
+        WORD_ATOM(146, 14, "args-1");
         mw_Token_2E_args_1();
-        WORD_ATOM(145, 21, "elab-type-arg!");
+        WORD_ATOM(146, 21, "elab-type-arg!");
         mw_elab_type_arg_21_();
-        WORD_ATOM(145, 36, "drop");
+        WORD_ATOM(146, 36, "drop");
         mw_prim_drop();
-        WORD_ATOM(145, 41, "TMut");
+        WORD_ATOM(146, 41, "TMut");
         mw_TMut();
-        WORD_ATOM(146, 9, "rotl");
+        WORD_ATOM(147, 9, "rotl");
         mw_rotl();
-        WORD_ATOM(146, 14, "next");
+        WORD_ATOM(147, 14, "next");
         mw_Token_2E_next();
     } else {
-        WORD_ATOM(148, 9, "dup");
+        WORD_ATOM(149, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(148, 13, "name?");
+        WORD_ATOM(149, 13, "name?");
         mw_Token_2E_name_3F_();
-        WORD_ATOM(148, 19, "unwrap");
+        WORD_ATOM(149, 19, "unwrap");
         mw_Maybe_2E_unwrap();
-        WORD_ATOM(148, 26, ">Def");
+        WORD_ATOM(149, 26, ">Def");
         mw_Name_3E_Def();
-        WORD_ATOM(148, 31, "match");
+        WORD_ATOM(149, 31, "match");
         switch (get_top_data_tag()) {
             case 3LL:
                 mw_prim_pack_uncons(); mw_prim_drop();
-                WORD_ATOM(150, 17, "over");
-                mw_over();
-                WORD_ATOM(150, 22, "num-args");
-                mw_Token_2E_num_args();
                 WORD_ATOM(151, 17, "over");
                 mw_over();
-                WORD_ATOM(151, 22, "arity");
+                WORD_ATOM(151, 22, "num-args");
+                mw_Token_2E_num_args();
+                WORD_ATOM(152, 17, "over");
+                mw_over();
+                WORD_ATOM(152, 22, "arity");
                 mw_Type_2E_arity();
-                WORD_ATOM(151, 28, "=");
+                WORD_ATOM(152, 28, "=");
                 mw_prim_int_eq();
-                WORD_ATOM(151, 30, "if");
+                WORD_ATOM(152, 30, "if");
                 if (pop_u64()) {
-                    WORD_ATOM(152, 21, "elab-type-args!");
+                    WORD_ATOM(153, 21, "elab-type-args!");
                     mw_elab_type_args_21_();
                 } else {
-                    WORD_ATOM(154, 21, "drop");
+                    WORD_ATOM(155, 21, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(154, 26, "dup");
+                    WORD_ATOM(155, 26, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(155, 21, "");
+                    WORD_ATOM(156, 21, "");
                     {
                         static bool vready = false;
                         static VAL v;
@@ -19257,17 +19383,17 @@ static void mw_elab_type_con_21_ (void){
                         push_value(v);
                         incref(v);
                     }
-                    WORD_ATOM(155, 59, "emit-error!");
+                    WORD_ATOM(156, 59, "emit-error!");
                     mw_emit_error_21_();
-                    WORD_ATOM(156, 21, "TYPE_ERROR");
+                    WORD_ATOM(157, 21, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                 }
                 break;
             case 0LL:
                 mw_prim_drop();
-                WORD_ATOM(159, 17, "dup");
+                WORD_ATOM(160, 17, "dup");
                 mw_prim_dup();
-                WORD_ATOM(159, 21, "");
+                WORD_ATOM(160, 21, "");
                 {
                     static bool vready = false;
                     static VAL v;
@@ -19278,17 +19404,17 @@ static void mw_elab_type_con_21_ (void){
                     push_value(v);
                     incref(v);
                 }
-                WORD_ATOM(159, 37, "emit-error!");
+                WORD_ATOM(160, 37, "emit-error!");
                 mw_emit_error_21_();
-                WORD_ATOM(159, 49, "TYPE_ERROR");
+                WORD_ATOM(160, 49, "TYPE_ERROR");
                 mw_TYPE_5F_ERROR();
                 break;
             default:
-                WORD_ATOM(161, 17, "drop");
+                WORD_ATOM(162, 17, "drop");
                 mw_prim_drop();
-                WORD_ATOM(161, 22, "dup");
+                WORD_ATOM(162, 22, "dup");
                 mw_prim_dup();
-                WORD_ATOM(161, 26, "");
+                WORD_ATOM(162, 26, "");
                 {
                     static bool vready = false;
                     static VAL v;
@@ -19299,124 +19425,124 @@ static void mw_elab_type_con_21_ (void){
                     push_value(v);
                     incref(v);
                 }
-                WORD_ATOM(161, 40, "emit-error!");
+                WORD_ATOM(162, 40, "emit-error!");
                 mw_emit_error_21_();
-                WORD_ATOM(161, 52, "TYPE_ERROR");
+                WORD_ATOM(162, 52, "TYPE_ERROR");
                 mw_TYPE_5F_ERROR();
                 break;
         
-}        WORD_ATOM(163, 9, "swap");
+}        WORD_ATOM(164, 9, "swap");
         mw_prim_swap();
-        WORD_ATOM(163, 14, "next");
+        WORD_ATOM(164, 14, "next");
         mw_Token_2E_next();
     }
     WORD_EXIT(mw_elab_type_con_21_);
 }
 static void mw_elab_resource_con_21_ (void){
-    WORD_ENTER(mw_elab_resource_con_21_, "elab-resource-con!", "src/mirth/elab.mth", 167, 5);
-    WORD_ATOM(167, 5, "elab-type-con!");
+    WORD_ENTER(mw_elab_resource_con_21_, "elab-resource-con!", "src/mirth/elab.mth", 168, 5);
+    WORD_ATOM(168, 5, "elab-type-con!");
     mw_elab_type_con_21_();
-    WORD_ATOM(167, 20, "dip");
+    WORD_ATOM(168, 20, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(167, 24, "RESOURCE");
+        WORD_ATOM(168, 24, "RESOURCE");
         mw_RESOURCE();
         push_value(d2);
     }
     WORD_EXIT(mw_elab_resource_con_21_);
 }
 static void mw_elab_type_args_21_ (void){
-    WORD_ENTER(mw_elab_type_args_21_, "elab-type-args!", "src/mirth/elab.mth", 170, 5);
-    WORD_ATOM(170, 5, "over");
+    WORD_ENTER(mw_elab_type_args_21_, "elab-type-args!", "src/mirth/elab.mth", 171, 5);
+    WORD_ATOM(171, 5, "over");
     mw_over();
-    WORD_ATOM(170, 10, "has-args?");
+    WORD_ATOM(171, 10, "has-args?");
     mw_Token_2E_has_args_3F_();
-    WORD_ATOM(170, 20, "if");
+    WORD_ATOM(171, 20, "if");
     if (pop_u64()) {
-        WORD_ATOM(171, 9, "dip");
+        WORD_ATOM(172, 9, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(171, 13, "tuck");
+            WORD_ATOM(172, 13, "tuck");
             mw_tuck();
             push_value(d3);
         }
-        WORD_ATOM(171, 19, "swap");
+        WORD_ATOM(172, 19, "swap");
         mw_prim_swap();
-        WORD_ATOM(171, 24, "succ");
+        WORD_ATOM(172, 24, "succ");
         mw_Token_2E_succ();
-        WORD_ATOM(172, 9, "while");
+        WORD_ATOM(173, 9, "while");
         while(1) {
-            WORD_ATOM(172, 15, "dup");
+            WORD_ATOM(173, 15, "dup");
             mw_prim_dup();
-            WORD_ATOM(172, 19, "args-end?");
+            WORD_ATOM(173, 19, "args-end?");
             mw_Token_2E_args_end_3F_();
-            WORD_ATOM(172, 29, "not");
+            WORD_ATOM(173, 29, "not");
             mw_Bool_2E_not();
             if (! pop_u64()) break;
-            WORD_ATOM(173, 13, "succ");
+            WORD_ATOM(174, 13, "succ");
             mw_Token_2E_succ();
-            WORD_ATOM(173, 18, "swap");
-            mw_prim_swap();
-            WORD_ATOM(174, 13, "dip");
-            {
-                VAL d4 = pop_value();
-                WORD_ATOM(174, 17, "elab-type-arg!");
-                mw_elab_type_arg_21_();
-                push_value(d4);
-            }
-            WORD_ATOM(174, 33, "swap");
+            WORD_ATOM(174, 18, "swap");
             mw_prim_swap();
             WORD_ATOM(175, 13, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(175, 17, "swap");
+                WORD_ATOM(175, 17, "elab-type-arg!");
+                mw_elab_type_arg_21_();
+                push_value(d4);
+            }
+            WORD_ATOM(175, 33, "swap");
+            mw_prim_swap();
+            WORD_ATOM(176, 13, "dip");
+            {
+                VAL d4 = pop_value();
+                WORD_ATOM(176, 17, "swap");
                 mw_prim_swap();
-                WORD_ATOM(175, 22, "TApp");
+                WORD_ATOM(176, 22, "TApp");
                 mw_TApp();
                 push_value(d4);
             }
         }
-        WORD_ATOM(176, 9, "drop");
+        WORD_ATOM(177, 9, "drop");
         mw_prim_drop();
-        WORD_ATOM(176, 14, "dip");
+        WORD_ATOM(177, 14, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(176, 18, "swap");
+            WORD_ATOM(177, 18, "swap");
             mw_prim_swap();
             push_value(d3);
         }
     } else {
-        WORD_ATOM(178, 9, "id");
+        WORD_ATOM(179, 9, "id");
         mw_prim_id();
     }
     WORD_EXIT(mw_elab_type_args_21_);
 }
 static void mw_elab_type_hole_21_ (void){
-    WORD_ENTER(mw_elab_type_hole_21_, "elab-type-hole!", "src/mirth/elab.mth", 182, 5);
-    WORD_ATOM(182, 5, "over");
+    WORD_ENTER(mw_elab_type_hole_21_, "elab-type-hole!", "src/mirth/elab.mth", 183, 5);
+    WORD_ATOM(183, 5, "over");
     mw_over();
-    WORD_ATOM(182, 10, "type-elab-holes-allowed");
+    WORD_ATOM(183, 10, "type-elab-holes-allowed");
     mw_type_elab_holes_allowed();
-    WORD_ATOM(182, 34, "if");
+    WORD_ATOM(183, 34, "if");
     if (pop_u64()) {
-        WORD_ATOM(183, 9, "dup");
-        mw_prim_dup();
-        WORD_ATOM(183, 13, "args-0");
-        mw_Token_2E_args_0();
         WORD_ATOM(184, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(184, 13, "name?");
+        WORD_ATOM(184, 13, "args-0");
+        mw_Token_2E_args_0();
+        WORD_ATOM(185, 9, "dup");
+        mw_prim_dup();
+        WORD_ATOM(185, 13, "name?");
         mw_Token_2E_name_3F_();
-        WORD_ATOM(184, 19, "unwrap");
+        WORD_ATOM(185, 19, "unwrap");
         mw_Maybe_2E_unwrap();
-        WORD_ATOM(184, 26, "THole");
+        WORD_ATOM(185, 26, "THole");
         mw_THole();
-        WORD_ATOM(185, 9, "swap");
+        WORD_ATOM(186, 9, "swap");
         mw_prim_swap();
-        WORD_ATOM(185, 14, "next");
+        WORD_ATOM(186, 14, "next");
         mw_Token_2E_next();
     } else {
-        WORD_ATOM(186, 9, "");
+        WORD_ATOM(187, 9, "");
         {
             static bool vready = false;
             static VAL v;
@@ -19427,31 +19553,31 @@ static void mw_elab_type_hole_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(186, 43, "emit-fatal-error!");
+        WORD_ATOM(187, 43, "emit-fatal-error!");
         mw_emit_fatal_error_21_();
     }
     WORD_EXIT(mw_elab_type_hole_21_);
 }
 static void mw_elab_type_dont_care_21_ (void){
-    WORD_ENTER(mw_elab_type_dont_care_21_, "elab-type-dont-care!", "src/mirth/elab.mth", 190, 5);
-    WORD_ATOM(190, 5, "over");
+    WORD_ENTER(mw_elab_type_dont_care_21_, "elab-type-dont-care!", "src/mirth/elab.mth", 191, 5);
+    WORD_ATOM(191, 5, "over");
     mw_over();
-    WORD_ATOM(190, 10, "type-elab-holes-allowed");
+    WORD_ATOM(191, 10, "type-elab-holes-allowed");
     mw_type_elab_holes_allowed();
-    WORD_ATOM(190, 34, "if");
+    WORD_ATOM(191, 34, "if");
     if (pop_u64()) {
-        WORD_ATOM(191, 9, "dup");
+        WORD_ATOM(192, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(191, 13, "args-0");
+        WORD_ATOM(192, 13, "args-0");
         mw_Token_2E_args_0();
-        WORD_ATOM(192, 9, "TYPE_DONT_CARE");
+        WORD_ATOM(193, 9, "TYPE_DONT_CARE");
         mw_TYPE_5F_DONT_5F_CARE();
-        WORD_ATOM(193, 9, "swap");
+        WORD_ATOM(194, 9, "swap");
         mw_prim_swap();
-        WORD_ATOM(193, 14, "next");
+        WORD_ATOM(194, 14, "next");
         mw_Token_2E_next();
     } else {
-        WORD_ATOM(194, 9, "");
+        WORD_ATOM(195, 9, "");
         {
             static bool vready = false;
             static VAL v;
@@ -19462,48 +19588,48 @@ static void mw_elab_type_dont_care_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(194, 42, "emit-fatal-error!");
+        WORD_ATOM(195, 42, "emit-fatal-error!");
         mw_emit_fatal_error_21_();
     }
     WORD_EXIT(mw_elab_type_dont_care_21_);
 }
 static void mw_elab_type_quote_21_ (void){
-    WORD_ENTER(mw_elab_type_quote_21_, "elab-type-quote!", "src/mirth/elab.mth", 198, 5);
-    WORD_ATOM(198, 5, "args-1");
+    WORD_ENTER(mw_elab_type_quote_21_, "elab-type-quote!", "src/mirth/elab.mth", 199, 5);
+    WORD_ATOM(199, 5, "args-1");
     mw_Token_2E_args_1();
-    WORD_ATOM(198, 12, "dup");
+    WORD_ATOM(199, 12, "dup");
     mw_prim_dup();
-    WORD_ATOM(198, 16, "sig-has-dashes?");
+    WORD_ATOM(199, 16, "sig-has-dashes?");
     mw_Token_2E_sig_has_dashes_3F_();
-    WORD_ATOM(198, 32, "if");
+    WORD_ATOM(199, 32, "if");
     if (pop_u64()) {
-        WORD_ATOM(199, 9, "elab-type-sig!");
+        WORD_ATOM(200, 9, "elab-type-sig!");
         mw_elab_type_sig_21_();
-        WORD_ATOM(199, 24, "dip");
+        WORD_ATOM(200, 24, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(199, 28, ">Type");
+            WORD_ATOM(200, 28, ">Type");
             mw_ArrowType_3E_Type();
             push_value(d3);
         }
     } else {
-        WORD_ATOM(200, 9, "elab-type-stack!");
+        WORD_ATOM(201, 9, "elab-type-stack!");
         mw_elab_type_stack_21_();
-        WORD_ATOM(200, 26, "dip");
+        WORD_ATOM(201, 26, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(200, 30, ">Type");
+            WORD_ATOM(201, 30, ">Type");
             mw_StackType_3E_Type();
             push_value(d3);
         }
     }
-    WORD_ATOM(201, 7, "next");
+    WORD_ATOM(202, 7, "next");
     mw_Token_2E_next();
     WORD_EXIT(mw_elab_type_quote_21_);
 }
 static void mw_elab_type_unify_21_ (void){
-    WORD_ENTER(mw_elab_type_unify_21_, "elab-type-unify!", "src/mirth/elab.mth", 204, 5);
-    WORD_ATOM(204, 5, "sip");
+    WORD_ENTER(mw_elab_type_unify_21_, "elab-type-unify!", "src/mirth/elab.mth", 205, 5);
+    WORD_ATOM(205, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_type_unify_21__1);
     mw_prim_pack_cons();
@@ -19511,8 +19637,8 @@ static void mw_elab_type_unify_21_ (void){
     WORD_EXIT(mw_elab_type_unify_21_);
 }
 static void mw_elab_stack_type_unify_21_ (void){
-    WORD_ENTER(mw_elab_stack_type_unify_21_, "elab-stack-type-unify!", "src/mirth/elab.mth", 206, 5);
-    WORD_ATOM(206, 5, "sip");
+    WORD_ENTER(mw_elab_stack_type_unify_21_, "elab-stack-type-unify!", "src/mirth/elab.mth", 207, 5);
+    WORD_ATOM(207, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_stack_type_unify_21__1);
     mw_prim_pack_cons();
@@ -19520,93 +19646,93 @@ static void mw_elab_stack_type_unify_21_ (void){
     WORD_EXIT(mw_elab_stack_type_unify_21_);
 }
 static void mw_elab_simple_type_arg_21_ (void){
-    WORD_ENTER(mw_elab_simple_type_arg_21_, "elab-simple-type-arg!", "src/mirth/elab.mth", 209, 5);
-    WORD_ATOM(209, 5, "dip");
+    WORD_ENTER(mw_elab_simple_type_arg_21_, "elab-simple-type-arg!", "src/mirth/elab.mth", 210, 5);
+    WORD_ATOM(210, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(209, 9, "type-elab-default");
+        WORD_ATOM(210, 9, "type-elab-default");
         mw_type_elab_default();
         push_value(d2);
     }
-    WORD_ATOM(209, 28, "elab-type-arg!");
+    WORD_ATOM(210, 28, "elab-type-arg!");
     mw_elab_type_arg_21_();
-    WORD_ATOM(209, 43, "drop");
+    WORD_ATOM(210, 43, "drop");
     mw_prim_drop();
-    WORD_ATOM(209, 48, "nip");
+    WORD_ATOM(210, 48, "nip");
     mw_nip();
     WORD_EXIT(mw_elab_simple_type_arg_21_);
 }
 static void mw_ab_ctx (void){
-    WORD_ENTER(mw_ab_ctx, "ab-ctx", "src/mirth/elab.mth", 219, 23);
-    WORD_ATOM(219, 23, "ab-arrow");
+    WORD_ENTER(mw_ab_ctx, "ab-ctx", "src/mirth/elab.mth", 220, 23);
+    WORD_ATOM(220, 23, "ab-arrow");
     mw_ab_arrow();
-    WORD_ATOM(219, 32, "@");
+    WORD_ATOM(220, 32, "@");
     mw_prim_mut_get();
-    WORD_ATOM(219, 34, "~ctx");
+    WORD_ATOM(220, 34, "~ctx");
     mw_Arrow_7E_ctx();
     WORD_EXIT(mw_ab_ctx);
 }
 static void mw_ab_token (void){
-    WORD_ENTER(mw_ab_token, "ab-token", "src/mirth/elab.mth", 220, 27);
-    WORD_ATOM(220, 27, "ab-arrow");
+    WORD_ENTER(mw_ab_token, "ab-token", "src/mirth/elab.mth", 221, 27);
+    WORD_ATOM(221, 27, "ab-arrow");
     mw_ab_arrow();
-    WORD_ATOM(220, 36, "@");
+    WORD_ATOM(221, 36, "@");
     mw_prim_mut_get();
-    WORD_ATOM(220, 38, "~token-end");
+    WORD_ATOM(221, 38, "~token-end");
     mw_Arrow_7E_token_end();
     WORD_EXIT(mw_ab_token);
 }
 static void mw_ab_type (void){
-    WORD_ENTER(mw_ab_type, "ab-type", "src/mirth/elab.mth", 221, 30);
-    WORD_ATOM(221, 30, "ab-arrow");
+    WORD_ENTER(mw_ab_type, "ab-type", "src/mirth/elab.mth", 222, 30);
+    WORD_ATOM(222, 30, "ab-arrow");
     mw_ab_arrow();
-    WORD_ATOM(221, 39, "@");
+    WORD_ATOM(222, 39, "@");
     mw_prim_mut_get();
-    WORD_ATOM(221, 41, "~cod");
+    WORD_ATOM(222, 41, "~cod");
     mw_Arrow_7E_cod();
     WORD_EXIT(mw_ab_type);
 }
 static void mw_init_elab_21_ (void){
-    WORD_ENTER(mw_init_elab_21_, "init-elab!", "src/mirth/elab.mth", 224, 5);
-    WORD_ATOM(224, 5, "Arrow.nil");
+    WORD_ENTER(mw_init_elab_21_, "init-elab!", "src/mirth/elab.mth", 225, 5);
+    WORD_ATOM(225, 5, "Arrow.nil");
     mw_Arrow_2E_nil();
-    WORD_ATOM(224, 15, "ab-arrow");
+    WORD_ATOM(225, 15, "ab-arrow");
     mw_ab_arrow();
-    WORD_ATOM(224, 24, "!");
+    WORD_ATOM(225, 24, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_init_elab_21_);
 }
 static void mw_ab_save_21_ (void){
-    WORD_ENTER(mw_ab_save_21_, "ab-save!", "src/mirth/elab.mth", 227, 5);
-    WORD_ATOM(227, 5, "ab-arrow");
+    WORD_ENTER(mw_ab_save_21_, "ab-save!", "src/mirth/elab.mth", 228, 5);
+    WORD_ATOM(228, 5, "ab-arrow");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(227, 5, "ab-arrow");
+        WORD_ATOM(228, 5, "ab-arrow");
         mw_ab_arrow();
-        WORD_ATOM(227, 14, "@");
+        WORD_ATOM(228, 14, "@");
         mw_prim_mut_get();
-        WORD_ATOM(227, 16, "dip");
+        WORD_ATOM(228, 16, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(227, 20, "f");
+            WORD_ATOM(228, 20, "f");
             incref(var_f);
             run_value(var_f);
             push_value(d3);
         }
-        WORD_ATOM(227, 23, "ab-arrow");
+        WORD_ATOM(228, 23, "ab-arrow");
         mw_ab_arrow();
-        WORD_ATOM(227, 32, "!");
+        WORD_ATOM(228, 32, "!");
         mw_prim_mut_set();
         decref(var_f);
     }
     WORD_EXIT(mw_ab_save_21_);
 }
 static void mw_ab_build_21_ (void){
-    WORD_ENTER(mw_ab_build_21_, "ab-build!", "src/mirth/elab.mth", 230, 5);
-    WORD_ATOM(230, 5, "ab-save!");
+    WORD_ENTER(mw_ab_build_21_, "ab-build!", "src/mirth/elab.mth", 231, 5);
+    WORD_ATOM(231, 5, "ab-save!");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(230, 5, "ab-save!");
+        WORD_ATOM(231, 5, "ab-save!");
         push_u64(0);
         incref(var_f);
         push_value(var_f);
@@ -19619,20 +19745,20 @@ static void mw_ab_build_21_ (void){
     WORD_EXIT(mw_ab_build_21_);
 }
 static void mw_ab_build_hom_21_ (void){
-    WORD_ENTER(mw_ab_build_hom_21_, "ab-build-hom!", "src/mirth/elab.mth", 248, 5);
-    WORD_ATOM(248, 5, "dip");
+    WORD_ENTER(mw_ab_build_hom_21_, "ab-build-hom!", "src/mirth/elab.mth", 249, 5);
+    WORD_ATOM(249, 5, "dip");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(248, 5, "dip");
+        WORD_ATOM(249, 5, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(248, 9, "unpack");
+            WORD_ATOM(249, 9, "unpack");
             mw_ArrowType_2E_unpack();
-            WORD_ATOM(248, 16, "rotr");
+            WORD_ATOM(249, 16, "rotr");
             mw_rotr();
             push_value(d3);
         }
-        WORD_ATOM(249, 5, "ab-build!");
+        WORD_ATOM(250, 5, "ab-build!");
         push_u64(0);
         incref(var_f);
         push_value(var_f);
@@ -19645,25 +19771,25 @@ static void mw_ab_build_hom_21_ (void){
     WORD_EXIT(mw_ab_build_hom_21_);
 }
 static void mw_ab_build_word_arrow_21_ (void){
-    WORD_ENTER(mw_ab_build_word_arrow_21_, "ab-build-word-arrow!", "src/mirth/elab.mth", 251, 5);
-    WORD_ATOM(251, 5, "dup");
+    WORD_ENTER(mw_ab_build_word_arrow_21_, "ab-build-word-arrow!", "src/mirth/elab.mth", 252, 5);
+    WORD_ATOM(252, 5, "dup");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(251, 5, "dup");
+        WORD_ATOM(252, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(251, 9, "SOME");
+        WORD_ATOM(252, 9, "SOME");
         mw_SOME();
-        WORD_ATOM(251, 14, "ab-home");
+        WORD_ATOM(252, 14, "ab-home");
         mw_ab_home();
-        WORD_ATOM(251, 22, "!");
+        WORD_ATOM(252, 22, "!");
         mw_prim_mut_set();
-        WORD_ATOM(251, 24, "");
+        WORD_ATOM(252, 24, "");
         push_i64(0LL);
-        WORD_ATOM(251, 26, "ab-homeidx");
+        WORD_ATOM(252, 26, "ab-homeidx");
         mw_ab_homeidx();
-        WORD_ATOM(251, 37, "!");
+        WORD_ATOM(252, 37, "!");
         mw_prim_mut_set();
-        WORD_ATOM(252, 5, "sip");
+        WORD_ATOM(253, 5, "sip");
         push_u64(0);
         incref(var_f);
         push_value(var_f);
@@ -19671,28 +19797,28 @@ static void mw_ab_build_word_arrow_21_ (void){
         push_fnptr(&mb_ab_build_word_arrow_21__2);
         mw_prim_pack_cons();
         mw_sip();
-        WORD_ATOM(253, 5, "body");
+        WORD_ATOM(254, 5, "body");
         mw_Word_2E_body();
-        WORD_ATOM(253, 10, "ab-build-hom!");
+        WORD_ATOM(254, 10, "ab-build-hom!");
         incref(var_f);
         push_value(var_f);
         mw_ab_build_hom_21_();
-        WORD_ATOM(254, 5, "NONE");
+        WORD_ATOM(255, 5, "NONE");
         mw_NONE();
-        WORD_ATOM(254, 10, "ab-home");
+        WORD_ATOM(255, 10, "ab-home");
         mw_ab_home();
-        WORD_ATOM(254, 18, "!");
+        WORD_ATOM(255, 18, "!");
         mw_prim_mut_set();
         decref(var_f);
     }
     WORD_EXIT(mw_ab_build_word_arrow_21_);
 }
 static void mw_ab_build_word_21_ (void){
-    WORD_ENTER(mw_ab_build_word_21_, "ab-build-word!", "src/mirth/elab.mth", 256, 5);
-    WORD_ATOM(256, 5, "sip");
+    WORD_ENTER(mw_ab_build_word_21_, "ab-build-word!", "src/mirth/elab.mth", 257, 5);
+    WORD_ATOM(257, 5, "sip");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(256, 5, "sip");
+        WORD_ATOM(257, 5, "sip");
         push_u64(0);
         incref(var_f);
         push_value(var_f);
@@ -19700,241 +19826,241 @@ static void mw_ab_build_word_21_ (void){
         push_fnptr(&mb_ab_build_word_21__2);
         mw_prim_pack_cons();
         mw_sip();
-        WORD_ATOM(257, 5, "tuck");
+        WORD_ATOM(258, 5, "tuck");
         mw_tuck();
-        WORD_ATOM(257, 10, "~arrow");
+        WORD_ATOM(258, 10, "~arrow");
         mw_Word_7E_arrow();
-        WORD_ATOM(257, 17, "!");
+        WORD_ATOM(258, 17, "!");
         mw_prim_mut_set();
         decref(var_f);
     }
     WORD_EXIT(mw_ab_build_word_21_);
 }
 static void mw_ab_unify_type_21_ (void){
-    WORD_ENTER(mw_ab_unify_type_21_, "ab-unify-type!", "src/mirth/elab.mth", 260, 5);
-    WORD_ATOM(260, 5, "dip");
+    WORD_ENTER(mw_ab_unify_type_21_, "ab-unify-type!", "src/mirth/elab.mth", 261, 5);
+    WORD_ATOM(261, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(260, 9, "ab-token");
+        WORD_ATOM(261, 9, "ab-token");
         mw_ab_token();
-        WORD_ATOM(260, 18, "@");
+        WORD_ATOM(261, 18, "@");
         mw_prim_mut_get();
-        WORD_ATOM(260, 20, "GAMMA");
+        WORD_ATOM(261, 20, "GAMMA");
         mw_GAMMA();
-        WORD_ATOM(260, 26, "ab-type");
+        WORD_ATOM(261, 26, "ab-type");
         mw_ab_type();
-        WORD_ATOM(260, 34, "@");
+        WORD_ATOM(261, 34, "@");
         mw_prim_mut_get();
         push_value(d2);
     }
-    WORD_ATOM(260, 37, "unify!");
+    WORD_ATOM(261, 37, "unify!");
     mw_StackType_2E_unify_21_();
-    WORD_ATOM(260, 44, "ab-type");
+    WORD_ATOM(261, 44, "ab-type");
     mw_ab_type();
-    WORD_ATOM(260, 52, "!");
+    WORD_ATOM(261, 52, "!");
     mw_prim_mut_set();
-    WORD_ATOM(260, 54, "drop");
+    WORD_ATOM(261, 54, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_ab_unify_type_21_);
 }
 static void mw_ab_atom_21_ (void){
-    WORD_ENTER(mw_ab_atom_21_, "ab-atom!", "src/mirth/elab.mth", 263, 5);
-    WORD_ATOM(263, 5, "dup");
+    WORD_ENTER(mw_ab_atom_21_, "ab-atom!", "src/mirth/elab.mth", 264, 5);
+    WORD_ATOM(264, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(263, 9, "token");
+    WORD_ATOM(264, 9, "token");
     mw_Atom_2E_token();
-    WORD_ATOM(263, 15, "ab-token");
+    WORD_ATOM(264, 15, "ab-token");
     mw_ab_token();
-    WORD_ATOM(263, 24, "!");
+    WORD_ATOM(264, 24, "!");
     mw_prim_mut_set();
-    WORD_ATOM(267, 5, "dup");
+    WORD_ATOM(268, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(267, 9, "cod");
+    WORD_ATOM(268, 9, "cod");
     mw_Atom_2E_cod();
-    WORD_ATOM(267, 13, "ab-type");
+    WORD_ATOM(268, 13, "ab-type");
     mw_ab_type();
-    WORD_ATOM(267, 21, "!");
+    WORD_ATOM(268, 21, "!");
     mw_prim_mut_set();
-    WORD_ATOM(268, 5, "dip");
+    WORD_ATOM(269, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(268, 9, "ab-arrow");
+        WORD_ATOM(269, 9, "ab-arrow");
         mw_ab_arrow();
-        WORD_ATOM(268, 18, "@");
+        WORD_ATOM(269, 18, "@");
         mw_prim_mut_get();
-        WORD_ATOM(268, 20, "atoms");
+        WORD_ATOM(269, 20, "atoms");
         mw_Arrow_2E_atoms();
         push_value(d2);
     }
-    WORD_ATOM(269, 5, "ab-optimized-snoc!");
+    WORD_ATOM(270, 5, "ab-optimized-snoc!");
     mw_ab_optimized_snoc_21_();
-    WORD_ATOM(270, 5, "ab-arrow");
+    WORD_ATOM(271, 5, "ab-arrow");
     mw_ab_arrow();
-    WORD_ATOM(270, 14, "@");
+    WORD_ATOM(271, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(270, 16, "~atoms");
+    WORD_ATOM(271, 16, "~atoms");
     mw_Arrow_7E_atoms();
-    WORD_ATOM(270, 23, "!");
+    WORD_ATOM(271, 23, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_ab_atom_21_);
 }
 static void mw_ab_optimized_snoc_21_ (void){
-    WORD_ENTER(mw_ab_optimized_snoc_21_, "ab-optimized-snoc!", "src/mirth/elab.mth", 274, 5);
-    WORD_ATOM(274, 5, "while");
+    WORD_ENTER(mw_ab_optimized_snoc_21_, "ab-optimized-snoc!", "src/mirth/elab.mth", 275, 5);
+    WORD_ATOM(275, 5, "while");
     while(1) {
-        WORD_ATOM(274, 11, "dip?");
+        WORD_ATOM(275, 11, "dip?");
         push_u64(0);
         push_fnptr(&mb_ab_optimized_snoc_21__2);
         mw_prim_pack_cons();
         mw_dip_3F_();
-        WORD_ATOM(274, 39, "and");
+        WORD_ATOM(275, 39, "and");
         push_u64(0);
         push_fnptr(&mb_ab_optimized_snoc_21__3);
         mw_prim_pack_cons();
         mw_Bool_2E_and();
         if (! pop_u64()) break;
-        WORD_ATOM(275, 9, "swap");
+        WORD_ATOM(276, 9, "swap");
         mw_prim_swap();
-        WORD_ATOM(275, 14, "atoms-turn-last-block-to-arg");
+        WORD_ATOM(276, 14, "atoms-turn-last-block-to-arg");
         mw_atoms_turn_last_block_to_arg();
-        WORD_ATOM(275, 43, "swap");
+        WORD_ATOM(276, 43, "swap");
         mw_prim_swap();
     }
-    WORD_ATOM(276, 5, "snoc");
+    WORD_ATOM(277, 5, "snoc");
     mw_snoc();
     WORD_EXIT(mw_ab_optimized_snoc_21_);
 }
 static void mw_atom_accepts_args_3F_ (void){
-    WORD_ENTER(mw_atom_accepts_args_3F_, "atom-accepts-args?", "src/mirth/elab.mth", 279, 5);
-    WORD_ATOM(279, 5, "dup");
+    WORD_ENTER(mw_atom_accepts_args_3F_, "atom-accepts-args?", "src/mirth/elab.mth", 280, 5);
+    WORD_ATOM(280, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(279, 9, "op");
+    WORD_ATOM(280, 9, "op");
     mw_Atom_2E_op();
-    WORD_ATOM(279, 12, "match");
+    WORD_ATOM(280, 12, "match");
     switch (get_top_data_tag()) {
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(280, 20, "dip");
+            WORD_ATOM(281, 20, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(280, 24, "dup");
+                WORD_ATOM(281, 24, "dup");
                 mw_prim_dup();
-                WORD_ATOM(280, 28, "args");
+                WORD_ATOM(281, 28, "args");
                 mw_Atom_2E_args();
-                WORD_ATOM(280, 33, "len");
+                WORD_ATOM(281, 33, "len");
                 mw_List_2E_len();
                 push_value(d4);
             }
-            WORD_ATOM(280, 38, "type");
+            WORD_ATOM(281, 38, "type");
             mw_Word_2E_type();
-            WORD_ATOM(280, 43, "max-num-params");
+            WORD_ATOM(281, 43, "max-num-params");
             mw_ArrowType_2E_max_num_params();
-            WORD_ATOM(280, 58, "<");
+            WORD_ATOM(281, 58, "<");
             mw_prim_int_lt();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(282, 13, "match");
+            WORD_ATOM(283, 13, "match");
             switch (get_top_data_tag()) {
                 case 4LL:
                     mw_prim_drop();
-                    WORD_ATOM(283, 34, "dup");
+                    WORD_ATOM(284, 34, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(283, 38, "args");
+                    WORD_ATOM(284, 38, "args");
                     mw_Atom_2E_args();
-                    WORD_ATOM(283, 43, "len");
+                    WORD_ATOM(284, 43, "len");
                     mw_List_2E_len();
-                    WORD_ATOM(283, 47, "");
+                    WORD_ATOM(284, 47, "");
                     push_i64(1LL);
-                    WORD_ATOM(283, 49, "<");
+                    WORD_ATOM(284, 49, "<");
                     mw_prim_int_lt();
                     break;
                 case 13LL:
                     mw_prim_drop();
-                    WORD_ATOM(284, 35, "dup");
+                    WORD_ATOM(285, 35, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(284, 39, "args");
+                    WORD_ATOM(285, 39, "args");
                     mw_Atom_2E_args();
-                    WORD_ATOM(284, 44, "len");
+                    WORD_ATOM(285, 44, "len");
                     mw_List_2E_len();
-                    WORD_ATOM(284, 48, "");
+                    WORD_ATOM(285, 48, "");
                     push_i64(1LL);
-                    WORD_ATOM(284, 50, "<");
+                    WORD_ATOM(285, 50, "<");
                     mw_prim_int_lt();
                     break;
                 case 5LL:
                     mw_prim_drop();
-                    WORD_ATOM(285, 33, "dup");
+                    WORD_ATOM(286, 33, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(285, 37, "args");
+                    WORD_ATOM(286, 37, "args");
                     mw_Atom_2E_args();
-                    WORD_ATOM(285, 42, "len");
+                    WORD_ATOM(286, 42, "len");
                     mw_List_2E_len();
-                    WORD_ATOM(285, 46, "");
+                    WORD_ATOM(286, 46, "");
                     push_i64(2LL);
-                    WORD_ATOM(285, 48, "<");
+                    WORD_ATOM(286, 48, "<");
                     mw_prim_int_lt();
                     break;
                 case 6LL:
                     mw_prim_drop();
-                    WORD_ATOM(286, 36, "dup");
+                    WORD_ATOM(287, 36, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(286, 40, "args");
+                    WORD_ATOM(287, 40, "args");
                     mw_Atom_2E_args();
-                    WORD_ATOM(286, 45, "len");
+                    WORD_ATOM(287, 45, "len");
                     mw_List_2E_len();
-                    WORD_ATOM(286, 49, "");
+                    WORD_ATOM(287, 49, "");
                     push_i64(2LL);
-                    WORD_ATOM(286, 51, "<");
+                    WORD_ATOM(287, 51, "<");
                     mw_prim_int_lt();
                     break;
                 default:
-                    WORD_ATOM(287, 22, "drop");
+                    WORD_ATOM(288, 22, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(287, 27, "F");
+                    WORD_ATOM(288, 27, "F");
                     mw_F();
                     break;
             
 }            break;
         default:
-            WORD_ATOM(289, 14, "drop");
+            WORD_ATOM(290, 14, "drop");
             mw_prim_drop();
-            WORD_ATOM(289, 19, "F");
+            WORD_ATOM(290, 19, "F");
             mw_F();
             break;
     
 }    WORD_EXIT(mw_atom_accepts_args_3F_);
 }
 static void mw_atoms_has_last_block_3F_ (void){
-    WORD_ENTER(mw_atoms_has_last_block_3F_, "atoms-has-last-block?", "src/mirth/elab.mth", 293, 5);
-    WORD_ATOM(293, 5, "dup");
+    WORD_ENTER(mw_atoms_has_last_block_3F_, "atoms-has-last-block?", "src/mirth/elab.mth", 294, 5);
+    WORD_ATOM(294, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(293, 9, "last");
-    mw_last();
-    WORD_ATOM(293, 14, "match");
+    WORD_ATOM(294, 9, "last");
+    mw_List_2E_last();
+    WORD_ATOM(294, 14, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(294, 17, "F");
+            WORD_ATOM(295, 17, "F");
             mw_F();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(296, 13, "op");
+            WORD_ATOM(297, 13, "op");
             mw_Atom_2E_op();
-            WORD_ATOM(296, 16, "match");
+            WORD_ATOM(297, 16, "match");
             switch (get_top_data_tag()) {
                 case 14LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(297, 29, "drop");
+                    WORD_ATOM(298, 29, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(297, 34, "T");
+                    WORD_ATOM(298, 34, "T");
                     mw_T();
                     break;
                 default:
-                    WORD_ATOM(298, 22, "drop");
+                    WORD_ATOM(299, 22, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(298, 27, "F");
+                    WORD_ATOM(299, 27, "F");
                     mw_F();
                     break;
             
@@ -19944,56 +20070,56 @@ static void mw_atoms_has_last_block_3F_ (void){
 }    WORD_EXIT(mw_atoms_has_last_block_3F_);
 }
 static void mw_atoms_turn_last_block_to_arg (void){
-    WORD_ENTER(mw_atoms_turn_last_block_to_arg, "atoms-turn-last-block-to-arg", "src/mirth/elab.mth", 303, 5);
-    WORD_ATOM(303, 5, ">List+");
+    WORD_ENTER(mw_atoms_turn_last_block_to_arg, "atoms-turn-last-block-to-arg", "src/mirth/elab.mth", 304, 5);
+    WORD_ATOM(304, 5, ">List+");
     mw_List_3E_List_2B_();
-    WORD_ATOM(303, 12, "match");
+    WORD_ATOM(304, 12, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(304, 17, "L0");
+            WORD_ATOM(305, 17, "L0");
             mw_L0();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(306, 13, "unsnoc");
+            WORD_ATOM(307, 13, "unsnoc");
             mw_List_2B__2E_unsnoc();
-            WORD_ATOM(306, 20, "dup");
+            WORD_ATOM(307, 20, "dup");
             mw_prim_dup();
-            WORD_ATOM(306, 24, "op");
+            WORD_ATOM(307, 24, "op");
             mw_Atom_2E_op();
-            WORD_ATOM(306, 27, "match");
+            WORD_ATOM(307, 27, "match");
             switch (get_top_data_tag()) {
                 case 14LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(309, 21, "dip");
+                    WORD_ATOM(310, 21, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(309, 25, "cod");
+                        WORD_ATOM(310, 25, "cod");
                         mw_Atom_2E_cod();
-                        WORD_ATOM(309, 29, "rotl");
+                        WORD_ATOM(310, 29, "rotl");
                         mw_rotl();
-                        WORD_ATOM(309, 34, "tuck");
+                        WORD_ATOM(310, 34, "tuck");
                         mw_tuck();
-                        WORD_ATOM(309, 39, "~dom");
+                        WORD_ATOM(310, 39, "~dom");
                         mw_Atom_7E_dom();
-                        WORD_ATOM(309, 44, "!");
+                        WORD_ATOM(310, 44, "!");
                         mw_prim_mut_set();
                         push_value(d6);
                     }
-                    WORD_ATOM(311, 21, "ARG_BLOCK");
+                    WORD_ATOM(312, 21, "ARG_BLOCK");
                     mw_ARG_5F_BLOCK();
-                    WORD_ATOM(311, 31, "over");
+                    WORD_ATOM(312, 31, "over");
                     mw_over();
-                    WORD_ATOM(311, 36, "add-arg-left!");
+                    WORD_ATOM(312, 36, "add-arg-left!");
                     mw_Atom_2E_add_arg_left_21_();
-                    WORD_ATOM(312, 21, "swap");
+                    WORD_ATOM(313, 21, "swap");
                     mw_prim_swap();
                     break;
                 default:
-                    WORD_ATOM(313, 22, "drop");
+                    WORD_ATOM(314, 22, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(313, 27, "snoc");
+                    WORD_ATOM(314, 27, "snoc");
                     mw_snoc();
                     break;
             
@@ -20003,193 +20129,193 @@ static void mw_atoms_turn_last_block_to_arg (void){
 }    WORD_EXIT(mw_atoms_turn_last_block_to_arg);
 }
 static void mw_block_to_run_var (void){
-    WORD_ENTER(mw_block_to_run_var, "block-to-run-var", "src/mirth/elab.mth", 318, 5);
-    WORD_ATOM(318, 5, "arrow");
+    WORD_ENTER(mw_block_to_run_var, "block-to-run-var", "src/mirth/elab.mth", 319, 5);
+    WORD_ATOM(319, 5, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(318, 11, "arrow-to-run-var");
+    WORD_ATOM(319, 11, "arrow-to-run-var");
     mw_arrow_to_run_var();
     WORD_EXIT(mw_block_to_run_var);
 }
 static void mw_arrow_to_run_var (void){
-    WORD_ENTER(mw_arrow_to_run_var, "arrow-to-run-var", "src/mirth/elab.mth", 321, 5);
-    WORD_ATOM(321, 5, "atoms");
+    WORD_ENTER(mw_arrow_to_run_var, "arrow-to-run-var", "src/mirth/elab.mth", 322, 5);
+    WORD_ATOM(322, 5, "atoms");
     mw_Arrow_2E_atoms();
-    WORD_ATOM(321, 11, "match");
+    WORD_ATOM(322, 11, "match");
     switch (get_top_data_tag()) {
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(322, 15, "atom-to-run-var");
+            WORD_ATOM(323, 15, "atom-to-run-var");
             mw_atom_to_run_var();
             break;
         default:
-            WORD_ATOM(323, 14, "drop");
+            WORD_ATOM(324, 14, "drop");
             mw_prim_drop();
-            WORD_ATOM(323, 19, "NONE");
+            WORD_ATOM(324, 19, "NONE");
             mw_NONE();
             break;
     
 }    WORD_EXIT(mw_arrow_to_run_var);
 }
 static void mw_atom_to_run_var (void){
-    WORD_ENTER(mw_atom_to_run_var, "atom-to-run-var", "src/mirth/elab.mth", 327, 5);
-    WORD_ATOM(327, 5, "op");
+    WORD_ENTER(mw_atom_to_run_var, "atom-to-run-var", "src/mirth/elab.mth", 328, 5);
+    WORD_ATOM(328, 5, "op");
     mw_Atom_2E_op();
-    WORD_ATOM(327, 8, "match");
+    WORD_ATOM(328, 8, "match");
     switch (get_top_data_tag()) {
         case 13LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(328, 19, "dup");
+            WORD_ATOM(329, 19, "dup");
             mw_prim_dup();
-            WORD_ATOM(328, 23, "auto-run?");
+            WORD_ATOM(329, 23, "auto-run?");
             mw_Var_2E_auto_run_3F_();
-            WORD_ATOM(328, 33, "if");
+            WORD_ATOM(329, 33, "if");
             if (pop_u64()) {
-                WORD_ATOM(328, 36, "SOME");
+                WORD_ATOM(329, 36, "SOME");
                 mw_SOME();
             } else {
-                WORD_ATOM(328, 42, "drop");
+                WORD_ATOM(329, 42, "drop");
                 mw_prim_drop();
-                WORD_ATOM(328, 47, "NONE");
+                WORD_ATOM(329, 47, "NONE");
                 mw_NONE();
             }
             break;
         default:
-            WORD_ATOM(329, 14, "drop");
+            WORD_ATOM(330, 14, "drop");
             mw_prim_drop();
-            WORD_ATOM(329, 19, "NONE");
+            WORD_ATOM(330, 19, "NONE");
             mw_NONE();
             break;
     
 }    WORD_EXIT(mw_atom_to_run_var);
 }
 static void mw_ab_op_21_ (void){
-    WORD_ENTER(mw_ab_op_21_, "ab-op!", "src/mirth/elab.mth", 333, 5);
-    WORD_ATOM(333, 5, "Atom.alloc!");
+    WORD_ENTER(mw_ab_op_21_, "ab-op!", "src/mirth/elab.mth", 334, 5);
+    WORD_ATOM(334, 5, "Atom.alloc!");
     mw_Atom_2E_alloc_21_();
-    WORD_ATOM(334, 5, "ab-ctx");
+    WORD_ATOM(335, 5, "ab-ctx");
     mw_ab_ctx();
-    WORD_ATOM(334, 12, "@");
+    WORD_ATOM(335, 12, "@");
     mw_prim_mut_get();
-    WORD_ATOM(334, 14, "over");
+    WORD_ATOM(335, 14, "over");
     mw_over();
-    WORD_ATOM(334, 19, "~ctx");
+    WORD_ATOM(335, 19, "~ctx");
     mw_Atom_7E_ctx();
-    WORD_ATOM(334, 24, "!");
+    WORD_ATOM(335, 24, "!");
     mw_prim_mut_set();
-    WORD_ATOM(335, 5, "ab-token");
+    WORD_ATOM(336, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(335, 14, "@");
+    WORD_ATOM(336, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(335, 16, "over");
+    WORD_ATOM(336, 16, "over");
     mw_over();
-    WORD_ATOM(335, 21, "~token");
+    WORD_ATOM(336, 21, "~token");
     mw_Atom_7E_token();
-    WORD_ATOM(335, 28, "!");
+    WORD_ATOM(336, 28, "!");
     mw_prim_mut_set();
-    WORD_ATOM(336, 5, "dup2");
+    WORD_ATOM(337, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(336, 10, "~op");
+    WORD_ATOM(337, 10, "~op");
     mw_Atom_7E_op();
-    WORD_ATOM(336, 14, "!");
+    WORD_ATOM(337, 14, "!");
     mw_prim_mut_set();
-    WORD_ATOM(337, 5, "swap");
+    WORD_ATOM(338, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(337, 10, "elab-op-fresh-sig!");
+    WORD_ATOM(338, 10, "elab-op-fresh-sig!");
     mw_elab_op_fresh_sig_21_();
-    WORD_ATOM(338, 5, "dip");
+    WORD_ATOM(339, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(338, 9, "over");
+        WORD_ATOM(339, 9, "over");
         mw_over();
-        WORD_ATOM(338, 14, "~subst");
+        WORD_ATOM(339, 14, "~subst");
         mw_Atom_7E_subst();
-        WORD_ATOM(338, 21, "!");
+        WORD_ATOM(339, 21, "!");
         mw_prim_mut_set();
         push_value(d2);
     }
-    WORD_ATOM(339, 5, "ab-expand-opsig!");
+    WORD_ATOM(340, 5, "ab-expand-opsig!");
     mw_ab_expand_opsig_21_();
-    WORD_ATOM(340, 5, "dip");
+    WORD_ATOM(341, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(340, 9, "over");
+        WORD_ATOM(341, 9, "over");
         mw_over();
-        WORD_ATOM(340, 14, "~dom");
+        WORD_ATOM(341, 14, "~dom");
         mw_Atom_7E_dom();
-        WORD_ATOM(340, 19, "!");
+        WORD_ATOM(341, 19, "!");
         mw_prim_mut_set();
         push_value(d2);
     }
-    WORD_ATOM(340, 22, "over");
+    WORD_ATOM(341, 22, "over");
     mw_over();
-    WORD_ATOM(340, 27, "~cod");
+    WORD_ATOM(341, 27, "~cod");
     mw_Atom_7E_cod();
-    WORD_ATOM(340, 32, "!");
+    WORD_ATOM(341, 32, "!");
     mw_prim_mut_set();
-    WORD_ATOM(341, 5, "L0");
+    WORD_ATOM(342, 5, "L0");
     mw_L0();
-    WORD_ATOM(341, 8, "over");
+    WORD_ATOM(342, 8, "over");
     mw_over();
-    WORD_ATOM(341, 13, "~args");
+    WORD_ATOM(342, 13, "~args");
     mw_Atom_7E_args();
-    WORD_ATOM(341, 19, "!");
+    WORD_ATOM(342, 19, "!");
     mw_prim_mut_set();
-    WORD_ATOM(342, 5, "ab-atom!");
+    WORD_ATOM(343, 5, "ab-atom!");
     mw_ab_atom_21_();
     WORD_EXIT(mw_ab_op_21_);
 }
 static void mw_ab_expand_opsig_21_ (void){
-    WORD_ENTER(mw_ab_expand_opsig_21_, "ab-expand-opsig!", "src/mirth/elab.mth", 345, 5);
-    WORD_ATOM(345, 5, "OPSIG_ID");
+    WORD_ENTER(mw_ab_expand_opsig_21_, "ab-expand-opsig!", "src/mirth/elab.mth", 346, 5);
+    WORD_ATOM(346, 5, "OPSIG_ID");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(345, 17, "ab-type");
+            WORD_ATOM(346, 17, "ab-type");
             mw_ab_type();
-            WORD_ATOM(345, 25, "@");
+            WORD_ATOM(346, 25, "@");
             mw_prim_mut_get();
-            WORD_ATOM(345, 27, "dup");
+            WORD_ATOM(346, 27, "dup");
             mw_prim_dup();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(346, 19, "dip");
+            WORD_ATOM(347, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(346, 23, "ab-type");
+                WORD_ATOM(347, 23, "ab-type");
                 mw_ab_type();
-                WORD_ATOM(346, 31, "@");
+                WORD_ATOM(347, 31, "@");
                 mw_prim_mut_get();
-                WORD_ATOM(346, 33, "dup");
+                WORD_ATOM(347, 33, "dup");
                 mw_prim_dup();
                 push_value(d4);
             }
-            WORD_ATOM(346, 38, "STCons");
+            WORD_ATOM(347, 38, "STCons");
             mw_STCons();
             break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(348, 9, "dip");
-            {
-                VAL d4 = pop_value();
-                WORD_ATOM(348, 13, "ab-type");
-                mw_ab_type();
-                WORD_ATOM(348, 21, "@");
-                mw_prim_mut_get();
-                push_value(d4);
-            }
-            WORD_ATOM(348, 24, "unpack");
-            mw_ArrowType_2E_unpack();
             WORD_ATOM(349, 9, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(349, 13, "ab-token");
-                mw_ab_token();
-                WORD_ATOM(349, 22, "@");
+                WORD_ATOM(349, 13, "ab-type");
+                mw_ab_type();
+                WORD_ATOM(349, 21, "@");
                 mw_prim_mut_get();
-                WORD_ATOM(349, 24, "elab-stack-type-unify!");
+                push_value(d4);
+            }
+            WORD_ATOM(349, 24, "unpack");
+            mw_ArrowType_2E_unpack();
+            WORD_ATOM(350, 9, "dip");
+            {
+                VAL d4 = pop_value();
+                WORD_ATOM(350, 13, "ab-token");
+                mw_ab_token();
+                WORD_ATOM(350, 22, "@");
+                mw_prim_mut_get();
+                WORD_ATOM(350, 24, "elab-stack-type-unify!");
                 mw_elab_stack_type_unify_21_();
-                WORD_ATOM(349, 47, "drop");
+                WORD_ATOM(350, 47, "drop");
                 mw_prim_drop();
                 push_value(d4);
             }
@@ -20199,89 +20325,89 @@ static void mw_ab_expand_opsig_21_ (void){
 }    WORD_EXIT(mw_ab_expand_opsig_21_);
 }
 static void mw_ab_int_21_ (void){
-    WORD_ENTER(mw_ab_int_21_, "ab-int!", "src/mirth/elab.mth", 351, 22);
-    WORD_ATOM(351, 22, "OP_INT");
+    WORD_ENTER(mw_ab_int_21_, "ab-int!", "src/mirth/elab.mth", 352, 22);
+    WORD_ATOM(352, 22, "OP_INT");
     mw_OP_5F_INT();
-    WORD_ATOM(351, 29, "ab-op!");
+    WORD_ATOM(352, 29, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_int_21_);
 }
 static void mw_ab_str_21_ (void){
-    WORD_ENTER(mw_ab_str_21_, "ab-str!", "src/mirth/elab.mth", 352, 22);
-    WORD_ATOM(352, 22, "OP_STR");
+    WORD_ENTER(mw_ab_str_21_, "ab-str!", "src/mirth/elab.mth", 353, 22);
+    WORD_ATOM(353, 22, "OP_STR");
     mw_OP_5F_STR();
-    WORD_ATOM(352, 29, "ab-op!");
+    WORD_ATOM(353, 29, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_str_21_);
 }
 static void mw_ab_buffer_21_ (void){
-    WORD_ENTER(mw_ab_buffer_21_, "ab-buffer!", "src/mirth/elab.mth", 353, 28);
-    WORD_ATOM(353, 28, "OP_BUFFER");
+    WORD_ENTER(mw_ab_buffer_21_, "ab-buffer!", "src/mirth/elab.mth", 354, 28);
+    WORD_ATOM(354, 28, "OP_BUFFER");
     mw_OP_5F_BUFFER();
-    WORD_ATOM(353, 38, "ab-op!");
+    WORD_ATOM(354, 38, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_buffer_21_);
 }
 static void mw_ab_variable_21_ (void){
-    WORD_ENTER(mw_ab_variable_21_, "ab-variable!", "src/mirth/elab.mth", 354, 32);
-    WORD_ATOM(354, 32, "OP_VARIABLE");
+    WORD_ENTER(mw_ab_variable_21_, "ab-variable!", "src/mirth/elab.mth", 355, 32);
+    WORD_ATOM(355, 32, "OP_VARIABLE");
     mw_OP_5F_VARIABLE();
-    WORD_ATOM(354, 44, "ab-op!");
+    WORD_ATOM(355, 44, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_variable_21_);
 }
 static void mw_ab_constant_21_ (void){
-    WORD_ENTER(mw_ab_constant_21_, "ab-constant!", "src/mirth/elab.mth", 355, 32);
-    WORD_ATOM(355, 32, "OP_CONSTANT");
+    WORD_ENTER(mw_ab_constant_21_, "ab-constant!", "src/mirth/elab.mth", 356, 32);
+    WORD_ATOM(356, 32, "OP_CONSTANT");
     mw_OP_5F_CONSTANT();
-    WORD_ATOM(355, 44, "ab-op!");
+    WORD_ATOM(356, 44, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_constant_21_);
 }
 static void mw_ab_field_21_ (void){
-    WORD_ENTER(mw_ab_field_21_, "ab-field!", "src/mirth/elab.mth", 356, 26);
-    WORD_ATOM(356, 26, "OP_FIELD");
+    WORD_ENTER(mw_ab_field_21_, "ab-field!", "src/mirth/elab.mth", 357, 26);
+    WORD_ATOM(357, 26, "OP_FIELD");
     mw_OP_5F_FIELD();
-    WORD_ATOM(356, 35, "ab-op!");
+    WORD_ATOM(357, 35, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_field_21_);
 }
 static void mw_ab_var_21_ (void){
-    WORD_ENTER(mw_ab_var_21_, "ab-var!", "src/mirth/elab.mth", 357, 22);
-    WORD_ATOM(357, 22, "OP_VAR");
+    WORD_ENTER(mw_ab_var_21_, "ab-var!", "src/mirth/elab.mth", 358, 22);
+    WORD_ATOM(358, 22, "OP_VAR");
     mw_OP_5F_VAR();
-    WORD_ATOM(357, 29, "ab-op!");
+    WORD_ATOM(358, 29, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_var_21_);
 }
 static void mw_ab_tag_21_ (void){
-    WORD_ENTER(mw_ab_tag_21_, "ab-tag!", "src/mirth/elab.mth", 358, 22);
-    WORD_ATOM(358, 22, "OP_TAG");
+    WORD_ENTER(mw_ab_tag_21_, "ab-tag!", "src/mirth/elab.mth", 359, 22);
+    WORD_ATOM(359, 22, "OP_TAG");
     mw_OP_5F_TAG();
-    WORD_ATOM(358, 29, "ab-op!");
+    WORD_ATOM(359, 29, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_tag_21_);
 }
 static void mw_ab_prim_21_ (void){
-    WORD_ENTER(mw_ab_prim_21_, "ab-prim!", "src/mirth/elab.mth", 360, 5);
-    WORD_ATOM(360, 5, "dup");
+    WORD_ENTER(mw_ab_prim_21_, "ab-prim!", "src/mirth/elab.mth", 361, 5);
+    WORD_ATOM(361, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(360, 9, "~type");
+    WORD_ATOM(361, 9, "~type");
     mw_Prim_7E_type();
-    WORD_ATOM(360, 15, "mut-is-set");
+    WORD_ATOM(361, 15, "mut-is-set");
     mw_prim_mut_is_set();
-    WORD_ATOM(360, 26, "if");
+    WORD_ATOM(361, 26, "if");
     if (pop_u64()) {
-        WORD_ATOM(361, 9, "OP_PRIM");
+        WORD_ATOM(362, 9, "OP_PRIM");
         mw_OP_5F_PRIM();
-        WORD_ATOM(361, 17, "ab-op!");
+        WORD_ATOM(362, 17, "ab-op!");
         mw_ab_op_21_();
     } else {
-        WORD_ATOM(362, 9, "ab-token");
+        WORD_ATOM(363, 9, "ab-token");
         mw_ab_token();
-        WORD_ATOM(362, 18, "@");
+        WORD_ATOM(363, 18, "@");
         mw_prim_mut_get();
-        WORD_ATOM(362, 20, "");
+        WORD_ATOM(363, 20, "");
         {
             static bool vready = false;
             static VAL v;
@@ -20292,66 +20418,66 @@ static void mw_ab_prim_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(362, 46, "emit-fatal-error!");
+        WORD_ATOM(363, 46, "emit-fatal-error!");
         mw_emit_fatal_error_21_();
     }
     WORD_EXIT(mw_ab_prim_21_);
 }
 static void mw_ab_word_21_ (void){
-    WORD_ENTER(mw_ab_word_21_, "ab-word!", "src/mirth/elab.mth", 364, 24);
-    WORD_ATOM(364, 24, "OP_WORD");
+    WORD_ENTER(mw_ab_word_21_, "ab-word!", "src/mirth/elab.mth", 365, 24);
+    WORD_ATOM(365, 24, "OP_WORD");
     mw_OP_5F_WORD();
-    WORD_ATOM(364, 32, "ab-op!");
+    WORD_ATOM(365, 32, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_word_21_);
 }
 static void mw_ab_external_21_ (void){
-    WORD_ENTER(mw_ab_external_21_, "ab-external!", "src/mirth/elab.mth", 365, 32);
-    WORD_ATOM(365, 32, "OP_EXTERNAL");
+    WORD_ENTER(mw_ab_external_21_, "ab-external!", "src/mirth/elab.mth", 366, 32);
+    WORD_ATOM(366, 32, "OP_EXTERNAL");
     mw_OP_5F_EXTERNAL();
-    WORD_ATOM(365, 44, "ab-op!");
+    WORD_ATOM(366, 44, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_external_21_);
 }
 static void mw_ab_block_at_21_ (void){
-    WORD_ENTER(mw_ab_block_at_21_, "ab-block-at!", "src/mirth/elab.mth", 368, 5);
-    WORD_ATOM(368, 5, "ab-ctx");
+    WORD_ENTER(mw_ab_block_at_21_, "ab-block-at!", "src/mirth/elab.mth", 369, 5);
+    WORD_ATOM(369, 5, "ab-ctx");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(368, 5, "ab-ctx");
+        WORD_ATOM(369, 5, "ab-ctx");
         mw_ab_ctx();
-        WORD_ATOM(368, 12, "@");
+        WORD_ATOM(369, 12, "@");
         mw_prim_mut_get();
-        WORD_ATOM(368, 14, "MetaVar.new!");
+        WORD_ATOM(369, 14, "MetaVar.new!");
         mw_MetaVar_2E_new_21_();
-        WORD_ATOM(368, 27, "STMeta");
+        WORD_ATOM(369, 27, "STMeta");
         mw_STMeta();
-        WORD_ATOM(368, 34, "rotl");
+        WORD_ATOM(369, 34, "rotl");
         mw_rotl();
-        WORD_ATOM(368, 39, "ab-build!");
+        WORD_ATOM(369, 39, "ab-build!");
         incref(var_f);
         push_value(var_f);
         mw_ab_build_21_();
-        WORD_ATOM(369, 5, "Block.new!");
+        WORD_ATOM(370, 5, "Block.new!");
         mw_Block_2E_new_21_();
-        WORD_ATOM(369, 16, "OP_BLOCK");
+        WORD_ATOM(370, 16, "OP_BLOCK");
         mw_OP_5F_BLOCK();
-        WORD_ATOM(369, 25, "ab-op!");
+        WORD_ATOM(370, 25, "ab-op!");
         mw_ab_op_21_();
         decref(var_f);
     }
     WORD_EXIT(mw_ab_block_at_21_);
 }
 static void mw_ab_block_21_ (void){
-    WORD_ENTER(mw_ab_block_21_, "ab-block!", "src/mirth/elab.mth", 372, 5);
-    WORD_ATOM(372, 5, "ab-token");
+    WORD_ENTER(mw_ab_block_21_, "ab-block!", "src/mirth/elab.mth", 373, 5);
+    WORD_ATOM(373, 5, "ab-token");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(372, 5, "ab-token");
+        WORD_ATOM(373, 5, "ab-token");
         mw_ab_token();
-        WORD_ATOM(372, 14, "@");
+        WORD_ATOM(373, 14, "@");
         mw_prim_mut_get();
-        WORD_ATOM(372, 16, "ab-block-at!");
+        WORD_ATOM(373, 16, "ab-block-at!");
         incref(var_f);
         push_value(var_f);
         mw_ab_block_at_21_();
@@ -20360,39 +20486,39 @@ static void mw_ab_block_21_ (void){
     WORD_EXIT(mw_ab_block_21_);
 }
 static void mw_ab_dip_21_ (void){
-    WORD_ENTER(mw_ab_dip_21_, "ab-dip!", "src/mirth/elab.mth", 375, 5);
-    WORD_ATOM(375, 5, "ab-block!");
+    WORD_ENTER(mw_ab_dip_21_, "ab-dip!", "src/mirth/elab.mth", 376, 5);
+    WORD_ATOM(376, 5, "ab-block!");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(375, 5, "ab-block!");
+        WORD_ATOM(376, 5, "ab-block!");
         incref(var_f);
         push_value(var_f);
         mw_ab_block_21_();
-        WORD_ATOM(375, 18, "PRIM_CORE_DIP");
+        WORD_ATOM(376, 18, "PRIM_CORE_DIP");
         mw_PRIM_5F_CORE_5F_DIP();
-        WORD_ATOM(375, 32, "ab-prim!");
+        WORD_ATOM(376, 32, "ab-prim!");
         mw_ab_prim_21_();
         decref(var_f);
     }
     WORD_EXIT(mw_ab_dip_21_);
 }
 static void mw_ab_if_21_ (void){
-    WORD_ENTER(mw_ab_if_21_, "ab-if!", "src/mirth/elab.mth", 378, 5);
-    WORD_ATOM(378, 5, "ab-block!");
+    WORD_ENTER(mw_ab_if_21_, "ab-if!", "src/mirth/elab.mth", 379, 5);
+    WORD_ATOM(379, 5, "ab-block!");
     {
         VAL var_g = pop_value();
         VAL var_f = pop_value();
-        WORD_ATOM(378, 5, "ab-block!");
+        WORD_ATOM(379, 5, "ab-block!");
         incref(var_f);
         push_value(var_f);
         mw_ab_block_21_();
-        WORD_ATOM(378, 18, "ab-block!");
+        WORD_ATOM(379, 18, "ab-block!");
         incref(var_g);
         push_value(var_g);
         mw_ab_block_21_();
-        WORD_ATOM(378, 31, "PRIM_CORE_IF");
+        WORD_ATOM(379, 31, "PRIM_CORE_IF");
         mw_PRIM_5F_CORE_5F_IF();
-        WORD_ATOM(378, 44, "ab-prim!");
+        WORD_ATOM(379, 44, "ab-prim!");
         mw_ab_prim_21_();
         decref(var_g);
         decref(var_f);
@@ -20400,22 +20526,22 @@ static void mw_ab_if_21_ (void){
     WORD_EXIT(mw_ab_if_21_);
 }
 static void mw_ab_while_21_ (void){
-    WORD_ENTER(mw_ab_while_21_, "ab-while!", "src/mirth/elab.mth", 381, 5);
-    WORD_ATOM(381, 5, "ab-block!");
+    WORD_ENTER(mw_ab_while_21_, "ab-while!", "src/mirth/elab.mth", 382, 5);
+    WORD_ATOM(382, 5, "ab-block!");
     {
         VAL var_g = pop_value();
         VAL var_f = pop_value();
-        WORD_ATOM(381, 5, "ab-block!");
+        WORD_ATOM(382, 5, "ab-block!");
         incref(var_f);
         push_value(var_f);
         mw_ab_block_21_();
-        WORD_ATOM(381, 18, "ab-block!");
+        WORD_ATOM(382, 18, "ab-block!");
         incref(var_g);
         push_value(var_g);
         mw_ab_block_21_();
-        WORD_ATOM(381, 31, "PRIM_CORE_WHILE");
+        WORD_ATOM(382, 31, "PRIM_CORE_WHILE");
         mw_PRIM_5F_CORE_5F_WHILE();
-        WORD_ATOM(381, 47, "ab-prim!");
+        WORD_ATOM(382, 47, "ab-prim!");
         mw_ab_prim_21_();
         decref(var_g);
         decref(var_f);
@@ -20423,62 +20549,62 @@ static void mw_ab_while_21_ (void){
     WORD_EXIT(mw_ab_while_21_);
 }
 static void mw_ab_lambda_21_ (void){
-    WORD_ENTER(mw_ab_lambda_21_, "ab-lambda!", "src/mirth/elab.mth", 384, 5);
-    WORD_ATOM(384, 5, "Lambda.alloc!");
+    WORD_ENTER(mw_ab_lambda_21_, "ab-lambda!", "src/mirth/elab.mth", 385, 5);
+    WORD_ATOM(385, 5, "Lambda.alloc!");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(384, 5, "Lambda.alloc!");
+        WORD_ATOM(385, 5, "Lambda.alloc!");
         mw_Lambda_2E_alloc_21_();
-        WORD_ATOM(385, 5, "ab-ctx");
+        WORD_ATOM(386, 5, "ab-ctx");
         mw_ab_ctx();
-        WORD_ATOM(385, 12, "@");
+        WORD_ATOM(386, 12, "@");
         mw_prim_mut_get();
-        WORD_ATOM(385, 14, "over");
+        WORD_ATOM(386, 14, "over");
         mw_over();
-        WORD_ATOM(385, 19, "~outer-ctx");
+        WORD_ATOM(386, 19, "~outer-ctx");
         mw_Lambda_7E_outer_ctx();
-        WORD_ATOM(385, 30, "!");
+        WORD_ATOM(386, 30, "!");
         mw_prim_mut_set();
-        WORD_ATOM(386, 5, "ab-type");
+        WORD_ATOM(387, 5, "ab-type");
         mw_ab_type();
-        WORD_ATOM(386, 13, "@");
+        WORD_ATOM(387, 13, "@");
         mw_prim_mut_get();
-        WORD_ATOM(386, 15, "over");
+        WORD_ATOM(387, 15, "over");
         mw_over();
-        WORD_ATOM(386, 20, "~dom");
+        WORD_ATOM(387, 20, "~dom");
         mw_Lambda_7E_dom();
-        WORD_ATOM(386, 25, "!");
+        WORD_ATOM(387, 25, "!");
         mw_prim_mut_set();
-        WORD_ATOM(387, 5, "ab-token");
+        WORD_ATOM(388, 5, "ab-token");
         mw_ab_token();
-        WORD_ATOM(387, 14, "@");
+        WORD_ATOM(388, 14, "@");
         mw_prim_mut_get();
-        WORD_ATOM(387, 16, "over");
+        WORD_ATOM(388, 16, "over");
         mw_over();
-        WORD_ATOM(387, 21, "~token");
+        WORD_ATOM(388, 21, "~token");
         mw_Lambda_7E_token();
-        WORD_ATOM(387, 28, "!");
+        WORD_ATOM(388, 28, "!");
         mw_prim_mut_set();
-        WORD_ATOM(388, 5, "dup2");
+        WORD_ATOM(389, 5, "dup2");
         mw_dup2();
-        WORD_ATOM(388, 10, "~params");
+        WORD_ATOM(389, 10, "~params");
         mw_Lambda_7E_params();
-        WORD_ATOM(388, 18, "!");
+        WORD_ATOM(389, 18, "!");
         mw_prim_mut_set();
-        WORD_ATOM(389, 5, "dip");
+        WORD_ATOM(390, 5, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(389, 9, "ab-ctx");
+            WORD_ATOM(390, 9, "ab-ctx");
             mw_ab_ctx();
-            WORD_ATOM(389, 16, "@");
+            WORD_ATOM(390, 16, "@");
             mw_prim_mut_get();
-            WORD_ATOM(389, 18, "ab-type");
+            WORD_ATOM(390, 18, "ab-type");
             mw_ab_type();
-            WORD_ATOM(389, 26, "@");
+            WORD_ATOM(390, 26, "@");
             mw_prim_mut_get();
-            WORD_ATOM(389, 28, "rotl");
+            WORD_ATOM(390, 28, "rotl");
             mw_rotl();
-            WORD_ATOM(389, 33, "reverse-for");
+            WORD_ATOM(390, 33, "reverse-for");
             push_u64(0);
             incref(var_f);
             push_value(var_f);
@@ -20488,31 +20614,31 @@ static void mw_ab_lambda_21_ (void){
             mw_List_2E_reverse_for();
             push_value(d3);
         }
-        WORD_ATOM(394, 5, "tuck");
-        mw_tuck();
-        WORD_ATOM(394, 10, "~mid");
-        mw_Lambda_7E_mid();
-        WORD_ATOM(394, 15, "!");
-        mw_prim_mut_set();
         WORD_ATOM(395, 5, "tuck");
         mw_tuck();
-        WORD_ATOM(395, 10, "~inner-ctx");
-        mw_Lambda_7E_inner_ctx();
-        WORD_ATOM(395, 21, "!");
+        WORD_ATOM(395, 10, "~mid");
+        mw_Lambda_7E_mid();
+        WORD_ATOM(395, 15, "!");
         mw_prim_mut_set();
-        WORD_ATOM(399, 5, "dup");
+        WORD_ATOM(396, 5, "tuck");
+        mw_tuck();
+        WORD_ATOM(396, 10, "~inner-ctx");
+        mw_Lambda_7E_inner_ctx();
+        WORD_ATOM(396, 21, "!");
+        mw_prim_mut_set();
+        WORD_ATOM(400, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(399, 9, "inner-ctx");
+        WORD_ATOM(400, 9, "inner-ctx");
         mw_Lambda_2E_inner_ctx();
-        WORD_ATOM(400, 5, "over");
+        WORD_ATOM(401, 5, "over");
         mw_over();
-        WORD_ATOM(400, 10, "mid");
+        WORD_ATOM(401, 10, "mid");
         mw_Lambda_2E_mid();
-        WORD_ATOM(401, 5, "ab-token");
+        WORD_ATOM(402, 5, "ab-token");
         mw_ab_token();
-        WORD_ATOM(401, 14, "@");
+        WORD_ATOM(402, 14, "@");
         mw_prim_mut_get();
-        WORD_ATOM(402, 5, "ab-build!");
+        WORD_ATOM(403, 5, "ab-build!");
         push_u64(0);
         incref(var_f);
         push_value(var_f);
@@ -20520,141 +20646,141 @@ static void mw_ab_lambda_21_ (void){
         push_fnptr(&mb_ab_lambda_21__7);
         mw_prim_pack_cons();
         mw_ab_build_21_();
-        WORD_ATOM(406, 5, "over");
+        WORD_ATOM(407, 5, "over");
         mw_over();
-        WORD_ATOM(406, 10, "~body");
+        WORD_ATOM(407, 10, "~body");
         mw_Lambda_7E_body();
-        WORD_ATOM(406, 16, "!");
+        WORD_ATOM(407, 16, "!");
         mw_prim_mut_set();
-        WORD_ATOM(407, 5, "OP_LAMBDA");
+        WORD_ATOM(408, 5, "OP_LAMBDA");
         mw_OP_5F_LAMBDA();
-        WORD_ATOM(407, 15, "ab-op!");
+        WORD_ATOM(408, 15, "ab-op!");
         mw_ab_op_21_();
         decref(var_f);
     }
     WORD_EXIT(mw_ab_lambda_21_);
 }
 static void mw_elab_op_fresh_sig_21_ (void){
-    WORD_ENTER(mw_elab_op_fresh_sig_21_, "elab-op-fresh-sig!", "src/mirth/elab.mth", 415, 5);
-    WORD_ATOM(415, 5, "Subst.nil");
+    WORD_ENTER(mw_elab_op_fresh_sig_21_, "elab-op-fresh-sig!", "src/mirth/elab.mth", 416, 5);
+    WORD_ATOM(416, 5, "Subst.nil");
     mw_Subst_2E_nil();
-    WORD_ATOM(415, 15, "swap");
+    WORD_ATOM(416, 15, "swap");
     mw_prim_swap();
-    WORD_ATOM(415, 20, "match");
+    WORD_ATOM(416, 20, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(416, 20, "OPSIG_ID");
+            WORD_ATOM(417, 20, "OPSIG_ID");
             mw_OPSIG_5F_ID();
             break;
         case 8LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(417, 19, "VALUE_INT");
+            WORD_ATOM(418, 19, "VALUE_INT");
             mw_VALUE_5F_INT();
-            WORD_ATOM(417, 29, "TValue");
-            mw_TValue();
-            WORD_ATOM(417, 36, "OPSIG_PUSH");
-            mw_OPSIG_5F_PUSH();
-            break;
-        case 9LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(418, 19, "VALUE_STR");
-            mw_VALUE_5F_STR();
             WORD_ATOM(418, 29, "TValue");
             mw_TValue();
             WORD_ATOM(418, 36, "OPSIG_PUSH");
             mw_OPSIG_5F_PUSH();
             break;
+        case 9LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(419, 19, "VALUE_STR");
+            mw_VALUE_5F_STR();
+            WORD_ATOM(419, 29, "TValue");
+            mw_TValue();
+            WORD_ATOM(419, 36, "OPSIG_PUSH");
+            mw_OPSIG_5F_PUSH();
+            break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(419, 22, "drop");
+            WORD_ATOM(420, 22, "drop");
             mw_prim_drop();
-            WORD_ATOM(419, 27, "TYPE_PTR");
+            WORD_ATOM(420, 27, "TYPE_PTR");
             mw_TYPE_5F_PTR();
-            WORD_ATOM(419, 36, "OPSIG_PUSH");
+            WORD_ATOM(420, 36, "OPSIG_PUSH");
             mw_OPSIG_5F_PUSH();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(420, 24, "type");
+            WORD_ATOM(421, 24, "type");
             mw_Variable_2E_type();
-            WORD_ATOM(420, 29, "TMut");
+            WORD_ATOM(421, 29, "TMut");
             mw_TMut();
-            WORD_ATOM(420, 34, "OPSIG_PUSH");
+            WORD_ATOM(421, 34, "OPSIG_PUSH");
             mw_OPSIG_5F_PUSH();
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(421, 24, "value");
+            WORD_ATOM(422, 24, "value");
             mw_Constant_2E_value();
-            WORD_ATOM(421, 30, "TValue");
+            WORD_ATOM(422, 30, "TValue");
             mw_TValue();
-            WORD_ATOM(421, 37, "OPSIG_PUSH");
+            WORD_ATOM(422, 37, "OPSIG_PUSH");
             mw_OPSIG_5F_PUSH();
             break;
         case 10LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(422, 19, "type");
+            WORD_ATOM(423, 19, "type");
             mw_Tag_2E_type();
-            WORD_ATOM(422, 24, "freshen-sig");
+            WORD_ATOM(423, 24, "freshen-sig");
             mw_ArrowType_2E_freshen_sig();
-            WORD_ATOM(422, 36, "OPSIG_APPLY");
+            WORD_ATOM(423, 36, "OPSIG_APPLY");
             mw_OPSIG_5F_APPLY();
             break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(423, 20, "type");
-            mw_Word_2E_type();
-            WORD_ATOM(423, 25, "freshen-sig");
-            mw_ArrowType_2E_freshen_sig();
-            WORD_ATOM(423, 37, "OPSIG_APPLY");
-            mw_OPSIG_5F_APPLY();
-            break;
-        case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
             WORD_ATOM(424, 20, "type");
-            mw_Prim_2E_type();
+            mw_Word_2E_type();
             WORD_ATOM(424, 25, "freshen-sig");
             mw_ArrowType_2E_freshen_sig();
             WORD_ATOM(424, 37, "OPSIG_APPLY");
             mw_OPSIG_5F_APPLY();
             break;
+        case 1LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(425, 20, "type");
+            mw_Prim_2E_type();
+            WORD_ATOM(425, 25, "freshen-sig");
+            mw_ArrowType_2E_freshen_sig();
+            WORD_ATOM(425, 37, "OPSIG_APPLY");
+            mw_OPSIG_5F_APPLY();
+            break;
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(425, 24, "type");
+            WORD_ATOM(426, 24, "type");
             mw_External_2E_type();
-            WORD_ATOM(425, 29, "freshen-sig");
+            WORD_ATOM(426, 29, "freshen-sig");
             mw_ArrowType_2E_freshen_sig();
-            WORD_ATOM(425, 41, "OPSIG_APPLY");
+            WORD_ATOM(426, 41, "OPSIG_APPLY");
             mw_OPSIG_5F_APPLY();
             break;
         case 7LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(426, 21, "type");
+            WORD_ATOM(427, 21, "type");
             mw_Field_2E_type();
-            WORD_ATOM(426, 26, "freshen-sig");
+            WORD_ATOM(427, 26, "freshen-sig");
             mw_ArrowType_2E_freshen_sig();
-            WORD_ATOM(426, 38, "OPSIG_APPLY");
+            WORD_ATOM(427, 38, "OPSIG_APPLY");
             mw_OPSIG_5F_APPLY();
             break;
         case 14LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(427, 21, "elab-block-sig!");
+            WORD_ATOM(428, 21, "elab-block-sig!");
             mw_elab_block_sig_21_();
             break;
         case 13LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(428, 19, "elab-var-sig!");
+            WORD_ATOM(429, 19, "elab-var-sig!");
             mw_elab_var_sig_21_();
             break;
         case 11LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(429, 21, "elab-match-sig!");
+            WORD_ATOM(430, 21, "elab-match-sig!");
             mw_elab_match_sig_21_();
             break;
         case 12LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(430, 22, "elab-lambda-sig!");
+            WORD_ATOM(431, 22, "elab-lambda-sig!");
             mw_elab_lambda_sig_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -20662,115 +20788,115 @@ static void mw_elab_op_fresh_sig_21_ (void){
 }    WORD_EXIT(mw_elab_op_fresh_sig_21_);
 }
 static void mw_elab_block_sig_21_ (void){
-    WORD_ENTER(mw_elab_block_sig_21_, "elab-block-sig!", "src/mirth/elab.mth", 434, 5);
-    WORD_ATOM(434, 5, "VALUE_BLOCK");
+    WORD_ENTER(mw_elab_block_sig_21_, "elab-block-sig!", "src/mirth/elab.mth", 435, 5);
+    WORD_ATOM(435, 5, "VALUE_BLOCK");
     mw_VALUE_5F_BLOCK();
-    WORD_ATOM(434, 17, "TValue");
+    WORD_ATOM(435, 17, "TValue");
     mw_TValue();
-    WORD_ATOM(434, 24, "OPSIG_PUSH");
+    WORD_ATOM(435, 24, "OPSIG_PUSH");
     mw_OPSIG_5F_PUSH();
     WORD_EXIT(mw_elab_block_sig_21_);
 }
 static void mw_elab_match_sig_21_ (void){
-    WORD_ENTER(mw_elab_match_sig_21_, "elab-match-sig!", "src/mirth/elab.mth", 437, 5);
-    WORD_ATOM(437, 5, "sip");
+    WORD_ENTER(mw_elab_match_sig_21_, "elab-match-sig!", "src/mirth/elab.mth", 438, 5);
+    WORD_ATOM(438, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_match_sig_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(437, 14, "cod");
+    WORD_ATOM(438, 14, "cod");
     mw_Match_2E_cod();
-    WORD_ATOM(437, 18, "T->");
+    WORD_ATOM(438, 18, "T->");
     mw_T__3E_();
-    WORD_ATOM(437, 22, "OPSIG_APPLY");
+    WORD_ATOM(438, 22, "OPSIG_APPLY");
     mw_OPSIG_5F_APPLY();
     WORD_EXIT(mw_elab_match_sig_21_);
 }
 static void mw_elab_lambda_sig_21_ (void){
-    WORD_ENTER(mw_elab_lambda_sig_21_, "elab-lambda-sig!", "src/mirth/elab.mth", 440, 5);
-    WORD_ATOM(440, 5, "sip");
+    WORD_ENTER(mw_elab_lambda_sig_21_, "elab-lambda-sig!", "src/mirth/elab.mth", 441, 5);
+    WORD_ATOM(441, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_lambda_sig_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(440, 14, "cod");
+    WORD_ATOM(441, 14, "cod");
     mw_Lambda_2E_cod();
-    WORD_ATOM(440, 18, "T->");
+    WORD_ATOM(441, 18, "T->");
     mw_T__3E_();
-    WORD_ATOM(440, 22, "OPSIG_APPLY");
+    WORD_ATOM(441, 22, "OPSIG_APPLY");
     mw_OPSIG_5F_APPLY();
     WORD_EXIT(mw_elab_lambda_sig_21_);
 }
 static void mw_elab_var_sig_21_ (void){
-    WORD_ENTER(mw_elab_var_sig_21_, "elab-var-sig!", "src/mirth/elab.mth", 443, 5);
-    WORD_ATOM(443, 5, "dup");
+    WORD_ENTER(mw_elab_var_sig_21_, "elab-var-sig!", "src/mirth/elab.mth", 444, 5);
+    WORD_ATOM(444, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(443, 9, "auto-run?");
+    WORD_ATOM(444, 9, "auto-run?");
     mw_Var_2E_auto_run_3F_();
-    WORD_ATOM(443, 19, "if");
+    WORD_ATOM(444, 19, "if");
     if (pop_u64()) {
-        WORD_ATOM(444, 9, "type");
-        mw_Var_2E_type();
-        WORD_ATOM(444, 14, "morphism?");
-        mw_Type_2E_morphism_3F_();
-        WORD_ATOM(444, 24, "unwrap");
-        mw_Maybe_2E_unwrap();
-        WORD_ATOM(444, 31, "semifreshen-sig");
-        mw_ArrowType_2E_semifreshen_sig();
-        WORD_ATOM(444, 47, "OPSIG_APPLY");
-        mw_OPSIG_5F_APPLY();
-    } else {
         WORD_ATOM(445, 9, "type");
         mw_Var_2E_type();
-        WORD_ATOM(445, 14, "OPSIG_PUSH");
+        WORD_ATOM(445, 14, "morphism?");
+        mw_Type_2E_morphism_3F_();
+        WORD_ATOM(445, 24, "unwrap");
+        mw_Maybe_2E_unwrap();
+        WORD_ATOM(445, 31, "semifreshen-sig");
+        mw_ArrowType_2E_semifreshen_sig();
+        WORD_ATOM(445, 47, "OPSIG_APPLY");
+        mw_OPSIG_5F_APPLY();
+    } else {
+        WORD_ATOM(446, 9, "type");
+        mw_Var_2E_type();
+        WORD_ATOM(446, 14, "OPSIG_PUSH");
         mw_OPSIG_5F_PUSH();
     }
     WORD_EXIT(mw_elab_var_sig_21_);
 }
 static void mw_elab_word_ctx_type_weak_21_ (void){
-    WORD_ENTER(mw_elab_word_ctx_type_weak_21_, "elab-word-ctx-type-weak!", "src/mirth/elab.mth", 449, 5);
-    WORD_ATOM(449, 5, "dup");
+    WORD_ENTER(mw_elab_word_ctx_type_weak_21_, "elab-word-ctx-type-weak!", "src/mirth/elab.mth", 450, 5);
+    WORD_ATOM(450, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(449, 9, "sig");
+    WORD_ATOM(450, 9, "sig");
     mw_Word_2E_sig();
-    WORD_ATOM(449, 13, "match");
+    WORD_ATOM(450, 13, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(450, 17, "~ctx-type");
+            WORD_ATOM(451, 17, "~ctx-type");
             mw_Word_7E_ctx_type();
-            WORD_ATOM(450, 27, "@");
+            WORD_ATOM(451, 27, "@");
             mw_prim_mut_get();
-            WORD_ATOM(450, 29, "match");
+            WORD_ATOM(451, 29, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(451, 27, "unpack2");
+                    WORD_ATOM(452, 27, "unpack2");
                     mw_unpack2();
                     break;
                 default:
-                    WORD_ATOM(452, 18, "drop");
+                    WORD_ATOM(453, 18, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(452, 23, "CTX0");
+                    WORD_ATOM(453, 23, "CTX0");
                     mw_CTX0();
-                    WORD_ATOM(452, 28, "MetaVar.new!");
+                    WORD_ATOM(453, 28, "MetaVar.new!");
                     mw_MetaVar_2E_new_21_();
-                    WORD_ATOM(452, 41, "STMeta");
+                    WORD_ATOM(453, 41, "STMeta");
                     mw_STMeta();
-                    WORD_ATOM(452, 48, "MetaVar.new!");
+                    WORD_ATOM(453, 48, "MetaVar.new!");
                     mw_MetaVar_2E_new_21_();
-                    WORD_ATOM(452, 61, "STMeta");
+                    WORD_ATOM(453, 61, "STMeta");
                     mw_STMeta();
-                    WORD_ATOM(452, 68, "T->");
+                    WORD_ATOM(453, 68, "T->");
                     mw_T__3E_();
                     break;
             
 }            break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(454, 17, "drop");
+            WORD_ATOM(455, 17, "drop");
             mw_prim_drop();
-            WORD_ATOM(454, 22, "ctx-type");
+            WORD_ATOM(455, 22, "ctx-type");
             mw_Word_2E_ctx_type();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -20778,48 +20904,48 @@ static void mw_elab_word_ctx_type_weak_21_ (void){
 }    WORD_EXIT(mw_elab_word_ctx_type_weak_21_);
 }
 static void mw_elab_arrow_21_ (void){
-    WORD_ENTER(mw_elab_arrow_21_, "elab-arrow!", "src/mirth/elab.mth", 458, 5);
-    WORD_ATOM(458, 5, "dip");
+    WORD_ENTER(mw_elab_arrow_21_, "elab-arrow!", "src/mirth/elab.mth", 459, 5);
+    WORD_ATOM(459, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(458, 9, "unpack");
+        WORD_ATOM(459, 9, "unpack");
         mw_ArrowType_2E_unpack();
         push_value(d2);
     }
-    WORD_ATOM(458, 17, "elab-arrow-hom!");
+    WORD_ATOM(459, 17, "elab-arrow-hom!");
     mw_elab_arrow_hom_21_();
     WORD_EXIT(mw_elab_arrow_21_);
 }
 static void mw_elab_arrow_hom_21_ (void){
-    WORD_ENTER(mw_elab_arrow_hom_21_, "elab-arrow-hom!", "src/mirth/elab.mth", 461, 5);
-    WORD_ATOM(461, 5, "swap");
+    WORD_ENTER(mw_elab_arrow_hom_21_, "elab-arrow-hom!", "src/mirth/elab.mth", 462, 5);
+    WORD_ATOM(462, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(461, 10, "dip");
+    WORD_ATOM(462, 10, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(462, 9, "elab-arrow-fwd!");
+        WORD_ATOM(463, 9, "elab-arrow-fwd!");
         mw_elab_arrow_fwd_21_();
-        WORD_ATOM(463, 9, "dup");
+        WORD_ATOM(464, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(463, 13, "token-end");
+        WORD_ATOM(464, 13, "token-end");
         mw_Arrow_2E_token_end();
-        WORD_ATOM(463, 23, "GAMMA");
+        WORD_ATOM(464, 23, "GAMMA");
         mw_GAMMA();
-        WORD_ATOM(464, 9, "over");
+        WORD_ATOM(465, 9, "over");
         mw_over();
-        WORD_ATOM(464, 14, "cod");
+        WORD_ATOM(465, 14, "cod");
         mw_Arrow_2E_cod();
         push_value(d2);
     }
-    WORD_ATOM(466, 5, "unify!");
+    WORD_ATOM(467, 5, "unify!");
     mw_StackType_2E_unify_21_();
-    WORD_ATOM(466, 12, "drop2");
+    WORD_ATOM(467, 12, "drop2");
     mw_drop2();
     WORD_EXIT(mw_elab_arrow_hom_21_);
 }
 static void mw_elab_arrow_fwd_21_ (void){
-    WORD_ENTER(mw_elab_arrow_fwd_21_, "elab-arrow-fwd!", "src/mirth/elab.mth", 469, 5);
-    WORD_ATOM(469, 5, "ab-build!");
+    WORD_ENTER(mw_elab_arrow_fwd_21_, "elab-arrow-fwd!", "src/mirth/elab.mth", 470, 5);
+    WORD_ATOM(470, 5, "ab-build!");
     push_u64(0);
     push_fnptr(&mb_elab_arrow_fwd_21__1);
     mw_prim_pack_cons();
@@ -20827,19 +20953,19 @@ static void mw_elab_arrow_fwd_21_ (void){
     WORD_EXIT(mw_elab_arrow_fwd_21_);
 }
 static void mw_elab_atoms_21_ (void){
-    WORD_ENTER(mw_elab_atoms_21_, "elab-atoms!", "src/mirth/elab.mth", 472, 5);
-    WORD_ATOM(472, 5, "while");
+    WORD_ENTER(mw_elab_atoms_21_, "elab-atoms!", "src/mirth/elab.mth", 473, 5);
+    WORD_ATOM(473, 5, "while");
     while(1) {
-        WORD_ATOM(473, 9, "elab-atoms-done?");
+        WORD_ATOM(474, 9, "elab-atoms-done?");
         mw_elab_atoms_done_3F_();
-        WORD_ATOM(473, 26, "not");
+        WORD_ATOM(474, 26, "not");
         mw_Bool_2E_not();
         if (! pop_u64()) break;
-        WORD_ATOM(474, 9, "elab-atom!");
+        WORD_ATOM(475, 9, "elab-atom!");
         mw_elab_atom_21_();
-        WORD_ATOM(474, 20, "ab-token");
+        WORD_ATOM(475, 20, "ab-token");
         mw_ab_token();
-        WORD_ATOM(474, 29, "modify");
+        WORD_ATOM(475, 29, "modify");
         push_u64(0);
         push_fnptr(&mb_elab_atoms_21__3);
         mw_prim_pack_cons();
@@ -20848,60 +20974,60 @@ static void mw_elab_atoms_21_ (void){
     WORD_EXIT(mw_elab_atoms_21_);
 }
 static void mw_elab_atoms_done_3F_ (void){
-    WORD_ENTER(mw_elab_atoms_done_3F_, "elab-atoms-done?", "src/mirth/elab.mth", 478, 5);
-    WORD_ATOM(478, 5, "ab-token");
+    WORD_ENTER(mw_elab_atoms_done_3F_, "elab-atoms-done?", "src/mirth/elab.mth", 479, 5);
+    WORD_ATOM(479, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(478, 14, "@");
+    WORD_ATOM(479, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(478, 16, "run-end?");
+    WORD_ATOM(479, 16, "run-end?");
     mw_Token_2E_run_end_3F_();
     WORD_EXIT(mw_elab_atoms_done_3F_);
 }
 static void mw_elab_atom_21_ (void){
-    WORD_ENTER(mw_elab_atom_21_, "elab-atom!", "src/mirth/elab.mth", 481, 5);
-    WORD_ATOM(481, 5, "ab-token");
+    WORD_ENTER(mw_elab_atom_21_, "elab-atom!", "src/mirth/elab.mth", 482, 5);
+    WORD_ATOM(482, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(481, 14, "@");
+    WORD_ATOM(482, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(481, 16, "value");
+    WORD_ATOM(482, 16, "value");
     mw_Token_2E_value();
-    WORD_ATOM(481, 22, "match");
+    WORD_ATOM(482, 22, "match");
     switch (get_top_data_tag()) {
         case 13LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(482, 23, "elab-atom-name!");
+            WORD_ATOM(483, 23, "elab-atom-name!");
             mw_elab_atom_name_21_();
             break;
         case 11LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(483, 22, "ab-int!");
+            WORD_ATOM(484, 22, "ab-int!");
             mw_ab_int_21_();
             break;
         case 12LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(484, 22, "ab-str!");
+            WORD_ATOM(485, 22, "ab-str!");
             mw_ab_str_21_();
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(485, 26, "drop");
+            WORD_ATOM(486, 26, "drop");
             mw_prim_drop();
-            WORD_ATOM(485, 31, "elab-atom-block!");
+            WORD_ATOM(486, 31, "elab-atom-block!");
             mw_elab_atom_block_21_();
             break;
         case 9LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(486, 25, "drop");
+            WORD_ATOM(487, 25, "drop");
             mw_prim_drop();
-            WORD_ATOM(486, 30, "elab-atom-assert!");
+            WORD_ATOM(487, 30, "elab-atom-assert!");
             mw_elab_atom_assert_21_();
             break;
         default:
-            WORD_ATOM(487, 14, "ab-token");
+            WORD_ATOM(488, 14, "ab-token");
             mw_ab_token();
-            WORD_ATOM(487, 23, "@");
+            WORD_ATOM(488, 23, "@");
             mw_prim_mut_get();
-            WORD_ATOM(487, 25, "");
+            WORD_ATOM(488, 25, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20912,49 +21038,49 @@ static void mw_elab_atom_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(487, 58, "emit-fatal-error!");
+            WORD_ATOM(488, 58, "emit-fatal-error!");
             mw_emit_fatal_error_21_();
             break;
     
 }    WORD_EXIT(mw_elab_atom_21_);
 }
 static void mw_elab_atom_block_21_ (void){
-    WORD_ENTER(mw_elab_atom_block_21_, "elab-atom-block!", "src/mirth/elab.mth", 491, 5);
-    WORD_ATOM(491, 5, "ab-token");
+    WORD_ENTER(mw_elab_atom_block_21_, "elab-atom-block!", "src/mirth/elab.mth", 492, 5);
+    WORD_ATOM(492, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(491, 14, "@");
+    WORD_ATOM(492, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(491, 16, "args-1");
+    WORD_ATOM(492, 16, "args-1");
     mw_Token_2E_args_1();
-    WORD_ATOM(491, 23, "elab-block-at!");
+    WORD_ATOM(492, 23, "elab-block-at!");
     mw_elab_block_at_21_();
     WORD_EXIT(mw_elab_atom_block_21_);
 }
 static void mw_elab_block_at_21_ (void){
-    WORD_ENTER(mw_elab_block_at_21_, "elab-block-at!", "src/mirth/elab.mth", 494, 5);
-    WORD_ATOM(494, 5, "ab-ctx");
+    WORD_ENTER(mw_elab_block_at_21_, "elab-block-at!", "src/mirth/elab.mth", 495, 5);
+    WORD_ATOM(495, 5, "ab-ctx");
     mw_ab_ctx();
-    WORD_ATOM(494, 12, "@");
+    WORD_ATOM(495, 12, "@");
     mw_prim_mut_get();
-    WORD_ATOM(494, 14, "swap");
+    WORD_ATOM(495, 14, "swap");
     mw_prim_swap();
-    WORD_ATOM(494, 19, "Block.new-deferred!");
+    WORD_ATOM(495, 19, "Block.new-deferred!");
     mw_Block_2E_new_deferred_21_();
-    WORD_ATOM(494, 39, "OP_BLOCK");
+    WORD_ATOM(495, 39, "OP_BLOCK");
     mw_OP_5F_BLOCK();
-    WORD_ATOM(494, 48, "ab-op!");
+    WORD_ATOM(495, 48, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_elab_block_at_21_);
 }
 static void mw_elab_args_21_ (void){
-    WORD_ENTER(mw_elab_args_21_, "elab-args!", "src/mirth/elab.mth", 497, 5);
-    WORD_ATOM(497, 5, "ab-token");
+    WORD_ENTER(mw_elab_args_21_, "elab-args!", "src/mirth/elab.mth", 498, 5);
+    WORD_ATOM(498, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(497, 14, "@");
+    WORD_ATOM(498, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(497, 16, "args");
+    WORD_ATOM(498, 16, "args");
     mw_Token_2E_args();
-    WORD_ATOM(497, 21, "for");
+    WORD_ATOM(498, 21, "for");
     push_u64(0);
     push_fnptr(&mb_elab_args_21__1);
     mw_prim_pack_cons();
@@ -20962,86 +21088,169 @@ static void mw_elab_args_21_ (void){
     WORD_EXIT(mw_elab_args_21_);
 }
 static void mw_elab_no_args_21_ (void){
-    WORD_ENTER(mw_elab_no_args_21_, "elab-no-args!", "src/mirth/elab.mth", 500, 5);
-    WORD_ATOM(500, 5, "ab-token");
+    WORD_ENTER(mw_elab_no_args_21_, "elab-no-args!", "src/mirth/elab.mth", 501, 5);
+    WORD_ATOM(501, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(500, 14, "@");
+    WORD_ATOM(501, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(500, 16, "args-0");
+    WORD_ATOM(501, 16, "args-0");
     mw_Token_2E_args_0();
     WORD_EXIT(mw_elab_no_args_21_);
 }
 static void mw_elab_atom_name_21_ (void){
-    WORD_ENTER(mw_elab_atom_name_21_, "elab-atom-name!", "src/mirth/elab.mth", 503, 5);
-    WORD_ATOM(503, 5, "dup");
+    WORD_ENTER(mw_elab_atom_name_21_, "elab-atom-name!", "src/mirth/elab.mth", 504, 5);
+    WORD_ATOM(504, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(503, 9, "ab-ctx");
+    WORD_ATOM(504, 9, "ab-ctx");
     mw_ab_ctx();
-    WORD_ATOM(503, 16, "@");
+    WORD_ATOM(504, 16, "@");
     mw_prim_mut_get();
-    WORD_ATOM(503, 18, "lookup");
+    WORD_ATOM(504, 18, "lookup");
     mw_Ctx_2E_lookup();
-    WORD_ATOM(503, 25, "match");
+    WORD_ATOM(504, 25, "match");
     switch (get_top_data_tag()) {
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(504, 17, "nip");
+            WORD_ATOM(505, 17, "nip");
             mw_nip();
-            WORD_ATOM(504, 21, "elab-args!");
+            WORD_ATOM(505, 21, "elab-args!");
             mw_elab_args_21_();
-            WORD_ATOM(504, 32, "ab-var!");
+            WORD_ATOM(505, 32, "ab-var!");
             mw_ab_var_21_();
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(506, 13, "elab-relativize-name!");
+            WORD_ATOM(507, 13, "elab-relativize-name!");
             mw_elab_relativize_name_21_();
-            WORD_ATOM(507, 13, "elab-check-name-visible!");
+            WORD_ATOM(508, 13, "elab-check-name-visible!");
             mw_elab_check_name_visible_21_();
-            WORD_ATOM(508, 13, "elab-atom-name-global!");
+            WORD_ATOM(509, 13, "elab-atom-name-global!");
             mw_elab_atom_name_global_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
     
 }    WORD_EXIT(mw_elab_atom_name_21_);
 }
+static void mw_elab_needs_dot (void){
+    WORD_ENTER(mw_elab_needs_dot, "elab-needs-dot", "src/mirth/elab.mth", 514, 5);
+    WORD_ATOM(514, 5, "first-byte");
+    mw_Str_2E_first_byte();
+    WORD_ATOM(514, 16, "if-some");
+    push_u64(0);
+    push_fnptr(&mb_elab_needs_dot_1);
+    mw_prim_pack_cons();
+    push_u64(0);
+    push_fnptr(&mb_elab_needs_dot_2);
+    mw_prim_pack_cons();
+    mw_Maybe_2E_if_some();
+    WORD_EXIT(mw_elab_needs_dot);
+}
+static void mw_elab_combine_prefix (void){
+    WORD_ENTER(mw_elab_combine_prefix, "elab-combine-prefix", "src/mirth/elab.mth", 517, 5);
+    WORD_ATOM(517, 5, "over");
+    mw_over();
+    WORD_ATOM(517, 10, "elab-needs-dot");
+    mw_elab_needs_dot();
+    WORD_ATOM(517, 25, "then");
+    push_u64(0);
+    push_fnptr(&mb_elab_combine_prefix_1);
+    mw_prim_pack_cons();
+    mw_Bool_2E_then();
+    WORD_ATOM(517, 39, "swap");
+    mw_prim_swap();
+    WORD_ATOM(517, 44, "cat");
+    mw_prim_str_cat();
+    WORD_EXIT(mw_elab_combine_prefix);
+}
+static void mw_elab_combine_prefixes (void){
+    WORD_ENTER(mw_elab_combine_prefixes, "elab-combine-prefixes", "src/mirth/elab.mth", 520, 5);
+    WORD_ATOM(520, 5, "if-some");
+    push_u64(0);
+    push_fnptr(&mb_elab_combine_prefixes_1);
+    mw_prim_pack_cons();
+    push_u64(0);
+    push_fnptr(&mb_elab_combine_prefixes_3);
+    mw_prim_pack_cons();
+    mw_Maybe_2E_if_some();
+    WORD_EXIT(mw_elab_combine_prefixes);
+}
+static void mw_elab_word_search (void){
+    WORD_ENTER(mw_elab_word_search, "elab-word-search", "src/mirth/elab.mth", 526, 5);
+    WORD_ATOM(526, 5, "Name.search");
+    mw_Name_2E_search();
+    WORD_ATOM(526, 17, "filter");
+    push_u64(0);
+    push_fnptr(&mb_elab_word_search_1);
+    mw_prim_pack_cons();
+    mw_Maybe_2E_filter();
+    WORD_EXIT(mw_elab_word_search);
+}
+static void mw_elab_name_candidates (void){
+    WORD_ENTER(mw_elab_name_candidates, "elab-name-candidates", "src/mirth/elab.mth", 529, 5);
+    WORD_ATOM(529, 5, ">Str");
+    mw_Name_3E_Str();
+    WORD_ATOM(529, 10, "L1+");
+    mw_L1_2B_();
+    WORD_ATOM(530, 5, "ab-type");
+    mw_ab_type();
+    WORD_ATOM(530, 13, "@");
+    mw_prim_mut_get();
+    WORD_ATOM(530, 15, "top-resource-name");
+    mw_StackType_2E_top_resource_name();
+    WORD_ATOM(530, 33, "map");
+    push_u64(0);
+    push_fnptr(&mb_elab_name_candidates_1);
+    mw_prim_pack_cons();
+    mw_Maybe_2E_map();
+    WORD_ATOM(530, 43, "elab-combine-prefixes");
+    mw_elab_combine_prefixes();
+    WORD_ATOM(531, 5, "ab-type");
+    mw_ab_type();
+    WORD_ATOM(531, 13, "@");
+    mw_prim_mut_get();
+    WORD_ATOM(531, 15, "top-tycon-name");
+    mw_StackType_2E_top_tycon_name();
+    WORD_ATOM(531, 30, "map");
+    push_u64(0);
+    push_fnptr(&mb_elab_name_candidates_2);
+    mw_prim_pack_cons();
+    mw_Maybe_2E_map();
+    WORD_ATOM(531, 40, "elab-combine-prefixes");
+    mw_elab_combine_prefixes();
+    WORD_ATOM(532, 5, "filter-some");
+    push_u64(0);
+    push_fnptr(&mb_elab_name_candidates_3);
+    mw_prim_pack_cons();
+    mw_List_2B__2E_filter_some();
+    WORD_EXIT(mw_elab_name_candidates);
+}
 static void mw_elab_relativize_name_21_ (void){
-    WORD_ENTER(mw_elab_relativize_name_21_, "elab-relativize-name!", "src/mirth/elab.mth", 512, 5);
-    WORD_ATOM(512, 5, "name-undefined?");
-    mw_name_undefined_3F_();
-    WORD_ATOM(512, 21, "and");
+    WORD_ENTER(mw_elab_relativize_name_21_, "elab-relativize-name!", "src/mirth/elab.mth", 535, 5);
+    WORD_ATOM(535, 5, "dup");
+    mw_prim_dup();
+    WORD_ATOM(535, 9, "elab-name-candidates");
+    mw_elab_name_candidates();
+    WORD_ATOM(535, 30, "first");
+    mw_List_2E_first();
+    WORD_ATOM(535, 36, "if-some");
     push_u64(0);
     push_fnptr(&mb_elab_relativize_name_21__1);
     mw_prim_pack_cons();
-    mw_Bool_2E_and();
-    WORD_ATOM(512, 48, "if");
-    if (pop_u64()) {
-        WORD_ATOM(513, 9, "ab-type");
-        mw_ab_type();
-        WORD_ATOM(513, 17, "@");
-        mw_prim_mut_get();
-        WORD_ATOM(513, 19, "top-tycon-name");
-        mw_StackType_2E_top_tycon_name();
-        WORD_ATOM(513, 34, "for");
-        push_u64(0);
-        push_fnptr(&mb_elab_relativize_name_21__3);
-        mw_prim_pack_cons();
-        mw_Maybe_2E_for();
-    } else {
-        WORD_ATOM(521, 9, "id");
-        mw_prim_id();
-    }
+    push_u64(0);
+    push_fnptr(&mb_elab_relativize_name_21__2);
+    mw_prim_pack_cons();
+    mw_Maybe_2E_if_some();
     WORD_EXIT(mw_elab_relativize_name_21_);
 }
 static void mw_elab_check_name_visible_21_ (void){
-    WORD_ENTER(mw_elab_check_name_visible_21_, "elab-check-name-visible!", "src/mirth/elab.mth", 525, 5);
-    WORD_ATOM(525, 5, "dup");
+    WORD_ENTER(mw_elab_check_name_visible_21_, "elab-check-name-visible!", "src/mirth/elab.mth", 538, 5);
+    WORD_ATOM(538, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(525, 9, ">Def");
+    WORD_ATOM(538, 9, ">Def");
     mw_Name_3E_Def();
-    WORD_ATOM(525, 14, ">Module?");
+    WORD_ATOM(538, 14, ">Module?");
     mw_Def_3E_Module_3F_();
-    WORD_ATOM(525, 23, "for");
+    WORD_ATOM(538, 23, "for");
     push_u64(0);
     push_fnptr(&mb_elab_check_name_visible_21__1);
     mw_prim_pack_cons();
@@ -21049,115 +21258,115 @@ static void mw_elab_check_name_visible_21_ (void){
     WORD_EXIT(mw_elab_check_name_visible_21_);
 }
 static void mw_elab_module_is_visible (void){
-    WORD_ENTER(mw_elab_module_is_visible, "elab-module-is-visible", "src/mirth/elab.mth", 532, 5);
-    WORD_ATOM(532, 5, "ab-token");
+    WORD_ENTER(mw_elab_module_is_visible, "elab-module-is-visible", "src/mirth/elab.mth", 545, 5);
+    WORD_ATOM(545, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(532, 14, "@");
+    WORD_ATOM(545, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(532, 16, ".module");
+    WORD_ATOM(545, 16, ".module");
     mw_Token_2E_module();
-    WORD_ATOM(532, 24, "visible");
+    WORD_ATOM(545, 24, "visible");
     mw_Module_2E_visible();
     WORD_EXIT(mw_elab_module_is_visible);
 }
 static void mw_elab_atom_name_global_21_ (void){
-    WORD_ENTER(mw_elab_atom_name_global_21_, "elab-atom-name-global!", "src/mirth/elab.mth", 535, 5);
-    WORD_ATOM(535, 5, "dup");
+    WORD_ENTER(mw_elab_atom_name_global_21_, "elab-atom-name-global!", "src/mirth/elab.mth", 548, 5);
+    WORD_ATOM(548, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(535, 9, ">Def");
+    WORD_ATOM(548, 9, ">Def");
     mw_Name_3E_Def();
-    WORD_ATOM(535, 14, "match");
+    WORD_ATOM(548, 14, "match");
     switch (get_top_data_tag()) {
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(536, 22, "nip");
+            WORD_ATOM(549, 22, "nip");
             mw_nip();
-            WORD_ATOM(536, 26, "target");
+            WORD_ATOM(549, 26, "target");
             mw_Alias_2E_target();
-            WORD_ATOM(536, 33, "elab-atom-name-global!");
+            WORD_ATOM(549, 33, "elab-atom-name-global!");
             mw_elab_atom_name_global_21_();
             break;
         case 7LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(537, 23, "nip");
+            WORD_ATOM(550, 23, "nip");
             mw_nip();
-            WORD_ATOM(537, 27, "elab-no-args!");
+            WORD_ATOM(550, 27, "elab-no-args!");
             mw_elab_no_args_21_();
-            WORD_ATOM(537, 41, "ab-buffer!");
+            WORD_ATOM(550, 41, "ab-buffer!");
             mw_ab_buffer_21_();
             break;
         case 8LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(538, 25, "nip");
+            WORD_ATOM(551, 25, "nip");
             mw_nip();
-            WORD_ATOM(538, 29, "elab-no-args!");
+            WORD_ATOM(551, 29, "elab-no-args!");
             mw_elab_no_args_21_();
-            WORD_ATOM(538, 43, "ab-variable!");
+            WORD_ATOM(551, 43, "ab-variable!");
             mw_ab_variable_21_();
             break;
         case 9LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(539, 25, "nip");
+            WORD_ATOM(552, 25, "nip");
             mw_nip();
-            WORD_ATOM(539, 29, "elab-no-args!");
+            WORD_ATOM(552, 29, "elab-no-args!");
             mw_elab_no_args_21_();
-            WORD_ATOM(539, 43, "ab-constant!");
+            WORD_ATOM(552, 43, "ab-constant!");
             mw_ab_constant_21_();
             break;
         case 10LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(540, 25, "nip");
+            WORD_ATOM(553, 25, "nip");
             mw_nip();
-            WORD_ATOM(540, 29, "elab-no-args!");
+            WORD_ATOM(553, 29, "elab-no-args!");
             mw_elab_no_args_21_();
-            WORD_ATOM(540, 43, "ab-external!");
+            WORD_ATOM(553, 43, "ab-external!");
             mw_ab_external_21_();
             break;
         case 11LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(541, 22, "nip");
+            WORD_ATOM(554, 22, "nip");
             mw_nip();
-            WORD_ATOM(541, 26, "elab-no-args!");
+            WORD_ATOM(554, 26, "elab-no-args!");
             mw_elab_no_args_21_();
-            WORD_ATOM(541, 40, "ab-field!");
+            WORD_ATOM(554, 40, "ab-field!");
             mw_ab_field_21_();
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(542, 21, "nip");
+            WORD_ATOM(555, 21, "nip");
             mw_nip();
-            WORD_ATOM(542, 25, "elab-args!");
+            WORD_ATOM(555, 25, "elab-args!");
             mw_elab_args_21_();
-            WORD_ATOM(542, 36, "ab-word!");
+            WORD_ATOM(555, 36, "ab-word!");
             mw_ab_word_21_();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(543, 20, "nip");
+            WORD_ATOM(556, 20, "nip");
             mw_nip();
-            WORD_ATOM(543, 24, "elab-args!");
+            WORD_ATOM(556, 24, "elab-args!");
             mw_elab_args_21_();
-            WORD_ATOM(543, 35, "ab-tag!");
+            WORD_ATOM(556, 35, "ab-tag!");
             mw_ab_tag_21_();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(544, 21, "nip");
+            WORD_ATOM(557, 21, "nip");
             mw_nip();
-            WORD_ATOM(544, 25, "elab-prim!");
+            WORD_ATOM(557, 25, "elab-prim!");
             mw_elab_prim_21_();
             break;
         default:
-            WORD_ATOM(547, 13, "drop");
+            WORD_ATOM(560, 13, "drop");
             mw_prim_drop();
-            WORD_ATOM(548, 13, "dip");
+            WORD_ATOM(561, 13, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(548, 17, "ab-token");
+                WORD_ATOM(561, 17, "ab-token");
                 mw_ab_token();
-                WORD_ATOM(548, 26, "@");
+                WORD_ATOM(561, 26, "@");
                 mw_prim_mut_get();
-                WORD_ATOM(548, 28, "");
+                WORD_ATOM(561, 28, "");
                 {
                     static bool vready = false;
                     static VAL v;
@@ -21170,223 +21379,223 @@ static void mw_elab_atom_name_global_21_ (void){
                 }
                 push_value(d4);
             }
-            WORD_ATOM(549, 13, ">Str");
+            WORD_ATOM(562, 13, ">Str");
             mw_Name_3E_Str();
-            WORD_ATOM(549, 18, "cat");
+            WORD_ATOM(562, 18, "cat");
             mw_prim_str_cat();
-            WORD_ATOM(549, 22, "emit-error!");
+            WORD_ATOM(562, 22, "emit-error!");
             mw_emit_error_21_();
-            WORD_ATOM(549, 34, "STACK_TYPE_ERROR");
+            WORD_ATOM(562, 34, "STACK_TYPE_ERROR");
             mw_STACK_5F_TYPE_5F_ERROR();
-            WORD_ATOM(549, 51, "ab-type");
+            WORD_ATOM(562, 51, "ab-type");
             mw_ab_type();
-            WORD_ATOM(549, 59, "!");
+            WORD_ATOM(562, 59, "!");
             mw_prim_mut_set();
             break;
     
 }    WORD_EXIT(mw_elab_atom_name_global_21_);
 }
 static void mw_elab_prim_21_ (void){
-    WORD_ENTER(mw_elab_prim_21_, "elab-prim!", "src/mirth/elab.mth", 553, 5);
-    WORD_ATOM(553, 5, "match");
+    WORD_ENTER(mw_elab_prim_21_, "elab-prim!", "src/mirth/elab.mth", 566, 5);
+    WORD_ATOM(566, 5, "match");
     switch (get_top_data_tag()) {
         case 10LL:
             mw_prim_drop();
-            WORD_ATOM(554, 28, "elab-atom-match!");
+            WORD_ATOM(567, 28, "elab-atom-match!");
             mw_elab_atom_match_21_();
             break;
         case 11LL:
             mw_prim_drop();
-            WORD_ATOM(555, 29, "elab-atom-lambda!");
+            WORD_ATOM(568, 29, "elab-atom-lambda!");
             mw_elab_atom_lambda_21_();
             break;
         default:
-            WORD_ATOM(556, 14, "elab-args!");
+            WORD_ATOM(569, 14, "elab-args!");
             mw_elab_args_21_();
-            WORD_ATOM(556, 25, "ab-prim!");
+            WORD_ATOM(569, 25, "ab-prim!");
             mw_ab_prim_21_();
             break;
     
 }    WORD_EXIT(mw_elab_prim_21_);
 }
 static void mw_elab_atom_assert_21_ (void){
-    WORD_ENTER(mw_elab_atom_assert_21_, "elab-atom-assert!", "src/mirth/elab.mth", 560, 5);
-    WORD_ATOM(560, 5, "ab-token");
+    WORD_ENTER(mw_elab_atom_assert_21_, "elab-atom-assert!", "src/mirth/elab.mth", 573, 5);
+    WORD_ATOM(573, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(560, 14, "@");
+    WORD_ATOM(573, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(560, 16, "GAMMA");
+    WORD_ATOM(573, 16, "GAMMA");
     mw_GAMMA();
-    WORD_ATOM(561, 5, "ab-ctx");
+    WORD_ATOM(574, 5, "ab-ctx");
     mw_ab_ctx();
-    WORD_ATOM(561, 12, "@");
+    WORD_ATOM(574, 12, "@");
     mw_prim_mut_get();
-    WORD_ATOM(561, 14, "type-elab-stack-assertion");
+    WORD_ATOM(574, 14, "type-elab-stack-assertion");
     mw_type_elab_stack_assertion();
-    WORD_ATOM(562, 5, "ab-token");
+    WORD_ATOM(575, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(562, 14, "@");
+    WORD_ATOM(575, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(562, 16, "args-1");
+    WORD_ATOM(575, 16, "args-1");
     mw_Token_2E_args_1();
-    WORD_ATOM(562, 23, "elab-type-stack!");
+    WORD_ATOM(575, 23, "elab-type-stack!");
     mw_elab_type_stack_21_();
-    WORD_ATOM(563, 5, "drop");
+    WORD_ATOM(576, 5, "drop");
     mw_prim_drop();
-    WORD_ATOM(563, 10, "nip");
+    WORD_ATOM(576, 10, "nip");
     mw_nip();
-    WORD_ATOM(563, 14, "ab-type");
+    WORD_ATOM(576, 14, "ab-type");
     mw_ab_type();
-    WORD_ATOM(563, 22, "@");
+    WORD_ATOM(576, 22, "@");
     mw_prim_mut_get();
-    WORD_ATOM(563, 24, "swap");
+    WORD_ATOM(576, 24, "swap");
     mw_prim_swap();
-    WORD_ATOM(563, 29, "unify!");
+    WORD_ATOM(576, 29, "unify!");
     mw_StackType_2E_unify_21_();
-    WORD_ATOM(563, 36, "drop2");
+    WORD_ATOM(576, 36, "drop2");
     mw_drop2();
     WORD_EXIT(mw_elab_atom_assert_21_);
 }
 static void mw_elab_atom_lambda_21_ (void){
-    WORD_ENTER(mw_elab_atom_lambda_21_, "elab-atom-lambda!", "src/mirth/elab.mth", 566, 5);
-    WORD_ATOM(566, 5, "Lambda.alloc!");
+    WORD_ENTER(mw_elab_atom_lambda_21_, "elab-atom-lambda!", "src/mirth/elab.mth", 579, 5);
+    WORD_ATOM(579, 5, "Lambda.alloc!");
     mw_Lambda_2E_alloc_21_();
-    WORD_ATOM(567, 5, "ab-ctx");
+    WORD_ATOM(580, 5, "ab-ctx");
     mw_ab_ctx();
-    WORD_ATOM(567, 12, "@");
+    WORD_ATOM(580, 12, "@");
     mw_prim_mut_get();
-    WORD_ATOM(567, 14, "over");
+    WORD_ATOM(580, 14, "over");
     mw_over();
-    WORD_ATOM(567, 19, "~outer-ctx");
+    WORD_ATOM(580, 19, "~outer-ctx");
     mw_Lambda_7E_outer_ctx();
-    WORD_ATOM(567, 30, "!");
+    WORD_ATOM(580, 30, "!");
     mw_prim_mut_set();
-    WORD_ATOM(568, 5, "ab-type");
+    WORD_ATOM(581, 5, "ab-type");
     mw_ab_type();
-    WORD_ATOM(568, 13, "@");
+    WORD_ATOM(581, 13, "@");
     mw_prim_mut_get();
-    WORD_ATOM(568, 15, "over");
+    WORD_ATOM(581, 15, "over");
     mw_over();
-    WORD_ATOM(568, 20, "~dom");
+    WORD_ATOM(581, 20, "~dom");
     mw_Lambda_7E_dom();
-    WORD_ATOM(568, 25, "!");
+    WORD_ATOM(581, 25, "!");
     mw_prim_mut_set();
-    WORD_ATOM(569, 5, "ab-token");
+    WORD_ATOM(582, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(569, 14, "@");
+    WORD_ATOM(582, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(569, 16, "over");
+    WORD_ATOM(582, 16, "over");
     mw_over();
-    WORD_ATOM(569, 21, "~token");
+    WORD_ATOM(582, 21, "~token");
     mw_Lambda_7E_token();
-    WORD_ATOM(569, 28, "!");
+    WORD_ATOM(582, 28, "!");
     mw_prim_mut_set();
-    WORD_ATOM(570, 5, "elab-lambda!");
+    WORD_ATOM(583, 5, "elab-lambda!");
     mw_elab_lambda_21_();
-    WORD_ATOM(571, 5, "OP_LAMBDA");
+    WORD_ATOM(584, 5, "OP_LAMBDA");
     mw_OP_5F_LAMBDA();
-    WORD_ATOM(571, 15, "ab-op!");
+    WORD_ATOM(584, 15, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_elab_atom_lambda_21_);
 }
 static void mw_elab_match_at_21_ (void){
-    WORD_ENTER(mw_elab_match_at_21_, "elab-match-at!", "src/mirth/elab.mth", 577, 5);
-    WORD_ATOM(577, 5, "Match.alloc!");
+    WORD_ENTER(mw_elab_match_at_21_, "elab-match-at!", "src/mirth/elab.mth", 590, 5);
+    WORD_ATOM(590, 5, "Match.alloc!");
     mw_Match_2E_alloc_21_();
-    WORD_ATOM(578, 5, "ab-ctx");
+    WORD_ATOM(591, 5, "ab-ctx");
     mw_ab_ctx();
-    WORD_ATOM(578, 12, "@");
+    WORD_ATOM(591, 12, "@");
     mw_prim_mut_get();
-    WORD_ATOM(578, 14, "over");
+    WORD_ATOM(591, 14, "over");
     mw_over();
-    WORD_ATOM(578, 19, "~ctx");
+    WORD_ATOM(591, 19, "~ctx");
     mw_Match_7E_ctx();
-    WORD_ATOM(578, 24, "!");
+    WORD_ATOM(591, 24, "!");
     mw_prim_mut_set();
-    WORD_ATOM(579, 5, "ab-type");
+    WORD_ATOM(592, 5, "ab-type");
     mw_ab_type();
-    WORD_ATOM(579, 13, "@");
+    WORD_ATOM(592, 13, "@");
     mw_prim_mut_get();
-    WORD_ATOM(579, 15, "over");
+    WORD_ATOM(592, 15, "over");
     mw_over();
-    WORD_ATOM(579, 20, "~dom");
+    WORD_ATOM(592, 20, "~dom");
     mw_Match_7E_dom();
-    WORD_ATOM(579, 25, "!");
+    WORD_ATOM(592, 25, "!");
     mw_prim_mut_set();
-    WORD_ATOM(580, 5, "ab-token");
+    WORD_ATOM(593, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(580, 14, "@");
+    WORD_ATOM(593, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(580, 16, "over");
+    WORD_ATOM(593, 16, "over");
     mw_over();
-    WORD_ATOM(580, 21, "~token");
+    WORD_ATOM(593, 21, "~token");
     mw_Match_7E_token();
-    WORD_ATOM(580, 28, "!");
+    WORD_ATOM(593, 28, "!");
     mw_prim_mut_set();
-    WORD_ATOM(581, 5, "tuck");
+    WORD_ATOM(594, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(581, 10, "~body");
+    WORD_ATOM(594, 10, "~body");
     mw_Match_7E_body();
-    WORD_ATOM(581, 16, "!");
+    WORD_ATOM(594, 16, "!");
     mw_prim_mut_set();
-    WORD_ATOM(582, 5, "tuck");
+    WORD_ATOM(595, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(582, 10, "~cod");
+    WORD_ATOM(595, 10, "~cod");
     mw_Match_7E_cod();
-    WORD_ATOM(582, 15, "!");
+    WORD_ATOM(595, 15, "!");
     mw_prim_mut_set();
-    WORD_ATOM(583, 5, "elab-match-cases!");
+    WORD_ATOM(596, 5, "elab-match-cases!");
     mw_elab_match_cases_21_();
-    WORD_ATOM(584, 5, "elab-match-exhaustive!");
+    WORD_ATOM(597, 5, "elab-match-exhaustive!");
     mw_elab_match_exhaustive_21_();
-    WORD_ATOM(585, 5, "OP_MATCH");
+    WORD_ATOM(598, 5, "OP_MATCH");
     mw_OP_5F_MATCH();
-    WORD_ATOM(585, 14, "ab-op!");
+    WORD_ATOM(598, 14, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_elab_match_at_21_);
 }
 static void mw_elab_atom_match_21_ (void){
-    WORD_ENTER(mw_elab_atom_match_21_, "elab-atom-match!", "src/mirth/elab.mth", 588, 5);
-    WORD_ATOM(588, 5, "MetaVar.new!");
+    WORD_ENTER(mw_elab_atom_match_21_, "elab-atom-match!", "src/mirth/elab.mth", 601, 5);
+    WORD_ATOM(601, 5, "MetaVar.new!");
     mw_MetaVar_2E_new_21_();
-    WORD_ATOM(588, 18, "STMeta");
+    WORD_ATOM(601, 18, "STMeta");
     mw_STMeta();
-    WORD_ATOM(589, 5, "ab-token");
+    WORD_ATOM(602, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(589, 14, "@");
+    WORD_ATOM(602, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(589, 16, "args+");
+    WORD_ATOM(602, 16, "args+");
     mw_Token_2E_args_2B_();
-    WORD_ATOM(589, 22, "first+");
-    mw_first_2B_();
-    WORD_ATOM(590, 5, "elab-match-at!");
+    WORD_ATOM(602, 22, "first");
+    mw_List_2B__2E_first();
+    WORD_ATOM(603, 5, "elab-match-at!");
     mw_elab_match_at_21_();
     WORD_EXIT(mw_elab_atom_match_21_);
 }
 static void mw_elab_lambda_21_ (void){
-    WORD_ENTER(mw_elab_lambda_21_, "elab-lambda!", "src/mirth/elab.mth", 593, 5);
-    WORD_ATOM(593, 5, "elab-lambda-params!");
+    WORD_ENTER(mw_elab_lambda_21_, "elab-lambda!", "src/mirth/elab.mth", 606, 5);
+    WORD_ATOM(606, 5, "elab-lambda-params!");
     mw_elab_lambda_params_21_();
-    WORD_ATOM(594, 5, "elab-lambda-body!");
+    WORD_ATOM(607, 5, "elab-lambda-body!");
     mw_elab_lambda_body_21_();
     WORD_EXIT(mw_elab_lambda_21_);
 }
 static void mw_elab_expand_tensor_21_ (void){
-    WORD_ENTER(mw_elab_expand_tensor_21_, "elab-expand-tensor!", "src/mirth/elab.mth", 597, 5);
-    WORD_ATOM(597, 5, "swap");
+    WORD_ENTER(mw_elab_expand_tensor_21_, "elab-expand-tensor!", "src/mirth/elab.mth", 610, 5);
+    WORD_ATOM(610, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(597, 10, "expand");
+    WORD_ATOM(610, 10, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(597, 17, "match");
+    WORD_ATOM(610, 17, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(598, 29, "dip");
+            WORD_ATOM(611, 29, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(598, 33, "STACK_TYPE_ERROR");
+                WORD_ATOM(611, 33, "STACK_TYPE_ERROR");
                 mw_STACK_5F_TYPE_5F_ERROR();
-                WORD_ATOM(598, 50, "TYPE_ERROR");
+                WORD_ATOM(611, 50, "TYPE_ERROR");
                 mw_TYPE_5F_ERROR();
                 push_value(d4);
             }
@@ -21394,45 +21603,45 @@ static void mw_elab_expand_tensor_21_ (void){
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(599, 19, "rotl");
+            WORD_ATOM(612, 19, "rotl");
             mw_rotl();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(601, 13, "dip");
+            WORD_ATOM(614, 13, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(601, 17, "MetaVar.new!");
+                WORD_ATOM(614, 17, "MetaVar.new!");
                 mw_MetaVar_2E_new_21_();
-                WORD_ATOM(601, 30, "STMeta");
+                WORD_ATOM(614, 30, "STMeta");
                 mw_STMeta();
-                WORD_ATOM(602, 17, "MetaVar.new!");
+                WORD_ATOM(615, 17, "MetaVar.new!");
                 mw_MetaVar_2E_new_21_();
-                WORD_ATOM(602, 30, "TMeta");
+                WORD_ATOM(615, 30, "TMeta");
                 mw_TMeta();
-                WORD_ATOM(603, 17, "dup2");
+                WORD_ATOM(616, 17, "dup2");
                 mw_dup2();
-                WORD_ATOM(603, 22, "T*");
+                WORD_ATOM(616, 22, "T*");
                 mw_T_2A_();
-                WORD_ATOM(603, 25, ">Type");
+                WORD_ATOM(616, 25, ">Type");
                 mw_StackType_3E_Type();
-                WORD_ATOM(603, 31, "SOME");
+                WORD_ATOM(616, 31, "SOME");
                 mw_SOME();
                 push_value(d4);
             }
-            WORD_ATOM(604, 13, "~type?");
+            WORD_ATOM(617, 13, "~type?");
             mw_MetaVar_7E_type_3F_();
-            WORD_ATOM(604, 20, "!");
+            WORD_ATOM(617, 20, "!");
             mw_prim_mut_set();
-            WORD_ATOM(604, 22, "rotl");
+            WORD_ATOM(617, 22, "rotl");
             mw_rotl();
             break;
         default:
-            WORD_ATOM(606, 13, "drop");
+            WORD_ATOM(619, 13, "drop");
             mw_prim_drop();
-            WORD_ATOM(606, 18, "dup");
+            WORD_ATOM(619, 18, "dup");
             mw_prim_dup();
-            WORD_ATOM(606, 22, "");
+            WORD_ATOM(619, 22, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -21443,14 +21652,14 @@ static void mw_elab_expand_tensor_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(606, 44, "emit-error!");
+            WORD_ATOM(619, 44, "emit-error!");
             mw_emit_error_21_();
-            WORD_ATOM(607, 13, "dip");
+            WORD_ATOM(620, 13, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(607, 17, "STACK_TYPE_ERROR");
+                WORD_ATOM(620, 17, "STACK_TYPE_ERROR");
                 mw_STACK_5F_TYPE_5F_ERROR();
-                WORD_ATOM(607, 34, "TYPE_ERROR");
+                WORD_ATOM(620, 34, "TYPE_ERROR");
                 mw_TYPE_5F_ERROR();
                 push_value(d4);
             }
@@ -21459,19 +21668,19 @@ static void mw_elab_expand_tensor_21_ (void){
 }    WORD_EXIT(mw_elab_expand_tensor_21_);
 }
 static void mw_elab_lambda_pop_from_mid_21_ (void){
-    WORD_ENTER(mw_elab_lambda_pop_from_mid_21_, "elab-lambda-pop-from-mid!", "src/mirth/elab.mth", 625, 5);
-    WORD_ATOM(625, 5, "dip");
+    WORD_ENTER(mw_elab_lambda_pop_from_mid_21_, "elab-lambda-pop-from-mid!", "src/mirth/elab.mth", 638, 5);
+    WORD_ATOM(638, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(625, 9, "dup");
+        WORD_ATOM(638, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(625, 13, "mid");
+        WORD_ATOM(638, 13, "mid");
         mw_Lambda_2E_mid();
         push_value(d2);
     }
-    WORD_ATOM(626, 5, "elab-expand-tensor!");
+    WORD_ATOM(639, 5, "elab-expand-tensor!");
     mw_elab_expand_tensor_21_();
-    WORD_ATOM(627, 5, "dip2");
+    WORD_ATOM(640, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_elab_lambda_pop_from_mid_21__2);
     mw_prim_pack_cons();
@@ -21479,25 +21688,25 @@ static void mw_elab_lambda_pop_from_mid_21_ (void){
     WORD_EXIT(mw_elab_lambda_pop_from_mid_21_);
 }
 static void mw_token_is_lambda_param_3F_ (void){
-    WORD_ENTER(mw_token_is_lambda_param_3F_, "token-is-lambda-param?", "src/mirth/elab.mth", 630, 5);
-    WORD_ATOM(630, 5, "dup");
+    WORD_ENTER(mw_token_is_lambda_param_3F_, "token-is-lambda-param?", "src/mirth/elab.mth", 643, 5);
+    WORD_ATOM(643, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(630, 9, "sig-type-var?");
+    WORD_ATOM(643, 9, "sig-type-var?");
     mw_Token_2E_sig_type_var_3F_();
-    WORD_ATOM(630, 23, "if");
+    WORD_ATOM(643, 23, "if");
     if (pop_u64()) {
-        WORD_ATOM(631, 9, "dup");
+        WORD_ATOM(644, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(631, 13, "has-args?");
+        WORD_ATOM(644, 13, "has-args?");
         mw_Token_2E_has_args_3F_();
-        WORD_ATOM(631, 23, "not");
+        WORD_ATOM(644, 23, "not");
         mw_Bool_2E_not();
     } else {
-        WORD_ATOM(632, 5, "dup");
+        WORD_ATOM(645, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(632, 9, "lsquare?");
+        WORD_ATOM(645, 9, "lsquare?");
         mw_Token_2E_lsquare_3F_();
-        WORD_ATOM(632, 18, ".if");
+        WORD_ATOM(645, 18, ".if");
         push_u64(0);
         push_fnptr(&mb_token_is_lambda_param_3F__3);
         mw_prim_pack_cons();
@@ -21509,135 +21718,135 @@ static void mw_token_is_lambda_param_3F_ (void){
     WORD_EXIT(mw_token_is_lambda_param_3F_);
 }
 static void mw_elab_lambda_params_21_ (void){
-    WORD_ENTER(mw_elab_lambda_params_21_, "elab-lambda-params!", "src/mirth/elab.mth", 641, 5);
-    WORD_ATOM(641, 5, "L0");
+    WORD_ENTER(mw_elab_lambda_params_21_, "elab-lambda-params!", "src/mirth/elab.mth", 654, 5);
+    WORD_ATOM(654, 5, "L0");
     mw_L0();
-    WORD_ATOM(641, 8, "over");
+    WORD_ATOM(654, 8, "over");
     mw_over();
-    WORD_ATOM(641, 13, "~params");
+    WORD_ATOM(654, 13, "~params");
     mw_Lambda_7E_params();
-    WORD_ATOM(641, 21, "!");
+    WORD_ATOM(654, 21, "!");
     mw_prim_mut_set();
-    WORD_ATOM(642, 5, "dup");
+    WORD_ATOM(655, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(642, 9, "outer-ctx");
+    WORD_ATOM(655, 9, "outer-ctx");
     mw_Lambda_2E_outer_ctx();
-    WORD_ATOM(642, 19, "over");
+    WORD_ATOM(655, 19, "over");
     mw_over();
-    WORD_ATOM(642, 24, "~inner-ctx");
+    WORD_ATOM(655, 24, "~inner-ctx");
     mw_Lambda_7E_inner_ctx();
-    WORD_ATOM(642, 35, "!");
+    WORD_ATOM(655, 35, "!");
     mw_prim_mut_set();
-    WORD_ATOM(643, 5, "dup");
+    WORD_ATOM(656, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(643, 9, "dom");
+    WORD_ATOM(656, 9, "dom");
     mw_Lambda_2E_dom();
-    WORD_ATOM(643, 13, "over");
+    WORD_ATOM(656, 13, "over");
     mw_over();
-    WORD_ATOM(643, 18, "~mid");
+    WORD_ATOM(656, 18, "~mid");
     mw_Lambda_7E_mid();
-    WORD_ATOM(643, 23, "!");
+    WORD_ATOM(656, 23, "!");
     mw_prim_mut_set();
-    WORD_ATOM(644, 5, "dup");
+    WORD_ATOM(657, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(644, 9, "token");
+    WORD_ATOM(657, 9, "token");
     mw_Lambda_2E_token();
-    WORD_ATOM(644, 15, "args-1");
+    WORD_ATOM(657, 15, "args-1");
     mw_Token_2E_args_1();
-    WORD_ATOM(645, 5, "while");
+    WORD_ATOM(658, 5, "while");
     while(1) {
-        WORD_ATOM(645, 11, "token-is-lambda-param?");
+        WORD_ATOM(658, 11, "token-is-lambda-param?");
         mw_token_is_lambda_param_3F_();
         if (! pop_u64()) break;
-        WORD_ATOM(645, 35, "next");
+        WORD_ATOM(658, 35, "next");
         mw_Token_2E_next();
     }
-    WORD_ATOM(646, 5, "expect-token-arrow");
+    WORD_ATOM(659, 5, "expect-token-arrow");
     mw_expect_token_arrow();
-    WORD_ATOM(646, 24, "prev");
+    WORD_ATOM(659, 24, "prev");
     mw_Token_2E_prev();
-    WORD_ATOM(647, 5, "while");
+    WORD_ATOM(660, 5, "while");
     while(1) {
-        WORD_ATOM(647, 11, "token-is-lambda-param?");
+        WORD_ATOM(660, 11, "token-is-lambda-param?");
         mw_token_is_lambda_param_3F_();
         if (! pop_u64()) break;
-        WORD_ATOM(648, 9, "elab-lambda-pop-from-mid!");
+        WORD_ATOM(661, 9, "elab-lambda-pop-from-mid!");
         mw_elab_lambda_pop_from_mid_21_();
-        WORD_ATOM(648, 35, "sip");
+        WORD_ATOM(661, 35, "sip");
         push_u64(0);
         push_fnptr(&mb_elab_lambda_params_21__5);
         mw_prim_pack_cons();
         mw_sip();
-        WORD_ATOM(661, 9, "prev");
+        WORD_ATOM(674, 9, "prev");
         mw_Token_2E_prev();
     }
-    WORD_ATOM(662, 5, "drop");
+    WORD_ATOM(675, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_lambda_params_21_);
 }
 static void mw_elab_lambda_body_21_ (void){
-    WORD_ENTER(mw_elab_lambda_body_21_, "elab-lambda-body!", "src/mirth/elab.mth", 665, 5);
-    WORD_ATOM(665, 5, "dup");
+    WORD_ENTER(mw_elab_lambda_body_21_, "elab-lambda-body!", "src/mirth/elab.mth", 678, 5);
+    WORD_ATOM(678, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(665, 9, "token");
+    WORD_ATOM(678, 9, "token");
     mw_Lambda_2E_token();
-    WORD_ATOM(665, 15, "args-1");
+    WORD_ATOM(678, 15, "args-1");
     mw_Token_2E_args_1();
-    WORD_ATOM(666, 5, "while");
+    WORD_ATOM(679, 5, "while");
     while(1) {
-        WORD_ATOM(666, 11, "token-is-lambda-param?");
+        WORD_ATOM(679, 11, "token-is-lambda-param?");
         mw_token_is_lambda_param_3F_();
         if (! pop_u64()) break;
-        WORD_ATOM(666, 35, "next");
+        WORD_ATOM(679, 35, "next");
         mw_Token_2E_next();
     }
-    WORD_ATOM(666, 41, "succ");
+    WORD_ATOM(679, 41, "succ");
     mw_Token_2E_succ();
-    WORD_ATOM(667, 5, "dip");
+    WORD_ATOM(680, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(667, 9, "dup");
+        WORD_ATOM(680, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(667, 13, "mid");
+        WORD_ATOM(680, 13, "mid");
         mw_Lambda_2E_mid();
-        WORD_ATOM(667, 17, "dip");
+        WORD_ATOM(680, 17, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(667, 21, "dup");
+            WORD_ATOM(680, 21, "dup");
             mw_prim_dup();
-            WORD_ATOM(667, 25, "inner-ctx");
+            WORD_ATOM(680, 25, "inner-ctx");
             mw_Lambda_2E_inner_ctx();
             push_value(d3);
         }
         push_value(d2);
     }
-    WORD_ATOM(668, 5, "elab-arrow-fwd!");
+    WORD_ATOM(681, 5, "elab-arrow-fwd!");
     mw_elab_arrow_fwd_21_();
-    WORD_ATOM(669, 5, "dup2");
+    WORD_ATOM(682, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(669, 10, "swap");
+    WORD_ATOM(682, 10, "swap");
     mw_prim_swap();
-    WORD_ATOM(669, 15, "~body");
+    WORD_ATOM(682, 15, "~body");
     mw_Lambda_7E_body();
-    WORD_ATOM(669, 21, "!");
+    WORD_ATOM(682, 21, "!");
     mw_prim_mut_set();
-    WORD_ATOM(670, 5, "cod");
+    WORD_ATOM(683, 5, "cod");
     mw_Arrow_2E_cod();
-    WORD_ATOM(670, 9, "over");
+    WORD_ATOM(683, 9, "over");
     mw_over();
-    WORD_ATOM(670, 14, "~cod");
+    WORD_ATOM(683, 14, "~cod");
     mw_Lambda_7E_cod();
-    WORD_ATOM(670, 19, "!");
+    WORD_ATOM(683, 19, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_elab_lambda_body_21_);
 }
 static void mw_elab_match_exhaustive_21_ (void){
-    WORD_ENTER(mw_elab_match_exhaustive_21_, "elab-match-exhaustive!", "src/mirth/elab.mth", 674, 5);
-    WORD_ATOM(674, 5, "dup");
+    WORD_ENTER(mw_elab_match_exhaustive_21_, "elab-match-exhaustive!", "src/mirth/elab.mth", 687, 5);
+    WORD_ATOM(687, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(674, 9, "is-exhaustive?");
+    WORD_ATOM(687, 9, "is-exhaustive?");
     mw_Match_2E_is_exhaustive_3F_();
-    WORD_ATOM(674, 24, "else");
+    WORD_ATOM(687, 24, "else");
     push_u64(0);
     push_fnptr(&mb_elab_match_exhaustive_21__1);
     mw_prim_pack_cons();
@@ -21645,80 +21854,80 @@ static void mw_elab_match_exhaustive_21_ (void){
     WORD_EXIT(mw_elab_match_exhaustive_21_);
 }
 static void mw_elab_match_cases_21_ (void){
-    WORD_ENTER(mw_elab_match_cases_21_, "elab-match-cases!", "src/mirth/elab.mth", 680, 5);
-    WORD_ATOM(680, 5, "L0");
+    WORD_ENTER(mw_elab_match_cases_21_, "elab-match-cases!", "src/mirth/elab.mth", 693, 5);
+    WORD_ATOM(693, 5, "L0");
     mw_L0();
-    WORD_ATOM(680, 8, "over");
+    WORD_ATOM(693, 8, "over");
     mw_over();
-    WORD_ATOM(680, 13, "~cases");
+    WORD_ATOM(693, 13, "~cases");
     mw_Match_7E_cases();
-    WORD_ATOM(680, 20, "!");
+    WORD_ATOM(693, 20, "!");
     mw_prim_mut_set();
-    WORD_ATOM(681, 5, "dup");
+    WORD_ATOM(694, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(681, 9, "body");
+    WORD_ATOM(694, 9, "body");
     mw_Match_2E_body();
-    WORD_ATOM(682, 5, "while");
+    WORD_ATOM(695, 5, "while");
     while(1) {
-        WORD_ATOM(682, 11, "dup");
+        WORD_ATOM(695, 11, "dup");
         mw_prim_dup();
-        WORD_ATOM(682, 15, "rparen?");
+        WORD_ATOM(695, 15, "rparen?");
         mw_Token_2E_rparen_3F_();
-        WORD_ATOM(682, 23, "not");
+        WORD_ATOM(695, 23, "not");
         mw_Maybe_2E_not();
         if (! pop_u64()) break;
-        WORD_ATOM(682, 28, "elab-match-case!");
+        WORD_ATOM(695, 28, "elab-match-case!");
         mw_elab_match_case_21_();
     }
-    WORD_ATOM(683, 5, "drop");
+    WORD_ATOM(696, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_match_cases_21_);
 }
 static void mw_elab_match_case_21_ (void){
-    WORD_ENTER(mw_elab_match_case_21_, "elab-match-case!", "src/mirth/elab.mth", 687, 5);
-    WORD_ATOM(687, 5, "Case.alloc!");
+    WORD_ENTER(mw_elab_match_case_21_, "elab-match-case!", "src/mirth/elab.mth", 700, 5);
+    WORD_ATOM(700, 5, "Case.alloc!");
     mw_Case_2E_alloc_21_();
-    WORD_ATOM(688, 5, "dup2");
+    WORD_ATOM(701, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(688, 10, "~token");
+    WORD_ATOM(701, 10, "~token");
     mw_Case_7E_token();
-    WORD_ATOM(688, 17, "!");
+    WORD_ATOM(701, 17, "!");
     mw_prim_mut_set();
-    WORD_ATOM(689, 5, "swap");
+    WORD_ATOM(702, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(689, 10, "dip");
+    WORD_ATOM(702, 10, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(689, 14, "dup2");
+        WORD_ATOM(702, 14, "dup2");
         mw_dup2();
-        WORD_ATOM(689, 19, "~match");
+        WORD_ATOM(702, 19, "~match");
         mw_Case_7E_match();
-        WORD_ATOM(689, 26, "!");
+        WORD_ATOM(702, 26, "!");
         mw_prim_mut_set();
         push_value(d2);
     }
-    WORD_ATOM(690, 5, "elab-case-pattern!");
+    WORD_ATOM(703, 5, "elab-case-pattern!");
     mw_elab_case_pattern_21_();
-    WORD_ATOM(691, 5, "expect-token-arrow");
+    WORD_ATOM(704, 5, "expect-token-arrow");
     mw_expect_token_arrow();
-    WORD_ATOM(691, 24, "succ");
+    WORD_ATOM(704, 24, "succ");
     mw_Token_2E_succ();
-    WORD_ATOM(692, 5, "elab-case-body!");
+    WORD_ATOM(705, 5, "elab-case-body!");
     mw_elab_case_body_21_();
-    WORD_ATOM(693, 5, "dip");
+    WORD_ATOM(706, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(693, 9, "over");
+        WORD_ATOM(706, 9, "over");
         mw_over();
-        WORD_ATOM(693, 14, "add-case!");
+        WORD_ATOM(706, 14, "add-case!");
         mw_Match_2E_add_case_21_();
         push_value(d2);
     }
-    WORD_ATOM(694, 5, "dup");
+    WORD_ATOM(707, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(694, 9, "comma?");
+    WORD_ATOM(707, 9, "comma?");
     mw_Token_2E_comma_3F_();
-    WORD_ATOM(694, 16, "then");
+    WORD_ATOM(707, 16, "then");
     push_u64(0);
     push_fnptr(&mb_elab_match_case_21__3);
     mw_prim_pack_cons();
@@ -21726,64 +21935,64 @@ static void mw_elab_match_case_21_ (void){
     WORD_EXIT(mw_elab_match_case_21_);
 }
 static void mw_elab_case_pattern_21_ (void){
-    WORD_ENTER(mw_elab_case_pattern_21_, "elab-case-pattern!", "src/mirth/elab.mth", 698, 5);
-    WORD_ATOM(698, 5, "dup");
+    WORD_ENTER(mw_elab_case_pattern_21_, "elab-case-pattern!", "src/mirth/elab.mth", 711, 5);
+    WORD_ATOM(711, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(698, 9, "pat-underscore?");
+    WORD_ATOM(711, 9, "pat-underscore?");
     mw_Token_2E_pat_underscore_3F_();
-    WORD_ATOM(698, 25, "if");
+    WORD_ATOM(711, 25, "if");
     if (pop_u64()) {
-        WORD_ATOM(700, 9, "dip");
+        WORD_ATOM(713, 9, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(700, 13, "PATTERN_UNDERSCORE");
+            WORD_ATOM(713, 13, "PATTERN_UNDERSCORE");
             mw_PATTERN_5F_UNDERSCORE();
-            WORD_ATOM(700, 32, "over");
+            WORD_ATOM(713, 32, "over");
             mw_over();
-            WORD_ATOM(700, 37, "~pattern");
+            WORD_ATOM(713, 37, "~pattern");
             mw_Case_7E_pattern();
-            WORD_ATOM(700, 46, "!");
+            WORD_ATOM(713, 46, "!");
             mw_prim_mut_set();
             push_value(d3);
         }
-        WORD_ATOM(703, 9, "dip");
+        WORD_ATOM(716, 9, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(703, 13, "dup");
+            WORD_ATOM(716, 13, "dup");
             mw_prim_dup();
-            WORD_ATOM(703, 17, ".match");
+            WORD_ATOM(716, 17, ".match");
             mw_Case_2E_match();
-            WORD_ATOM(703, 24, "dom");
+            WORD_ATOM(716, 24, "dom");
             mw_Match_2E_dom();
-            WORD_ATOM(703, 28, "STACK_TYPE_DONT_CARE");
+            WORD_ATOM(716, 28, "STACK_TYPE_DONT_CARE");
             mw_STACK_5F_TYPE_5F_DONT_5F_CARE();
-            WORD_ATOM(703, 49, "TYPE_DONT_CARE");
+            WORD_ATOM(716, 49, "TYPE_DONT_CARE");
             mw_TYPE_5F_DONT_5F_CARE();
-            WORD_ATOM(703, 64, "T*");
+            WORD_ATOM(716, 64, "T*");
             mw_T_2A_();
             push_value(d3);
         }
-        WORD_ATOM(704, 9, "elab-stack-type-unify!");
+        WORD_ATOM(717, 9, "elab-stack-type-unify!");
         mw_elab_stack_type_unify_21_();
-        WORD_ATOM(704, 32, "dip");
+        WORD_ATOM(717, 32, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(704, 36, "over");
+            WORD_ATOM(717, 36, "over");
             mw_over();
-            WORD_ATOM(704, 41, "~mid");
+            WORD_ATOM(717, 41, "~mid");
             mw_Case_7E_mid();
-            WORD_ATOM(704, 46, "!");
+            WORD_ATOM(717, 46, "!");
             mw_prim_mut_set();
             push_value(d3);
         }
-        WORD_ATOM(707, 9, "succ");
+        WORD_ATOM(720, 9, "succ");
         mw_Token_2E_succ();
     } else {
-        WORD_ATOM(709, 5, "dup");
+        WORD_ATOM(722, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(709, 9, "name?");
+        WORD_ATOM(722, 9, "name?");
         mw_Token_2E_name_3F_();
-        WORD_ATOM(709, 15, "if-some");
+        WORD_ATOM(722, 15, "if-some");
         push_u64(0);
         push_fnptr(&mb_elab_case_pattern_21__6);
         mw_prim_pack_cons();
@@ -21795,147 +22004,147 @@ static void mw_elab_case_pattern_21_ (void){
     WORD_EXIT(mw_elab_case_pattern_21_);
 }
 static void mw_elab_case_body_21_ (void){
-    WORD_ENTER(mw_elab_case_body_21_, "elab-case-body!", "src/mirth/elab.mth", 742, 5);
-    WORD_ATOM(742, 5, "dip");
+    WORD_ENTER(mw_elab_case_body_21_, "elab-case-body!", "src/mirth/elab.mth", 755, 5);
+    WORD_ATOM(755, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(742, 9, "dup");
+        WORD_ATOM(755, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(742, 13, "mid");
+        WORD_ATOM(755, 13, "mid");
         mw_Case_2E_mid();
-        WORD_ATOM(742, 17, "dip");
+        WORD_ATOM(755, 17, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(742, 21, "dup");
+            WORD_ATOM(755, 21, "dup");
             mw_prim_dup();
-            WORD_ATOM(742, 25, ".match");
+            WORD_ATOM(755, 25, ".match");
             mw_Case_2E_match();
-            WORD_ATOM(742, 32, "ctx");
+            WORD_ATOM(755, 32, "ctx");
             mw_Match_2E_ctx();
             push_value(d3);
         }
         push_value(d2);
     }
-    WORD_ATOM(742, 38, "elab-arrow-fwd!");
+    WORD_ATOM(755, 38, "elab-arrow-fwd!");
     mw_elab_arrow_fwd_21_();
-    WORD_ATOM(743, 5, "dup");
+    WORD_ATOM(756, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(743, 9, "token-end");
+    WORD_ATOM(756, 9, "token-end");
     mw_Arrow_2E_token_end();
-    WORD_ATOM(743, 19, "dip");
+    WORD_ATOM(756, 19, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(743, 23, "dup");
+        WORD_ATOM(756, 23, "dup");
         mw_prim_dup();
-        WORD_ATOM(743, 27, "cod");
+        WORD_ATOM(756, 27, "cod");
         mw_Arrow_2E_cod();
         push_value(d2);
     }
-    WORD_ATOM(744, 5, "dip2");
+    WORD_ATOM(757, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_elab_case_body_21__4);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(745, 5, "dip2");
+    WORD_ATOM(758, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_elab_case_body_21__5);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(745, 26, "elab-stack-type-unify!");
+    WORD_ATOM(758, 26, "elab-stack-type-unify!");
     mw_elab_stack_type_unify_21_();
-    WORD_ATOM(745, 49, "nip");
+    WORD_ATOM(758, 49, "nip");
     mw_nip();
     WORD_EXIT(mw_elab_case_body_21_);
 }
 static void mw_elab_module_21_ (void){
-    WORD_ENTER(mw_elab_module_21_, "elab-module!", "src/mirth/elab.mth", 753, 5);
-    WORD_ATOM(753, 5, "dup");
+    WORD_ENTER(mw_elab_module_21_, "elab-module!", "src/mirth/elab.mth", 766, 5);
+    WORD_ATOM(766, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(753, 9, "start");
+    WORD_ATOM(766, 9, "start");
     mw_Module_2E_start();
-    WORD_ATOM(754, 5, "elab-module-header!");
+    WORD_ATOM(767, 5, "elab-module-header!");
     mw_elab_module_header_21_();
-    WORD_ATOM(755, 5, "while");
+    WORD_ATOM(768, 5, "while");
     while(1) {
-        WORD_ATOM(755, 11, "dup");
+        WORD_ATOM(768, 11, "dup");
         mw_prim_dup();
-        WORD_ATOM(755, 15, "module-end?");
+        WORD_ATOM(768, 15, "module-end?");
         mw_Token_2E_module_end_3F_();
-        WORD_ATOM(755, 27, "not");
+        WORD_ATOM(768, 27, "not");
         mw_Bool_2E_not();
         if (! pop_u64()) break;
-        WORD_ATOM(755, 32, "elab-module-decl!");
+        WORD_ATOM(768, 32, "elab-module-decl!");
         mw_elab_module_decl_21_();
     }
-    WORD_ATOM(756, 5, "drop");
+    WORD_ATOM(769, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_module_21_);
 }
 static void mw_elab_module_header_21_ (void){
-    WORD_ENTER(mw_elab_module_header_21_, "elab-module-header!", "src/mirth/elab.mth", 761, 5);
-    WORD_ATOM(761, 5, "dup");
+    WORD_ENTER(mw_elab_module_header_21_, "elab-module-header!", "src/mirth/elab.mth", 774, 5);
+    WORD_ATOM(774, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(761, 9, "module-header?");
+    WORD_ATOM(774, 9, "module-header?");
     mw_Token_2E_module_header_3F_();
-    WORD_ATOM(761, 24, "if");
+    WORD_ATOM(774, 24, "if");
     if (pop_u64()) {
-        WORD_ATOM(762, 9, "sip");
+        WORD_ATOM(775, 9, "sip");
         push_u64(0);
         push_fnptr(&mb_elab_module_header_21__2);
         mw_prim_pack_cons();
         mw_sip();
-        WORD_ATOM(762, 19, "args-1");
+        WORD_ATOM(775, 19, "args-1");
         mw_Token_2E_args_1();
-        WORD_ATOM(763, 9, "dup");
+        WORD_ATOM(776, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(763, 13, "name?");
+        WORD_ATOM(776, 13, "name?");
         mw_Token_2E_name_3F_();
-        WORD_ATOM(763, 19, "unwrap-or");
+        WORD_ATOM(776, 19, "unwrap-or");
         push_u64(0);
         push_fnptr(&mb_elab_module_header_21__3);
         mw_prim_pack_cons();
         mw_Maybe_2E_unwrap_or();
-        WORD_ATOM(764, 9, "name-defined?");
+        WORD_ATOM(777, 9, "name-defined?");
         mw_name_defined_3F_();
-        WORD_ATOM(764, 23, "then");
+        WORD_ATOM(777, 23, "then");
         push_u64(0);
         push_fnptr(&mb_elab_module_header_21__4);
         mw_prim_pack_cons();
         mw_Bool_2E_then();
-        WORD_ATOM(765, 9, "over");
+        WORD_ATOM(778, 9, "over");
         mw_over();
-        WORD_ATOM(765, 14, ".module");
+        WORD_ATOM(778, 14, ".module");
         mw_Token_2E_module();
-        WORD_ATOM(766, 9, "dup2");
+        WORD_ATOM(779, 9, "dup2");
         mw_dup2();
-        WORD_ATOM(766, 14, "~name");
+        WORD_ATOM(779, 14, "~name");
         mw_Module_7E_name();
-        WORD_ATOM(766, 20, "!");
+        WORD_ATOM(779, 20, "!");
         mw_prim_mut_set();
-        WORD_ATOM(767, 9, "dup2");
+        WORD_ATOM(780, 9, "dup2");
         mw_dup2();
-        WORD_ATOM(767, 14, "DEF_MODULE");
+        WORD_ATOM(780, 14, "DEF_MODULE");
         mw_DEF_5F_MODULE();
-        WORD_ATOM(767, 25, "swap");
+        WORD_ATOM(780, 25, "swap");
         mw_prim_swap();
-        WORD_ATOM(767, 30, "~Def");
+        WORD_ATOM(780, 30, "~Def");
         mw_Name_7E_Def();
-        WORD_ATOM(767, 35, "!");
+        WORD_ATOM(780, 35, "!");
         mw_prim_mut_set();
-        WORD_ATOM(768, 9, "path");
+        WORD_ATOM(781, 9, "path");
         mw_Module_2E_path();
-        WORD_ATOM(768, 14, "swap");
+        WORD_ATOM(781, 14, "swap");
         mw_prim_swap();
-        WORD_ATOM(769, 9, "to-module-path");
+        WORD_ATOM(782, 9, "to-module-path");
         mw_Name_2E_to_module_path();
-        WORD_ATOM(769, 24, "=");
+        WORD_ATOM(782, 24, "=");
         mw_Path_3D_();
-        WORD_ATOM(769, 26, "if");
+        WORD_ATOM(782, 26, "if");
         if (pop_u64()) {
-            WORD_ATOM(769, 29, "drop");
+            WORD_ATOM(782, 29, "drop");
             mw_prim_drop();
         } else {
-            WORD_ATOM(770, 13, "");
+            WORD_ATOM(783, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -21946,13 +22155,13 @@ static void mw_elab_module_header_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(770, 46, "emit-error!");
+            WORD_ATOM(783, 46, "emit-error!");
             mw_emit_error_21_();
         }
     } else {
-        WORD_ATOM(771, 9, "dup");
+        WORD_ATOM(784, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(771, 13, "");
+        WORD_ATOM(784, 13, "");
         {
             static bool vready = false;
             static VAL v;
@@ -21963,107 +22172,107 @@ static void mw_elab_module_header_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(771, 39, "emit-error!");
+        WORD_ATOM(784, 39, "emit-error!");
         mw_emit_error_21_();
     }
     WORD_EXIT(mw_elab_module_header_21_);
 }
 static void mw_elab_module_decl_21_ (void){
-    WORD_ENTER(mw_elab_module_decl_21_, "elab-module-decl!", "src/mirth/elab.mth", 776, 5);
-    WORD_ATOM(776, 5, "dup");
+    WORD_ENTER(mw_elab_module_decl_21_, "elab-module-decl!", "src/mirth/elab.mth", 789, 5);
+    WORD_ATOM(789, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(777, 5, "name?");
+    WORD_ATOM(790, 5, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(777, 11, "unwrap-or");
+    WORD_ATOM(790, 11, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_module_decl_21__1);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(778, 5, ">Def");
+    WORD_ATOM(791, 5, ">Def");
     mw_Name_3E_Def();
-    WORD_ATOM(778, 10, "prim?");
+    WORD_ATOM(791, 10, "prim?");
     mw_Def_2E_prim_3F_();
-    WORD_ATOM(778, 16, "unwrap-or");
+    WORD_ATOM(791, 16, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_module_decl_21__2);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(779, 5, "decl");
+    WORD_ATOM(792, 5, "decl");
     mw_Prim_2E_decl();
-    WORD_ATOM(779, 10, "unwrap-or");
+    WORD_ATOM(792, 10, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_module_decl_21__3);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(780, 5, "run");
+    WORD_ATOM(793, 5, "run");
     mw_prim_run();
     WORD_EXIT(mw_elab_module_decl_21_);
 }
 static void mw_elab_module_import_21_ (void){
-    WORD_ENTER(mw_elab_module_import_21_, "elab-module-import!", "src/mirth/elab.mth", 784, 5);
-    WORD_ATOM(784, 5, "sip");
+    WORD_ENTER(mw_elab_module_import_21_, "elab-module-import!", "src/mirth/elab.mth", 797, 5);
+    WORD_ATOM(797, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_module_import_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(785, 5, "args-1");
+    WORD_ATOM(798, 5, "args-1");
     mw_Token_2E_args_1();
-    WORD_ATOM(785, 12, "dup");
+    WORD_ATOM(798, 12, "dup");
     mw_prim_dup();
-    WORD_ATOM(785, 16, "value");
+    WORD_ATOM(798, 16, "value");
     mw_Token_2E_value();
-    WORD_ATOM(785, 22, "match");
+    WORD_ATOM(798, 22, "match");
     switch (get_top_data_tag()) {
         case 13LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(787, 13, "dup");
+            WORD_ATOM(800, 13, "dup");
             mw_prim_dup();
-            WORD_ATOM(787, 17, ">Def");
+            WORD_ATOM(800, 17, ">Def");
             mw_Name_3E_Def();
-            WORD_ATOM(787, 22, "match");
+            WORD_ATOM(800, 22, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(789, 21, "dip");
+                    WORD_ATOM(802, 21, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(789, 25, "drop2");
+                        WORD_ATOM(802, 25, "drop2");
                         mw_drop2();
-                        WORD_ATOM(789, 31, "dup");
+                        WORD_ATOM(802, 31, "dup");
                         mw_prim_dup();
-                        WORD_ATOM(789, 35, ".module");
+                        WORD_ATOM(802, 35, ".module");
                         mw_Token_2E_module();
                         push_value(d6);
                     }
-                    WORD_ATOM(789, 44, "add-import!");
+                    WORD_ATOM(802, 44, "add-import!");
                     mw_Module_2E_add_import_21_();
                     break;
                 case 0LL:
                     mw_prim_drop();
-                    WORD_ATOM(793, 21, "to-module-path");
+                    WORD_ATOM(806, 21, "to-module-path");
                     mw_Name_2E_to_module_path();
-                    WORD_ATOM(793, 36, "run-lexer!");
+                    WORD_ATOM(806, 36, "run-lexer!");
                     mw_run_lexer_21_();
-                    WORD_ATOM(794, 21, "elab-module!");
+                    WORD_ATOM(807, 21, "elab-module!");
                     mw_elab_module_21_();
-                    WORD_ATOM(795, 21, "dip");
+                    WORD_ATOM(808, 21, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(795, 25, "drop");
+                        WORD_ATOM(808, 25, "drop");
                         mw_prim_drop();
-                        WORD_ATOM(795, 30, "dup");
+                        WORD_ATOM(808, 30, "dup");
                         mw_prim_dup();
-                        WORD_ATOM(795, 34, ".module");
+                        WORD_ATOM(808, 34, ".module");
                         mw_Token_2E_module();
                         push_value(d6);
                     }
-                    WORD_ATOM(795, 43, "add-import!");
+                    WORD_ATOM(808, 43, "add-import!");
                     mw_Module_2E_add_import_21_();
                     break;
                 default:
-                    WORD_ATOM(801, 21, "drop2");
+                    WORD_ATOM(814, 21, "drop2");
                     mw_drop2();
-                    WORD_ATOM(801, 27, "");
+                    WORD_ATOM(814, 27, "");
                     {
                         static bool vready = false;
                         static VAL v;
@@ -22074,15 +22283,15 @@ static void mw_elab_module_import_21_ (void){
                         push_value(v);
                         incref(v);
                     }
-                    WORD_ATOM(801, 55, "emit-fatal-error!");
+                    WORD_ATOM(814, 55, "emit-fatal-error!");
                     mw_emit_fatal_error_21_();
                     break;
             
 }            break;
         default:
-            WORD_ATOM(804, 13, "drop");
+            WORD_ATOM(817, 13, "drop");
             mw_prim_drop();
-            WORD_ATOM(804, 18, "");
+            WORD_ATOM(817, 18, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -22093,187 +22302,187 @@ static void mw_elab_module_import_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(804, 41, "emit-fatal-error!");
+            WORD_ATOM(817, 41, "emit-fatal-error!");
             mw_emit_fatal_error_21_();
             break;
     
 }    WORD_EXIT(mw_elab_module_import_21_);
 }
 static void mw_elab_data_21_ (void){
-    WORD_ENTER(mw_elab_data_21_, "elab-data!", "src/mirth/elab.mth", 809, 5);
-    WORD_ATOM(809, 5, "sip");
+    WORD_ENTER(mw_elab_data_21_, "elab-data!", "src/mirth/elab.mth", 822, 5);
+    WORD_ATOM(822, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_data_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(816, 7, "next");
+    WORD_ATOM(829, 7, "next");
     mw_Token_2E_next();
     WORD_EXIT(mw_elab_data_21_);
 }
 static void mw_elab_data_header_21_ (void){
-    WORD_ENTER(mw_elab_data_header_21_, "elab-data-header!", "src/mirth/elab.mth", 820, 5);
-    WORD_ATOM(820, 5, "dup2");
+    WORD_ENTER(mw_elab_data_header_21_, "elab-data-header!", "src/mirth/elab.mth", 833, 5);
+    WORD_ATOM(833, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(820, 10, "SOME");
+    WORD_ATOM(833, 10, "SOME");
     mw_SOME();
-    WORD_ATOM(820, 15, "swap");
+    WORD_ATOM(833, 15, "swap");
     mw_prim_swap();
-    WORD_ATOM(820, 20, "~head?");
+    WORD_ATOM(833, 20, "~head?");
     mw_Data_7E_head_3F_();
-    WORD_ATOM(820, 27, "!");
+    WORD_ATOM(833, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(821, 5, "dup");
+    WORD_ATOM(834, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(821, 9, "sig-type-con?");
+    WORD_ATOM(834, 9, "sig-type-con?");
     mw_Token_2E_sig_type_con_3F_();
-    WORD_ATOM(821, 23, "or");
+    WORD_ATOM(834, 23, "or");
     push_u64(0);
     push_fnptr(&mb_elab_data_header_21__1);
     mw_prim_pack_cons();
     mw_Bool_2E_or();
-    WORD_ATOM(821, 49, "else");
+    WORD_ATOM(834, 49, "else");
     push_u64(0);
     push_fnptr(&mb_elab_data_header_21__2);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(822, 5, "dup2");
+    WORD_ATOM(835, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(822, 10, "name?");
+    WORD_ATOM(835, 10, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(822, 16, "unwrap");
+    WORD_ATOM(835, 16, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(822, 23, "name-undefined?");
+    WORD_ATOM(835, 23, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(822, 39, "else");
+    WORD_ATOM(835, 39, "else");
     push_u64(0);
     push_fnptr(&mb_elab_data_header_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(823, 5, "over");
+    WORD_ATOM(836, 5, "over");
     mw_over();
-    WORD_ATOM(823, 10, "TData");
+    WORD_ATOM(836, 10, "TData");
     mw_TData();
-    WORD_ATOM(823, 16, "DEF_TYPE");
+    WORD_ATOM(836, 16, "DEF_TYPE");
     mw_DEF_5F_TYPE();
-    WORD_ATOM(823, 25, "over");
+    WORD_ATOM(836, 25, "over");
     mw_over();
-    WORD_ATOM(823, 30, "~Def");
+    WORD_ATOM(836, 30, "~Def");
     mw_Name_7E_Def();
-    WORD_ATOM(823, 35, "!");
+    WORD_ATOM(836, 35, "!");
     mw_prim_mut_set();
-    WORD_ATOM(824, 5, "swap");
+    WORD_ATOM(837, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(824, 10, "~name");
+    WORD_ATOM(837, 10, "~name");
     mw_Data_7E_name();
-    WORD_ATOM(824, 16, "!");
+    WORD_ATOM(837, 16, "!");
     mw_prim_mut_set();
-    WORD_ATOM(826, 5, "num-args");
+    WORD_ATOM(839, 5, "num-args");
     mw_Token_2E_num_args();
-    WORD_ATOM(826, 14, "over");
+    WORD_ATOM(839, 14, "over");
     mw_over();
-    WORD_ATOM(826, 19, "~arity");
+    WORD_ATOM(839, 19, "~arity");
     mw_Data_7E_arity();
-    WORD_ATOM(826, 26, "!");
+    WORD_ATOM(839, 26, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_elab_data_header_21_);
 }
 static void mw_elab_data_tag_21_ (void){
-    WORD_ENTER(mw_elab_data_tag_21_, "elab-data-tag!", "src/mirth/elab.mth", 831, 5);
-    WORD_ATOM(831, 5, "dup");
+    WORD_ENTER(mw_elab_data_tag_21_, "elab-data-tag!", "src/mirth/elab.mth", 844, 5);
+    WORD_ATOM(844, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(831, 9, "name?");
+    WORD_ATOM(844, 9, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(831, 15, "unwrap-or");
+    WORD_ATOM(844, 15, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_data_tag_21__1);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(832, 5, "name-undefined?");
+    WORD_ATOM(845, 5, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(832, 21, "else");
+    WORD_ATOM(845, 21, "else");
     push_u64(0);
     push_fnptr(&mb_elab_data_tag_21__2);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(833, 5, "Tag.alloc!");
+    WORD_ATOM(846, 5, "Tag.alloc!");
     mw_Tag_2E_alloc_21_();
-    WORD_ATOM(834, 5, "dup2");
+    WORD_ATOM(847, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(834, 10, "DEF_TAG");
+    WORD_ATOM(847, 10, "DEF_TAG");
     mw_DEF_5F_TAG();
-    WORD_ATOM(834, 18, "swap");
+    WORD_ATOM(847, 18, "swap");
     mw_prim_swap();
-    WORD_ATOM(834, 23, "~Def");
+    WORD_ATOM(847, 23, "~Def");
     mw_Name_7E_Def();
-    WORD_ATOM(834, 28, "!");
+    WORD_ATOM(847, 28, "!");
     mw_prim_mut_set();
-    WORD_ATOM(835, 5, "tuck");
+    WORD_ATOM(848, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(835, 10, "~name");
+    WORD_ATOM(848, 10, "~name");
     mw_Tag_7E_name();
-    WORD_ATOM(835, 16, "!");
+    WORD_ATOM(848, 16, "!");
     mw_prim_mut_set();
-    WORD_ATOM(837, 5, "dip");
+    WORD_ATOM(850, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(837, 9, "over");
+        WORD_ATOM(850, 9, "over");
         mw_over();
         push_value(d2);
     }
-    WORD_ATOM(837, 15, "dup2");
+    WORD_ATOM(850, 15, "dup2");
     mw_dup2();
-    WORD_ATOM(837, 20, "~data");
+    WORD_ATOM(850, 20, "~data");
     mw_Tag_7E_data();
-    WORD_ATOM(837, 26, "!");
+    WORD_ATOM(850, 26, "!");
     mw_prim_mut_set();
-    WORD_ATOM(838, 5, "tuck");
+    WORD_ATOM(851, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(838, 10, "dip");
+    WORD_ATOM(851, 10, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(838, 14, "add-tag!");
+        WORD_ATOM(851, 14, "add-tag!");
         mw_Data_2E_add_tag_21_();
         push_value(d2);
     }
-    WORD_ATOM(840, 5, "swap");
+    WORD_ATOM(853, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(840, 10, "succ");
+    WORD_ATOM(853, 10, "succ");
     mw_Token_2E_succ();
-    WORD_ATOM(841, 5, "dup");
+    WORD_ATOM(854, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(841, 9, "pat-arrow?");
+    WORD_ATOM(854, 9, "pat-arrow?");
     mw_Token_2E_pat_arrow_3F_();
-    WORD_ATOM(841, 20, "if");
+    WORD_ATOM(854, 20, "if");
     if (pop_u64()) {
-        WORD_ATOM(842, 9, "succ");
+        WORD_ATOM(855, 9, "succ");
         mw_Token_2E_succ();
-        WORD_ATOM(842, 14, "SOME");
+        WORD_ATOM(855, 14, "SOME");
         mw_SOME();
-        WORD_ATOM(842, 19, "over");
+        WORD_ATOM(855, 19, "over");
         mw_over();
-        WORD_ATOM(842, 24, "~sig?");
+        WORD_ATOM(855, 24, "~sig?");
         mw_Tag_7E_sig_3F_();
-        WORD_ATOM(842, 30, "!");
+        WORD_ATOM(855, 30, "!");
         mw_prim_mut_set();
     } else {
-        WORD_ATOM(843, 5, "dup");
+        WORD_ATOM(856, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(843, 9, "run-end?");
+        WORD_ATOM(856, 9, "run-end?");
         mw_Token_2E_run_end_3F_();
-        WORD_ATOM(843, 18, "if");
+        WORD_ATOM(856, 18, "if");
         if (pop_u64()) {
-            WORD_ATOM(844, 9, "drop");
+            WORD_ATOM(857, 9, "drop");
             mw_prim_drop();
-            WORD_ATOM(844, 14, "NONE");
+            WORD_ATOM(857, 14, "NONE");
             mw_NONE();
-            WORD_ATOM(844, 19, "over");
+            WORD_ATOM(857, 19, "over");
             mw_over();
-            WORD_ATOM(844, 24, "~sig?");
+            WORD_ATOM(857, 24, "~sig?");
             mw_Tag_7E_sig_3F_();
-            WORD_ATOM(844, 30, "!");
+            WORD_ATOM(857, 30, "!");
             mw_prim_mut_set();
         } else {
-            WORD_ATOM(845, 9, "");
+            WORD_ATOM(858, 9, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -22284,41 +22493,41 @@ static void mw_elab_data_tag_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(845, 50, "emit-fatal-error!");
+            WORD_ATOM(858, 50, "emit-fatal-error!");
             mw_emit_fatal_error_21_();
         }
     }
-    WORD_ATOM(848, 5, "dup");
+    WORD_ATOM(861, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(848, 9, "delay");
+    WORD_ATOM(861, 9, "delay");
     push_u64(0);
     push_fnptr(&mb_elab_data_tag_21__9);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(857, 5, "over");
+    WORD_ATOM(870, 5, "over");
     mw_over();
-    WORD_ATOM(857, 10, "~ctx-type");
+    WORD_ATOM(870, 10, "~ctx-type");
     mw_Tag_7E_ctx_type();
-    WORD_ATOM(857, 20, "!");
+    WORD_ATOM(870, 20, "!");
     mw_prim_mut_set();
-    WORD_ATOM(858, 5, "sip");
+    WORD_ATOM(871, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_data_tag_21__15);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(858, 30, "~num-inputs");
+    WORD_ATOM(871, 30, "~num-inputs");
     mw_Tag_7E_num_inputs();
-    WORD_ATOM(858, 42, "!");
+    WORD_ATOM(871, 42, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_elab_data_tag_21_);
 }
 static void mw_expect_token_arrow (void){
-    WORD_ENTER(mw_expect_token_arrow, "expect-token-arrow", "src/mirth/elab.mth", 861, 5);
-    WORD_ATOM(861, 5, "dup");
+    WORD_ENTER(mw_expect_token_arrow, "expect-token-arrow", "src/mirth/elab.mth", 874, 5);
+    WORD_ATOM(874, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(861, 9, "pat-arrow?");
+    WORD_ATOM(874, 9, "pat-arrow?");
     mw_Token_2E_pat_arrow_3F_();
-    WORD_ATOM(861, 20, "else");
+    WORD_ATOM(874, 20, "else");
     push_u64(0);
     push_fnptr(&mb_expect_token_arrow_1);
     mw_prim_pack_cons();
@@ -22326,27 +22535,27 @@ static void mw_expect_token_arrow (void){
     WORD_EXIT(mw_expect_token_arrow);
 }
 static void mw_token_def_args (void){
-    WORD_ENTER(mw_token_def_args, "token-def-args", "src/mirth/elab.mth", 868, 5);
-    WORD_ATOM(868, 5, "dup");
+    WORD_ENTER(mw_token_def_args, "token-def-args", "src/mirth/elab.mth", 881, 5);
+    WORD_ATOM(881, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(868, 9, "args");
+    WORD_ATOM(881, 9, "args");
     mw_Token_2E_args();
-    WORD_ATOM(868, 14, "dup");
+    WORD_ATOM(881, 14, "dup");
     mw_prim_dup();
-    WORD_ATOM(868, 18, "len");
+    WORD_ATOM(881, 18, "len");
     mw_List_2E_len();
-    WORD_ATOM(868, 22, "");
+    WORD_ATOM(881, 22, "");
     push_i64(2LL);
-    WORD_ATOM(868, 24, ">=");
+    WORD_ATOM(881, 24, ">=");
     mw_Int_3E__3D_();
-    WORD_ATOM(868, 27, "if");
+    WORD_ATOM(881, 27, "if");
     if (pop_u64()) {
-        WORD_ATOM(868, 30, "nip");
+        WORD_ATOM(881, 30, "nip");
         mw_nip();
     } else {
-        WORD_ATOM(869, 9, "drop");
+        WORD_ATOM(882, 9, "drop");
         mw_prim_drop();
-        WORD_ATOM(869, 14, "");
+        WORD_ATOM(882, 14, "");
         {
             static bool vready = false;
             static VAL v;
@@ -22357,24 +22566,24 @@ static void mw_token_def_args (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(869, 51, "emit-fatal-error!");
+        WORD_ATOM(882, 51, "emit-fatal-error!");
         mw_emit_fatal_error_21_();
     }
-    WORD_ATOM(870, 5, ">List+");
+    WORD_ATOM(883, 5, ">List+");
     mw_List_3E_List_2B_();
-    WORD_ATOM(870, 12, "unwrap");
+    WORD_ATOM(883, 12, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(870, 19, "uncons");
+    WORD_ATOM(883, 19, "uncons");
     mw_List_2B__2E_uncons();
-    WORD_ATOM(871, 5, ">List+");
+    WORD_ATOM(884, 5, ">List+");
     mw_List_3E_List_2B_();
-    WORD_ATOM(871, 12, "unwrap");
+    WORD_ATOM(884, 12, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(871, 19, "uncons");
+    WORD_ATOM(884, 19, "uncons");
     mw_List_2B__2E_uncons();
-    WORD_ATOM(872, 5, ">List+");
+    WORD_ATOM(885, 5, ">List+");
     mw_List_3E_List_2B_();
-    WORD_ATOM(872, 12, "if-some");
+    WORD_ATOM(885, 12, "if-some");
     push_u64(0);
     push_fnptr(&mb_token_def_args_3);
     mw_prim_pack_cons();
@@ -22385,126 +22594,126 @@ static void mw_token_def_args (void){
     WORD_EXIT(mw_token_def_args);
 }
 static void mw_elab_alias_21_ (void){
-    WORD_ENTER(mw_elab_alias_21_, "elab-alias!", "src/mirth/elab.mth", 882, 5);
-    WORD_ATOM(882, 5, "sip");
+    WORD_ENTER(mw_elab_alias_21_, "elab-alias!", "src/mirth/elab.mth", 895, 5);
+    WORD_ATOM(895, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_alias_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(882, 15, "args-2");
+    WORD_ATOM(895, 15, "args-2");
     mw_Token_2E_args_2();
-    WORD_ATOM(882, 22, "swap");
+    WORD_ATOM(895, 22, "swap");
     mw_prim_swap();
-    WORD_ATOM(883, 5, "dup");
+    WORD_ATOM(896, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(883, 9, "name?");
+    WORD_ATOM(896, 9, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(883, 15, "unwrap-or");
+    WORD_ATOM(896, 15, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_alias_21__2);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(883, 65, "dip");
+    WORD_ATOM(896, 65, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(883, 69, "dup");
+        WORD_ATOM(896, 69, "dup");
         mw_prim_dup();
-        WORD_ATOM(883, 73, "args-0");
+        WORD_ATOM(896, 73, "args-0");
         mw_Token_2E_args_0();
         push_value(d2);
     }
-    WORD_ATOM(884, 5, "name-undefined?");
+    WORD_ATOM(897, 5, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(884, 21, "else");
+    WORD_ATOM(897, 21, "else");
     push_u64(0);
     push_fnptr(&mb_elab_alias_21__4);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(884, 73, "rotl");
+    WORD_ATOM(897, 73, "rotl");
     mw_rotl();
-    WORD_ATOM(885, 5, "dup");
+    WORD_ATOM(898, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(885, 9, "name?");
+    WORD_ATOM(898, 9, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(885, 15, "unwrap-or");
+    WORD_ATOM(898, 15, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_alias_21__5);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(885, 65, "dip");
+    WORD_ATOM(898, 65, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(885, 69, "args-0");
+        WORD_ATOM(898, 69, "args-0");
         mw_Token_2E_args_0();
         push_value(d2);
     }
-    WORD_ATOM(886, 5, "Alias.new!");
+    WORD_ATOM(899, 5, "Alias.new!");
     mw_Alias_2E_new_21_();
-    WORD_ATOM(886, 16, "drop");
+    WORD_ATOM(899, 16, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_alias_21_);
 }
 static void mw_elab_def_missing_21_ (void){
-    WORD_ENTER(mw_elab_def_missing_21_, "elab-def-missing!", "src/mirth/elab.mth", 891, 5);
-    WORD_ATOM(891, 5, "dup");
+    WORD_ENTER(mw_elab_def_missing_21_, "elab-def-missing!", "src/mirth/elab.mth", 904, 5);
+    WORD_ATOM(904, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(891, 9, "succ");
+    WORD_ATOM(904, 9, "succ");
     mw_Token_2E_succ();
-    WORD_ATOM(891, 14, "succ");
+    WORD_ATOM(904, 14, "succ");
     mw_Token_2E_succ();
-    WORD_ATOM(891, 19, "dup");
+    WORD_ATOM(904, 19, "dup");
     mw_prim_dup();
-    WORD_ATOM(891, 23, "name?");
+    WORD_ATOM(904, 23, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(891, 29, "unwrap-or");
+    WORD_ATOM(904, 29, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_def_missing_21__1);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(891, 74, "nip");
+    WORD_ATOM(904, 74, "nip");
     mw_nip();
-    WORD_ATOM(891, 78, "name-defined?");
+    WORD_ATOM(904, 78, "name-defined?");
     mw_name_defined_3F_();
-    WORD_ATOM(891, 92, "nip");
+    WORD_ATOM(904, 92, "nip");
     mw_nip();
-    WORD_ATOM(891, 96, "if");
+    WORD_ATOM(904, 96, "if");
     if (pop_u64()) {
-        WORD_ATOM(892, 9, "next");
+        WORD_ATOM(905, 9, "next");
         mw_Token_2E_next();
     } else {
-        WORD_ATOM(893, 9, "elab-def!");
+        WORD_ATOM(906, 9, "elab-def!");
         mw_elab_def_21_();
     }
     WORD_EXIT(mw_elab_def_missing_21_);
 }
 static void mw_elab_def_21_ (void){
-    WORD_ENTER(mw_elab_def_21_, "elab-def!", "src/mirth/elab.mth", 898, 5);
-    WORD_ATOM(898, 5, "sip");
+    WORD_ENTER(mw_elab_def_21_, "elab-def!", "src/mirth/elab.mth", 911, 5);
+    WORD_ATOM(911, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_def_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(898, 15, "token-def-args");
+    WORD_ATOM(911, 15, "token-def-args");
     mw_token_def_args();
-    WORD_ATOM(899, 5, "uncons");
+    WORD_ATOM(912, 5, "uncons");
     mw_List_2B__2E_uncons();
-    WORD_ATOM(899, 12, "is-empty");
+    WORD_ATOM(912, 12, "is-empty");
     mw_List_2E_is_empty();
-    WORD_ATOM(899, 21, "if");
+    WORD_ATOM(912, 21, "if");
     if (pop_u64()) {
-        WORD_ATOM(899, 24, "id");
+        WORD_ATOM(912, 24, "id");
         mw_prim_id();
     } else {
-        WORD_ATOM(900, 9, "dup");
+        WORD_ATOM(913, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(900, 13, "run-has-arrow?");
+        WORD_ATOM(913, 13, "run-has-arrow?");
         mw_Token_2E_run_has_arrow_3F_();
-        WORD_ATOM(900, 28, "if");
+        WORD_ATOM(913, 28, "if");
         if (pop_u64()) {
-            WORD_ATOM(900, 31, "id");
+            WORD_ATOM(913, 31, "id");
             mw_prim_id();
         } else {
-            WORD_ATOM(901, 13, "");
+            WORD_ATOM(914, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -22515,31 +22724,31 @@ static void mw_elab_def_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(901, 35, "emit-fatal-error!");
+            WORD_ATOM(914, 35, "emit-fatal-error!");
             mw_emit_fatal_error_21_();
         }
     }
-    WORD_ATOM(902, 5, "rotl");
+    WORD_ATOM(915, 5, "rotl");
     mw_rotl();
-    WORD_ATOM(902, 10, "dup");
+    WORD_ATOM(915, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(902, 14, "name?");
+    WORD_ATOM(915, 14, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(902, 20, "unwrap-or");
+    WORD_ATOM(915, 20, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_def_21__6);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(903, 5, "name-undefined?");
+    WORD_ATOM(916, 5, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(903, 21, "if");
+    WORD_ATOM(916, 21, "if");
     if (pop_u64()) {
-        WORD_ATOM(903, 24, "id");
+        WORD_ATOM(916, 24, "id");
         mw_prim_id();
     } else {
-        WORD_ATOM(903, 28, "drop");
+        WORD_ATOM(916, 28, "drop");
         mw_prim_drop();
-        WORD_ATOM(903, 33, "");
+        WORD_ATOM(916, 33, "");
         {
             static bool vready = false;
             static VAL v;
@@ -22550,445 +22759,453 @@ static void mw_elab_def_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(903, 56, "emit-fatal-error!");
+        WORD_ATOM(916, 56, "emit-fatal-error!");
         mw_emit_fatal_error_21_();
     }
-    WORD_ATOM(905, 5, "Word.new!");
+    WORD_ATOM(918, 5, "Word.new!");
     mw_Word_2E_new_21_();
-    WORD_ATOM(906, 5, "tuck");
+    WORD_ATOM(919, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(906, 10, "~sig");
+    WORD_ATOM(919, 10, "~sig");
     mw_Word_7E_sig();
-    WORD_ATOM(906, 15, "!");
+    WORD_ATOM(919, 15, "!");
     mw_prim_mut_set();
-    WORD_ATOM(908, 5, "dup");
+    WORD_ATOM(921, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(908, 9, "delay");
+    WORD_ATOM(921, 9, "delay");
     push_u64(0);
     push_fnptr(&mb_elab_def_21__9);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(913, 7, "over");
+    WORD_ATOM(926, 7, "over");
     mw_over();
-    WORD_ATOM(913, 12, "~ctx-type");
+    WORD_ATOM(926, 12, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(913, 22, "!");
+    WORD_ATOM(926, 22, "!");
     mw_prim_mut_set();
-    WORD_ATOM(914, 5, "dup");
+    WORD_ATOM(927, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(914, 9, "delay");
+    WORD_ATOM(927, 9, "delay");
     push_u64(0);
     push_fnptr(&mb_elab_def_21__12);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(914, 33, "over");
+    WORD_ATOM(927, 33, "over");
     mw_over();
-    WORD_ATOM(914, 38, "~params");
+    WORD_ATOM(927, 38, "~params");
     mw_Word_7E_params();
-    WORD_ATOM(914, 46, "!");
+    WORD_ATOM(927, 46, "!");
     mw_prim_mut_set();
-    WORD_ATOM(915, 5, "dup");
+    WORD_ATOM(928, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(915, 9, "delay");
+    WORD_ATOM(928, 9, "delay");
     push_u64(0);
     push_fnptr(&mb_elab_def_21__13);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(922, 7, "swap");
+    WORD_ATOM(935, 7, "swap");
     mw_prim_swap();
-    WORD_ATOM(922, 12, "~arrow");
+    WORD_ATOM(935, 12, "~arrow");
     mw_Word_7E_arrow();
-    WORD_ATOM(922, 19, "!");
+    WORD_ATOM(935, 19, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_elab_def_21_);
 }
 static void mw_elab_def_params_21_ (void){
-    WORD_ENTER(mw_elab_def_params_21_, "elab-def-params!", "src/mirth/elab.mth", 926, 5);
-    WORD_ATOM(926, 5, "L0");
+    WORD_ENTER(mw_elab_def_params_21_, "elab-def-params!", "src/mirth/elab.mth", 939, 5);
+    WORD_ATOM(939, 5, "L0");
     mw_L0();
-    WORD_ATOM(926, 8, "over");
+    WORD_ATOM(939, 8, "over");
     mw_over();
-    WORD_ATOM(926, 13, "elab-word-ctx-type-weak!");
+    WORD_ATOM(939, 13, "elab-word-ctx-type-weak!");
     mw_elab_word_ctx_type_weak_21_();
-    WORD_ATOM(926, 38, "nip");
+    WORD_ATOM(939, 38, "nip");
     mw_nip();
-    WORD_ATOM(927, 5, "rotl");
+    WORD_ATOM(940, 5, "rotl");
     mw_rotl();
-    WORD_ATOM(927, 10, "head");
+    WORD_ATOM(940, 10, "head");
     mw_Word_2E_head();
-    WORD_ATOM(927, 15, "dip");
+    WORD_ATOM(940, 15, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(927, 19, "unpack");
+        WORD_ATOM(940, 19, "unpack");
         mw_ArrowType_2E_unpack();
         push_value(d2);
     }
-    WORD_ATOM(927, 27, "nip");
+    WORD_ATOM(940, 27, "nip");
     mw_nip();
-    WORD_ATOM(928, 5, "args");
+    WORD_ATOM(941, 5, "args");
     mw_Token_2E_args();
-    WORD_ATOM(928, 10, "reverse-for");
+    WORD_ATOM(941, 10, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_elab_def_params_21__2);
     mw_prim_pack_cons();
     mw_List_2E_reverse_for();
-    WORD_ATOM(936, 7, "drop");
+    WORD_ATOM(949, 7, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_def_params_21_);
 }
 static void mw_elab_def_body_21_ (void){
-    WORD_ENTER(mw_elab_def_body_21_, "elab-def-body!", "src/mirth/elab.mth", 941, 5);
-    WORD_ATOM(941, 5, "ab-token");
+    WORD_ENTER(mw_elab_def_body_21_, "elab-def-body!", "src/mirth/elab.mth", 954, 5);
+    WORD_ATOM(954, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(941, 14, "@");
+    WORD_ATOM(954, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(941, 16, "run-has-arrow?");
+    WORD_ATOM(954, 16, "run-has-arrow?");
     mw_Token_2E_run_has_arrow_3F_();
-    WORD_ATOM(941, 31, "if");
+    WORD_ATOM(954, 31, "if");
     if (pop_u64()) {
-        WORD_ATOM(942, 9, "dup");
+        WORD_ATOM(955, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(942, 13, "ab-token");
+        WORD_ATOM(955, 13, "ab-token");
         mw_ab_token();
-        WORD_ATOM(942, 22, "@");
+        WORD_ATOM(955, 22, "@");
         mw_prim_mut_get();
-        WORD_ATOM(942, 24, "elab-match-at!");
+        WORD_ATOM(955, 24, "elab-match-at!");
         mw_elab_match_at_21_();
     } else {
-        WORD_ATOM(943, 9, "elab-atoms!");
+        WORD_ATOM(956, 9, "elab-atoms!");
         mw_elab_atoms_21_();
     }
     WORD_EXIT(mw_elab_def_body_21_);
 }
 static void mw_elab_def_external_21_ (void){
-    WORD_ENTER(mw_elab_def_external_21_, "elab-def-external!", "src/mirth/elab.mth", 948, 5);
-    WORD_ATOM(948, 5, "sip");
+    WORD_ENTER(mw_elab_def_external_21_, "elab-def-external!", "src/mirth/elab.mth", 961, 5);
+    WORD_ATOM(961, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_def_external_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(948, 15, "args-2");
+    WORD_ATOM(961, 15, "args-2");
     mw_Token_2E_args_2();
-    WORD_ATOM(949, 5, "swap");
+    WORD_ATOM(962, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(949, 10, "dup");
+    WORD_ATOM(962, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(949, 14, "name?");
+    WORD_ATOM(962, 14, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(949, 20, "unwrap-or");
+    WORD_ATOM(962, 20, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_def_external_21__2);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(950, 5, "name-undefined?");
+    WORD_ATOM(963, 5, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(950, 21, "else");
+    WORD_ATOM(963, 21, "else");
     push_u64(0);
     push_fnptr(&mb_elab_def_external_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(951, 5, "nip");
+    WORD_ATOM(964, 5, "nip");
     mw_nip();
-    WORD_ATOM(952, 5, "External.alloc!");
+    WORD_ATOM(965, 5, "External.alloc!");
     mw_External_2E_alloc_21_();
-    WORD_ATOM(953, 5, "dup2");
+    WORD_ATOM(966, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(953, 10, "DEF_EXTERNAL");
+    WORD_ATOM(966, 10, "DEF_EXTERNAL");
     mw_DEF_5F_EXTERNAL();
-    WORD_ATOM(953, 23, "swap");
+    WORD_ATOM(966, 23, "swap");
     mw_prim_swap();
-    WORD_ATOM(953, 28, "~Def");
+    WORD_ATOM(966, 28, "~Def");
     mw_Name_7E_Def();
-    WORD_ATOM(953, 33, "!");
+    WORD_ATOM(966, 33, "!");
     mw_prim_mut_set();
-    WORD_ATOM(954, 5, "tuck");
+    WORD_ATOM(967, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(954, 10, "~name");
+    WORD_ATOM(967, 10, "~name");
     mw_External_7E_name();
-    WORD_ATOM(954, 16, "!");
+    WORD_ATOM(967, 16, "!");
     mw_prim_mut_set();
-    WORD_ATOM(955, 5, "tuck");
+    WORD_ATOM(968, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(955, 10, "~sig");
+    WORD_ATOM(968, 10, "~sig");
     mw_External_7E_sig();
-    WORD_ATOM(955, 15, "!");
+    WORD_ATOM(968, 15, "!");
     mw_prim_mut_set();
-    WORD_ATOM(956, 5, "dup");
+    WORD_ATOM(969, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(956, 9, "delay");
+    WORD_ATOM(969, 9, "delay");
     push_u64(0);
     push_fnptr(&mb_elab_def_external_21__4);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(959, 7, "swap");
+    WORD_ATOM(972, 7, "swap");
     mw_prim_swap();
-    WORD_ATOM(959, 12, "~ctx-type");
+    WORD_ATOM(972, 12, "~ctx-type");
     mw_External_7E_ctx_type();
-    WORD_ATOM(959, 22, "!");
+    WORD_ATOM(972, 22, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_elab_def_external_21_);
 }
 static void mw_elab_def_type_21_ (void){
-    WORD_ENTER(mw_elab_def_type_21_, "elab-def-type!", "src/mirth/elab.mth", 963, 5);
-    WORD_ATOM(963, 5, "sip");
+    WORD_ENTER(mw_elab_def_type_21_, "elab-def-type!", "src/mirth/elab.mth", 976, 5);
+    WORD_ATOM(976, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_def_type_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(963, 15, "args-2");
+    WORD_ATOM(976, 15, "args-2");
     mw_Token_2E_args_2();
-    WORD_ATOM(964, 5, "swap");
+    WORD_ATOM(977, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(964, 10, "dup");
+    WORD_ATOM(977, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(964, 14, "sig-type-con?");
+    WORD_ATOM(977, 14, "sig-type-con?");
     mw_Token_2E_sig_type_con_3F_();
-    WORD_ATOM(964, 28, "else");
+    WORD_ATOM(977, 28, "else");
     push_u64(0);
     push_fnptr(&mb_elab_def_type_21__2);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(965, 5, "dup");
+    WORD_ATOM(978, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(965, 9, "name?");
+    WORD_ATOM(978, 9, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(965, 15, "unwrap");
+    WORD_ATOM(978, 15, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(965, 22, "name-undefined?");
+    WORD_ATOM(978, 22, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(965, 38, "else");
+    WORD_ATOM(978, 38, "else");
     push_u64(0);
     push_fnptr(&mb_elab_def_type_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(966, 5, "nip");
+    WORD_ATOM(979, 5, "nip");
     mw_nip();
-    WORD_ATOM(966, 9, "swap");
+    WORD_ATOM(979, 9, "swap");
     mw_prim_swap();
-    WORD_ATOM(966, 14, "elab-simple-type-arg!");
+    WORD_ATOM(979, 14, "elab-simple-type-arg!");
     mw_elab_simple_type_arg_21_();
-    WORD_ATOM(966, 36, "DEF_TYPE");
+    WORD_ATOM(979, 36, "DEF_TYPE");
     mw_DEF_5F_TYPE();
-    WORD_ATOM(966, 45, "swap");
+    WORD_ATOM(979, 45, "swap");
     mw_prim_swap();
-    WORD_ATOM(966, 50, "~Def");
+    WORD_ATOM(979, 50, "~Def");
     mw_Name_7E_Def();
-    WORD_ATOM(966, 55, "!");
+    WORD_ATOM(979, 55, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_elab_def_type_21_);
 }
 static void mw_elab_buffer_21_ (void){
-    WORD_ENTER(mw_elab_buffer_21_, "elab-buffer!", "src/mirth/elab.mth", 970, 5);
-    WORD_ATOM(970, 5, "sip");
+    WORD_ENTER(mw_elab_buffer_21_, "elab-buffer!", "src/mirth/elab.mth", 983, 5);
+    WORD_ATOM(983, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_buffer_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(970, 15, "args-2");
+    WORD_ATOM(983, 15, "args-2");
     mw_Token_2E_args_2();
-    WORD_ATOM(971, 5, "swap");
+    WORD_ATOM(984, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(971, 10, "dup");
+    WORD_ATOM(984, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(971, 14, "name?");
+    WORD_ATOM(984, 14, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(971, 20, "unwrap-or");
+    WORD_ATOM(984, 20, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_buffer_21__2);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(972, 5, "name-undefined?");
+    WORD_ATOM(985, 5, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(972, 21, "else");
+    WORD_ATOM(985, 21, "else");
     push_u64(0);
     push_fnptr(&mb_elab_buffer_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(973, 5, "rotl");
+    WORD_ATOM(986, 5, "rotl");
     mw_rotl();
-    WORD_ATOM(973, 10, "dup");
+    WORD_ATOM(986, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(973, 14, "int?");
+    WORD_ATOM(986, 14, "int?");
     mw_Token_2E_int_3F_();
-    WORD_ATOM(973, 19, "unwrap-or");
+    WORD_ATOM(986, 19, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_buffer_21__4);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(973, 71, "nip");
+    WORD_ATOM(986, 71, "nip");
     mw_nip();
-    WORD_ATOM(974, 5, "Buffer.new!");
+    WORD_ATOM(987, 5, "Buffer.new!");
     mw_Buffer_2E_new_21_();
-    WORD_ATOM(974, 17, "drop");
+    WORD_ATOM(987, 17, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_buffer_21_);
 }
 static void mw_elab_variable_21_ (void){
-    WORD_ENTER(mw_elab_variable_21_, "elab-variable!", "src/mirth/elab.mth", 978, 5);
-    WORD_ATOM(978, 5, "sip");
+    WORD_ENTER(mw_elab_variable_21_, "elab-variable!", "src/mirth/elab.mth", 991, 5);
+    WORD_ATOM(991, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_variable_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(978, 15, "args-2");
+    WORD_ATOM(991, 15, "args-2");
     mw_Token_2E_args_2();
-    WORD_ATOM(979, 5, "swap");
+    WORD_ATOM(992, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(979, 10, "dup");
+    WORD_ATOM(992, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(979, 14, "name?");
+    WORD_ATOM(992, 14, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(979, 20, "unwrap-or");
+    WORD_ATOM(992, 20, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_variable_21__2);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(980, 5, "name-undefined?");
+    WORD_ATOM(993, 5, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(980, 21, "else");
+    WORD_ATOM(993, 21, "else");
     push_u64(0);
     push_fnptr(&mb_elab_variable_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(981, 5, "rotl");
+    WORD_ATOM(994, 5, "rotl");
     mw_rotl();
-    WORD_ATOM(981, 10, "delay");
+    WORD_ATOM(994, 10, "delay");
     push_u64(0);
     push_fnptr(&mb_elab_variable_21__4);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(982, 5, "Variable.new!");
+    WORD_ATOM(995, 5, "Variable.new!");
     mw_Variable_2E_new_21_();
-    WORD_ATOM(982, 19, "drop");
+    WORD_ATOM(995, 19, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_variable_21_);
 }
 static void mw_elab_table_21_ (void){
-    WORD_ENTER(mw_elab_table_21_, "elab-table!", "src/mirth/elab.mth", 986, 5);
-    WORD_ATOM(986, 5, "sip");
+    WORD_ENTER(mw_elab_table_21_, "elab-table!", "src/mirth/elab.mth", 999, 5);
+    WORD_ATOM(999, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_table_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(986, 15, "args-1");
+    WORD_ATOM(999, 15, "args-1");
     mw_Token_2E_args_1();
-    WORD_ATOM(987, 5, "dup");
+    WORD_ATOM(1000, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(987, 9, "sig-type-con?");
+    WORD_ATOM(1000, 9, "sig-type-con?");
     mw_Token_2E_sig_type_con_3F_();
-    WORD_ATOM(987, 23, "else");
+    WORD_ATOM(1000, 23, "else");
     push_u64(0);
     push_fnptr(&mb_elab_table_21__2);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(988, 5, "dup");
+    WORD_ATOM(1001, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(988, 9, "name?");
+    WORD_ATOM(1001, 9, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(988, 15, "unwrap");
+    WORD_ATOM(1001, 15, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(988, 22, "name-undefined?");
+    WORD_ATOM(1001, 22, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(988, 38, "else");
+    WORD_ATOM(1001, 38, "else");
     push_u64(0);
     push_fnptr(&mb_elab_table_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(989, 5, "table-new!");
+    WORD_ATOM(1002, 5, "table-new!");
     mw_table_new_21_();
-    WORD_ATOM(989, 16, "drop");
+    WORD_ATOM(1002, 16, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_table_21_);
 }
 static void mw_elab_target_c99_21_ (void){
-    WORD_ENTER(mw_elab_target_c99_21_, "elab-target-c99!", "src/mirth/elab.mth", 993, 5);
-    WORD_ATOM(993, 5, "typecheck-everything!");
+    WORD_ENTER(mw_elab_target_c99_21_, "elab-target-c99!", "src/mirth/elab.mth", 1006, 5);
+    WORD_ATOM(1006, 5, "typecheck-everything!");
     mw_typecheck_everything_21_();
-    WORD_ATOM(994, 5, "sip");
+    WORD_ATOM(1007, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_target_c99_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(994, 15, "args-2");
+    WORD_ATOM(1007, 15, "args-2");
     mw_Token_2E_args_2();
-    WORD_ATOM(995, 5, "dip");
+    WORD_ATOM(1008, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(995, 9, "dup");
+        WORD_ATOM(1008, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(995, 13, "str?");
+        WORD_ATOM(1008, 13, "str?");
         mw_Token_2E_str_3F_();
-        WORD_ATOM(995, 18, "unwrap-or");
+        WORD_ATOM(1008, 18, "unwrap-or");
         push_u64(0);
         push_fnptr(&mb_elab_target_c99_21__3);
         mw_prim_pack_cons();
         mw_Maybe_2E_unwrap_or();
-        WORD_ATOM(995, 70, "nip");
+        WORD_ATOM(1008, 70, "nip");
         mw_nip();
-        WORD_ATOM(995, 74, ">Path");
+        WORD_ATOM(1008, 74, ">Path");
         mw_Str_3E_Path();
         push_value(d2);
     }
-    WORD_ATOM(996, 5, "dip");
+    WORD_ATOM(1009, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(996, 9, "CTX0");
+        WORD_ATOM(1009, 9, "CTX0");
         mw_CTX0();
-        WORD_ATOM(996, 14, "T0");
+        WORD_ATOM(1009, 14, "T0");
         mw_T0();
-        WORD_ATOM(996, 17, "T0");
+        WORD_ATOM(1009, 17, "RESOURCE_+PLATFORM");
+        mw_RESOURCE_5F__2B_PLATFORM();
+        WORD_ATOM(1009, 36, "T+");
+        mw_T_2B_();
+        WORD_ATOM(1009, 39, "T0");
         mw_T0();
-        WORD_ATOM(996, 20, "T->");
+        WORD_ATOM(1009, 42, "RESOURCE_+PLATFORM");
+        mw_RESOURCE_5F__2B_PLATFORM();
+        WORD_ATOM(1009, 61, "T+");
+        mw_T_2B_();
+        WORD_ATOM(1009, 64, "T->");
         mw_T__3E_();
         push_value(d2);
     }
-    WORD_ATOM(997, 5, "elab-arrow!");
+    WORD_ATOM(1010, 5, "elab-arrow!");
     mw_elab_arrow_21_();
-    WORD_ATOM(998, 5, "swap");
+    WORD_ATOM(1011, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(998, 10, "run-output-c99!");
+    WORD_ATOM(1011, 10, "run-output-c99!");
     mw_run_output_c99_21_();
     WORD_EXIT(mw_elab_target_c99_21_);
 }
 static void mw_elab_embed_str_21_ (void){
-    WORD_ENTER(mw_elab_embed_str_21_, "elab-embed-str!", "src/mirth/elab.mth", 1003, 5);
-    WORD_ATOM(1003, 5, "sip");
+    WORD_ENTER(mw_elab_embed_str_21_, "elab-embed-str!", "src/mirth/elab.mth", 1016, 5);
+    WORD_ATOM(1016, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_embed_str_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(1003, 15, "args-2");
+    WORD_ATOM(1016, 15, "args-2");
     mw_Token_2E_args_2();
-    WORD_ATOM(1003, 22, "swap");
+    WORD_ATOM(1016, 22, "swap");
     mw_prim_swap();
-    WORD_ATOM(1004, 5, "dup");
+    WORD_ATOM(1017, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1004, 9, "name?");
+    WORD_ATOM(1017, 9, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(1004, 15, "unwrap-or");
+    WORD_ATOM(1017, 15, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_embed_str_21__2);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(1005, 5, "name-undefined?");
+    WORD_ATOM(1018, 5, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(1005, 21, "else");
+    WORD_ATOM(1018, 21, "else");
     push_u64(0);
     push_fnptr(&mb_elab_embed_str_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(1006, 5, "rotl");
+    WORD_ATOM(1019, 5, "rotl");
     mw_rotl();
-    WORD_ATOM(1006, 10, "dup");
+    WORD_ATOM(1019, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(1006, 14, "str?");
+    WORD_ATOM(1019, 14, "str?");
     mw_Token_2E_str_3F_();
-    WORD_ATOM(1006, 19, "unwrap-or");
+    WORD_ATOM(1019, 19, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_embed_str_21__4);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(1007, 5, "with-open-file!");
+    WORD_ATOM(1020, 5, "with-open-file!");
     push_u64(0);
     push_fnptr(&mb_elab_embed_str_21__5);
     mw_prim_pack_cons();
@@ -22996,22 +23213,22 @@ static void mw_elab_embed_str_21_ (void){
     push_fnptr(&mb_elab_embed_str_21__6);
     mw_prim_pack_cons();
     mw_with_open_file_21_();
-    WORD_ATOM(1008, 5, "VALUE_STR");
+    WORD_ATOM(1021, 5, "VALUE_STR");
     mw_VALUE_5F_STR();
-    WORD_ATOM(1008, 15, "Constant.new!");
+    WORD_ATOM(1021, 15, "Constant.new!");
     mw_Constant_2E_new_21_();
-    WORD_ATOM(1008, 29, "drop");
+    WORD_ATOM(1021, 29, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_embed_str_21_);
 }
 static void mw_typecheck_everything_21_ (void){
-    WORD_ENTER(mw_typecheck_everything_21_, "typecheck-everything!", "src/mirth/elab.mth", 1012, 5);
-    WORD_ATOM(1012, 5, "Name.for");
+    WORD_ENTER(mw_typecheck_everything_21_, "typecheck-everything!", "src/mirth/elab.mth", 1025, 5);
+    WORD_ATOM(1025, 5, "Name.for");
     push_u64(0);
     push_fnptr(&mb_typecheck_everything_21__1);
     mw_prim_pack_cons();
     mw_Name_2E_for();
-    WORD_ATOM(1013, 5, "Block.for");
+    WORD_ATOM(1026, 5, "Block.for");
     push_u64(0);
     push_fnptr(&mb_typecheck_everything_21__2);
     mw_prim_pack_cons();
@@ -23019,75 +23236,75 @@ static void mw_typecheck_everything_21_ (void){
     WORD_EXIT(mw_typecheck_everything_21_);
 }
 static void mw_TABLE_5F_MAX_5F_SIZE (void){
-    WORD_ENTER(mw_TABLE_5F_MAX_5F_SIZE, "TABLE_MAX_SIZE", "src/mirth/elab.mth", 1019, 26);
-    WORD_ATOM(1019, 26, "");
+    WORD_ENTER(mw_TABLE_5F_MAX_5F_SIZE, "TABLE_MAX_SIZE", "src/mirth/elab.mth", 1032, 26);
+    WORD_ATOM(1032, 26, "");
     push_i64(65536LL);
     WORD_EXIT(mw_TABLE_5F_MAX_5F_SIZE);
 }
 static void mw_table_word_new_21_ (void){
-    WORD_ENTER(mw_table_word_new_21_, "table-word-new!", "src/mirth/elab.mth", 1022, 5);
-    WORD_ATOM(1022, 5, "dip");
+    WORD_ENTER(mw_table_word_new_21_, "table-word-new!", "src/mirth/elab.mth", 1035, 5);
+    WORD_ATOM(1035, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(1022, 9, "dup");
+        WORD_ATOM(1035, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(1022, 13, "head");
+        WORD_ATOM(1035, 13, "head");
         mw_Table_2E_head();
-        WORD_ATOM(1022, 18, "dup");
+        WORD_ATOM(1035, 18, "dup");
         mw_prim_dup();
-        WORD_ATOM(1022, 22, "rotl");
+        WORD_ATOM(1035, 22, "rotl");
         mw_rotl();
-        WORD_ATOM(1022, 27, "name");
+        WORD_ATOM(1035, 27, "name");
         mw_Table_2E_name();
         push_value(d2);
     }
-    WORD_ATOM(1022, 33, "Name.cat");
+    WORD_ATOM(1035, 33, "Name.cat");
     mw_Name_2E_cat();
-    WORD_ATOM(1022, 42, "Word.new!");
+    WORD_ATOM(1035, 42, "Word.new!");
     mw_Word_2E_new_21_();
     WORD_EXIT(mw_table_word_new_21_);
 }
 static void mw_table_new_21_ (void){
-    WORD_ENTER(mw_table_new_21_, "table-new!", "src/mirth/elab.mth", 1025, 5);
-    WORD_ATOM(1025, 5, "Table.alloc!");
+    WORD_ENTER(mw_table_new_21_, "table-new!", "src/mirth/elab.mth", 1038, 5);
+    WORD_ATOM(1038, 5, "Table.alloc!");
     mw_Table_2E_alloc_21_();
-    WORD_ATOM(1026, 5, "tuck");
+    WORD_ATOM(1039, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(1026, 10, "~name");
+    WORD_ATOM(1039, 10, "~name");
     mw_Table_7E_name();
-    WORD_ATOM(1026, 16, "!");
+    WORD_ATOM(1039, 16, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1027, 5, "tuck");
+    WORD_ATOM(1040, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(1027, 10, "~head");
+    WORD_ATOM(1040, 10, "~head");
     mw_Table_7E_head();
-    WORD_ATOM(1027, 16, "!");
+    WORD_ATOM(1040, 16, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1028, 5, "TABLE_MAX_SIZE");
+    WORD_ATOM(1041, 5, "TABLE_MAX_SIZE");
     mw_TABLE_5F_MAX_5F_SIZE();
-    WORD_ATOM(1028, 20, "over");
+    WORD_ATOM(1041, 20, "over");
     mw_over();
-    WORD_ATOM(1028, 25, "~max-count");
+    WORD_ATOM(1041, 25, "~max-count");
     mw_Table_7E_max_count();
-    WORD_ATOM(1028, 36, "!");
+    WORD_ATOM(1041, 36, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1029, 5, "dup");
+    WORD_ATOM(1042, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1029, 9, "TTable");
+    WORD_ATOM(1042, 9, "TTable");
     mw_TTable();
-    WORD_ATOM(1029, 16, "DEF_TYPE");
+    WORD_ATOM(1042, 16, "DEF_TYPE");
     mw_DEF_5F_TYPE();
-    WORD_ATOM(1029, 25, "over");
+    WORD_ATOM(1042, 25, "over");
     mw_over();
-    WORD_ATOM(1029, 30, "name");
+    WORD_ATOM(1042, 30, "name");
     mw_Table_2E_name();
-    WORD_ATOM(1029, 35, "~Def");
+    WORD_ATOM(1042, 35, "~Def");
     mw_Name_7E_Def();
-    WORD_ATOM(1029, 40, "!");
+    WORD_ATOM(1042, 40, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1033, 5, "dup");
+    WORD_ATOM(1046, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1033, 9, "");
+    WORD_ATOM(1046, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23098,38 +23315,38 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1033, 16, "table-word-new!");
+    WORD_ATOM(1046, 16, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1035, 5, "L0");
+    WORD_ATOM(1048, 5, "L0");
     mw_L0();
-    WORD_ATOM(1035, 8, "CTX");
+    WORD_ATOM(1048, 8, "CTX");
     mw_CTX();
-    WORD_ATOM(1036, 5, "T0");
+    WORD_ATOM(1049, 5, "T0");
     mw_T0();
-    WORD_ATOM(1036, 8, "TYPE_INT");
+    WORD_ATOM(1049, 8, "TYPE_INT");
     mw_TYPE_5F_INT();
-    WORD_ATOM(1036, 17, "T1");
+    WORD_ATOM(1049, 17, "T1");
     mw_T1();
-    WORD_ATOM(1036, 20, "T->");
+    WORD_ATOM(1049, 20, "T->");
     mw_T__3E_();
-    WORD_ATOM(1037, 5, "ready2");
+    WORD_ATOM(1050, 5, "ready2");
     mw_ready2();
-    WORD_ATOM(1037, 12, "over");
+    WORD_ATOM(1050, 12, "over");
     mw_over();
-    WORD_ATOM(1037, 17, "~ctx-type");
+    WORD_ATOM(1050, 17, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(1037, 27, "!");
+    WORD_ATOM(1050, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1039, 5, "ab-build-word!");
+    WORD_ATOM(1052, 5, "ab-build-word!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__1);
     mw_prim_pack_cons();
     mw_ab_build_word_21_();
-    WORD_ATOM(1042, 7, "drop");
+    WORD_ATOM(1055, 7, "drop");
     mw_prim_drop();
-    WORD_ATOM(1045, 5, "dup");
+    WORD_ATOM(1058, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1045, 9, "");
+    WORD_ATOM(1058, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23140,46 +23357,46 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1045, 16, "table-word-new!");
+    WORD_ATOM(1058, 16, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1047, 5, "L0");
+    WORD_ATOM(1060, 5, "L0");
     mw_L0();
-    WORD_ATOM(1047, 8, "CTX");
+    WORD_ATOM(1060, 8, "CTX");
     mw_CTX();
-    WORD_ATOM(1048, 5, "T0");
+    WORD_ATOM(1061, 5, "T0");
     mw_T0();
-    WORD_ATOM(1048, 8, "over3");
+    WORD_ATOM(1061, 8, "over3");
     mw_over3();
-    WORD_ATOM(1048, 14, "TTable");
+    WORD_ATOM(1061, 14, "TTable");
     mw_TTable();
-    WORD_ATOM(1048, 21, "T1");
+    WORD_ATOM(1061, 21, "T1");
     mw_T1();
-    WORD_ATOM(1048, 24, "T->");
+    WORD_ATOM(1061, 24, "T->");
     mw_T__3E_();
-    WORD_ATOM(1049, 5, "ready2");
+    WORD_ATOM(1062, 5, "ready2");
     mw_ready2();
-    WORD_ATOM(1049, 12, "over");
+    WORD_ATOM(1062, 12, "over");
     mw_over();
-    WORD_ATOM(1049, 17, "~ctx-type");
+    WORD_ATOM(1062, 17, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(1049, 27, "!");
+    WORD_ATOM(1062, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1051, 5, "ab-build-word!");
+    WORD_ATOM(1064, 5, "ab-build-word!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__2);
     mw_prim_pack_cons();
     mw_ab_build_word_21_();
-    WORD_ATOM(1055, 7, "drop");
+    WORD_ATOM(1068, 7, "drop");
     mw_prim_drop();
-    WORD_ATOM(1058, 5, "dup");
+    WORD_ATOM(1071, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1058, 9, "head");
+    WORD_ATOM(1071, 9, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1059, 5, "over");
+    WORD_ATOM(1072, 5, "over");
     mw_over();
-    WORD_ATOM(1059, 10, "name");
+    WORD_ATOM(1072, 10, "name");
     mw_Table_2E_name();
-    WORD_ATOM(1059, 15, "");
+    WORD_ATOM(1072, 15, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23190,21 +23407,21 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1059, 22, "Name.cat");
+    WORD_ATOM(1072, 22, "Name.cat");
     mw_Name_2E_cat();
-    WORD_ATOM(1060, 5, "");
+    WORD_ATOM(1073, 5, "");
     push_i64(8LL);
-    WORD_ATOM(1060, 7, "Buffer.new!");
+    WORD_ATOM(1073, 7, "Buffer.new!");
     mw_Buffer_2E_new_21_();
-    WORD_ATOM(1061, 5, "over");
+    WORD_ATOM(1074, 5, "over");
     mw_over();
-    WORD_ATOM(1061, 10, "~num-buffer");
+    WORD_ATOM(1074, 10, "~num-buffer");
     mw_Table_7E_num_buffer();
-    WORD_ATOM(1061, 22, "!");
+    WORD_ATOM(1074, 22, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1064, 5, "dup");
+    WORD_ATOM(1077, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1064, 9, "");
+    WORD_ATOM(1077, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23215,42 +23432,42 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1064, 15, "table-word-new!");
+    WORD_ATOM(1077, 15, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1066, 5, "L0");
+    WORD_ATOM(1079, 5, "L0");
     mw_L0();
-    WORD_ATOM(1066, 8, "CTX");
+    WORD_ATOM(1079, 8, "CTX");
     mw_CTX();
-    WORD_ATOM(1067, 5, "over2");
+    WORD_ATOM(1080, 5, "over2");
     mw_over2();
-    WORD_ATOM(1067, 11, "TTable");
+    WORD_ATOM(1080, 11, "TTable");
     mw_TTable();
-    WORD_ATOM(1067, 18, "T1");
+    WORD_ATOM(1080, 18, "T1");
     mw_T1();
-    WORD_ATOM(1067, 21, "TYPE_INT");
+    WORD_ATOM(1080, 21, "TYPE_INT");
     mw_TYPE_5F_INT();
-    WORD_ATOM(1067, 30, "T1");
+    WORD_ATOM(1080, 30, "T1");
     mw_T1();
-    WORD_ATOM(1067, 33, "T->");
+    WORD_ATOM(1080, 33, "T->");
     mw_T__3E_();
-    WORD_ATOM(1068, 5, "ready2");
+    WORD_ATOM(1081, 5, "ready2");
     mw_ready2();
-    WORD_ATOM(1068, 12, "over");
+    WORD_ATOM(1081, 12, "over");
     mw_over();
-    WORD_ATOM(1068, 17, "~ctx-type");
+    WORD_ATOM(1081, 17, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(1068, 27, "!");
+    WORD_ATOM(1081, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1070, 5, "ab-build-word!");
+    WORD_ATOM(1083, 5, "ab-build-word!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__3);
     mw_prim_pack_cons();
     mw_ab_build_word_21_();
-    WORD_ATOM(1073, 7, "drop");
+    WORD_ATOM(1086, 7, "drop");
     mw_prim_drop();
-    WORD_ATOM(1076, 5, "dup");
+    WORD_ATOM(1089, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1076, 9, "");
+    WORD_ATOM(1089, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23261,44 +23478,44 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1076, 20, "table-word-new!");
+    WORD_ATOM(1089, 20, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1078, 5, "L0");
+    WORD_ATOM(1091, 5, "L0");
     mw_L0();
-    WORD_ATOM(1078, 8, "CTX");
+    WORD_ATOM(1091, 8, "CTX");
     mw_CTX();
-    WORD_ATOM(1079, 5, "over2");
+    WORD_ATOM(1092, 5, "over2");
     mw_over2();
-    WORD_ATOM(1079, 11, "TTable");
+    WORD_ATOM(1092, 11, "TTable");
     mw_TTable();
-    WORD_ATOM(1079, 18, "T1");
+    WORD_ATOM(1092, 18, "T1");
     mw_T1();
-    WORD_ATOM(1079, 21, "TYPE_INT");
+    WORD_ATOM(1092, 21, "TYPE_INT");
     mw_TYPE_5F_INT();
-    WORD_ATOM(1079, 30, "T1");
+    WORD_ATOM(1092, 30, "T1");
     mw_T1();
-    WORD_ATOM(1079, 33, "swap");
+    WORD_ATOM(1092, 33, "swap");
     mw_prim_swap();
-    WORD_ATOM(1079, 38, "T->");
+    WORD_ATOM(1092, 38, "T->");
     mw_T__3E_();
-    WORD_ATOM(1080, 5, "ready2");
+    WORD_ATOM(1093, 5, "ready2");
     mw_ready2();
-    WORD_ATOM(1080, 12, "over");
+    WORD_ATOM(1093, 12, "over");
     mw_over();
-    WORD_ATOM(1080, 17, "~ctx-type");
+    WORD_ATOM(1093, 17, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(1080, 27, "!");
+    WORD_ATOM(1093, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1082, 5, "ab-build-word!");
+    WORD_ATOM(1095, 5, "ab-build-word!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__4);
     mw_prim_pack_cons();
     mw_ab_build_word_21_();
-    WORD_ATOM(1085, 7, "drop");
+    WORD_ATOM(1098, 7, "drop");
     mw_prim_drop();
-    WORD_ATOM(1088, 5, "dup");
+    WORD_ATOM(1101, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1088, 9, "");
+    WORD_ATOM(1101, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23309,40 +23526,40 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1088, 17, "table-word-new!");
+    WORD_ATOM(1101, 17, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1090, 5, "L0");
+    WORD_ATOM(1103, 5, "L0");
     mw_L0();
-    WORD_ATOM(1090, 8, "CTX");
+    WORD_ATOM(1103, 8, "CTX");
     mw_CTX();
-    WORD_ATOM(1091, 5, "over2");
+    WORD_ATOM(1104, 5, "over2");
     mw_over2();
-    WORD_ATOM(1091, 11, "TTable");
+    WORD_ATOM(1104, 11, "TTable");
     mw_TTable();
-    WORD_ATOM(1091, 18, "T1");
+    WORD_ATOM(1104, 18, "T1");
     mw_T1();
-    WORD_ATOM(1091, 21, "dup");
+    WORD_ATOM(1104, 21, "dup");
     mw_prim_dup();
-    WORD_ATOM(1091, 25, "T->");
+    WORD_ATOM(1104, 25, "T->");
     mw_T__3E_();
-    WORD_ATOM(1092, 5, "ready2");
+    WORD_ATOM(1105, 5, "ready2");
     mw_ready2();
-    WORD_ATOM(1092, 12, "over");
+    WORD_ATOM(1105, 12, "over");
     mw_over();
-    WORD_ATOM(1092, 17, "~ctx-type");
+    WORD_ATOM(1105, 17, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(1092, 27, "!");
+    WORD_ATOM(1105, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1094, 5, "ab-build-word!");
+    WORD_ATOM(1107, 5, "ab-build-word!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__5);
     mw_prim_pack_cons();
     mw_ab_build_word_21_();
-    WORD_ATOM(1106, 7, "drop");
+    WORD_ATOM(1119, 7, "drop");
     mw_prim_drop();
-    WORD_ATOM(1109, 5, "dup");
+    WORD_ATOM(1122, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1109, 9, "");
+    WORD_ATOM(1122, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23353,40 +23570,40 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1109, 17, "table-word-new!");
+    WORD_ATOM(1122, 17, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1111, 5, "L0");
+    WORD_ATOM(1124, 5, "L0");
     mw_L0();
-    WORD_ATOM(1111, 8, "CTX");
+    WORD_ATOM(1124, 8, "CTX");
     mw_CTX();
-    WORD_ATOM(1112, 5, "over2");
+    WORD_ATOM(1125, 5, "over2");
     mw_over2();
-    WORD_ATOM(1112, 11, "TTable");
+    WORD_ATOM(1125, 11, "TTable");
     mw_TTable();
-    WORD_ATOM(1112, 18, "T1");
+    WORD_ATOM(1125, 18, "T1");
     mw_T1();
-    WORD_ATOM(1112, 21, "dup");
+    WORD_ATOM(1125, 21, "dup");
     mw_prim_dup();
-    WORD_ATOM(1112, 25, "T->");
+    WORD_ATOM(1125, 25, "T->");
     mw_T__3E_();
-    WORD_ATOM(1113, 5, "ready2");
+    WORD_ATOM(1126, 5, "ready2");
     mw_ready2();
-    WORD_ATOM(1113, 12, "over");
+    WORD_ATOM(1126, 12, "over");
     mw_over();
-    WORD_ATOM(1113, 17, "~ctx-type");
+    WORD_ATOM(1126, 17, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(1113, 27, "!");
+    WORD_ATOM(1126, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1115, 5, "ab-build-word!");
+    WORD_ATOM(1128, 5, "ab-build-word!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__6);
     mw_prim_pack_cons();
     mw_ab_build_word_21_();
-    WORD_ATOM(1127, 7, "drop");
+    WORD_ATOM(1140, 7, "drop");
     mw_prim_drop();
-    WORD_ATOM(1131, 5, "dup");
+    WORD_ATOM(1144, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1131, 9, "");
+    WORD_ATOM(1144, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23397,11 +23614,11 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1131, 16, "table-word-new!");
+    WORD_ATOM(1144, 16, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1132, 5, "TYPE_STACK");
+    WORD_ATOM(1145, 5, "TYPE_STACK");
     mw_TYPE_5F_STACK();
-    WORD_ATOM(1132, 16, "");
+    WORD_ATOM(1145, 16, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23412,38 +23629,38 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1132, 21, ">Name");
+    WORD_ATOM(1145, 21, ">Name");
     mw_Str_3E_Name();
-    WORD_ATOM(1132, 27, "Var.new!");
+    WORD_ATOM(1145, 27, "Var.new!");
     mw_Var_2E_new_21_();
-    WORD_ATOM(1132, 36, "dup");
+    WORD_ATOM(1145, 36, "dup");
     mw_prim_dup();
-    WORD_ATOM(1132, 40, "STVar");
+    WORD_ATOM(1145, 40, "STVar");
     mw_STVar();
-    WORD_ATOM(1133, 5, "\\");
+    WORD_ATOM(1146, 5, "\\");
     {
         VAL var_a = pop_value();
         VAL var_va = pop_value();
         VAL var_w = pop_value();
         VAL var_t = pop_value();
-        WORD_ATOM(1133, 19, "a");
+        WORD_ATOM(1146, 19, "a");
         incref(var_a);
         push_value(var_a);
-        WORD_ATOM(1133, 21, "t");
+        WORD_ATOM(1146, 21, "t");
         incref(var_t);
         push_value(var_t);
-        WORD_ATOM(1133, 23, "TTable");
+        WORD_ATOM(1146, 23, "TTable");
         mw_TTable();
-        WORD_ATOM(1133, 30, "T*");
+        WORD_ATOM(1146, 30, "T*");
         mw_T_2A_();
-        WORD_ATOM(1133, 33, "a");
+        WORD_ATOM(1146, 33, "a");
         incref(var_a);
         push_value(var_a);
-        WORD_ATOM(1133, 35, "T->");
+        WORD_ATOM(1146, 35, "T->");
         mw_T__3E_();
-        WORD_ATOM(1133, 39, ">Type");
+        WORD_ATOM(1146, 39, ">Type");
         mw_ArrowType_3E_Type();
-        WORD_ATOM(1133, 45, "");
+        WORD_ATOM(1146, 45, "");
         {
             static bool vready = false;
             static VAL v;
@@ -23454,58 +23671,58 @@ static void mw_table_new_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(1133, 49, ">Name");
+        WORD_ATOM(1146, 49, ">Name");
         mw_Str_3E_Name();
-        WORD_ATOM(1133, 55, "Var.new-auto-run!");
+        WORD_ATOM(1146, 55, "Var.new-auto-run!");
         mw_Var_2E_new_auto_run_21_();
-        WORD_ATOM(1134, 5, "\\");
+        WORD_ATOM(1147, 5, "\\");
         {
             VAL var_x = pop_value();
-            WORD_ATOM(1135, 9, "va");
+            WORD_ATOM(1148, 9, "va");
             incref(var_va);
             push_value(var_va);
-            WORD_ATOM(1135, 12, "CTX1");
+            WORD_ATOM(1148, 12, "CTX1");
             mw_CTX1();
-            WORD_ATOM(1136, 9, "a");
+            WORD_ATOM(1149, 9, "a");
             incref(var_a);
             push_value(var_a);
-            WORD_ATOM(1136, 11, "a");
+            WORD_ATOM(1149, 11, "a");
             incref(var_a);
             push_value(var_a);
-            WORD_ATOM(1136, 13, "t");
+            WORD_ATOM(1149, 13, "t");
             incref(var_t);
             push_value(var_t);
-            WORD_ATOM(1136, 15, "TTable");
+            WORD_ATOM(1149, 15, "TTable");
             mw_TTable();
-            WORD_ATOM(1136, 22, "T*");
+            WORD_ATOM(1149, 22, "T*");
             mw_T_2A_();
-            WORD_ATOM(1136, 25, "a");
+            WORD_ATOM(1149, 25, "a");
             incref(var_a);
             push_value(var_a);
-            WORD_ATOM(1136, 27, "T->");
+            WORD_ATOM(1149, 27, "T->");
             mw_T__3E_();
-            WORD_ATOM(1136, 31, ">Type");
+            WORD_ATOM(1149, 31, ">Type");
             mw_ArrowType_3E_Type();
-            WORD_ATOM(1136, 37, "T*");
+            WORD_ATOM(1149, 37, "T*");
             mw_T_2A_();
-            WORD_ATOM(1136, 40, "a");
+            WORD_ATOM(1149, 40, "a");
             incref(var_a);
             push_value(var_a);
-            WORD_ATOM(1136, 42, "T->");
+            WORD_ATOM(1149, 42, "T->");
             mw_T__3E_();
-            WORD_ATOM(1137, 9, "ready2");
+            WORD_ATOM(1150, 9, "ready2");
             mw_ready2();
-            WORD_ATOM(1137, 16, "w");
+            WORD_ATOM(1150, 16, "w");
             incref(var_w);
             push_value(var_w);
-            WORD_ATOM(1137, 18, "~ctx-type");
+            WORD_ATOM(1150, 18, "~ctx-type");
             mw_Word_7E_ctx_type();
-            WORD_ATOM(1137, 28, "!");
+            WORD_ATOM(1150, 28, "!");
             mw_prim_mut_set();
-            WORD_ATOM(1139, 9, "w");
+            WORD_ATOM(1152, 9, "w");
             incref(var_w);
             push_value(var_w);
-            WORD_ATOM(1139, 11, "ab-build-word!");
+            WORD_ATOM(1152, 11, "ab-build-word!");
             push_u64(0);
             incref(var_a);
             push_value(var_a);
@@ -23525,9 +23742,9 @@ static void mw_table_new_21_ (void){
             push_fnptr(&mb_table_new_21__11);
             mw_prim_pack_cons();
             mw_ab_build_word_21_();
-            WORD_ATOM(1162, 11, "drop");
+            WORD_ATOM(1175, 11, "drop");
             mw_prim_drop();
-            WORD_ATOM(1164, 5, "t");
+            WORD_ATOM(1177, 5, "t");
             incref(var_t);
             push_value(var_t);
             decref(var_x);
@@ -23537,9 +23754,9 @@ static void mw_table_new_21_ (void){
         decref(var_w);
         decref(var_t);
     }
-    WORD_ATOM(1167, 5, "dup");
+    WORD_ATOM(1180, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1167, 9, "");
+    WORD_ATOM(1180, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23550,68 +23767,68 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1167, 19, "table-word-new!");
+    WORD_ATOM(1180, 19, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1169, 5, "L0");
+    WORD_ATOM(1182, 5, "L0");
     mw_L0();
-    WORD_ATOM(1169, 8, "CTX");
+    WORD_ATOM(1182, 8, "CTX");
     mw_CTX();
-    WORD_ATOM(1170, 5, "T0");
+    WORD_ATOM(1183, 5, "T0");
     mw_T0();
-    WORD_ATOM(1170, 8, "over3");
+    WORD_ATOM(1183, 8, "over3");
     mw_over3();
-    WORD_ATOM(1170, 14, "TTable");
+    WORD_ATOM(1183, 14, "TTable");
     mw_TTable();
-    WORD_ATOM(1170, 21, "T1");
+    WORD_ATOM(1183, 21, "T1");
     mw_T1();
-    WORD_ATOM(1170, 24, "T->");
+    WORD_ATOM(1183, 24, "T->");
     mw_T__3E_();
-    WORD_ATOM(1171, 5, "ready2");
+    WORD_ATOM(1184, 5, "ready2");
     mw_ready2();
-    WORD_ATOM(1171, 12, "over");
+    WORD_ATOM(1184, 12, "over");
     mw_over();
-    WORD_ATOM(1171, 17, "~ctx-type");
+    WORD_ATOM(1184, 17, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(1171, 27, "!");
+    WORD_ATOM(1184, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1173, 5, "ab-build-word!");
+    WORD_ATOM(1186, 5, "ab-build-word!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__16);
     mw_prim_pack_cons();
     mw_ab_build_word_21_();
-    WORD_ATOM(1186, 5, "drop");
+    WORD_ATOM(1199, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_table_new_21_);
 }
 static void mw_elab_field_21_ (void){
-    WORD_ENTER(mw_elab_field_21_, "elab-field!", "src/mirth/elab.mth", 1195, 5);
-    WORD_ATOM(1195, 5, "sip");
+    WORD_ENTER(mw_elab_field_21_, "elab-field!", "src/mirth/elab.mth", 1208, 5);
+    WORD_ATOM(1208, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_field_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(1195, 15, "args-3");
+    WORD_ATOM(1208, 15, "args-3");
     mw_Token_2E_args_3();
-    WORD_ATOM(1195, 22, "rotl");
+    WORD_ATOM(1208, 22, "rotl");
     mw_rotl();
-    WORD_ATOM(1195, 27, "dup");
+    WORD_ATOM(1208, 27, "dup");
     mw_prim_dup();
-    WORD_ATOM(1195, 31, "value");
+    WORD_ATOM(1208, 31, "value");
     mw_Token_2E_value();
-    WORD_ATOM(1195, 37, "match");
+    WORD_ATOM(1208, 37, "match");
     switch (get_top_data_tag()) {
         case 13LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(1197, 13, "name-undefined?");
+            WORD_ATOM(1210, 13, "name-undefined?");
             mw_name_undefined_3F_();
-            WORD_ATOM(1197, 29, "if");
+            WORD_ATOM(1210, 29, "if");
             if (pop_u64()) {
-                WORD_ATOM(1197, 32, "id");
+                WORD_ATOM(1210, 32, "id");
                 mw_prim_id();
             } else {
-                WORD_ATOM(1198, 17, "drop");
+                WORD_ATOM(1211, 17, "drop");
                 mw_prim_drop();
-                WORD_ATOM(1198, 22, "");
+                WORD_ATOM(1211, 22, "");
                 {
                     static bool vready = false;
                     static VAL v;
@@ -23622,18 +23839,18 @@ static void mw_elab_field_21_ (void){
                     push_value(v);
                     incref(v);
                 }
-                WORD_ATOM(1198, 45, "emit-fatal-error!");
+                WORD_ATOM(1211, 45, "emit-fatal-error!");
                 mw_emit_fatal_error_21_();
             }
-            WORD_ATOM(1199, 13, "field-new!");
+            WORD_ATOM(1212, 13, "field-new!");
             mw_field_new_21_();
-            WORD_ATOM(1199, 24, "drop");
+            WORD_ATOM(1212, 24, "drop");
             mw_prim_drop();
             break;
         default:
-            WORD_ATOM(1201, 13, "drop");
+            WORD_ATOM(1214, 13, "drop");
             mw_prim_drop();
-            WORD_ATOM(1201, 18, "");
+            WORD_ATOM(1214, 18, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -23644,63 +23861,63 @@ static void mw_elab_field_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(1201, 40, "emit-fatal-error!");
+            WORD_ATOM(1214, 40, "emit-fatal-error!");
             mw_emit_fatal_error_21_();
             break;
     
 }    WORD_EXIT(mw_elab_field_21_);
 }
 static void mw_field_new_21_ (void){
-    WORD_ENTER(mw_field_new_21_, "field-new!", "src/mirth/elab.mth", 1205, 5);
-    WORD_ATOM(1205, 5, "Field.alloc!");
+    WORD_ENTER(mw_field_new_21_, "field-new!", "src/mirth/elab.mth", 1218, 5);
+    WORD_ATOM(1218, 5, "Field.alloc!");
     mw_Field_2E_alloc_21_();
-    WORD_ATOM(1206, 5, "tuck");
+    WORD_ATOM(1219, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(1206, 10, "dup2");
+    WORD_ATOM(1219, 10, "dup2");
     mw_dup2();
-    WORD_ATOM(1206, 15, "~name");
+    WORD_ATOM(1219, 15, "~name");
     mw_Field_7E_name();
-    WORD_ATOM(1206, 21, "!");
+    WORD_ATOM(1219, 21, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1207, 5, "DEF_FIELD");
+    WORD_ATOM(1220, 5, "DEF_FIELD");
     mw_DEF_5F_FIELD();
-    WORD_ATOM(1207, 15, "swap");
+    WORD_ATOM(1220, 15, "swap");
     mw_prim_swap();
-    WORD_ATOM(1207, 20, "~Def");
+    WORD_ATOM(1220, 20, "~Def");
     mw_Name_7E_Def();
-    WORD_ATOM(1207, 25, "!");
+    WORD_ATOM(1220, 25, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1208, 5, "tuck");
+    WORD_ATOM(1221, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(1208, 10, "~head");
+    WORD_ATOM(1221, 10, "~head");
     mw_Field_7E_head();
-    WORD_ATOM(1208, 16, "!");
+    WORD_ATOM(1221, 16, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1209, 5, "swap");
+    WORD_ATOM(1222, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(1209, 10, "delay");
+    WORD_ATOM(1222, 10, "delay");
     push_u64(0);
     push_fnptr(&mb_field_new_21__1);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(1209, 39, "over");
+    WORD_ATOM(1222, 39, "over");
     mw_over();
-    WORD_ATOM(1209, 44, "~value-type");
+    WORD_ATOM(1222, 44, "~value-type");
     mw_Field_7E_value_type();
-    WORD_ATOM(1209, 56, "!");
+    WORD_ATOM(1222, 56, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1210, 5, "swap");
+    WORD_ATOM(1223, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(1210, 10, "delay");
+    WORD_ATOM(1223, 10, "delay");
     push_u64(0);
     push_fnptr(&mb_field_new_21__2);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(1210, 39, "over");
+    WORD_ATOM(1223, 39, "over");
     mw_over();
-    WORD_ATOM(1210, 44, "~index-type");
+    WORD_ATOM(1223, 44, "~index-type");
     mw_Field_7E_index_type();
-    WORD_ATOM(1210, 56, "!");
+    WORD_ATOM(1223, 56, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_field_new_21_);
 }
@@ -24269,55 +24486,55 @@ static void mw_block_unify_type_21_ (void){
     WORD_EXIT(mw_block_unify_type_21_);
 }
 static void mw_PrimType_2E_is_physical_3F_ (void){
-    WORD_ENTER(mw_PrimType_2E_is_physical_3F_, "PrimType.is-physical?", "src/mirth/data/type.mth", 49, 5);
-    WORD_ATOM(49, 5, "PRIM_TYPE_TYPE");
+    WORD_ENTER(mw_PrimType_2E_is_physical_3F_, "PrimType.is-physical?", "src/mirth/data/type.mth", 51, 5);
+    WORD_ATOM(51, 5, "PRIM_TYPE_TYPE");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(49, 23, "F");
+            WORD_ATOM(51, 23, "F");
             mw_F();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(50, 24, "F");
+            WORD_ATOM(52, 24, "F");
             mw_F();
             break;
         case 2LL:
             mw_prim_drop();
-            WORD_ATOM(51, 27, "F");
+            WORD_ATOM(53, 27, "F");
             mw_F();
             break;
         default:
-            WORD_ATOM(52, 10, "drop");
+            WORD_ATOM(54, 10, "drop");
             mw_prim_drop();
-            WORD_ATOM(52, 15, "T");
+            WORD_ATOM(54, 15, "T");
             mw_T();
             break;
     
 }    WORD_EXIT(mw_PrimType_2E_is_physical_3F_);
 }
 static void mw_Type_2E_tycon_name (void){
-    WORD_ENTER(mw_Type_2E_tycon_name, "Type.tycon-name", "src/mirth/data/type.mth", 56, 5);
-    WORD_ATOM(56, 5, "TYPE_ERROR");
+    WORD_ENTER(mw_Type_2E_tycon_name, "Type.tycon-name", "src/mirth/data/type.mth", 58, 5);
+    WORD_ATOM(58, 5, "TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(56, 19, "NONE");
+            WORD_ATOM(58, 19, "NONE");
             mw_NONE();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(57, 23, "NONE");
+            WORD_ATOM(59, 23, "NONE");
             mw_NONE();
             break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(58, 14, "tycon-name");
+            WORD_ATOM(60, 14, "tycon-name");
             mw_PrimType_2E_tycon_name();
             break;
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(59, 14, "expand-if");
+            WORD_ATOM(61, 14, "expand-if");
             push_u64(0);
             push_fnptr(&mb_Type_2E_tycon_name_5);
             mw_prim_pack_cons();
@@ -24328,62 +24545,62 @@ static void mw_Type_2E_tycon_name (void){
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(60, 14, "drop");
+            WORD_ATOM(62, 14, "drop");
             mw_prim_drop();
-            WORD_ATOM(60, 19, "NONE");
+            WORD_ATOM(62, 19, "NONE");
             mw_NONE();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(61, 13, "drop");
+            WORD_ATOM(63, 13, "drop");
             mw_prim_drop();
-            WORD_ATOM(61, 18, "NONE");
+            WORD_ATOM(63, 18, "NONE");
             mw_NONE();
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(62, 15, "name");
+            WORD_ATOM(64, 15, "name");
             mw_Table_2E_name();
-            WORD_ATOM(62, 20, "SOME");
+            WORD_ATOM(64, 20, "SOME");
             mw_SOME();
             break;
         case 7LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(63, 14, "name");
+            WORD_ATOM(65, 14, "name");
             mw_Data_2E_name();
-            WORD_ATOM(63, 19, "SOME");
+            WORD_ATOM(65, 19, "SOME");
             mw_SOME();
             break;
         case 9LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(64, 18, "drop");
+            WORD_ATOM(66, 18, "drop");
             mw_prim_drop();
-            WORD_ATOM(64, 23, "NONE");
+            WORD_ATOM(66, 23, "NONE");
             mw_NONE();
             break;
         case 8LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(65, 16, "drop");
+            WORD_ATOM(67, 16, "drop");
             mw_prim_drop();
-            WORD_ATOM(65, 21, "NONE");
+            WORD_ATOM(67, 21, "NONE");
             mw_NONE();
             break;
         case 10LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(66, 13, "drop");
+            WORD_ATOM(68, 13, "drop");
             mw_prim_drop();
-            WORD_ATOM(66, 18, "tycon-name");
+            WORD_ATOM(68, 18, "tycon-name");
             mw_Type_2E_tycon_name();
             break;
         case 11LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(67, 13, "tycon-name");
+            WORD_ATOM(69, 13, "tycon-name");
             mw_Type_2E_tycon_name();
             break;
         case 12LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(68, 15, "tycon-name");
+            WORD_ATOM(70, 15, "tycon-name");
             mw_Value_2E_tycon_name();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -24391,68 +24608,32 @@ static void mw_Type_2E_tycon_name (void){
 }    WORD_EXIT(mw_Type_2E_tycon_name);
 }
 static void mw_PrimType_2E_tycon_name (void){
-    WORD_ENTER(mw_PrimType_2E_tycon_name, "PrimType.tycon-name", "src/mirth/data/type.mth", 72, 5);
-    WORD_ATOM(72, 5, "PRIM_TYPE_TYPE");
+    WORD_ENTER(mw_PrimType_2E_tycon_name, "PrimType.tycon-name", "src/mirth/data/type.mth", 74, 5);
+    WORD_ATOM(74, 5, "PRIM_TYPE_TYPE");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(72, 23, "NONE");
+            WORD_ATOM(74, 23, "NONE");
             mw_NONE();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(73, 24, "NONE");
+            WORD_ATOM(75, 24, "NONE");
             mw_NONE();
             break;
         case 2LL:
             mw_prim_drop();
-            WORD_ATOM(74, 27, "NONE");
+            WORD_ATOM(76, 27, "NONE");
             mw_NONE();
             break;
         case 3LL:
-            mw_prim_drop();
-            WORD_ATOM(75, 22, "");
-            {
-                static bool vready = false;
-                static VAL v;
-                if (! vready) {
-                    v = mkstr("Int", 3);
-                    vready = true;
-                }
-                push_value(v);
-                incref(v);
-            }
-            WORD_ATOM(75, 28, ">Name");
-            mw_Str_3E_Name();
-            WORD_ATOM(75, 34, "SOME");
-            mw_SOME();
-            break;
-        case 5LL:
-            mw_prim_drop();
-            WORD_ATOM(76, 22, "");
-            {
-                static bool vready = false;
-                static VAL v;
-                if (! vready) {
-                    v = mkstr("Str", 3);
-                    vready = true;
-                }
-                push_value(v);
-                incref(v);
-            }
-            WORD_ATOM(76, 28, ">Name");
-            mw_Str_3E_Name();
-            WORD_ATOM(76, 34, "SOME");
-            mw_SOME();
-            break;
-        case 4LL:
             mw_prim_drop();
             WORD_ATOM(77, 22, "");
             {
                 static bool vready = false;
                 static VAL v;
                 if (! vready) {
-                    v = mkstr("Ptr", 3);
+                    v = mkstr("Int", 3);
                     vready = true;
                 }
                 push_value(v);
@@ -24463,39 +24644,9 @@ static void mw_PrimType_2E_tycon_name (void){
             WORD_ATOM(77, 34, "SOME");
             mw_SOME();
             break;
-        default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
-    
-}    WORD_EXIT(mw_PrimType_2E_tycon_name);
-}
-static void mw_Value_2E_tycon_name (void){
-    WORD_ENTER(mw_Value_2E_tycon_name, "Value.tycon-name", "src/mirth/data/type.mth", 81, 5);
-    WORD_ATOM(81, 5, "VALUE_INT");
-    switch (get_top_data_tag()) {
-        case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(81, 18, "drop");
+        case 5LL:
             mw_prim_drop();
-            WORD_ATOM(81, 23, "");
-            {
-                static bool vready = false;
-                static VAL v;
-                if (! vready) {
-                    v = mkstr("Int", 3);
-                    vready = true;
-                }
-                push_value(v);
-                incref(v);
-            }
-            WORD_ATOM(81, 29, ">Name");
-            mw_Str_3E_Name();
-            WORD_ATOM(81, 35, "SOME");
-            mw_SOME();
-            break;
-        case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(82, 18, "drop");
-            mw_prim_drop();
-            WORD_ATOM(82, 23, "");
+            WORD_ATOM(78, 22, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -24506,16 +24657,100 @@ static void mw_Value_2E_tycon_name (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(82, 29, ">Name");
+            WORD_ATOM(78, 28, ">Name");
             mw_Str_3E_Name();
-            WORD_ATOM(82, 35, "SOME");
+            WORD_ATOM(78, 34, "SOME");
+            mw_SOME();
+            break;
+        case 4LL:
+            mw_prim_drop();
+            WORD_ATOM(79, 22, "");
+            {
+                static bool vready = false;
+                static VAL v;
+                if (! vready) {
+                    v = mkstr("Ptr", 3);
+                    vready = true;
+                }
+                push_value(v);
+                incref(v);
+            }
+            WORD_ATOM(79, 28, ">Name");
+            mw_Str_3E_Name();
+            WORD_ATOM(79, 34, "SOME");
+            mw_SOME();
+            break;
+        case 6LL:
+            mw_prim_drop();
+            WORD_ATOM(80, 28, "");
+            {
+                static bool vready = false;
+                static VAL v;
+                if (! vready) {
+                    v = mkstr("+Platform", 9);
+                    vready = true;
+                }
+                push_value(v);
+                incref(v);
+            }
+            WORD_ATOM(80, 40, ">Name");
+            mw_Str_3E_Name();
+            WORD_ATOM(80, 46, "SOME");
+            mw_SOME();
+            break;
+        default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
+    
+}    WORD_EXIT(mw_PrimType_2E_tycon_name);
+}
+static void mw_Value_2E_tycon_name (void){
+    WORD_ENTER(mw_Value_2E_tycon_name, "Value.tycon-name", "src/mirth/data/type.mth", 84, 5);
+    WORD_ATOM(84, 5, "VALUE_INT");
+    switch (get_top_data_tag()) {
+        case 0LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(84, 18, "drop");
+            mw_prim_drop();
+            WORD_ATOM(84, 23, "");
+            {
+                static bool vready = false;
+                static VAL v;
+                if (! vready) {
+                    v = mkstr("Int", 3);
+                    vready = true;
+                }
+                push_value(v);
+                incref(v);
+            }
+            WORD_ATOM(84, 29, ">Name");
+            mw_Str_3E_Name();
+            WORD_ATOM(84, 35, "SOME");
+            mw_SOME();
+            break;
+        case 1LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(85, 18, "drop");
+            mw_prim_drop();
+            WORD_ATOM(85, 23, "");
+            {
+                static bool vready = false;
+                static VAL v;
+                if (! vready) {
+                    v = mkstr("Str", 3);
+                    vready = true;
+                }
+                push_value(v);
+                incref(v);
+            }
+            WORD_ATOM(85, 29, ">Name");
+            mw_Str_3E_Name();
+            WORD_ATOM(85, 35, "SOME");
             mw_SOME();
             break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(83, 20, "drop");
+            WORD_ATOM(86, 20, "drop");
             mw_prim_drop();
-            WORD_ATOM(83, 25, "NONE");
+            WORD_ATOM(86, 25, "NONE");
             mw_NONE();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -24523,44 +24758,44 @@ static void mw_Value_2E_tycon_name (void){
 }    WORD_EXIT(mw_Value_2E_tycon_name);
 }
 static void mw_PrimType_3E_Int (void){
-    WORD_ENTER(mw_PrimType_3E_Int, "PrimType>Int", "src/mirth/data/type.mth", 85, 36);
-    WORD_ATOM(85, 36, "prim-unsafe-cast");
+    WORD_ENTER(mw_PrimType_3E_Int, "PrimType>Int", "src/mirth/data/type.mth", 88, 36);
+    WORD_ATOM(88, 36, "prim-unsafe-cast");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_PrimType_3E_Int);
 }
 static void mw_PrimType_3D_ (void){
-    WORD_ENTER(mw_PrimType_3D_, "PrimType=", "src/mirth/data/type.mth", 86, 43);
-    WORD_ATOM(86, 43, "both");
+    WORD_ENTER(mw_PrimType_3D_, "PrimType=", "src/mirth/data/type.mth", 89, 43);
+    WORD_ATOM(89, 43, "both");
     push_u64(0);
     push_fnptr(&mb_PrimType_3D__1);
     mw_prim_pack_cons();
     mw_both();
-    WORD_ATOM(86, 54, "=");
+    WORD_ATOM(89, 54, "=");
     mw_prim_int_eq();
     WORD_EXIT(mw_PrimType_3D_);
 }
 static void mw_def_type_21_ (void){
-    WORD_ENTER(mw_def_type_21_, "def-type!", "src/mirth/data/type.mth", 88, 29);
-    WORD_ATOM(88, 29, "dip");
+    WORD_ENTER(mw_def_type_21_, "def-type!", "src/mirth/data/type.mth", 91, 29);
+    WORD_ATOM(91, 29, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(88, 33, "DEF_TYPE");
+        WORD_ATOM(91, 33, "DEF_TYPE");
         mw_DEF_5F_TYPE();
         push_value(d2);
     }
-    WORD_ATOM(88, 43, ">Name");
+    WORD_ATOM(91, 43, ">Name");
     mw_Str_3E_Name();
-    WORD_ATOM(88, 49, "~Def");
+    WORD_ATOM(91, 49, "~Def");
     mw_Name_7E_Def();
-    WORD_ATOM(88, 54, "!");
+    WORD_ATOM(91, 54, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_def_type_21_);
 }
 static void mw_init_types_21_ (void){
-    WORD_ENTER(mw_init_types_21_, "init-types!", "src/mirth/data/type.mth", 91, 5);
-    WORD_ATOM(91, 5, "TYPE_INT");
+    WORD_ENTER(mw_init_types_21_, "init-types!", "src/mirth/data/type.mth", 94, 5);
+    WORD_ATOM(94, 5, "TYPE_INT");
     mw_TYPE_5F_INT();
-    WORD_ATOM(91, 14, "");
+    WORD_ATOM(94, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -24571,11 +24806,11 @@ static void mw_init_types_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(91, 20, "def-type!");
+    WORD_ATOM(94, 20, "def-type!");
     mw_def_type_21_();
-    WORD_ATOM(92, 5, "TYPE_PTR");
+    WORD_ATOM(95, 5, "TYPE_PTR");
     mw_TYPE_5F_PTR();
-    WORD_ATOM(92, 14, "");
+    WORD_ATOM(95, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -24586,11 +24821,11 @@ static void mw_init_types_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(92, 20, "def-type!");
+    WORD_ATOM(95, 20, "def-type!");
     mw_def_type_21_();
-    WORD_ATOM(93, 5, "TYPE_STR");
+    WORD_ATOM(96, 5, "TYPE_STR");
     mw_TYPE_5F_STR();
-    WORD_ATOM(93, 14, "");
+    WORD_ATOM(96, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -24601,36 +24836,51 @@ static void mw_init_types_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(93, 20, "def-type!");
+    WORD_ATOM(96, 20, "def-type!");
     mw_def_type_21_();
-    WORD_ATOM(94, 5, "init-data!");
+    WORD_ATOM(97, 5, "TYPE_+PLATFORM");
+    mw_TYPE_5F__2B_PLATFORM();
+    WORD_ATOM(97, 20, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("+Platform", 9);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(97, 32, "def-type!");
+    mw_def_type_21_();
+    WORD_ATOM(98, 5, "init-data!");
     mw_init_data_21_();
     WORD_EXIT(mw_init_types_21_);
 }
 static void mw_T_2B_ (void){
-    WORD_ENTER(mw_T_2B_, "T+", "src/mirth/data/type.mth", 100, 42);
-    WORD_ATOM(100, 42, "STWith");
+    WORD_ENTER(mw_T_2B_, "T+", "src/mirth/data/type.mth", 104, 42);
+    WORD_ATOM(104, 42, "STWith");
     mw_STWith();
     WORD_EXIT(mw_T_2B_);
 }
 static void mw_T_2A_ (void){
-    WORD_ENTER(mw_T_2A_, "T*", "src/mirth/data/type.mth", 101, 38);
-    WORD_ATOM(101, 38, "STCons");
+    WORD_ENTER(mw_T_2A_, "T*", "src/mirth/data/type.mth", 105, 38);
+    WORD_ATOM(105, 38, "STCons");
     mw_STCons();
     WORD_EXIT(mw_T_2A_);
 }
 static void mw_T_2A__2B_ (void){
-    WORD_ENTER(mw_T_2A__2B_, "T*+", "src/mirth/data/type.mth", 102, 57);
-    WORD_ATOM(102, 57, "match");
+    WORD_ENTER(mw_T_2A__2B_, "T*+", "src/mirth/data/type.mth", 106, 57);
+    WORD_ATOM(106, 57, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(102, 71, "T*");
+            WORD_ATOM(106, 71, "T*");
             mw_T_2A_();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(102, 84, "T+");
+            WORD_ATOM(106, 84, "T+");
             mw_T_2B_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -24638,18 +24888,18 @@ static void mw_T_2A__2B_ (void){
 }    WORD_EXIT(mw_T_2A__2B_);
 }
 static void mw_T__3E_ (void){
-    WORD_ENTER(mw_T__3E_, "T->", "src/mirth/data/type.mth", 103, 44);
-    WORD_ATOM(103, 44, "ARROW_TYPE");
+    WORD_ENTER(mw_T__3E_, "T->", "src/mirth/data/type.mth", 107, 44);
+    WORD_ATOM(107, 44, "ARROW_TYPE");
     mw_ARROW_5F_TYPE();
     WORD_EXIT(mw_T__3E_);
 }
 static void mw_TT (void){
-    WORD_ENTER(mw_TT, "TT", "src/mirth/data/type.mth", 105, 34);
-    WORD_ATOM(105, 34, "T0");
+    WORD_ENTER(mw_TT, "TT", "src/mirth/data/type.mth", 109, 34);
+    WORD_ATOM(109, 34, "T0");
     mw_T0();
-    WORD_ATOM(105, 37, "swap");
+    WORD_ATOM(109, 37, "swap");
     mw_prim_swap();
-    WORD_ATOM(105, 42, "for");
+    WORD_ATOM(109, 42, "for");
     push_u64(0);
     push_fnptr(&mb_TT_1);
     mw_prim_pack_cons();
@@ -24657,154 +24907,154 @@ static void mw_TT (void){
     WORD_EXIT(mw_TT);
 }
 static void mw_T0 (void){
-    WORD_ENTER(mw_T0, "T0", "src/mirth/data/type.mth", 106, 20);
-    WORD_ATOM(106, 20, "STACK_TYPE_UNIT");
+    WORD_ENTER(mw_T0, "T0", "src/mirth/data/type.mth", 110, 20);
+    WORD_ATOM(110, 20, "STACK_TYPE_UNIT");
     mw_STACK_5F_TYPE_5F_UNIT();
     WORD_EXIT(mw_T0);
 }
 static void mw_T1 (void){
-    WORD_ENTER(mw_T1, "T1", "src/mirth/data/type.mth", 107, 28);
-    WORD_ATOM(107, 28, "dip");
+    WORD_ENTER(mw_T1, "T1", "src/mirth/data/type.mth", 111, 28);
+    WORD_ATOM(111, 28, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(107, 32, "T0");
+        WORD_ATOM(111, 32, "T0");
         mw_T0();
         push_value(d2);
     }
-    WORD_ATOM(107, 36, "T*");
+    WORD_ATOM(111, 36, "T*");
     mw_T_2A_();
     WORD_EXIT(mw_T1);
 }
 static void mw_T2 (void){
-    WORD_ENTER(mw_T2, "T2", "src/mirth/data/type.mth", 108, 33);
-    WORD_ATOM(108, 33, "dip");
+    WORD_ENTER(mw_T2, "T2", "src/mirth/data/type.mth", 112, 33);
+    WORD_ATOM(112, 33, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(108, 37, "T1");
+        WORD_ATOM(112, 37, "T1");
         mw_T1();
         push_value(d2);
     }
-    WORD_ATOM(108, 41, "T*");
+    WORD_ATOM(112, 41, "T*");
     mw_T_2A_();
     WORD_EXIT(mw_T2);
 }
 static void mw_T3 (void){
-    WORD_ENTER(mw_T3, "T3", "src/mirth/data/type.mth", 109, 38);
-    WORD_ATOM(109, 38, "dip");
+    WORD_ENTER(mw_T3, "T3", "src/mirth/data/type.mth", 113, 38);
+    WORD_ATOM(113, 38, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(109, 42, "T2");
+        WORD_ATOM(113, 42, "T2");
         mw_T2();
         push_value(d2);
     }
-    WORD_ATOM(109, 46, "T*");
+    WORD_ATOM(113, 46, "T*");
     mw_T_2A_();
     WORD_EXIT(mw_T3);
 }
 static void mw_T4 (void){
-    WORD_ENTER(mw_T4, "T4", "src/mirth/data/type.mth", 110, 43);
-    WORD_ATOM(110, 43, "dip");
+    WORD_ENTER(mw_T4, "T4", "src/mirth/data/type.mth", 114, 43);
+    WORD_ATOM(114, 43, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(110, 47, "T3");
+        WORD_ATOM(114, 47, "T3");
         mw_T3();
         push_value(d2);
     }
-    WORD_ATOM(110, 51, "T*");
+    WORD_ATOM(114, 51, "T*");
     mw_T_2A_();
     WORD_EXIT(mw_T4);
 }
 static void mw_T5 (void){
-    WORD_ENTER(mw_T5, "T5", "src/mirth/data/type.mth", 111, 48);
-    WORD_ATOM(111, 48, "dip");
+    WORD_ENTER(mw_T5, "T5", "src/mirth/data/type.mth", 115, 48);
+    WORD_ATOM(115, 48, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(111, 52, "T4");
+        WORD_ATOM(115, 52, "T4");
         mw_T4();
         push_value(d2);
     }
-    WORD_ATOM(111, 56, "T*");
+    WORD_ATOM(115, 56, "T*");
     mw_T_2A_();
     WORD_EXIT(mw_T5);
 }
 static void mw_T6 (void){
-    WORD_ENTER(mw_T6, "T6", "src/mirth/data/type.mth", 112, 53);
-    WORD_ATOM(112, 53, "dip");
+    WORD_ENTER(mw_T6, "T6", "src/mirth/data/type.mth", 116, 53);
+    WORD_ATOM(116, 53, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(112, 57, "T5");
+        WORD_ATOM(116, 57, "T5");
         mw_T5();
         push_value(d2);
     }
-    WORD_ATOM(112, 61, "T*");
+    WORD_ATOM(116, 61, "T*");
     mw_T_2A_();
     WORD_EXIT(mw_T6);
 }
 static void mw_Type_2E_morphism_3F_ (void){
-    WORD_ENTER(mw_Type_2E_morphism_3F_, "Type.morphism?", "src/mirth/data/type.mth", 126, 47);
-    WORD_ATOM(126, 47, "expand");
+    WORD_ENTER(mw_Type_2E_morphism_3F_, "Type.morphism?", "src/mirth/data/type.mth", 130, 47);
+    WORD_ATOM(130, 47, "expand");
     mw_Type_2E_expand();
-    WORD_ATOM(126, 54, "match");
+    WORD_ATOM(130, 54, "match");
     switch (get_top_data_tag()) {
         case 9LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(126, 73, "SOME");
+            WORD_ATOM(130, 73, "SOME");
             mw_SOME();
             break;
         default:
-            WORD_ATOM(126, 84, "drop");
+            WORD_ATOM(130, 84, "drop");
             mw_prim_drop();
-            WORD_ATOM(126, 89, "NONE");
+            WORD_ATOM(130, 89, "NONE");
             mw_NONE();
             break;
     
 }    WORD_EXIT(mw_Type_2E_morphism_3F_);
 }
 static void mw_Type_2E_prim_3F_ (void){
-    WORD_ENTER(mw_Type_2E_prim_3F_, "Type.prim?", "src/mirth/data/type.mth", 127, 42);
-    WORD_ATOM(127, 42, "expand");
+    WORD_ENTER(mw_Type_2E_prim_3F_, "Type.prim?", "src/mirth/data/type.mth", 131, 42);
+    WORD_ATOM(131, 42, "expand");
     mw_Type_2E_expand();
-    WORD_ATOM(127, 49, "match");
+    WORD_ATOM(131, 49, "match");
     switch (get_top_data_tag()) {
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(127, 64, "SOME");
+            WORD_ATOM(131, 64, "SOME");
             mw_SOME();
             break;
         default:
-            WORD_ATOM(127, 75, "drop");
+            WORD_ATOM(131, 75, "drop");
             mw_prim_drop();
-            WORD_ATOM(127, 80, "NONE");
+            WORD_ATOM(131, 80, "NONE");
             mw_NONE();
             break;
     
 }    WORD_EXIT(mw_Type_2E_prim_3F_);
 }
 static void mw_Type_3D_meta (void){
-    WORD_ENTER(mw_Type_3D_meta, "Type=meta", "src/mirth/data/type.mth", 138, 5);
-    WORD_ATOM(138, 5, "TMeta");
+    WORD_ENTER(mw_Type_3D_meta, "Type=meta", "src/mirth/data/type.mth", 142, 5);
+    WORD_ATOM(142, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(138, 14, "=");
+            WORD_ATOM(142, 14, "=");
             mw_MetaVar_3D_();
             break;
         default:
-            WORD_ATOM(139, 10, "drop2");
+            WORD_ATOM(143, 10, "drop2");
             mw_drop2();
-            WORD_ATOM(139, 16, "F");
+            WORD_ATOM(143, 16, "F");
             mw_F();
             break;
     
 }    WORD_EXIT(mw_Type_3D_meta);
 }
 static void mw_Type_2E_is_physical_3F_ (void){
-    WORD_ENTER(mw_Type_2E_is_physical_3F_, "Type.is-physical?", "src/mirth/data/type.mth", 142, 5);
-    WORD_ATOM(142, 5, "TMeta");
+    WORD_ENTER(mw_Type_2E_is_physical_3F_, "Type.is-physical?", "src/mirth/data/type.mth", 146, 5);
+    WORD_ATOM(146, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(142, 14, "expand-if");
+            WORD_ATOM(146, 14, "expand-if");
             push_u64(0);
             push_fnptr(&mb_Type_2E_is_physical_3F__2);
             mw_prim_pack_cons();
@@ -24815,100 +25065,116 @@ static void mw_Type_2E_is_physical_3F_ (void){
             break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(143, 14, "is-physical?");
+            WORD_ATOM(147, 14, "is-physical?");
             mw_PrimType_2E_is_physical_3F_();
             break;
         default:
-            WORD_ATOM(144, 10, "drop");
+            WORD_ATOM(148, 10, "drop");
             mw_prim_drop();
-            WORD_ATOM(144, 15, "T");
+            WORD_ATOM(148, 15, "T");
             mw_T();
             break;
     
 }    WORD_EXIT(mw_Type_2E_is_physical_3F_);
 }
 static void mw_TYPE_5F_TYPE (void){
-    WORD_ENTER(mw_TYPE_5F_TYPE, "TYPE_TYPE", "src/mirth/data/type.mth", 147, 22);
-    WORD_ATOM(147, 22, "PRIM_TYPE_TYPE");
+    WORD_ENTER(mw_TYPE_5F_TYPE, "TYPE_TYPE", "src/mirth/data/type.mth", 151, 22);
+    WORD_ATOM(151, 22, "PRIM_TYPE_TYPE");
     mw_PRIM_5F_TYPE_5F_TYPE();
-    WORD_ATOM(147, 37, "TPrim");
+    WORD_ATOM(151, 37, "TPrim");
     mw_TPrim();
     WORD_EXIT(mw_TYPE_5F_TYPE);
 }
 static void mw_TYPE_5F_STACK (void){
-    WORD_ENTER(mw_TYPE_5F_STACK, "TYPE_STACK", "src/mirth/data/type.mth", 148, 23);
-    WORD_ATOM(148, 23, "PRIM_TYPE_STACK");
+    WORD_ENTER(mw_TYPE_5F_STACK, "TYPE_STACK", "src/mirth/data/type.mth", 152, 23);
+    WORD_ATOM(152, 23, "PRIM_TYPE_STACK");
     mw_PRIM_5F_TYPE_5F_STACK();
-    WORD_ATOM(148, 39, "TPrim");
+    WORD_ATOM(152, 39, "TPrim");
     mw_TPrim();
     WORD_EXIT(mw_TYPE_5F_STACK);
 }
 static void mw_TYPE_5F_RESOURCE (void){
-    WORD_ENTER(mw_TYPE_5F_RESOURCE, "TYPE_RESOURCE", "src/mirth/data/type.mth", 149, 26);
-    WORD_ATOM(149, 26, "PRIM_TYPE_RESOURCE");
+    WORD_ENTER(mw_TYPE_5F_RESOURCE, "TYPE_RESOURCE", "src/mirth/data/type.mth", 153, 26);
+    WORD_ATOM(153, 26, "PRIM_TYPE_RESOURCE");
     mw_PRIM_5F_TYPE_5F_RESOURCE();
-    WORD_ATOM(149, 45, "TPrim");
+    WORD_ATOM(153, 45, "TPrim");
     mw_TPrim();
     WORD_EXIT(mw_TYPE_5F_RESOURCE);
 }
 static void mw_TYPE_5F_INT (void){
-    WORD_ENTER(mw_TYPE_5F_INT, "TYPE_INT", "src/mirth/data/type.mth", 150, 21);
-    WORD_ATOM(150, 21, "PRIM_TYPE_INT");
+    WORD_ENTER(mw_TYPE_5F_INT, "TYPE_INT", "src/mirth/data/type.mth", 154, 21);
+    WORD_ATOM(154, 21, "PRIM_TYPE_INT");
     mw_PRIM_5F_TYPE_5F_INT();
-    WORD_ATOM(150, 35, "TPrim");
+    WORD_ATOM(154, 35, "TPrim");
     mw_TPrim();
     WORD_EXIT(mw_TYPE_5F_INT);
 }
 static void mw_TYPE_5F_PTR (void){
-    WORD_ENTER(mw_TYPE_5F_PTR, "TYPE_PTR", "src/mirth/data/type.mth", 151, 21);
-    WORD_ATOM(151, 21, "PRIM_TYPE_PTR");
+    WORD_ENTER(mw_TYPE_5F_PTR, "TYPE_PTR", "src/mirth/data/type.mth", 155, 21);
+    WORD_ATOM(155, 21, "PRIM_TYPE_PTR");
     mw_PRIM_5F_TYPE_5F_PTR();
-    WORD_ATOM(151, 35, "TPrim");
+    WORD_ATOM(155, 35, "TPrim");
     mw_TPrim();
     WORD_EXIT(mw_TYPE_5F_PTR);
 }
 static void mw_TYPE_5F_STR (void){
-    WORD_ENTER(mw_TYPE_5F_STR, "TYPE_STR", "src/mirth/data/type.mth", 152, 21);
-    WORD_ATOM(152, 21, "PRIM_TYPE_STR");
+    WORD_ENTER(mw_TYPE_5F_STR, "TYPE_STR", "src/mirth/data/type.mth", 156, 21);
+    WORD_ATOM(156, 21, "PRIM_TYPE_STR");
     mw_PRIM_5F_TYPE_5F_STR();
-    WORD_ATOM(152, 35, "TPrim");
+    WORD_ATOM(156, 35, "TPrim");
     mw_TPrim();
     WORD_EXIT(mw_TYPE_5F_STR);
 }
+static void mw_TYPE_5F__2B_PLATFORM (void){
+    WORD_ENTER(mw_TYPE_5F__2B_PLATFORM, "TYPE_+PLATFORM", "src/mirth/data/type.mth", 165, 27);
+    WORD_ATOM(165, 27, "PRIM_TYPE_+PLATFORM");
+    mw_PRIM_5F_TYPE_5F__2B_PLATFORM();
+    WORD_ATOM(165, 47, "TPrim");
+    mw_TPrim();
+    WORD_EXIT(mw_TYPE_5F__2B_PLATFORM);
+}
+static void mw_RESOURCE_5F__2B_PLATFORM (void){
+    WORD_ENTER(mw_RESOURCE_5F__2B_PLATFORM, "RESOURCE_+PLATFORM", "src/mirth/data/type.mth", 166, 35);
+    WORD_ATOM(166, 35, "TYPE_+PLATFORM");
+    mw_TYPE_5F__2B_PLATFORM();
+    WORD_ATOM(166, 50, "RESOURCE");
+    mw_RESOURCE();
+    WORD_EXIT(mw_RESOURCE_5F__2B_PLATFORM);
+}
 static void mw_Type_2E_expand (void){
-    WORD_ENTER(mw_Type_2E_expand, "Type.expand", "src/mirth/data/type.mth", 163, 5);
-    WORD_ATOM(163, 5, "TMeta");
+    WORD_ENTER(mw_Type_2E_expand, "Type.expand", "src/mirth/data/type.mth", 169, 5);
+    WORD_ATOM(169, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(163, 14, "expand");
+            WORD_ATOM(169, 14, "expand");
             mw_MetaVar_2E_expand();
             break;
         default:
-            WORD_ATOM(164, 10, "id");
+            WORD_ATOM(170, 10, "id");
             mw_prim_id();
             break;
     
 }    WORD_EXIT(mw_Type_2E_expand);
 }
 static void mw_Gamma_2E_token (void){
-    WORD_ENTER(mw_Gamma_2E_token, "Gamma.token", "src/mirth/data/type.mth", 167, 34);
-    WORD_ATOM(167, 34, "GAMMA");
-    WORD_ATOM(167, 43, "id");
+    WORD_ENTER(mw_Gamma_2E_token, "Gamma.token", "src/mirth/data/type.mth", 173, 34);
+    WORD_ATOM(173, 34, "GAMMA");
+    WORD_ATOM(173, 43, "id");
     mw_prim_id();
     WORD_EXIT(mw_Gamma_2E_token);
 }
 static void mw_Type_2E_unify_failed_21_ (void){
-    WORD_ENTER(mw_Type_2E_unify_failed_21_, "Type.unify-failed!", "src/mirth/data/type.mth", 171, 5);
-    WORD_ATOM(171, 5, "over2");
+    WORD_ENTER(mw_Type_2E_unify_failed_21_, "Type.unify-failed!", "src/mirth/data/type.mth", 177, 5);
+    WORD_ATOM(177, 5, "over2");
     mw_over2();
-    WORD_ATOM(171, 11, "token");
+    WORD_ATOM(177, 11, "token");
     mw_Gamma_2E_token();
-    WORD_ATOM(171, 17, "location");
+    WORD_ATOM(177, 17, "location");
     mw_Token_2E_location();
-    WORD_ATOM(171, 26, "trace!");
+    WORD_ATOM(177, 26, "trace!");
     mw_Location_2E_trace_21_();
-    WORD_ATOM(172, 5, "");
+    WORD_ATOM(178, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -24919,16 +25185,16 @@ static void mw_Type_2E_unify_failed_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(172, 33, "trace!");
+    WORD_ATOM(178, 33, "trace!");
     mw_Str_2E_trace_21_();
-    WORD_ATOM(173, 5, "dip");
+    WORD_ATOM(179, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(173, 9, "trace!");
+        WORD_ATOM(179, 9, "trace!");
         mw_Type_2E_trace_21_();
         push_value(d2);
     }
-    WORD_ATOM(174, 5, "");
+    WORD_ATOM(180, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -24939,17 +25205,17 @@ static void mw_Type_2E_unify_failed_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(174, 14, "trace!");
+    WORD_ATOM(180, 14, "trace!");
     mw_Str_2E_trace_21_();
-    WORD_ATOM(175, 5, "trace!");
+    WORD_ATOM(181, 5, "trace!");
     mw_Type_2E_trace_21_();
-    WORD_ATOM(176, 5, "line-trace!");
+    WORD_ATOM(182, 5, "line-trace!");
     mw_line_trace_21_();
-    WORD_ATOM(177, 5, "TYPE_ERROR");
+    WORD_ATOM(183, 5, "TYPE_ERROR");
     mw_TYPE_5F_ERROR();
-    WORD_ATOM(178, 5, "num-errors");
+    WORD_ATOM(184, 5, "num-errors");
     mw_num_errors();
-    WORD_ATOM(178, 16, "modify");
+    WORD_ATOM(184, 16, "modify");
     push_u64(0);
     push_fnptr(&mb_Type_2E_unify_failed_21__2);
     mw_prim_pack_cons();
@@ -24957,153 +25223,153 @@ static void mw_Type_2E_unify_failed_21_ (void){
     WORD_EXIT(mw_Type_2E_unify_failed_21_);
 }
 static void mw_Type_2E_unify_simple_21_ (void){
-    WORD_ENTER(mw_Type_2E_unify_simple_21_, "Type.unify-simple!", "src/mirth/data/type.mth", 182, 5);
-    WORD_ATOM(182, 5, "TVar");
+    WORD_ENTER(mw_Type_2E_unify_simple_21_, "Type.unify-simple!", "src/mirth/data/type.mth", 188, 5);
+    WORD_ATOM(188, 5, "TVar");
     switch (get_top_data_tag()) {
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(182, 13, "swap");
+            WORD_ATOM(188, 13, "swap");
             mw_prim_swap();
-            WORD_ATOM(182, 18, "match");
+            WORD_ATOM(188, 18, "match");
             switch (get_top_data_tag()) {
                 case 5LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(182, 32, "unify!");
+                    WORD_ATOM(188, 32, "unify!");
                     mw_Var_2E_unify_21_();
                     break;
                 default:
-                    WORD_ATOM(182, 45, "dip");
+                    WORD_ATOM(188, 45, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(182, 49, "TVar");
+                        WORD_ATOM(188, 49, "TVar");
                         mw_TVar();
                         push_value(d6);
                     }
-                    WORD_ATOM(182, 55, "unify-failed!");
+                    WORD_ATOM(188, 55, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
             
 }            break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(183, 14, "swap");
+            WORD_ATOM(189, 14, "swap");
             mw_prim_swap();
-            WORD_ATOM(183, 19, "match");
+            WORD_ATOM(189, 19, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(183, 34, "unify!");
+                    WORD_ATOM(189, 34, "unify!");
                     mw_PrimType_2E_unify_21_();
                     break;
                 default:
-                    WORD_ATOM(183, 47, "dip");
+                    WORD_ATOM(189, 47, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(183, 51, "TPrim");
+                        WORD_ATOM(189, 51, "TPrim");
                         mw_TPrim();
                         push_value(d6);
                     }
-                    WORD_ATOM(183, 58, "unify-failed!");
+                    WORD_ATOM(189, 58, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
             
 }            break;
         case 7LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(184, 14, "swap");
+            WORD_ATOM(190, 14, "swap");
             mw_prim_swap();
-            WORD_ATOM(184, 19, "match");
+            WORD_ATOM(190, 19, "match");
             switch (get_top_data_tag()) {
                 case 7LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(184, 34, "unify!");
+                    WORD_ATOM(190, 34, "unify!");
                     mw_Data_2E_unify_21_();
                     break;
                 default:
-                    WORD_ATOM(184, 47, "dip");
+                    WORD_ATOM(190, 47, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(184, 51, "TData");
+                        WORD_ATOM(190, 51, "TData");
                         mw_TData();
                         push_value(d6);
                     }
-                    WORD_ATOM(184, 58, "unify-failed!");
+                    WORD_ATOM(190, 58, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
             
 }            break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(185, 15, "swap");
+            WORD_ATOM(191, 15, "swap");
             mw_prim_swap();
-            WORD_ATOM(185, 20, "match");
+            WORD_ATOM(191, 20, "match");
             switch (get_top_data_tag()) {
                 case 6LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(185, 36, "unify!");
+                    WORD_ATOM(191, 36, "unify!");
                     mw_Table_2E_unify_21_();
                     break;
                 default:
-                    WORD_ATOM(185, 49, "dip");
+                    WORD_ATOM(191, 49, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(185, 53, "TTable");
+                        WORD_ATOM(191, 53, "TTable");
                         mw_TTable();
                         push_value(d6);
                     }
-                    WORD_ATOM(185, 61, "unify-failed!");
+                    WORD_ATOM(191, 61, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
             
 }            break;
         case 8LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(186, 16, "swap");
+            WORD_ATOM(192, 16, "swap");
             mw_prim_swap();
-            WORD_ATOM(186, 21, "match");
+            WORD_ATOM(192, 21, "match");
             switch (get_top_data_tag()) {
                 case 8LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(186, 38, "unify!");
+                    WORD_ATOM(192, 38, "unify!");
                     mw_StackType_2E_unify_21_();
-                    WORD_ATOM(186, 45, ">Type");
+                    WORD_ATOM(192, 45, ">Type");
                     mw_StackType_3E_Type();
                     break;
                 default:
-                    WORD_ATOM(186, 57, "dip");
+                    WORD_ATOM(192, 57, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(186, 61, "TTensor");
+                        WORD_ATOM(192, 61, "TTensor");
                         mw_TTensor();
                         push_value(d6);
                     }
-                    WORD_ATOM(186, 70, "unify-failed!");
+                    WORD_ATOM(192, 70, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
             
 }            break;
         case 9LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(187, 18, "swap");
+            WORD_ATOM(193, 18, "swap");
             mw_prim_swap();
-            WORD_ATOM(187, 23, "match");
+            WORD_ATOM(193, 23, "match");
             switch (get_top_data_tag()) {
                 case 9LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(187, 42, "unify!");
+                    WORD_ATOM(193, 42, "unify!");
                     mw_ArrowType_2E_unify_21_();
-                    WORD_ATOM(187, 49, "TMorphism");
+                    WORD_ATOM(193, 49, "TMorphism");
                     mw_TMorphism();
                     break;
                 default:
-                    WORD_ATOM(187, 65, "dip");
+                    WORD_ATOM(193, 65, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(187, 69, "TMorphism");
+                        WORD_ATOM(193, 69, "TMorphism");
                         mw_TMorphism();
                         push_value(d6);
                     }
-                    WORD_ATOM(187, 80, "unify-failed!");
+                    WORD_ATOM(193, 80, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
             
@@ -25111,236 +25377,236 @@ static void mw_Type_2E_unify_simple_21_ (void){
         case 10LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(188, 13, "rotl");
+            WORD_ATOM(194, 13, "rotl");
             mw_rotl();
-            WORD_ATOM(188, 18, "match");
+            WORD_ATOM(194, 18, "match");
             switch (get_top_data_tag()) {
                 case 10LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
                     mw_prim_pack_uncons(); mw_prim_swap();
-                    WORD_ATOM(188, 32, "unify2!");
+                    WORD_ATOM(194, 32, "unify2!");
                     mw_Type_2E_unify2_21_();
-                    WORD_ATOM(188, 40, "TApp");
+                    WORD_ATOM(194, 40, "TApp");
                     mw_TApp();
                     break;
                 default:
-                    WORD_ATOM(188, 51, "dip");
+                    WORD_ATOM(194, 51, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(188, 55, "TApp");
+                        WORD_ATOM(194, 55, "TApp");
                         mw_TApp();
                         push_value(d6);
                     }
-                    WORD_ATOM(188, 61, "unify-failed!");
+                    WORD_ATOM(194, 61, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
             
 }            break;
         case 11LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(189, 13, "swap");
+            WORD_ATOM(195, 13, "swap");
             mw_prim_swap();
-            WORD_ATOM(189, 18, "match");
+            WORD_ATOM(195, 18, "match");
             switch (get_top_data_tag()) {
                 case 11LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(189, 32, "unify!");
+                    WORD_ATOM(195, 32, "unify!");
                     mw_Type_2E_unify_21_();
-                    WORD_ATOM(189, 39, "TMut");
+                    WORD_ATOM(195, 39, "TMut");
                     mw_TMut();
                     break;
                 default:
-                    WORD_ATOM(189, 50, "dip");
+                    WORD_ATOM(195, 50, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(189, 54, "TMut");
+                        WORD_ATOM(195, 54, "TMut");
                         mw_TMut();
                         push_value(d6);
                     }
-                    WORD_ATOM(189, 60, "unify-failed!");
+                    WORD_ATOM(195, 60, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
             
 }            break;
         default:
-            WORD_ATOM(190, 10, "unify-failed!");
+            WORD_ATOM(196, 10, "unify-failed!");
             mw_Type_2E_unify_failed_21_();
             break;
     
 }    WORD_EXIT(mw_Type_2E_unify_simple_21_);
 }
 static void mw_Type_2E_unify_aux_21_ (void){
-    WORD_ENTER(mw_Type_2E_unify_aux_21_, "Type.unify-aux!", "src/mirth/data/type.mth", 194, 5);
-    WORD_ATOM(194, 5, "TYPE_ERROR");
+    WORD_ENTER(mw_Type_2E_unify_aux_21_, "Type.unify-aux!", "src/mirth/data/type.mth", 200, 5);
+    WORD_ATOM(200, 5, "TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(194, 19, "drop");
+            WORD_ATOM(200, 19, "drop");
             mw_prim_drop();
-            WORD_ATOM(194, 24, "TYPE_ERROR");
+            WORD_ATOM(200, 24, "TYPE_ERROR");
             mw_TYPE_5F_ERROR();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(195, 23, "id");
+            WORD_ATOM(201, 23, "id");
             mw_prim_id();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(196, 14, "type-hole-unify!");
+            WORD_ATOM(202, 14, "type-hole-unify!");
             mw_type_hole_unify_21_();
             break;
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(198, 9, "swap");
+            WORD_ATOM(204, 9, "swap");
             mw_prim_swap();
-            WORD_ATOM(198, 14, "match");
+            WORD_ATOM(204, 14, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
                     mw_prim_drop();
-                    WORD_ATOM(199, 27, "drop");
+                    WORD_ATOM(205, 27, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(199, 32, "TYPE_ERROR");
+                    WORD_ATOM(205, 32, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 case 1LL:
                     mw_prim_drop();
-                    WORD_ATOM(200, 31, "TMeta");
+                    WORD_ATOM(206, 31, "TMeta");
                     mw_TMeta();
                     break;
                 case 4LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(201, 22, "dip");
+                    WORD_ATOM(207, 22, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(201, 26, "TMeta");
+                        WORD_ATOM(207, 26, "TMeta");
                         mw_TMeta();
                         push_value(d6);
                     }
-                    WORD_ATOM(201, 33, "type-hole-unify!");
+                    WORD_ATOM(207, 33, "type-hole-unify!");
                     mw_type_hole_unify_21_();
                     break;
                 case 3LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(202, 22, "dip");
+                    WORD_ATOM(208, 22, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(202, 26, "TMeta");
+                        WORD_ATOM(208, 26, "TMeta");
                         mw_TMeta();
                         push_value(d6);
                     }
-                    WORD_ATOM(202, 33, "unify!");
+                    WORD_ATOM(208, 33, "unify!");
                     mw_MetaVar_2E_unify_21_();
                     break;
                 case 12LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(203, 23, "dip");
+                    WORD_ATOM(209, 23, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(203, 27, "TMeta");
+                        WORD_ATOM(209, 27, "TMeta");
                         mw_TMeta();
                         push_value(d6);
                     }
-                    WORD_ATOM(203, 34, "unify-type!");
+                    WORD_ATOM(209, 34, "unify-type!");
                     mw_Value_2E_unify_type_21_();
                     break;
                 default:
-                    WORD_ATOM(204, 18, "swap");
+                    WORD_ATOM(210, 18, "swap");
                     mw_prim_swap();
-                    WORD_ATOM(204, 23, "unify!");
+                    WORD_ATOM(210, 23, "unify!");
                     mw_MetaVar_2E_unify_21_();
                     break;
             
 }            break;
         case 12LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(207, 9, "swap");
+            WORD_ATOM(213, 9, "swap");
             mw_prim_swap();
-            WORD_ATOM(207, 14, "match");
+            WORD_ATOM(213, 14, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
                     mw_prim_drop();
-                    WORD_ATOM(208, 27, "drop");
+                    WORD_ATOM(214, 27, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(208, 32, "TYPE_ERROR");
+                    WORD_ATOM(214, 32, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 case 1LL:
                     mw_prim_drop();
-                    WORD_ATOM(209, 31, "TValue");
+                    WORD_ATOM(215, 31, "TValue");
                     mw_TValue();
                     break;
                 case 4LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(210, 22, "dip");
+                    WORD_ATOM(216, 22, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(210, 26, "TValue");
+                        WORD_ATOM(216, 26, "TValue");
                         mw_TValue();
                         push_value(d6);
                     }
-                    WORD_ATOM(210, 34, "type-hole-unify!");
+                    WORD_ATOM(216, 34, "type-hole-unify!");
                     mw_type_hole_unify_21_();
                     break;
                 case 3LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(211, 22, "dip");
+                    WORD_ATOM(217, 22, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(211, 26, "TValue");
+                        WORD_ATOM(217, 26, "TValue");
                         mw_TValue();
                         push_value(d6);
                     }
-                    WORD_ATOM(211, 34, "unify!");
+                    WORD_ATOM(217, 34, "unify!");
                     mw_MetaVar_2E_unify_21_();
                     break;
                 case 12LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(212, 23, "unify!");
+                    WORD_ATOM(218, 23, "unify!");
                     mw_Value_2E_unify_21_();
                     break;
                 default:
-                    WORD_ATOM(213, 18, "swap");
+                    WORD_ATOM(219, 18, "swap");
                     mw_prim_swap();
-                    WORD_ATOM(213, 23, "unify-type!");
+                    WORD_ATOM(219, 23, "unify-type!");
                     mw_Value_2E_unify_type_21_();
                     break;
             
 }            break;
         default:
-            WORD_ATOM(216, 9, "swap");
+            WORD_ATOM(222, 9, "swap");
             mw_prim_swap();
-            WORD_ATOM(216, 14, "match");
+            WORD_ATOM(222, 14, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
                     mw_prim_drop();
-                    WORD_ATOM(217, 27, "drop");
+                    WORD_ATOM(223, 27, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(217, 32, "TYPE_ERROR");
+                    WORD_ATOM(223, 32, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 case 1LL:
                     mw_prim_drop();
-                    WORD_ATOM(218, 31, "id");
+                    WORD_ATOM(224, 31, "id");
                     mw_prim_id();
                     break;
                 case 4LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(219, 22, "type-hole-unify!");
+                    WORD_ATOM(225, 22, "type-hole-unify!");
                     mw_type_hole_unify_21_();
                     break;
                 case 3LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(220, 22, "unify!");
+                    WORD_ATOM(226, 22, "unify!");
                     mw_MetaVar_2E_unify_21_();
                     break;
                 case 12LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(221, 23, "unify-type!");
+                    WORD_ATOM(227, 23, "unify-type!");
                     mw_Value_2E_unify_type_21_();
                     break;
                 default:
-                    WORD_ATOM(222, 18, "unify-simple!");
+                    WORD_ATOM(228, 18, "unify-simple!");
                     mw_Type_2E_unify_simple_21_();
                     break;
             
@@ -25349,58 +25615,58 @@ static void mw_Type_2E_unify_aux_21_ (void){
 }    WORD_EXIT(mw_Type_2E_unify_aux_21_);
 }
 static void mw_Type_2E_unify_21_ (void){
-    WORD_ENTER(mw_Type_2E_unify_21_, "Type.unify!", "src/mirth/data/type.mth", 228, 5);
-    WORD_ATOM(228, 5, "both");
+    WORD_ENTER(mw_Type_2E_unify_21_, "Type.unify!", "src/mirth/data/type.mth", 234, 5);
+    WORD_ATOM(234, 5, "both");
     push_u64(0);
     push_fnptr(&mb_Type_2E_unify_21__1);
     mw_prim_pack_cons();
     mw_both();
-    WORD_ATOM(228, 18, "unify-aux!");
+    WORD_ATOM(234, 18, "unify-aux!");
     mw_Type_2E_unify_aux_21_();
     WORD_EXIT(mw_Type_2E_unify_21_);
 }
 static void mw_Value_2E_unify_21_ (void){
-    WORD_ENTER(mw_Value_2E_unify_21_, "Value.unify!", "src/mirth/data/type.mth", 231, 5);
-    WORD_ATOM(231, 5, "swap");
+    WORD_ENTER(mw_Value_2E_unify_21_, "Value.unify!", "src/mirth/data/type.mth", 237, 5);
+    WORD_ATOM(237, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(231, 10, "match");
+    WORD_ATOM(237, 10, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(232, 22, "swap");
+            WORD_ATOM(238, 22, "swap");
             mw_prim_swap();
-            WORD_ATOM(232, 27, "match");
+            WORD_ATOM(238, 27, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(233, 26, "dup2");
+                    WORD_ATOM(239, 26, "dup2");
                     mw_dup2();
-                    WORD_ATOM(233, 31, "=");
+                    WORD_ATOM(239, 31, "=");
                     mw_prim_int_eq();
-                    WORD_ATOM(233, 33, "if");
+                    WORD_ATOM(239, 33, "if");
                     if (pop_u64()) {
-                        WORD_ATOM(233, 36, "drop");
+                        WORD_ATOM(239, 36, "drop");
                         mw_prim_drop();
-                        WORD_ATOM(233, 41, "VALUE_INT");
+                        WORD_ATOM(239, 41, "VALUE_INT");
                         mw_VALUE_5F_INT();
-                        WORD_ATOM(233, 51, "TValue");
+                        WORD_ATOM(239, 51, "TValue");
                         mw_TValue();
                     } else {
-                        WORD_ATOM(233, 59, "drop2");
+                        WORD_ATOM(239, 59, "drop2");
                         mw_drop2();
-                        WORD_ATOM(233, 65, "TYPE_INT");
+                        WORD_ATOM(239, 65, "TYPE_INT");
                         mw_TYPE_5F_INT();
                     }
                     break;
                 case 1LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(235, 17, "drop2");
+                    WORD_ATOM(241, 17, "drop2");
                     mw_drop2();
-                    WORD_ATOM(235, 23, "dup");
+                    WORD_ATOM(241, 23, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(235, 27, "token");
+                    WORD_ATOM(241, 27, "token");
                     mw_Gamma_2E_token();
-                    WORD_ATOM(236, 17, "");
+                    WORD_ATOM(242, 17, "");
                     {
                         static bool vready = false;
                         static VAL v;
@@ -25411,20 +25677,20 @@ static void mw_Value_2E_unify_21_ (void){
                         push_value(v);
                         incref(v);
                     }
-                    WORD_ATOM(237, 17, "emit-error!");
+                    WORD_ATOM(243, 17, "emit-error!");
                     mw_emit_error_21_();
-                    WORD_ATOM(237, 29, "TYPE_ERROR");
+                    WORD_ATOM(243, 29, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 case 2LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(239, 17, "drop2");
+                    WORD_ATOM(245, 17, "drop2");
                     mw_drop2();
-                    WORD_ATOM(239, 23, "dup");
+                    WORD_ATOM(245, 23, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(239, 27, "token");
+                    WORD_ATOM(245, 27, "token");
                     mw_Gamma_2E_token();
-                    WORD_ATOM(240, 17, "");
+                    WORD_ATOM(246, 17, "");
                     {
                         static bool vready = false;
                         static VAL v;
@@ -25435,9 +25701,9 @@ static void mw_Value_2E_unify_21_ (void){
                         push_value(v);
                         incref(v);
                     }
-                    WORD_ATOM(241, 17, "emit-error!");
+                    WORD_ATOM(247, 17, "emit-error!");
                     mw_emit_error_21_();
-                    WORD_ATOM(241, 29, "TYPE_ERROR");
+                    WORD_ATOM(247, 29, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -25445,40 +25711,40 @@ static void mw_Value_2E_unify_21_ (void){
 }            break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(244, 22, "swap");
+            WORD_ATOM(250, 22, "swap");
             mw_prim_swap();
-            WORD_ATOM(244, 27, "match");
+            WORD_ATOM(250, 27, "match");
             switch (get_top_data_tag()) {
                 case 1LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(245, 26, "dup2");
+                    WORD_ATOM(251, 26, "dup2");
                     mw_dup2();
-                    WORD_ATOM(245, 31, "=");
+                    WORD_ATOM(251, 31, "=");
                     mw_Str_3D_();
-                    WORD_ATOM(245, 33, "if");
+                    WORD_ATOM(251, 33, "if");
                     if (pop_u64()) {
-                        WORD_ATOM(245, 36, "drop");
+                        WORD_ATOM(251, 36, "drop");
                         mw_prim_drop();
-                        WORD_ATOM(245, 41, "VALUE_STR");
+                        WORD_ATOM(251, 41, "VALUE_STR");
                         mw_VALUE_5F_STR();
-                        WORD_ATOM(245, 51, "TValue");
+                        WORD_ATOM(251, 51, "TValue");
                         mw_TValue();
                     } else {
-                        WORD_ATOM(245, 59, "drop2");
+                        WORD_ATOM(251, 59, "drop2");
                         mw_drop2();
-                        WORD_ATOM(245, 65, "TYPE_STR");
+                        WORD_ATOM(251, 65, "TYPE_STR");
                         mw_TYPE_5F_STR();
                     }
                     break;
                 case 0LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(247, 17, "drop2");
+                    WORD_ATOM(253, 17, "drop2");
                     mw_drop2();
-                    WORD_ATOM(247, 23, "dup");
+                    WORD_ATOM(253, 23, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(247, 27, "token");
+                    WORD_ATOM(253, 27, "token");
                     mw_Gamma_2E_token();
-                    WORD_ATOM(248, 17, "");
+                    WORD_ATOM(254, 17, "");
                     {
                         static bool vready = false;
                         static VAL v;
@@ -25489,20 +25755,20 @@ static void mw_Value_2E_unify_21_ (void){
                         push_value(v);
                         incref(v);
                     }
-                    WORD_ATOM(249, 17, "emit-error!");
+                    WORD_ATOM(255, 17, "emit-error!");
                     mw_emit_error_21_();
-                    WORD_ATOM(249, 29, "TYPE_ERROR");
+                    WORD_ATOM(255, 29, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 case 2LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(251, 17, "drop2");
+                    WORD_ATOM(257, 17, "drop2");
                     mw_drop2();
-                    WORD_ATOM(251, 23, "dup");
+                    WORD_ATOM(257, 23, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(251, 27, "token");
+                    WORD_ATOM(257, 27, "token");
                     mw_Gamma_2E_token();
-                    WORD_ATOM(252, 17, "");
+                    WORD_ATOM(258, 17, "");
                     {
                         static bool vready = false;
                         static VAL v;
@@ -25513,9 +25779,9 @@ static void mw_Value_2E_unify_21_ (void){
                         push_value(v);
                         incref(v);
                     }
-                    WORD_ATOM(253, 17, "emit-error!");
+                    WORD_ATOM(259, 17, "emit-error!");
                     mw_emit_error_21_();
-                    WORD_ATOM(253, 29, "TYPE_ERROR");
+                    WORD_ATOM(259, 29, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -25523,44 +25789,44 @@ static void mw_Value_2E_unify_21_ (void){
 }            break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(256, 24, "swap");
+            WORD_ATOM(262, 24, "swap");
             mw_prim_swap();
-            WORD_ATOM(256, 29, "match");
+            WORD_ATOM(262, 29, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(258, 17, "dup2");
+                    WORD_ATOM(264, 17, "dup2");
                     mw_dup2();
-                    WORD_ATOM(258, 22, "=");
+                    WORD_ATOM(264, 22, "=");
                     mw_Block_3D_();
-                    WORD_ATOM(258, 24, "if");
+                    WORD_ATOM(264, 24, "if");
                     if (pop_u64()) {
-                        WORD_ATOM(259, 21, "drop");
+                        WORD_ATOM(265, 21, "drop");
                         mw_prim_drop();
-                        WORD_ATOM(259, 26, "VALUE_BLOCK");
+                        WORD_ATOM(265, 26, "VALUE_BLOCK");
                         mw_VALUE_5F_BLOCK();
-                        WORD_ATOM(259, 38, "TValue");
+                        WORD_ATOM(265, 38, "TValue");
                         mw_TValue();
                     } else {
-                        WORD_ATOM(260, 21, "arrow");
+                        WORD_ATOM(266, 21, "arrow");
                         mw_Block_2E_arrow();
-                        WORD_ATOM(260, 27, "type");
+                        WORD_ATOM(266, 27, "type");
                         mw_Arrow_2E_type();
-                        WORD_ATOM(260, 32, "block-unify-type!");
+                        WORD_ATOM(266, 32, "block-unify-type!");
                         mw_block_unify_type_21_();
-                        WORD_ATOM(260, 50, ">Type");
+                        WORD_ATOM(266, 50, ">Type");
                         mw_ArrowType_3E_Type();
                     }
                     break;
                 case 0LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(263, 17, "drop2");
+                    WORD_ATOM(269, 17, "drop2");
                     mw_drop2();
-                    WORD_ATOM(263, 23, "dup");
+                    WORD_ATOM(269, 23, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(263, 27, "token");
+                    WORD_ATOM(269, 27, "token");
                     mw_Gamma_2E_token();
-                    WORD_ATOM(264, 17, "");
+                    WORD_ATOM(270, 17, "");
                     {
                         static bool vready = false;
                         static VAL v;
@@ -25571,20 +25837,20 @@ static void mw_Value_2E_unify_21_ (void){
                         push_value(v);
                         incref(v);
                     }
-                    WORD_ATOM(265, 17, "emit-error!");
+                    WORD_ATOM(271, 17, "emit-error!");
                     mw_emit_error_21_();
-                    WORD_ATOM(265, 29, "TYPE_ERROR");
+                    WORD_ATOM(271, 29, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 case 1LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(267, 17, "drop2");
+                    WORD_ATOM(273, 17, "drop2");
                     mw_drop2();
-                    WORD_ATOM(267, 23, "dup");
+                    WORD_ATOM(273, 23, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(267, 27, "token");
+                    WORD_ATOM(273, 27, "token");
                     mw_Gamma_2E_token();
-                    WORD_ATOM(268, 17, "");
+                    WORD_ATOM(274, 17, "");
                     {
                         static bool vready = false;
                         static VAL v;
@@ -25595,9 +25861,9 @@ static void mw_Value_2E_unify_21_ (void){
                         push_value(v);
                         incref(v);
                     }
-                    WORD_ATOM(269, 17, "emit-error!");
+                    WORD_ATOM(275, 17, "emit-error!");
                     mw_emit_error_21_();
-                    WORD_ATOM(269, 29, "TYPE_ERROR");
+                    WORD_ATOM(275, 29, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -25608,32 +25874,32 @@ static void mw_Value_2E_unify_21_ (void){
 }    WORD_EXIT(mw_Value_2E_unify_21_);
 }
 static void mw_Value_2E_unify_type_21_ (void){
-    WORD_ENTER(mw_Value_2E_unify_type_21_, "Value.unify-type!", "src/mirth/data/type.mth", 274, 5);
-    WORD_ATOM(274, 5, "VALUE_INT");
+    WORD_ENTER(mw_Value_2E_unify_type_21_, "Value.unify-type!", "src/mirth/data/type.mth", 280, 5);
+    WORD_ATOM(280, 5, "VALUE_INT");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(274, 18, "drop");
+            WORD_ATOM(280, 18, "drop");
             mw_prim_drop();
-            WORD_ATOM(274, 23, "TYPE_INT");
+            WORD_ATOM(280, 23, "TYPE_INT");
             mw_TYPE_5F_INT();
-            WORD_ATOM(274, 32, "unify!");
+            WORD_ATOM(280, 32, "unify!");
             mw_Type_2E_unify_21_();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(275, 18, "drop");
+            WORD_ATOM(281, 18, "drop");
             mw_prim_drop();
-            WORD_ATOM(275, 23, "TYPE_STR");
+            WORD_ATOM(281, 23, "TYPE_STR");
             mw_TYPE_5F_STR();
-            WORD_ATOM(275, 32, "unify!");
+            WORD_ATOM(281, 32, "unify!");
             mw_Type_2E_unify_21_();
             break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(276, 20, "swap");
+            WORD_ATOM(282, 20, "swap");
             mw_prim_swap();
-            WORD_ATOM(276, 25, "unify-block!");
+            WORD_ATOM(282, 25, "unify-block!");
             mw_Type_2E_unify_block_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -25641,266 +25907,266 @@ static void mw_Value_2E_unify_type_21_ (void){
 }    WORD_EXIT(mw_Value_2E_unify_type_21_);
 }
 static void mw_Type_2E_unify_block_21_ (void){
-    WORD_ENTER(mw_Type_2E_unify_block_21_, "Type.unify-block!", "src/mirth/data/type.mth", 279, 5);
-    WORD_ATOM(279, 5, "expand");
+    WORD_ENTER(mw_Type_2E_unify_block_21_, "Type.unify-block!", "src/mirth/data/type.mth", 285, 5);
+    WORD_ATOM(285, 5, "expand");
     mw_Type_2E_expand();
-    WORD_ATOM(279, 12, "match");
+    WORD_ATOM(285, 12, "match");
     switch (get_top_data_tag()) {
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(280, 18, "over");
+            WORD_ATOM(286, 18, "over");
             mw_over();
-            WORD_ATOM(280, 23, "dip");
+            WORD_ATOM(286, 23, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(280, 27, "dip");
+                WORD_ATOM(286, 27, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(280, 31, "type");
+                    WORD_ATOM(286, 31, "type");
                     mw_Block_2E_type();
-                    WORD_ATOM(280, 36, ">Type");
+                    WORD_ATOM(286, 36, ">Type");
                     mw_ArrowType_3E_Type();
                     push_value(d5);
                 }
-                WORD_ATOM(280, 43, "unify!");
+                WORD_ATOM(286, 43, "unify!");
                 mw_MetaVar_2E_unify_21_();
-                WORD_ATOM(280, 50, "drop");
+                WORD_ATOM(286, 50, "drop");
                 mw_prim_drop();
                 push_value(d4);
             }
-            WORD_ATOM(280, 56, "arrow");
+            WORD_ATOM(286, 56, "arrow");
             mw_Block_2E_arrow();
-            WORD_ATOM(280, 62, "type");
+            WORD_ATOM(286, 62, "type");
             mw_Arrow_2E_type();
-            WORD_ATOM(280, 67, ">Type");
+            WORD_ATOM(286, 67, ">Type");
             mw_ArrowType_3E_Type();
             break;
         case 9LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(281, 22, "block-unify-type!");
+            WORD_ATOM(287, 22, "block-unify-type!");
             mw_block_unify_type_21_();
-            WORD_ATOM(281, 40, ">Type");
+            WORD_ATOM(287, 40, ">Type");
             mw_ArrowType_3E_Type();
             break;
         default:
-            WORD_ATOM(282, 14, "dip");
+            WORD_ATOM(288, 14, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(282, 18, "type");
+                WORD_ATOM(288, 18, "type");
                 mw_Block_2E_type();
-                WORD_ATOM(282, 23, ">Type");
+                WORD_ATOM(288, 23, ">Type");
                 mw_ArrowType_3E_Type();
                 push_value(d4);
             }
-            WORD_ATOM(282, 30, "unify!");
+            WORD_ATOM(288, 30, "unify!");
             mw_Type_2E_unify_21_();
             break;
     
 }    WORD_EXIT(mw_Type_2E_unify_block_21_);
 }
 static void mw_Type_2E_unify2_21_ (void){
-    WORD_ENTER(mw_Type_2E_unify2_21_, "Type.unify2!", "src/mirth/data/type.mth", 286, 5);
-    WORD_ATOM(286, 5, "dip");
+    WORD_ENTER(mw_Type_2E_unify2_21_, "Type.unify2!", "src/mirth/data/type.mth", 292, 5);
+    WORD_ATOM(292, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(286, 9, "swap");
+        WORD_ATOM(292, 9, "swap");
         mw_prim_swap();
-        WORD_ATOM(286, 14, "dip");
+        WORD_ATOM(292, 14, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(286, 18, "unify!");
+            WORD_ATOM(292, 18, "unify!");
             mw_Type_2E_unify_21_();
-            WORD_ATOM(286, 25, "swap");
+            WORD_ATOM(292, 25, "swap");
             mw_prim_swap();
             push_value(d3);
         }
         push_value(d2);
     }
-    WORD_ATOM(286, 32, "unify!");
+    WORD_ATOM(292, 32, "unify!");
     mw_Type_2E_unify_21_();
-    WORD_ATOM(286, 39, "dip");
+    WORD_ATOM(292, 39, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(286, 43, "swap");
+        WORD_ATOM(292, 43, "swap");
         mw_prim_swap();
         push_value(d2);
     }
     WORD_EXIT(mw_Type_2E_unify2_21_);
 }
 static void mw_PrimType_2E_unify_21_ (void){
-    WORD_ENTER(mw_PrimType_2E_unify_21_, "PrimType.unify!", "src/mirth/data/type.mth", 289, 5);
-    WORD_ATOM(289, 5, "dup2");
+    WORD_ENTER(mw_PrimType_2E_unify_21_, "PrimType.unify!", "src/mirth/data/type.mth", 295, 5);
+    WORD_ATOM(295, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(289, 10, "=");
+    WORD_ATOM(295, 10, "=");
     mw_PrimType_3D_();
-    WORD_ATOM(289, 12, "if");
+    WORD_ATOM(295, 12, "if");
     if (pop_u64()) {
-        WORD_ATOM(289, 15, "drop");
+        WORD_ATOM(295, 15, "drop");
         mw_prim_drop();
-        WORD_ATOM(289, 20, "TPrim");
+        WORD_ATOM(295, 20, "TPrim");
         mw_TPrim();
     } else {
-        WORD_ATOM(289, 27, "both");
+        WORD_ATOM(295, 27, "both");
         push_u64(0);
         push_fnptr(&mb_PrimType_2E_unify_21__3);
         mw_prim_pack_cons();
         mw_both();
-        WORD_ATOM(289, 39, "unify-failed!");
+        WORD_ATOM(295, 39, "unify-failed!");
         mw_Type_2E_unify_failed_21_();
     }
     WORD_EXIT(mw_PrimType_2E_unify_21_);
 }
 static void mw_Data_2E_unify_21_ (void){
-    WORD_ENTER(mw_Data_2E_unify_21_, "Data.unify!", "src/mirth/data/type.mth", 291, 5);
-    WORD_ATOM(291, 5, "dup2");
+    WORD_ENTER(mw_Data_2E_unify_21_, "Data.unify!", "src/mirth/data/type.mth", 297, 5);
+    WORD_ATOM(297, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(291, 10, "=");
+    WORD_ATOM(297, 10, "=");
     mw_Data_3D_();
-    WORD_ATOM(291, 12, "if");
+    WORD_ATOM(297, 12, "if");
     if (pop_u64()) {
-        WORD_ATOM(291, 15, "drop");
+        WORD_ATOM(297, 15, "drop");
         mw_prim_drop();
-        WORD_ATOM(291, 20, "TData");
+        WORD_ATOM(297, 20, "TData");
         mw_TData();
     } else {
-        WORD_ATOM(291, 27, "both");
+        WORD_ATOM(297, 27, "both");
         push_u64(0);
         push_fnptr(&mb_Data_2E_unify_21__3);
         mw_prim_pack_cons();
         mw_both();
-        WORD_ATOM(291, 39, "unify-failed!");
+        WORD_ATOM(297, 39, "unify-failed!");
         mw_Type_2E_unify_failed_21_();
     }
     WORD_EXIT(mw_Data_2E_unify_21_);
 }
 static void mw_Table_2E_unify_21_ (void){
-    WORD_ENTER(mw_Table_2E_unify_21_, "Table.unify!", "src/mirth/data/type.mth", 293, 5);
-    WORD_ATOM(293, 5, "dup2");
+    WORD_ENTER(mw_Table_2E_unify_21_, "Table.unify!", "src/mirth/data/type.mth", 299, 5);
+    WORD_ATOM(299, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(293, 10, "=");
+    WORD_ATOM(299, 10, "=");
     mw_Table_3D_();
-    WORD_ATOM(293, 12, "if");
+    WORD_ATOM(299, 12, "if");
     if (pop_u64()) {
-        WORD_ATOM(293, 15, "drop");
+        WORD_ATOM(299, 15, "drop");
         mw_prim_drop();
-        WORD_ATOM(293, 20, "TTable");
+        WORD_ATOM(299, 20, "TTable");
         mw_TTable();
     } else {
-        WORD_ATOM(293, 28, "both");
+        WORD_ATOM(299, 28, "both");
         push_u64(0);
         push_fnptr(&mb_Table_2E_unify_21__3);
         mw_prim_pack_cons();
         mw_both();
-        WORD_ATOM(293, 41, "unify-failed!");
+        WORD_ATOM(299, 41, "unify-failed!");
         mw_Type_2E_unify_failed_21_();
     }
     WORD_EXIT(mw_Table_2E_unify_21_);
 }
 static void mw_Var_2E_unify_21_ (void){
-    WORD_ENTER(mw_Var_2E_unify_21_, "Var.unify!", "src/mirth/data/type.mth", 295, 5);
-    WORD_ATOM(295, 5, "dup2");
+    WORD_ENTER(mw_Var_2E_unify_21_, "Var.unify!", "src/mirth/data/type.mth", 301, 5);
+    WORD_ATOM(301, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(295, 10, "=");
+    WORD_ATOM(301, 10, "=");
     mw_Var_3D_();
-    WORD_ATOM(295, 12, "if");
+    WORD_ATOM(301, 12, "if");
     if (pop_u64()) {
-        WORD_ATOM(295, 15, "drop");
+        WORD_ATOM(301, 15, "drop");
         mw_prim_drop();
-        WORD_ATOM(295, 20, "TVar");
+        WORD_ATOM(301, 20, "TVar");
         mw_TVar();
     } else {
-        WORD_ATOM(295, 26, "both");
+        WORD_ATOM(301, 26, "both");
         push_u64(0);
         push_fnptr(&mb_Var_2E_unify_21__3);
         mw_prim_pack_cons();
         mw_both();
-        WORD_ATOM(295, 37, "unify-failed!");
+        WORD_ATOM(301, 37, "unify-failed!");
         mw_Type_2E_unify_failed_21_();
     }
     WORD_EXIT(mw_Var_2E_unify_21_);
 }
 static void mw_Type_2E_has_meta_3F_ (void){
-    WORD_ENTER(mw_Type_2E_has_meta_3F_, "Type.has-meta?", "src/mirth/data/type.mth", 298, 5);
-    WORD_ATOM(298, 5, "TMeta");
+    WORD_ENTER(mw_Type_2E_has_meta_3F_, "Type.has-meta?", "src/mirth/data/type.mth", 304, 5);
+    WORD_ATOM(304, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(298, 14, "has-meta?");
+            WORD_ATOM(304, 14, "has-meta?");
             mw_MetaVar_2E_has_meta_3F_();
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(299, 19, "drop");
+            WORD_ATOM(305, 19, "drop");
             mw_prim_drop();
-            WORD_ATOM(299, 24, "F");
+            WORD_ATOM(305, 24, "F");
             mw_F();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(300, 23, "drop");
+            WORD_ATOM(306, 23, "drop");
             mw_prim_drop();
-            WORD_ATOM(300, 28, "F");
+            WORD_ATOM(306, 28, "F");
             mw_F();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(301, 14, "drop2");
-            mw_drop2();
-            WORD_ATOM(301, 20, "F");
-            mw_F();
-            break;
-        case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(302, 13, "drop2");
-            mw_drop2();
-            WORD_ATOM(302, 19, "F");
-            mw_F();
-            break;
-        case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(303, 14, "drop2");
-            mw_drop2();
-            WORD_ATOM(303, 20, "F");
-            mw_F();
-            break;
-        case 8LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(304, 16, "has-meta?");
-            mw_StackType_2E_has_meta_3F_();
-            break;
-        case 9LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(305, 18, "has-meta?");
-            mw_ArrowType_2E_has_meta_3F_();
-            break;
-        case 10LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(306, 13, "has-meta2?");
-            mw_Type_2E_has_meta2_3F_();
-            break;
-        case 7LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             WORD_ATOM(307, 14, "drop2");
             mw_drop2();
             WORD_ATOM(307, 20, "F");
             mw_F();
             break;
+        case 5LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(308, 13, "drop2");
+            mw_drop2();
+            WORD_ATOM(308, 19, "F");
+            mw_F();
+            break;
+        case 4LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(309, 14, "drop2");
+            mw_drop2();
+            WORD_ATOM(309, 20, "F");
+            mw_F();
+            break;
+        case 8LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(310, 16, "has-meta?");
+            mw_StackType_2E_has_meta_3F_();
+            break;
+        case 9LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(311, 18, "has-meta?");
+            mw_ArrowType_2E_has_meta_3F_();
+            break;
+        case 10LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            mw_prim_pack_uncons(); mw_prim_swap();
+            WORD_ATOM(312, 13, "has-meta2?");
+            mw_Type_2E_has_meta2_3F_();
+            break;
+        case 7LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(313, 14, "drop2");
+            mw_drop2();
+            WORD_ATOM(313, 20, "F");
+            mw_F();
+            break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(308, 15, "drop2");
+            WORD_ATOM(314, 15, "drop2");
             mw_drop2();
-            WORD_ATOM(308, 21, "F");
+            WORD_ATOM(314, 21, "F");
             mw_F();
             break;
         case 12LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(309, 15, "has-meta?");
+            WORD_ATOM(315, 15, "has-meta?");
             mw_Value_2E_has_meta_3F_();
             break;
         case 11LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(310, 13, "has-meta?");
+            WORD_ATOM(316, 13, "has-meta?");
             mw_Type_2E_has_meta_3F_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -25908,43 +26174,43 @@ static void mw_Type_2E_has_meta_3F_ (void){
 }    WORD_EXIT(mw_Type_2E_has_meta_3F_);
 }
 static void mw_Type_2E_has_meta2_3F_ (void){
-    WORD_ENTER(mw_Type_2E_has_meta2_3F_, "Type.has-meta2?", "src/mirth/data/type.mth", 313, 5);
-    WORD_ATOM(313, 5, "dip");
+    WORD_ENTER(mw_Type_2E_has_meta2_3F_, "Type.has-meta2?", "src/mirth/data/type.mth", 319, 5);
+    WORD_ATOM(319, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(313, 9, "over");
+        WORD_ATOM(319, 9, "over");
         mw_over();
         push_value(d2);
     }
-    WORD_ATOM(313, 15, "has-meta?");
+    WORD_ATOM(319, 15, "has-meta?");
     mw_Type_2E_has_meta_3F_();
-    WORD_ATOM(313, 25, "if");
+    WORD_ATOM(319, 25, "if");
     if (pop_u64()) {
-        WORD_ATOM(313, 28, "drop2");
+        WORD_ATOM(319, 28, "drop2");
         mw_drop2();
-        WORD_ATOM(313, 34, "T");
+        WORD_ATOM(319, 34, "T");
         mw_T();
     } else {
-        WORD_ATOM(313, 37, "has-meta?");
+        WORD_ATOM(319, 37, "has-meta?");
         mw_Type_2E_has_meta_3F_();
     }
     WORD_EXIT(mw_Type_2E_has_meta2_3F_);
 }
 static void mw_Value_2E_has_meta_3F_ (void){
-    WORD_ENTER(mw_Value_2E_has_meta_3F_, "Value.has-meta?", "src/mirth/data/type.mth", 316, 5);
-    WORD_ATOM(316, 5, "type");
+    WORD_ENTER(mw_Value_2E_has_meta_3F_, "Value.has-meta?", "src/mirth/data/type.mth", 322, 5);
+    WORD_ATOM(322, 5, "type");
     mw_Value_2E_type();
-    WORD_ATOM(316, 10, "has-meta?");
+    WORD_ATOM(322, 10, "has-meta?");
     mw_Type_2E_has_meta_3F_();
     WORD_EXIT(mw_Value_2E_has_meta_3F_);
 }
 static void mw_Type_2E_trace_sig_21_ (void){
-    WORD_ENTER(mw_Type_2E_trace_sig_21_, "Type.trace-sig!", "src/mirth/data/type.mth", 319, 5);
-    WORD_ATOM(319, 5, "TMeta");
+    WORD_ENTER(mw_Type_2E_trace_sig_21_, "Type.trace-sig!", "src/mirth/data/type.mth", 325, 5);
+    WORD_ATOM(325, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(319, 14, "expand-if");
+            WORD_ATOM(325, 14, "expand-if");
             push_u64(0);
             push_fnptr(&mb_Type_2E_trace_sig_21__2);
             mw_prim_pack_cons();
@@ -25955,7 +26221,7 @@ static void mw_Type_2E_trace_sig_21_ (void){
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(320, 19, "");
+            WORD_ATOM(326, 19, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -25966,28 +26232,28 @@ static void mw_Type_2E_trace_sig_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(320, 29, "trace!");
+            WORD_ATOM(326, 29, "trace!");
             mw_Str_2E_trace_21_();
             break;
         case 9LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(321, 18, "trace!");
+            WORD_ATOM(327, 18, "trace!");
             mw_ArrowType_2E_trace_21_();
             break;
         default:
-            WORD_ATOM(322, 10, "trace!");
+            WORD_ATOM(328, 10, "trace!");
             mw_Type_2E_trace_21_();
             break;
     
 }    WORD_EXIT(mw_Type_2E_trace_sig_21_);
 }
 static void mw_Type_2E_trace_21_ (void){
-    WORD_ENTER(mw_Type_2E_trace_21_, "Type.trace!", "src/mirth/data/type.mth", 325, 5);
-    WORD_ATOM(325, 5, "TYPE_ERROR");
+    WORD_ENTER(mw_Type_2E_trace_21_, "Type.trace!", "src/mirth/data/type.mth", 331, 5);
+    WORD_ATOM(331, 5, "TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(325, 19, "");
+            WORD_ATOM(331, 19, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -25998,12 +26264,12 @@ static void mw_Type_2E_trace_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(325, 29, "trace!");
+            WORD_ATOM(331, 29, "trace!");
             mw_Str_2E_trace_21_();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(326, 23, "");
+            WORD_ATOM(332, 23, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -26014,27 +26280,27 @@ static void mw_Type_2E_trace_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(326, 27, "trace!");
+            WORD_ATOM(332, 27, "trace!");
             mw_Str_2E_trace_21_();
             break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(327, 14, "trace!");
+            WORD_ATOM(333, 14, "trace!");
             mw_PrimType_2E_trace_21_();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(328, 13, "trace!");
+            WORD_ATOM(334, 13, "trace!");
             mw_Var_2E_trace_21_();
             break;
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(329, 14, "trace!");
+            WORD_ATOM(335, 14, "trace!");
             mw_MetaVar_2E_trace_21_();
             break;
         case 8LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(330, 16, "");
+            WORD_ATOM(336, 16, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -26045,11 +26311,11 @@ static void mw_Type_2E_trace_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(330, 20, "trace!");
+            WORD_ATOM(336, 20, "trace!");
             mw_Str_2E_trace_21_();
-            WORD_ATOM(330, 27, "trace!");
+            WORD_ATOM(336, 27, "trace!");
             mw_StackType_2E_trace_21_();
-            WORD_ATOM(330, 34, "");
+            WORD_ATOM(336, 34, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -26060,12 +26326,12 @@ static void mw_Type_2E_trace_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(330, 38, "trace!");
+            WORD_ATOM(336, 38, "trace!");
             mw_Str_2E_trace_21_();
             break;
         case 9LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(331, 18, "");
+            WORD_ATOM(337, 18, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -26076,13 +26342,13 @@ static void mw_Type_2E_trace_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(331, 22, "trace!");
+            WORD_ATOM(337, 22, "trace!");
             mw_Str_2E_trace_21_();
-            WORD_ATOM(331, 29, "TMorphism");
+            WORD_ATOM(337, 29, "TMorphism");
             mw_TMorphism();
-            WORD_ATOM(331, 39, "trace-sig!");
+            WORD_ATOM(337, 39, "trace-sig!");
             mw_Type_2E_trace_sig_21_();
-            WORD_ATOM(331, 50, "");
+            WORD_ATOM(337, 50, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -26093,44 +26359,44 @@ static void mw_Type_2E_trace_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(331, 54, "trace!");
+            WORD_ATOM(337, 54, "trace!");
             mw_Str_2E_trace_21_();
             break;
         case 7LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(332, 14, "name");
+            WORD_ATOM(338, 14, "name");
             mw_Data_2E_name();
-            WORD_ATOM(332, 19, "trace!");
+            WORD_ATOM(338, 19, "trace!");
             mw_Name_2E_trace_21_();
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(333, 15, "name");
+            WORD_ATOM(339, 15, "name");
             mw_Table_2E_name();
-            WORD_ATOM(333, 20, "trace!");
+            WORD_ATOM(339, 20, "trace!");
             mw_Name_2E_trace_21_();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(334, 14, "trace!");
+            WORD_ATOM(340, 14, "trace!");
             mw_Name_2E_trace_21_();
             break;
         case 10LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(335, 13, "trace-app!");
+            WORD_ATOM(341, 13, "trace-app!");
             mw_Type_2E_trace_app_21_();
             break;
         case 12LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(336, 15, "type");
+            WORD_ATOM(342, 15, "type");
             mw_Value_2E_type();
-            WORD_ATOM(336, 20, "trace!");
+            WORD_ATOM(342, 20, "trace!");
             mw_Type_2E_trace_21_();
             break;
         case 11LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(337, 13, "");
+            WORD_ATOM(343, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -26141,11 +26407,11 @@ static void mw_Type_2E_trace_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(337, 20, "trace!");
+            WORD_ATOM(343, 20, "trace!");
             mw_Str_2E_trace_21_();
-            WORD_ATOM(337, 27, "trace!");
+            WORD_ATOM(343, 27, "trace!");
             mw_Type_2E_trace_21_();
-            WORD_ATOM(337, 34, "");
+            WORD_ATOM(343, 34, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -26156,7 +26422,7 @@ static void mw_Type_2E_trace_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(337, 38, "trace!");
+            WORD_ATOM(343, 38, "trace!");
             mw_Str_2E_trace_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -26164,32 +26430,32 @@ static void mw_Type_2E_trace_21_ (void){
 }    WORD_EXIT(mw_Type_2E_trace_21_);
 }
 static void mw_Value_2E_type (void){
-    WORD_ENTER(mw_Value_2E_type, "Value.type", "src/mirth/data/type.mth", 340, 5);
-    WORD_ATOM(340, 5, "VALUE_INT");
+    WORD_ENTER(mw_Value_2E_type, "Value.type", "src/mirth/data/type.mth", 346, 5);
+    WORD_ATOM(346, 5, "VALUE_INT");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(340, 18, "drop");
+            WORD_ATOM(346, 18, "drop");
             mw_prim_drop();
-            WORD_ATOM(340, 23, "PRIM_TYPE_INT");
+            WORD_ATOM(346, 23, "PRIM_TYPE_INT");
             mw_PRIM_5F_TYPE_5F_INT();
-            WORD_ATOM(340, 37, "TPrim");
+            WORD_ATOM(346, 37, "TPrim");
             mw_TPrim();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(341, 18, "drop");
+            WORD_ATOM(347, 18, "drop");
             mw_prim_drop();
-            WORD_ATOM(341, 23, "PRIM_TYPE_STR");
+            WORD_ATOM(347, 23, "PRIM_TYPE_STR");
             mw_PRIM_5F_TYPE_5F_STR();
-            WORD_ATOM(341, 37, "TPrim");
+            WORD_ATOM(347, 37, "TPrim");
             mw_TPrim();
             break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(342, 20, "type");
+            WORD_ATOM(348, 20, "type");
             mw_Block_2E_type();
-            WORD_ATOM(342, 25, ">Type");
+            WORD_ATOM(348, 25, ">Type");
             mw_ArrowType_3E_Type();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -26197,12 +26463,12 @@ static void mw_Value_2E_type (void){
 }    WORD_EXIT(mw_Value_2E_type);
 }
 static void mw_PrimType_2E_trace_21_ (void){
-    WORD_ENTER(mw_PrimType_2E_trace_21_, "PrimType.trace!", "src/mirth/data/type.mth", 345, 5);
-    WORD_ATOM(345, 5, "match");
+    WORD_ENTER(mw_PrimType_2E_trace_21_, "PrimType.trace!", "src/mirth/data/type.mth", 351, 5);
+    WORD_ATOM(351, 5, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(346, 27, "");
+            WORD_ATOM(352, 27, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -26216,7 +26482,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(347, 28, "");
+            WORD_ATOM(353, 28, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -26230,7 +26496,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             break;
         case 2LL:
             mw_prim_drop();
-            WORD_ATOM(348, 31, "");
+            WORD_ATOM(354, 31, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -26244,7 +26510,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             break;
         case 3LL:
             mw_prim_drop();
-            WORD_ATOM(349, 26, "");
+            WORD_ATOM(355, 26, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -26258,7 +26524,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             break;
         case 4LL:
             mw_prim_drop();
-            WORD_ATOM(350, 26, "");
+            WORD_ATOM(356, 26, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -26272,7 +26538,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             break;
         case 5LL:
             mw_prim_drop();
-            WORD_ATOM(351, 26, "");
+            WORD_ATOM(357, 26, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -26284,88 +26550,102 @@ static void mw_PrimType_2E_trace_21_ (void){
                 incref(v);
             }
             break;
+        case 6LL:
+            mw_prim_drop();
+            WORD_ATOM(358, 32, "");
+            {
+                static bool vready = false;
+                static VAL v;
+                if (! vready) {
+                    v = mkstr("+Platform", 9);
+                    vready = true;
+                }
+                push_value(v);
+                incref(v);
+            }
+            break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
     
-}    WORD_ATOM(352, 7, "trace!");
+}    WORD_ATOM(359, 7, "trace!");
     mw_Str_2E_trace_21_();
     WORD_EXIT(mw_PrimType_2E_trace_21_);
 }
 static void mw_Type_2E_freshen (void){
-    WORD_ENTER(mw_Type_2E_freshen, "Type.freshen", "src/mirth/data/type.mth", 373, 5);
-    WORD_ATOM(373, 5, "TYPE_ERROR");
+    WORD_ENTER(mw_Type_2E_freshen, "Type.freshen", "src/mirth/data/type.mth", 380, 5);
+    WORD_ATOM(380, 5, "TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(373, 19, "TYPE_ERROR");
+            WORD_ATOM(380, 19, "TYPE_ERROR");
             mw_TYPE_5F_ERROR();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(374, 23, "TYPE_DONT_CARE");
+            WORD_ATOM(381, 23, "TYPE_DONT_CARE");
             mw_TYPE_5F_DONT_5F_CARE();
             break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(375, 14, "TPrim");
+            WORD_ATOM(382, 14, "TPrim");
             mw_TPrim();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(376, 14, "THole");
+            WORD_ATOM(383, 14, "THole");
             mw_THole();
             break;
         case 7LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(377, 14, "TData");
+            WORD_ATOM(384, 14, "TData");
             mw_TData();
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(378, 15, "TTable");
+            WORD_ATOM(385, 15, "TTable");
             mw_TTable();
             break;
         case 12LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(379, 15, "TValue");
+            WORD_ATOM(386, 15, "TValue");
             mw_TValue();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(380, 13, "freshen");
+            WORD_ATOM(387, 13, "freshen");
             mw_Var_2E_freshen();
             break;
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(381, 14, "freshen");
+            WORD_ATOM(388, 14, "freshen");
             mw_MetaVar_2E_freshen();
             break;
         case 8LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(382, 16, "freshen");
+            WORD_ATOM(389, 16, "freshen");
             mw_StackType_2E_freshen();
-            WORD_ATOM(382, 24, "TTensor");
+            WORD_ATOM(389, 24, "TTensor");
             mw_TTensor();
             break;
         case 9LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(383, 18, "freshen");
+            WORD_ATOM(390, 18, "freshen");
             mw_ArrowType_2E_freshen();
-            WORD_ATOM(383, 26, "TMorphism");
+            WORD_ATOM(390, 26, "TMorphism");
             mw_TMorphism();
             break;
         case 10LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(384, 13, "freshen2");
+            WORD_ATOM(391, 13, "freshen2");
             mw_Type_2E_freshen2();
-            WORD_ATOM(384, 22, "TApp");
+            WORD_ATOM(391, 22, "TApp");
             mw_TApp();
             break;
         case 11LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(385, 13, "freshen");
+            WORD_ATOM(392, 13, "freshen");
             mw_Type_2E_freshen();
-            WORD_ATOM(385, 21, "TMut");
+            WORD_ATOM(392, 21, "TMut");
             mw_TMut();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -26373,30 +26653,30 @@ static void mw_Type_2E_freshen (void){
 }    WORD_EXIT(mw_Type_2E_freshen);
 }
 static void mw_Type_2E_freshen2 (void){
-    WORD_ENTER(mw_Type_2E_freshen2, "Type.freshen2", "src/mirth/data/type.mth", 389, 5);
-    WORD_ATOM(389, 5, "dip");
+    WORD_ENTER(mw_Type_2E_freshen2, "Type.freshen2", "src/mirth/data/type.mth", 396, 5);
+    WORD_ATOM(396, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(389, 9, "freshen");
+        WORD_ATOM(396, 9, "freshen");
         mw_Type_2E_freshen();
-        WORD_ATOM(389, 17, "swap");
+        WORD_ATOM(396, 17, "swap");
         mw_prim_swap();
         push_value(d2);
     }
-    WORD_ATOM(389, 23, "freshen");
+    WORD_ATOM(396, 23, "freshen");
     mw_Type_2E_freshen();
-    WORD_ATOM(389, 31, "dip");
+    WORD_ATOM(396, 31, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(389, 35, "swap");
+        WORD_ATOM(396, 35, "swap");
         mw_prim_swap();
         push_value(d2);
     }
     WORD_EXIT(mw_Type_2E_freshen2);
 }
 static void mw_MetaVar_2E_freshen (void){
-    WORD_ENTER(mw_MetaVar_2E_freshen, "MetaVar.freshen", "src/mirth/data/type.mth", 392, 5);
-    WORD_ATOM(392, 5, "expand-if");
+    WORD_ENTER(mw_MetaVar_2E_freshen, "MetaVar.freshen", "src/mirth/data/type.mth", 399, 5);
+    WORD_ATOM(399, 5, "expand-if");
     push_u64(0);
     push_fnptr(&mb_MetaVar_2E_freshen_1);
     mw_prim_pack_cons();
@@ -26407,32 +26687,32 @@ static void mw_MetaVar_2E_freshen (void){
     WORD_EXIT(mw_MetaVar_2E_freshen);
 }
 static void mw_Var_2E_freshen (void){
-    WORD_ENTER(mw_Var_2E_freshen, "Var.freshen", "src/mirth/data/type.mth", 395, 5);
-    WORD_ATOM(395, 5, "swap");
+    WORD_ENTER(mw_Var_2E_freshen, "Var.freshen", "src/mirth/data/type.mth", 402, 5);
+    WORD_ATOM(402, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(395, 10, "dup2");
+    WORD_ATOM(402, 10, "dup2");
     mw_dup2();
-    WORD_ATOM(395, 15, "has-var?");
+    WORD_ATOM(402, 15, "has-var?");
     mw_Subst_2E_has_var_3F_();
-    WORD_ATOM(395, 24, "if");
+    WORD_ATOM(402, 24, "if");
     if (pop_u64()) {
-        WORD_ATOM(396, 9, "tuck");
+        WORD_ATOM(403, 9, "tuck");
         mw_tuck();
-        WORD_ATOM(396, 14, "get-var");
+        WORD_ATOM(403, 14, "get-var");
         mw_Subst_2E_get_var();
     } else {
-        WORD_ATOM(397, 9, "MetaVar.new!");
+        WORD_ATOM(404, 9, "MetaVar.new!");
         mw_MetaVar_2E_new_21_();
-        WORD_ATOM(397, 22, "TMeta");
+        WORD_ATOM(404, 22, "TMeta");
         mw_TMeta();
-        WORD_ATOM(397, 28, "dup");
+        WORD_ATOM(404, 28, "dup");
         mw_prim_dup();
-        WORD_ATOM(398, 9, "dip");
+        WORD_ATOM(405, 9, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(398, 13, "rotr");
+            WORD_ATOM(405, 13, "rotr");
             mw_rotr();
-            WORD_ATOM(398, 18, "cons");
+            WORD_ATOM(405, 18, "cons");
             mw_Subst_2E_cons();
             push_value(d3);
         }
@@ -26440,12 +26720,12 @@ static void mw_Var_2E_freshen (void){
     WORD_EXIT(mw_Var_2E_freshen);
 }
 static void mw_Type_2E_arity (void){
-    WORD_ENTER(mw_Type_2E_arity, "Type.arity", "src/mirth/data/type.mth", 438, 5);
-    WORD_ATOM(438, 5, "TMeta");
+    WORD_ENTER(mw_Type_2E_arity, "Type.arity", "src/mirth/data/type.mth", 445, 5);
+    WORD_ATOM(445, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(438, 14, "expand-if");
+            WORD_ATOM(445, 14, "expand-if");
             push_u64(0);
             push_fnptr(&mb_Type_2E_arity_2);
             mw_prim_pack_cons();
@@ -26456,84 +26736,84 @@ static void mw_Type_2E_arity (void){
             break;
         case 7LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(439, 14, "arity");
+            WORD_ATOM(446, 14, "arity");
             mw_Data_2E_arity();
             break;
         case 10LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(440, 13, "drop");
+            WORD_ATOM(447, 13, "drop");
             mw_prim_drop();
-            WORD_ATOM(440, 18, "arity");
+            WORD_ATOM(447, 18, "arity");
             mw_Type_2E_arity();
-            WORD_ATOM(440, 24, "1-");
+            WORD_ATOM(447, 24, "1-");
             mw_prim_int_pred();
             break;
         default:
-            WORD_ATOM(441, 10, "drop");
+            WORD_ATOM(448, 10, "drop");
             mw_prim_drop();
-            WORD_ATOM(441, 15, "");
+            WORD_ATOM(448, 15, "");
             push_i64(0LL);
             break;
     
 }    WORD_EXIT(mw_Type_2E_arity);
 }
 static void mw_MetaVar_2E_id (void){
-    WORD_ENTER(mw_MetaVar_2E_id, "MetaVar.id", "src/mirth/data/type.mth", 469, 7);
-    WORD_ATOM(469, 7, "MetaVar");
+    WORD_ENTER(mw_MetaVar_2E_id, "MetaVar.id", "src/mirth/data/type.mth", 476, 7);
+    WORD_ATOM(476, 7, "MetaVar");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_MetaVar_2E_id);
 }
 static void mw_MetaVar_2E_alloc_21_ (void){
-    WORD_ENTER(mw_MetaVar_2E_alloc_21_, "MetaVar.alloc!", "src/mirth/data/type.mth", 469, 7);
-    WORD_ATOM(469, 7, "MetaVar");
+    WORD_ENTER(mw_MetaVar_2E_alloc_21_, "MetaVar.alloc!", "src/mirth/data/type.mth", 476, 7);
+    WORD_ATOM(476, 7, "MetaVar");
     mw_MetaVar_2E_NUM();
-    WORD_ATOM(469, 7, "MetaVar");
+    WORD_ATOM(476, 7, "MetaVar");
     mw_prim_u64_get();
-    WORD_ATOM(469, 7, "MetaVar");
+    WORD_ATOM(476, 7, "MetaVar");
     mw_prim_unsafe_cast();
-    WORD_ATOM(469, 7, "MetaVar");
+    WORD_ATOM(476, 7, "MetaVar");
     push_i64(1LL);
-    WORD_ATOM(469, 7, "MetaVar");
+    WORD_ATOM(476, 7, "MetaVar");
     mw_prim_int_add();
-    WORD_ATOM(469, 7, "MetaVar");
+    WORD_ATOM(476, 7, "MetaVar");
     mw_prim_dup();
-    WORD_ATOM(469, 7, "MetaVar");
+    WORD_ATOM(476, 7, "MetaVar");
     mw_prim_unsafe_cast();
-    WORD_ATOM(469, 7, "MetaVar");
+    WORD_ATOM(476, 7, "MetaVar");
     mw_MetaVar_2E_NUM();
-    WORD_ATOM(469, 7, "MetaVar");
+    WORD_ATOM(476, 7, "MetaVar");
     mw_prim_u64_set();
-    WORD_ATOM(469, 7, "MetaVar");
+    WORD_ATOM(476, 7, "MetaVar");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_MetaVar_2E_alloc_21_);
 }
 static void mw_MetaVar_2E_type_3F_ (void){
-    WORD_ENTER(mw_MetaVar_2E_type_3F_, "MetaVar.type?", "src/mirth/data/type.mth", 471, 44);
-    WORD_ATOM(471, 44, "~type?");
+    WORD_ENTER(mw_MetaVar_2E_type_3F_, "MetaVar.type?", "src/mirth/data/type.mth", 478, 44);
+    WORD_ATOM(478, 44, "~type?");
     mw_MetaVar_7E_type_3F_();
-    WORD_ATOM(471, 51, "@");
+    WORD_ATOM(478, 51, "@");
     mw_prim_mut_get();
     WORD_EXIT(mw_MetaVar_2E_type_3F_);
 }
 static void mw_MetaVar_2E_has_meta_3F_ (void){
-    WORD_ENTER(mw_MetaVar_2E_has_meta_3F_, "MetaVar.has-meta?", "src/mirth/data/type.mth", 474, 5);
-    WORD_ATOM(474, 5, "dup");
+    WORD_ENTER(mw_MetaVar_2E_has_meta_3F_, "MetaVar.has-meta?", "src/mirth/data/type.mth", 481, 5);
+    WORD_ATOM(481, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(474, 9, "type?");
+    WORD_ATOM(481, 9, "type?");
     mw_MetaVar_2E_type_3F_();
-    WORD_ATOM(474, 15, "match");
+    WORD_ATOM(481, 15, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(475, 17, "=");
+            WORD_ATOM(482, 17, "=");
             mw_MetaVar_3D_();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(476, 17, "nip");
+            WORD_ATOM(483, 17, "nip");
             mw_nip();
-            WORD_ATOM(476, 21, "has-meta?");
+            WORD_ATOM(483, 21, "has-meta?");
             mw_Type_2E_has_meta_3F_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -26541,16 +26821,16 @@ static void mw_MetaVar_2E_has_meta_3F_ (void){
 }    WORD_EXIT(mw_MetaVar_2E_has_meta_3F_);
 }
 static void mw_MetaVar_2E_trace_21_ (void){
-    WORD_ENTER(mw_MetaVar_2E_trace_21_, "MetaVar.trace!", "src/mirth/data/type.mth", 480, 5);
-    WORD_ATOM(480, 5, "dup");
+    WORD_ENTER(mw_MetaVar_2E_trace_21_, "MetaVar.trace!", "src/mirth/data/type.mth", 487, 5);
+    WORD_ATOM(487, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(480, 9, "type?");
+    WORD_ATOM(487, 9, "type?");
     mw_MetaVar_2E_type_3F_();
-    WORD_ATOM(480, 15, "match");
+    WORD_ATOM(487, 15, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(481, 17, "");
+            WORD_ATOM(488, 17, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -26561,18 +26841,18 @@ static void mw_MetaVar_2E_trace_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(481, 21, "trace!");
+            WORD_ATOM(488, 21, "trace!");
             mw_Str_2E_trace_21_();
-            WORD_ATOM(481, 28, "MetaVar.id");
+            WORD_ATOM(488, 28, "MetaVar.id");
             mw_MetaVar_2E_id();
-            WORD_ATOM(481, 39, "trace!");
+            WORD_ATOM(488, 39, "trace!");
             mw_Int_2E_trace_21_();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(482, 17, "nip");
+            WORD_ATOM(489, 17, "nip");
             mw_nip();
-            WORD_ATOM(482, 21, "trace!");
+            WORD_ATOM(489, 21, "trace!");
             mw_Type_2E_trace_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -26580,52 +26860,52 @@ static void mw_MetaVar_2E_trace_21_ (void){
 }    WORD_EXIT(mw_MetaVar_2E_trace_21_);
 }
 static void mw_MetaVar_2E_new_21_ (void){
-    WORD_ENTER(mw_MetaVar_2E_new_21_, "MetaVar.new!", "src/mirth/data/type.mth", 485, 5);
-    WORD_ATOM(485, 5, "MetaVar.alloc!");
+    WORD_ENTER(mw_MetaVar_2E_new_21_, "MetaVar.new!", "src/mirth/data/type.mth", 492, 5);
+    WORD_ATOM(492, 5, "MetaVar.alloc!");
     mw_MetaVar_2E_alloc_21_();
-    WORD_ATOM(486, 5, "NONE");
+    WORD_ATOM(493, 5, "NONE");
     mw_NONE();
-    WORD_ATOM(486, 10, "over");
+    WORD_ATOM(493, 10, "over");
     mw_over();
-    WORD_ATOM(486, 15, "~type?");
+    WORD_ATOM(493, 15, "~type?");
     mw_MetaVar_7E_type_3F_();
-    WORD_ATOM(486, 22, "!");
+    WORD_ATOM(493, 22, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_MetaVar_2E_new_21_);
 }
 static void mw_MetaVar_2E_expand_if (void){
-    WORD_ENTER(mw_MetaVar_2E_expand_if, "MetaVar.expand-if", "src/mirth/data/type.mth", 489, 5);
-    WORD_ATOM(489, 5, "dup");
+    WORD_ENTER(mw_MetaVar_2E_expand_if, "MetaVar.expand-if", "src/mirth/data/type.mth", 496, 5);
+    WORD_ATOM(496, 5, "dup");
     {
         VAL var_g = pop_value();
         VAL var_f = pop_value();
-        WORD_ATOM(489, 5, "dup");
+        WORD_ATOM(496, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(489, 9, "type?");
+        WORD_ATOM(496, 9, "type?");
         mw_MetaVar_2E_type_3F_();
-        WORD_ATOM(489, 15, "match");
+        WORD_ATOM(496, 15, "match");
         switch (get_top_data_tag()) {
             case 0LL:
                 mw_prim_drop();
-                WORD_ATOM(490, 17, "g");
+                WORD_ATOM(497, 17, "g");
                 incref(var_g);
                 run_value(var_g);
                 break;
             case 1LL:
                 mw_prim_pack_uncons(); mw_prim_drop();
-                WORD_ATOM(491, 17, "expand");
+                WORD_ATOM(498, 17, "expand");
                 mw_Type_2E_expand();
-                WORD_ATOM(491, 24, "tuck");
+                WORD_ATOM(498, 24, "tuck");
                 mw_tuck();
-                WORD_ATOM(491, 29, "SOME");
+                WORD_ATOM(498, 29, "SOME");
                 mw_SOME();
-                WORD_ATOM(491, 34, "swap");
+                WORD_ATOM(498, 34, "swap");
                 mw_prim_swap();
-                WORD_ATOM(491, 39, "~type?");
+                WORD_ATOM(498, 39, "~type?");
                 mw_MetaVar_7E_type_3F_();
-                WORD_ATOM(491, 46, "!");
+                WORD_ATOM(498, 46, "!");
                 mw_prim_mut_set();
-                WORD_ATOM(491, 48, "f");
+                WORD_ATOM(498, 48, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
@@ -26637,8 +26917,8 @@ static void mw_MetaVar_2E_expand_if (void){
     WORD_EXIT(mw_MetaVar_2E_expand_if);
 }
 static void mw_MetaVar_2E_expand (void){
-    WORD_ENTER(mw_MetaVar_2E_expand, "MetaVar.expand", "src/mirth/data/type.mth", 494, 5);
-    WORD_ATOM(494, 5, "expand-if");
+    WORD_ENTER(mw_MetaVar_2E_expand, "MetaVar.expand", "src/mirth/data/type.mth", 501, 5);
+    WORD_ATOM(501, 5, "expand-if");
     push_u64(0);
     push_fnptr(&mb_MetaVar_2E_expand_1);
     mw_prim_pack_cons();
@@ -26649,57 +26929,57 @@ static void mw_MetaVar_2E_expand (void){
     WORD_EXIT(mw_MetaVar_2E_expand);
 }
 static void mw_MetaVar_2E_unify_21_ (void){
-    WORD_ENTER(mw_MetaVar_2E_unify_21_, "MetaVar.unify!", "src/mirth/data/type.mth", 496, 5);
-    WORD_ATOM(496, 5, "dup");
+    WORD_ENTER(mw_MetaVar_2E_unify_21_, "MetaVar.unify!", "src/mirth/data/type.mth", 503, 5);
+    WORD_ATOM(503, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(496, 9, "type?");
+    WORD_ATOM(503, 9, "type?");
     mw_MetaVar_2E_type_3F_();
-    WORD_ATOM(496, 15, "match");
+    WORD_ATOM(503, 15, "match");
     switch (get_top_data_tag()) {
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(497, 17, "nip");
+            WORD_ATOM(504, 17, "nip");
             mw_nip();
-            WORD_ATOM(497, 21, "unify!");
+            WORD_ATOM(504, 21, "unify!");
             mw_Type_2E_unify_21_();
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(498, 17, "dup2");
+            WORD_ATOM(505, 17, "dup2");
             mw_dup2();
-            WORD_ATOM(498, 22, "swap");
+            WORD_ATOM(505, 22, "swap");
             mw_prim_swap();
-            WORD_ATOM(498, 27, "=meta");
+            WORD_ATOM(505, 27, "=meta");
             mw_Type_3D_meta();
-            WORD_ATOM(498, 33, "if");
+            WORD_ATOM(505, 33, "if");
             if (pop_u64()) {
-                WORD_ATOM(499, 13, "drop");
+                WORD_ATOM(506, 13, "drop");
                 mw_prim_drop();
             } else {
-                WORD_ATOM(500, 13, "swap");
+                WORD_ATOM(507, 13, "swap");
                 mw_prim_swap();
-                WORD_ATOM(500, 18, "dup2");
+                WORD_ATOM(507, 18, "dup2");
                 mw_dup2();
-                WORD_ATOM(500, 23, "has-meta?");
+                WORD_ATOM(507, 23, "has-meta?");
                 mw_Type_2E_has_meta_3F_();
-                WORD_ATOM(500, 33, "if");
+                WORD_ATOM(507, 33, "if");
                 if (pop_u64()) {
-                    WORD_ATOM(501, 17, "swap");
+                    WORD_ATOM(508, 17, "swap");
                     mw_prim_swap();
-                    WORD_ATOM(501, 22, "TMeta");
+                    WORD_ATOM(508, 22, "TMeta");
                     mw_TMeta();
-                    WORD_ATOM(501, 28, "unify-failed!");
+                    WORD_ATOM(508, 28, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                 } else {
-                    WORD_ATOM(502, 17, "tuck");
+                    WORD_ATOM(509, 17, "tuck");
                     mw_tuck();
-                    WORD_ATOM(502, 22, "SOME");
+                    WORD_ATOM(509, 22, "SOME");
                     mw_SOME();
-                    WORD_ATOM(502, 27, "swap");
+                    WORD_ATOM(509, 27, "swap");
                     mw_prim_swap();
-                    WORD_ATOM(502, 32, "~type?");
+                    WORD_ATOM(509, 32, "~type?");
                     mw_MetaVar_7E_type_3F_();
-                    WORD_ATOM(502, 39, "!");
+                    WORD_ATOM(509, 39, "!");
                     mw_prim_mut_set();
                 }
             }
@@ -26709,23 +26989,23 @@ static void mw_MetaVar_2E_unify_21_ (void){
 }    WORD_EXIT(mw_MetaVar_2E_unify_21_);
 }
 static void mw_MetaVar_3D_ (void){
-    WORD_ENTER(mw_MetaVar_3D_, "MetaVar=", "src/mirth/data/type.mth", 512, 40);
-    WORD_ATOM(512, 40, "both");
+    WORD_ENTER(mw_MetaVar_3D_, "MetaVar=", "src/mirth/data/type.mth", 519, 40);
+    WORD_ATOM(519, 40, "both");
     push_u64(0);
     push_fnptr(&mb_MetaVar_3D__1);
     mw_prim_pack_cons();
     mw_both();
-    WORD_ATOM(512, 50, "=");
+    WORD_ATOM(519, 50, "=");
     mw_prim_int_eq();
     WORD_EXIT(mw_MetaVar_3D_);
 }
 static void mw_type_hole_unify_21_ (void){
-    WORD_ENTER(mw_type_hole_unify_21_, "type-hole-unify!", "src/mirth/data/type.mth", 519, 5);
-    WORD_ATOM(519, 5, "THole");
+    WORD_ENTER(mw_type_hole_unify_21_, "type-hole-unify!", "src/mirth/data/type.mth", 526, 5);
+    WORD_ATOM(526, 5, "THole");
     mw_THole();
-    WORD_ATOM(519, 11, "trace!");
+    WORD_ATOM(526, 11, "trace!");
     mw_Type_2E_trace_21_();
-    WORD_ATOM(520, 5, "");
+    WORD_ATOM(527, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -26736,21 +27016,21 @@ static void mw_type_hole_unify_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(520, 11, "trace!");
+    WORD_ATOM(527, 11, "trace!");
     mw_Str_2E_trace_21_();
-    WORD_ATOM(521, 5, "dup");
+    WORD_ATOM(528, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(521, 9, "trace!");
+    WORD_ATOM(528, 9, "trace!");
     mw_Type_2E_trace_21_();
-    WORD_ATOM(522, 5, "line-trace!");
+    WORD_ATOM(529, 5, "line-trace!");
     mw_line_trace_21_();
     WORD_EXIT(mw_type_hole_unify_21_);
 }
 static void mw_Type_2E_trace_app_21_ (void){
-    WORD_ENTER(mw_Type_2E_trace_app_21_, "Type.trace-app!", "src/mirth/data/type.mth", 529, 5);
-    WORD_ATOM(529, 5, "trace-app-open!");
+    WORD_ENTER(mw_Type_2E_trace_app_21_, "Type.trace-app!", "src/mirth/data/type.mth", 536, 5);
+    WORD_ATOM(536, 5, "trace-app-open!");
     mw_Type_2E_trace_app_open_21_();
-    WORD_ATOM(529, 21, "");
+    WORD_ATOM(536, 21, "");
     {
         static bool vready = false;
         static VAL v;
@@ -26761,24 +27041,24 @@ static void mw_Type_2E_trace_app_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(529, 25, "trace!");
+    WORD_ATOM(536, 25, "trace!");
     mw_Str_2E_trace_21_();
     WORD_EXIT(mw_Type_2E_trace_app_21_);
 }
 static void mw_Type_2E_trace_app_open_21_ (void){
-    WORD_ENTER(mw_Type_2E_trace_app_open_21_, "Type.trace-app-open!", "src/mirth/data/type.mth", 532, 5);
-    WORD_ATOM(532, 5, "swap");
+    WORD_ENTER(mw_Type_2E_trace_app_open_21_, "Type.trace-app-open!", "src/mirth/data/type.mth", 539, 5);
+    WORD_ATOM(539, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(532, 10, "expand");
+    WORD_ATOM(539, 10, "expand");
     mw_Type_2E_expand();
-    WORD_ATOM(532, 17, "match");
+    WORD_ATOM(539, 17, "match");
     switch (get_top_data_tag()) {
         case 10LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(534, 13, "trace-app-open!");
+            WORD_ATOM(541, 13, "trace-app-open!");
             mw_Type_2E_trace_app_open_21_();
-            WORD_ATOM(535, 13, "");
+            WORD_ATOM(542, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -26789,15 +27069,15 @@ static void mw_Type_2E_trace_app_open_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(535, 18, "trace!");
+            WORD_ATOM(542, 18, "trace!");
             mw_Str_2E_trace_21_();
-            WORD_ATOM(536, 13, "trace!");
+            WORD_ATOM(543, 13, "trace!");
             mw_Type_2E_trace_21_();
             break;
         default:
-            WORD_ATOM(538, 13, "trace!");
+            WORD_ATOM(545, 13, "trace!");
             mw_Type_2E_trace_21_();
-            WORD_ATOM(539, 13, "");
+            WORD_ATOM(546, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -26808,110 +27088,97 @@ static void mw_Type_2E_trace_app_open_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(539, 17, "trace!");
+            WORD_ATOM(546, 17, "trace!");
             mw_Str_2E_trace_21_();
-            WORD_ATOM(540, 13, "trace!");
+            WORD_ATOM(547, 13, "trace!");
             mw_Type_2E_trace_21_();
             break;
     
 }    WORD_EXIT(mw_Type_2E_trace_app_open_21_);
 }
 static void mw_Resource_3E_Type (void){
-    WORD_ENTER(mw_Resource_3E_Type, "Resource>Type", "src/mirth/data/type.mth", 548, 38);
-    WORD_ATOM(548, 38, "RESOURCE");
-    WORD_ATOM(548, 50, "id");
+    WORD_ENTER(mw_Resource_3E_Type, "Resource>Type", "src/mirth/data/type.mth", 555, 38);
+    WORD_ATOM(555, 38, "RESOURCE");
+    WORD_ATOM(555, 50, "id");
     mw_prim_id();
     WORD_EXIT(mw_Resource_3E_Type);
 }
 static void mw_Type_3E_Resource (void){
-    WORD_ENTER(mw_Type_3E_Resource, "Type>Resource", "src/mirth/data/type.mth", 549, 38);
-    WORD_ATOM(549, 38, "RESOURCE");
+    WORD_ENTER(mw_Type_3E_Resource, "Type>Resource", "src/mirth/data/type.mth", 556, 38);
+    WORD_ATOM(556, 38, "RESOURCE");
     mw_RESOURCE();
     WORD_EXIT(mw_Type_3E_Resource);
 }
 static void mw_Resource_2E_has_meta_3F_ (void){
-    WORD_ENTER(mw_Resource_2E_has_meta_3F_, "Resource.has-meta?", "src/mirth/data/type.mth", 550, 51);
-    WORD_ATOM(550, 51, ">Type");
+    WORD_ENTER(mw_Resource_2E_has_meta_3F_, "Resource.has-meta?", "src/mirth/data/type.mth", 557, 51);
+    WORD_ATOM(557, 51, ">Type");
     mw_Resource_3E_Type();
-    WORD_ATOM(550, 57, "has-meta?");
+    WORD_ATOM(557, 57, "has-meta?");
     mw_Type_2E_has_meta_3F_();
     WORD_EXIT(mw_Resource_2E_has_meta_3F_);
 }
 static void mw_Resource_2E_unify_21_ (void){
-    WORD_ENTER(mw_Resource_2E_unify_21_, "Resource.unify!", "src/mirth/data/type.mth", 552, 5);
-    WORD_ATOM(552, 5, "both");
+    WORD_ENTER(mw_Resource_2E_unify_21_, "Resource.unify!", "src/mirth/data/type.mth", 559, 5);
+    WORD_ATOM(559, 5, "both");
     push_u64(0);
     push_fnptr(&mb_Resource_2E_unify_21__1);
     mw_prim_pack_cons();
     mw_both();
-    WORD_ATOM(552, 17, "unify!");
+    WORD_ATOM(559, 17, "unify!");
     mw_Type_2E_unify_21_();
-    WORD_ATOM(552, 24, ">Resource");
+    WORD_ATOM(559, 24, ">Resource");
     mw_Type_3E_Resource();
     WORD_EXIT(mw_Resource_2E_unify_21_);
 }
 static void mw_Resource_2E_trace_21_ (void){
-    WORD_ENTER(mw_Resource_2E_trace_21_, "Resource.trace!", "src/mirth/data/type.mth", 554, 5);
-    WORD_ATOM(554, 5, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr("+", 1);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(554, 9, "trace!");
-    mw_Str_2E_trace_21_();
-    WORD_ATOM(555, 5, ">Type");
+    WORD_ENTER(mw_Resource_2E_trace_21_, "Resource.trace!", "src/mirth/data/type.mth", 560, 35);
+    WORD_ATOM(560, 35, ">Type");
     mw_Resource_3E_Type();
-    WORD_ATOM(555, 11, "trace!");
+    WORD_ATOM(560, 41, "trace!");
     mw_Type_2E_trace_21_();
     WORD_EXIT(mw_Resource_2E_trace_21_);
 }
 static void mw_Resource_2E_freshen (void){
-    WORD_ENTER(mw_Resource_2E_freshen, "Resource.freshen", "src/mirth/data/type.mth", 557, 5);
-    WORD_ATOM(557, 5, ">Type");
+    WORD_ENTER(mw_Resource_2E_freshen, "Resource.freshen", "src/mirth/data/type.mth", 562, 5);
+    WORD_ATOM(562, 5, ">Type");
     mw_Resource_3E_Type();
-    WORD_ATOM(557, 11, "freshen");
+    WORD_ATOM(562, 11, "freshen");
     mw_Type_2E_freshen();
-    WORD_ATOM(557, 19, ">Resource");
+    WORD_ATOM(562, 19, ">Resource");
     mw_Type_3E_Resource();
     WORD_EXIT(mw_Resource_2E_freshen);
 }
 static void mw_Type_3E_StackType (void){
-    WORD_ENTER(mw_Type_3E_StackType, "Type>StackType", "src/mirth/data/type.mth", 575, 5);
-    WORD_ATOM(575, 5, "TYPE_ERROR");
+    WORD_ENTER(mw_Type_3E_StackType, "Type>StackType", "src/mirth/data/type.mth", 580, 5);
+    WORD_ATOM(580, 5, "TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(575, 19, "STACK_TYPE_ERROR");
+            WORD_ATOM(580, 19, "STACK_TYPE_ERROR");
             mw_STACK_5F_TYPE_5F_ERROR();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(576, 23, "STACK_TYPE_DONT_CARE");
+            WORD_ATOM(581, 23, "STACK_TYPE_DONT_CARE");
             mw_STACK_5F_TYPE_5F_DONT_5F_CARE();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(577, 13, "STVar");
+            WORD_ATOM(582, 13, "STVar");
             mw_STVar();
             break;
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(578, 14, "STMeta");
+            WORD_ATOM(583, 14, "STMeta");
             mw_STMeta();
             break;
         case 8LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(579, 16, "id");
+            WORD_ATOM(584, 16, "id");
             mw_prim_id();
             break;
         default:
-            WORD_ATOM(580, 10, "");
+            WORD_ATOM(585, 10, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -26922,103 +27189,103 @@ static void mw_Type_3E_StackType (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(580, 63, "panic!");
+            WORD_ATOM(585, 63, "panic!");
             mw_prim_panic();
             break;
     
 }    WORD_EXIT(mw_Type_3E_StackType);
 }
 static void mw_StackType_3E_Type (void){
-    WORD_ENTER(mw_StackType_3E_Type, "StackType>Type", "src/mirth/data/type.mth", 583, 5);
-    WORD_ATOM(583, 5, "STACK_TYPE_ERROR");
+    WORD_ENTER(mw_StackType_3E_Type, "StackType>Type", "src/mirth/data/type.mth", 588, 5);
+    WORD_ATOM(588, 5, "STACK_TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(583, 25, "TYPE_ERROR");
+            WORD_ATOM(588, 25, "TYPE_ERROR");
             mw_TYPE_5F_ERROR();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(584, 29, "TYPE_DONT_CARE");
+            WORD_ATOM(589, 29, "TYPE_DONT_CARE");
             mw_TYPE_5F_DONT_5F_CARE();
             break;
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(585, 14, "TVar");
+            WORD_ATOM(590, 14, "TVar");
             mw_TVar();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(586, 15, "TMeta");
+            WORD_ATOM(591, 15, "TMeta");
             mw_TMeta();
             break;
         default:
-            WORD_ATOM(587, 10, "TTensor");
+            WORD_ATOM(592, 10, "TTensor");
             mw_TTensor();
             break;
     
 }    WORD_EXIT(mw_StackType_3E_Type);
 }
 static void mw_StackType_2E_expand (void){
-    WORD_ENTER(mw_StackType_2E_expand, "StackType.expand", "src/mirth/data/type.mth", 590, 5);
-    WORD_ATOM(590, 5, "STMeta");
+    WORD_ENTER(mw_StackType_2E_expand, "StackType.expand", "src/mirth/data/type.mth", 595, 5);
+    WORD_ATOM(595, 5, "STMeta");
     switch (get_top_data_tag()) {
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(590, 15, "expand");
+            WORD_ATOM(595, 15, "expand");
             mw_MetaVar_2E_expand();
-            WORD_ATOM(590, 22, ">StackType");
+            WORD_ATOM(595, 22, ">StackType");
             mw_Type_3E_StackType();
             break;
         default:
-            WORD_ATOM(591, 10, "id");
+            WORD_ATOM(596, 10, "id");
             mw_prim_id();
             break;
     
 }    WORD_EXIT(mw_StackType_2E_expand);
 }
 static void mw_StackType_2E_unit_3F_ (void){
-    WORD_ENTER(mw_StackType_2E_unit_3F_, "StackType.unit?", "src/mirth/data/type.mth", 594, 5);
-    WORD_ATOM(594, 5, "expand");
+    WORD_ENTER(mw_StackType_2E_unit_3F_, "StackType.unit?", "src/mirth/data/type.mth", 599, 5);
+    WORD_ATOM(599, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(594, 12, "match");
+    WORD_ATOM(599, 12, "match");
     switch (get_top_data_tag()) {
         case 2LL:
             mw_prim_drop();
-            WORD_ATOM(595, 28, "T");
+            WORD_ATOM(600, 28, "T");
             mw_T();
             break;
         default:
-            WORD_ATOM(596, 14, "drop");
+            WORD_ATOM(601, 14, "drop");
             mw_prim_drop();
-            WORD_ATOM(596, 19, "F");
+            WORD_ATOM(601, 19, "F");
             mw_F();
             break;
     
 }    WORD_EXIT(mw_StackType_2E_unit_3F_);
 }
 static void mw_StackType_2E_split3 (void){
-    WORD_ENTER(mw_StackType_2E_split3, "StackType.split3", "src/mirth/data/type.mth", 601, 5);
-    WORD_ATOM(601, 5, "expand");
+    WORD_ENTER(mw_StackType_2E_split3, "StackType.split3", "src/mirth/data/type.mth", 606, 5);
+    WORD_ATOM(606, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(601, 12, "match");
+    WORD_ATOM(606, 12, "match");
     switch (get_top_data_tag()) {
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(602, 19, "dip");
+            WORD_ATOM(607, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(602, 23, "split3");
+                WORD_ATOM(607, 23, "split3");
                 mw_StackType_2E_split3();
                 push_value(d4);
             }
-            WORD_ATOM(602, 31, "swap");
+            WORD_ATOM(607, 31, "swap");
             mw_prim_swap();
-            WORD_ATOM(602, 36, "dip");
+            WORD_ATOM(607, 36, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(602, 40, "snoc");
+                WORD_ATOM(607, 40, "snoc");
                 mw_snoc();
                 push_value(d4);
             }
@@ -27026,149 +27293,199 @@ static void mw_StackType_2E_split3 (void){
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(603, 19, "dip");
+            WORD_ATOM(608, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(603, 23, "split3");
+                WORD_ATOM(608, 23, "split3");
                 mw_StackType_2E_split3();
                 push_value(d4);
             }
-            WORD_ATOM(603, 31, "snoc");
+            WORD_ATOM(608, 31, "snoc");
             mw_snoc();
             break;
         default:
-            WORD_ATOM(604, 14, "L0");
+            WORD_ATOM(609, 14, "L0");
             mw_L0();
-            WORD_ATOM(604, 17, "L0");
+            WORD_ATOM(609, 17, "L0");
             mw_L0();
             break;
     
 }    WORD_EXIT(mw_StackType_2E_split3);
 }
 static void mw_StackType_2E_base (void){
-    WORD_ENTER(mw_StackType_2E_base, "StackType.base", "src/mirth/data/type.mth", 608, 45);
-    WORD_ATOM(608, 45, "split3");
+    WORD_ENTER(mw_StackType_2E_base, "StackType.base", "src/mirth/data/type.mth", 613, 45);
+    WORD_ATOM(613, 45, "split3");
     mw_StackType_2E_split3();
-    WORD_ATOM(608, 52, "drop2");
+    WORD_ATOM(613, 52, "drop2");
     mw_drop2();
     WORD_EXIT(mw_StackType_2E_base);
 }
 static void mw_StackType_2E_top_type (void){
-    WORD_ENTER(mw_StackType_2E_top_type, "StackType.top-type", "src/mirth/data/type.mth", 618, 5);
-    WORD_ATOM(618, 5, "expand");
+    WORD_ENTER(mw_StackType_2E_top_type, "StackType.top-type", "src/mirth/data/type.mth", 623, 5);
+    WORD_ATOM(623, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(618, 12, "match");
+    WORD_ATOM(623, 12, "match");
     switch (get_top_data_tag()) {
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(619, 19, "nip");
+            WORD_ATOM(624, 19, "nip");
             mw_nip();
-            WORD_ATOM(619, 23, "SOME");
+            WORD_ATOM(624, 23, "SOME");
             mw_SOME();
             break;
-        default:
-            WORD_ATOM(620, 14, "drop");
+        case 6LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            mw_prim_pack_uncons(); mw_prim_swap();
+            WORD_ATOM(625, 19, "drop");
             mw_prim_drop();
-            WORD_ATOM(620, 19, "NONE");
+            WORD_ATOM(625, 24, "top-type");
+            mw_StackType_2E_top_type();
+            break;
+        default:
+            WORD_ATOM(626, 14, "drop");
+            mw_prim_drop();
+            WORD_ATOM(626, 19, "NONE");
             mw_NONE();
             break;
     
 }    WORD_EXIT(mw_StackType_2E_top_type);
 }
 static void mw_StackType_2E_top_tycon_name (void){
-    WORD_ENTER(mw_StackType_2E_top_tycon_name, "StackType.top-tycon-name", "src/mirth/data/type.mth", 625, 5);
-    WORD_ATOM(625, 5, "top-type");
+    WORD_ENTER(mw_StackType_2E_top_tycon_name, "StackType.top-tycon-name", "src/mirth/data/type.mth", 631, 5);
+    WORD_ATOM(631, 5, "top-type");
     mw_StackType_2E_top_type();
-    WORD_ATOM(625, 14, "bind");
+    WORD_ATOM(631, 14, "bind");
     push_u64(0);
     push_fnptr(&mb_StackType_2E_top_tycon_name_1);
     mw_prim_pack_cons();
     mw_Maybe_2E_bind();
     WORD_EXIT(mw_StackType_2E_top_tycon_name);
 }
-static void mw_StackType_2E_has_meta_3F_ (void){
-    WORD_ENTER(mw_StackType_2E_has_meta_3F_, "StackType.has-meta?", "src/mirth/data/type.mth", 628, 5);
-    WORD_ATOM(628, 5, "expand");
+static void mw_StackType_2E_top_resource (void){
+    WORD_ENTER(mw_StackType_2E_top_resource, "StackType.top-resource", "src/mirth/data/type.mth", 635, 5);
+    WORD_ATOM(635, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(628, 12, "match");
+    WORD_ATOM(635, 12, "match");
+    switch (get_top_data_tag()) {
+        case 6LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            mw_prim_pack_uncons(); mw_prim_swap();
+            WORD_ATOM(636, 19, "nip");
+            mw_nip();
+            WORD_ATOM(636, 23, "SOME");
+            mw_SOME();
+            break;
+        case 5LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            mw_prim_pack_uncons(); mw_prim_swap();
+            WORD_ATOM(637, 19, "drop");
+            mw_prim_drop();
+            WORD_ATOM(637, 24, "top-resource");
+            mw_StackType_2E_top_resource();
+            break;
+        default:
+            WORD_ATOM(638, 14, "drop");
+            mw_prim_drop();
+            WORD_ATOM(638, 19, "NONE");
+            mw_NONE();
+            break;
+    
+}    WORD_EXIT(mw_StackType_2E_top_resource);
+}
+static void mw_StackType_2E_top_resource_name (void){
+    WORD_ENTER(mw_StackType_2E_top_resource_name, "StackType.top-resource-name", "src/mirth/data/type.mth", 643, 5);
+    WORD_ATOM(643, 5, "top-resource");
+    mw_StackType_2E_top_resource();
+    WORD_ATOM(643, 18, "bind");
+    push_u64(0);
+    push_fnptr(&mb_StackType_2E_top_resource_name_1);
+    mw_prim_pack_cons();
+    mw_Maybe_2E_bind();
+    WORD_EXIT(mw_StackType_2E_top_resource_name);
+}
+static void mw_StackType_2E_has_meta_3F_ (void){
+    WORD_ENTER(mw_StackType_2E_has_meta_3F_, "StackType.has-meta?", "src/mirth/data/type.mth", 646, 5);
+    WORD_ATOM(646, 5, "expand");
+    mw_StackType_2E_expand();
+    WORD_ATOM(646, 12, "match");
     switch (get_top_data_tag()) {
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(629, 19, "=");
+            WORD_ATOM(647, 19, "=");
             mw_MetaVar_3D_();
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(630, 29, "drop");
+            WORD_ATOM(648, 29, "drop");
             mw_prim_drop();
-            WORD_ATOM(630, 34, "F");
+            WORD_ATOM(648, 34, "F");
             mw_F();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(631, 33, "drop");
+            WORD_ATOM(649, 33, "drop");
             mw_prim_drop();
-            WORD_ATOM(631, 38, "F");
+            WORD_ATOM(649, 38, "F");
             mw_F();
             break;
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(632, 18, "drop2");
+            WORD_ATOM(650, 18, "drop2");
             mw_drop2();
-            WORD_ATOM(632, 24, "F");
+            WORD_ATOM(650, 24, "F");
             mw_F();
             break;
         case 2LL:
             mw_prim_drop();
-            WORD_ATOM(633, 28, "drop");
+            WORD_ATOM(651, 28, "drop");
             mw_prim_drop();
-            WORD_ATOM(633, 33, "F");
+            WORD_ATOM(651, 33, "F");
             mw_F();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(634, 19, "dip");
+            WORD_ATOM(652, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(634, 23, "over");
+                WORD_ATOM(652, 23, "over");
                 mw_over();
                 push_value(d4);
             }
-            WORD_ATOM(634, 29, "has-meta?");
+            WORD_ATOM(652, 29, "has-meta?");
             mw_Type_2E_has_meta_3F_();
-            WORD_ATOM(634, 39, "if");
+            WORD_ATOM(652, 39, "if");
             if (pop_u64()) {
-                WORD_ATOM(634, 42, "drop2");
+                WORD_ATOM(652, 42, "drop2");
                 mw_drop2();
-                WORD_ATOM(634, 48, "T");
+                WORD_ATOM(652, 48, "T");
                 mw_T();
             } else {
-                WORD_ATOM(634, 51, "has-meta?");
+                WORD_ATOM(652, 51, "has-meta?");
                 mw_StackType_2E_has_meta_3F_();
             }
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(635, 19, "dip");
+            WORD_ATOM(653, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(635, 23, "over");
+                WORD_ATOM(653, 23, "over");
                 mw_over();
                 push_value(d4);
             }
-            WORD_ATOM(635, 29, "has-meta?");
+            WORD_ATOM(653, 29, "has-meta?");
             mw_Resource_2E_has_meta_3F_();
-            WORD_ATOM(635, 39, "if");
+            WORD_ATOM(653, 39, "if");
             if (pop_u64()) {
-                WORD_ATOM(635, 42, "drop2");
+                WORD_ATOM(653, 42, "drop2");
                 mw_drop2();
-                WORD_ATOM(635, 48, "T");
+                WORD_ATOM(653, 48, "T");
                 mw_T();
             } else {
-                WORD_ATOM(635, 51, "has-meta?");
+                WORD_ATOM(653, 51, "has-meta?");
                 mw_StackType_2E_has_meta_3F_();
             }
             break;
@@ -27177,179 +27494,179 @@ static void mw_StackType_2E_has_meta_3F_ (void){
 }    WORD_EXIT(mw_StackType_2E_has_meta_3F_);
 }
 static void mw_StackType_2E_unify_failed_21_ (void){
-    WORD_ENTER(mw_StackType_2E_unify_failed_21_, "StackType.unify-failed!", "src/mirth/data/type.mth", 640, 4);
-    WORD_ATOM(640, 4, "both");
+    WORD_ENTER(mw_StackType_2E_unify_failed_21_, "StackType.unify-failed!", "src/mirth/data/type.mth", 658, 4);
+    WORD_ATOM(658, 4, "both");
     push_u64(0);
     push_fnptr(&mb_StackType_2E_unify_failed_21__1);
     mw_prim_pack_cons();
     mw_both();
-    WORD_ATOM(640, 16, "unify-failed!");
+    WORD_ATOM(658, 16, "unify-failed!");
     mw_Type_2E_unify_failed_21_();
-    WORD_ATOM(640, 30, ">StackType");
+    WORD_ATOM(658, 30, ">StackType");
     mw_Type_3E_StackType();
     WORD_EXIT(mw_StackType_2E_unify_failed_21_);
 }
 static void mw_StackType_2E_unify_21_ (void){
-    WORD_ENTER(mw_StackType_2E_unify_21_, "StackType.unify!", "src/mirth/data/type.mth", 643, 5);
-    WORD_ATOM(643, 5, "swap");
+    WORD_ENTER(mw_StackType_2E_unify_21_, "StackType.unify!", "src/mirth/data/type.mth", 661, 5);
+    WORD_ATOM(661, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(643, 10, "expand");
+    WORD_ATOM(661, 10, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(643, 17, "match");
+    WORD_ATOM(661, 17, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(644, 29, "drop");
+            WORD_ATOM(662, 29, "drop");
             mw_prim_drop();
-            WORD_ATOM(644, 34, "STACK_TYPE_ERROR");
+            WORD_ATOM(662, 34, "STACK_TYPE_ERROR");
             mw_STACK_5F_TYPE_5F_ERROR();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(645, 33, "id");
+            WORD_ATOM(663, 33, "id");
             mw_prim_id();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(646, 19, "swap");
+            WORD_ATOM(664, 19, "swap");
             mw_prim_swap();
-            WORD_ATOM(646, 24, "expand");
+            WORD_ATOM(664, 24, "expand");
             mw_StackType_2E_expand();
-            WORD_ATOM(646, 31, "match");
+            WORD_ATOM(664, 31, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
                     mw_prim_drop();
-                    WORD_ATOM(647, 33, "drop");
+                    WORD_ATOM(665, 33, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(647, 38, "STACK_TYPE_ERROR");
+                    WORD_ATOM(665, 38, "STACK_TYPE_ERROR");
                     mw_STACK_5F_TYPE_5F_ERROR();
                     break;
                 case 1LL:
                     mw_prim_drop();
-                    WORD_ATOM(648, 37, "STMeta");
+                    WORD_ATOM(666, 37, "STMeta");
                     mw_STMeta();
                     break;
                 case 4LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(649, 23, "dip");
+                    WORD_ATOM(667, 23, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(649, 27, "TMeta");
+                        WORD_ATOM(667, 27, "TMeta");
                         mw_TMeta();
                         push_value(d6);
                     }
-                    WORD_ATOM(649, 34, "unify!");
+                    WORD_ATOM(667, 34, "unify!");
                     mw_MetaVar_2E_unify_21_();
-                    WORD_ATOM(649, 41, ">StackType");
+                    WORD_ATOM(667, 41, ">StackType");
                     mw_Type_3E_StackType();
                     break;
                 default:
-                    WORD_ATOM(650, 18, ">Type");
+                    WORD_ATOM(668, 18, ">Type");
                     mw_StackType_3E_Type();
-                    WORD_ATOM(650, 24, "swap");
+                    WORD_ATOM(668, 24, "swap");
                     mw_prim_swap();
-                    WORD_ATOM(650, 29, "unify!");
+                    WORD_ATOM(668, 29, "unify!");
                     mw_MetaVar_2E_unify_21_();
-                    WORD_ATOM(650, 36, ">StackType");
+                    WORD_ATOM(668, 36, ">StackType");
                     mw_Type_3E_StackType();
                     break;
             
 }            break;
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(652, 18, "swap");
+            WORD_ATOM(670, 18, "swap");
             mw_prim_swap();
-            WORD_ATOM(652, 23, "expand");
+            WORD_ATOM(670, 23, "expand");
             mw_StackType_2E_expand();
-            WORD_ATOM(652, 30, "match");
+            WORD_ATOM(670, 30, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
                     mw_prim_drop();
-                    WORD_ATOM(653, 33, "drop");
+                    WORD_ATOM(671, 33, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(653, 38, "STACK_TYPE_ERROR");
+                    WORD_ATOM(671, 38, "STACK_TYPE_ERROR");
                     mw_STACK_5F_TYPE_5F_ERROR();
                     break;
                 case 1LL:
                     mw_prim_drop();
-                    WORD_ATOM(654, 37, "STVar");
+                    WORD_ATOM(672, 37, "STVar");
                     mw_STVar();
                     break;
                 case 4LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(655, 23, "dip");
+                    WORD_ATOM(673, 23, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(655, 27, "TVar");
+                        WORD_ATOM(673, 27, "TVar");
                         mw_TVar();
                         push_value(d6);
                     }
-                    WORD_ATOM(655, 33, "unify!");
+                    WORD_ATOM(673, 33, "unify!");
                     mw_MetaVar_2E_unify_21_();
-                    WORD_ATOM(655, 40, ">StackType");
+                    WORD_ATOM(673, 40, ">StackType");
                     mw_Type_3E_StackType();
                     break;
                 case 3LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(656, 22, "unify!");
+                    WORD_ATOM(674, 22, "unify!");
                     mw_Var_2E_unify_21_();
-                    WORD_ATOM(656, 29, ">StackType");
+                    WORD_ATOM(674, 29, ">StackType");
                     mw_Type_3E_StackType();
                     break;
                 default:
-                    WORD_ATOM(657, 18, "dip");
+                    WORD_ATOM(675, 18, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(657, 22, "STVar");
+                        WORD_ATOM(675, 22, "STVar");
                         mw_STVar();
                         push_value(d6);
                     }
-                    WORD_ATOM(657, 29, "unify-failed!");
+                    WORD_ATOM(675, 29, "unify-failed!");
                     mw_StackType_2E_unify_failed_21_();
                     break;
             
 }            break;
         case 2LL:
             mw_prim_drop();
-            WORD_ATOM(659, 28, "expand");
+            WORD_ATOM(677, 28, "expand");
             mw_StackType_2E_expand();
-            WORD_ATOM(659, 35, "match");
+            WORD_ATOM(677, 35, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
                     mw_prim_drop();
-                    WORD_ATOM(660, 33, "STACK_TYPE_ERROR");
+                    WORD_ATOM(678, 33, "STACK_TYPE_ERROR");
                     mw_STACK_5F_TYPE_5F_ERROR();
                     break;
                 case 4LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(661, 23, "dip");
+                    WORD_ATOM(679, 23, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(661, 27, "STACK_TYPE_UNIT");
+                        WORD_ATOM(679, 27, "STACK_TYPE_UNIT");
                         mw_STACK_5F_TYPE_5F_UNIT();
-                        WORD_ATOM(661, 43, ">Type");
+                        WORD_ATOM(679, 43, ">Type");
                         mw_StackType_3E_Type();
                         push_value(d6);
                     }
-                    WORD_ATOM(661, 50, "unify!");
+                    WORD_ATOM(679, 50, "unify!");
                     mw_MetaVar_2E_unify_21_();
-                    WORD_ATOM(661, 57, ">StackType");
+                    WORD_ATOM(679, 57, ">StackType");
                     mw_Type_3E_StackType();
                     break;
                 case 1LL:
                     mw_prim_drop();
-                    WORD_ATOM(662, 37, "STACK_TYPE_UNIT");
+                    WORD_ATOM(680, 37, "STACK_TYPE_UNIT");
                     mw_STACK_5F_TYPE_5F_UNIT();
                     break;
                 case 2LL:
                     mw_prim_drop();
-                    WORD_ATOM(663, 32, "STACK_TYPE_UNIT");
+                    WORD_ATOM(681, 32, "STACK_TYPE_UNIT");
                     mw_STACK_5F_TYPE_5F_UNIT();
                     break;
                 default:
-                    WORD_ATOM(664, 18, "STACK_TYPE_UNIT");
+                    WORD_ATOM(682, 18, "STACK_TYPE_UNIT");
                     mw_STACK_5F_TYPE_5F_UNIT();
-                    WORD_ATOM(664, 34, "unify-failed!");
+                    WORD_ATOM(682, 34, "unify-failed!");
                     mw_StackType_2E_unify_failed_21_();
                     break;
             
@@ -27357,46 +27674,46 @@ static void mw_StackType_2E_unify_21_ (void){
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(666, 19, "rotl");
+            WORD_ATOM(684, 19, "rotl");
             mw_rotl();
-            WORD_ATOM(666, 24, "expand");
+            WORD_ATOM(684, 24, "expand");
             mw_StackType_2E_expand();
-            WORD_ATOM(666, 31, "match");
+            WORD_ATOM(684, 31, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
                     mw_prim_drop();
-                    WORD_ATOM(667, 33, "drop2");
+                    WORD_ATOM(685, 33, "drop2");
                     mw_drop2();
-                    WORD_ATOM(667, 39, "STACK_TYPE_ERROR");
+                    WORD_ATOM(685, 39, "STACK_TYPE_ERROR");
                     mw_STACK_5F_TYPE_5F_ERROR();
                     break;
                 case 4LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(668, 23, "dip");
+                    WORD_ATOM(686, 23, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(668, 27, "STCons");
+                        WORD_ATOM(686, 27, "STCons");
                         mw_STCons();
-                        WORD_ATOM(668, 34, ">Type");
+                        WORD_ATOM(686, 34, ">Type");
                         mw_StackType_3E_Type();
                         push_value(d6);
                     }
-                    WORD_ATOM(668, 41, "unify!");
+                    WORD_ATOM(686, 41, "unify!");
                     mw_MetaVar_2E_unify_21_();
-                    WORD_ATOM(668, 48, ">StackType");
+                    WORD_ATOM(686, 48, ">StackType");
                     mw_Type_3E_StackType();
                     break;
                 case 1LL:
                     mw_prim_drop();
-                    WORD_ATOM(669, 37, "STCons");
+                    WORD_ATOM(687, 37, "STCons");
                     mw_STCons();
                     break;
                 default:
-                    WORD_ATOM(670, 18, "dup");
+                    WORD_ATOM(688, 18, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(670, 22, "force-cons?!");
+                    WORD_ATOM(688, 22, "force-cons?!");
                     mw_StackType_2E_force_cons_3F__21_();
-                    WORD_ATOM(670, 35, "if-some");
+                    WORD_ATOM(688, 35, "if-some");
                     push_u64(0);
                     push_fnptr(&mb_StackType_2E_unify_21__30);
                     mw_prim_pack_cons();
@@ -27410,46 +27727,46 @@ static void mw_StackType_2E_unify_21_ (void){
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(675, 19, "rotl");
+            WORD_ATOM(693, 19, "rotl");
             mw_rotl();
-            WORD_ATOM(675, 24, "expand");
+            WORD_ATOM(693, 24, "expand");
             mw_StackType_2E_expand();
-            WORD_ATOM(675, 31, "match");
+            WORD_ATOM(693, 31, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
                     mw_prim_drop();
-                    WORD_ATOM(676, 33, "drop2");
+                    WORD_ATOM(694, 33, "drop2");
                     mw_drop2();
-                    WORD_ATOM(676, 39, "STACK_TYPE_ERROR");
+                    WORD_ATOM(694, 39, "STACK_TYPE_ERROR");
                     mw_STACK_5F_TYPE_5F_ERROR();
                     break;
                 case 4LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(677, 23, "dip");
+                    WORD_ATOM(695, 23, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(677, 27, "STWith");
+                        WORD_ATOM(695, 27, "STWith");
                         mw_STWith();
-                        WORD_ATOM(677, 34, ">Type");
+                        WORD_ATOM(695, 34, ">Type");
                         mw_StackType_3E_Type();
                         push_value(d6);
                     }
-                    WORD_ATOM(677, 41, "unify!");
+                    WORD_ATOM(695, 41, "unify!");
                     mw_MetaVar_2E_unify_21_();
-                    WORD_ATOM(677, 48, ">StackType");
+                    WORD_ATOM(695, 48, ">StackType");
                     mw_Type_3E_StackType();
                     break;
                 case 1LL:
                     mw_prim_drop();
-                    WORD_ATOM(678, 37, "STWith");
+                    WORD_ATOM(696, 37, "STWith");
                     mw_STWith();
                     break;
                 default:
-                    WORD_ATOM(679, 18, "dup");
+                    WORD_ATOM(697, 18, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(679, 22, "force-with?!");
+                    WORD_ATOM(697, 22, "force-with?!");
                     mw_StackType_2E_force_with_3F__21_();
-                    WORD_ATOM(679, 35, "if-some");
+                    WORD_ATOM(697, 35, "if-some");
                     push_u64(0);
                     push_fnptr(&mb_StackType_2E_unify_21__42);
                     mw_prim_pack_cons();
@@ -27465,163 +27782,163 @@ static void mw_StackType_2E_unify_21_ (void){
 }    WORD_EXIT(mw_StackType_2E_unify_21_);
 }
 static void mw_StackType_2E_force_cons_3F__21_ (void){
-    WORD_ENTER(mw_StackType_2E_force_cons_3F__21_, "StackType.force-cons?!", "src/mirth/data/type.mth", 687, 5);
-    WORD_ATOM(687, 5, "expand");
+    WORD_ENTER(mw_StackType_2E_force_cons_3F__21_, "StackType.force-cons?!", "src/mirth/data/type.mth", 705, 5);
+    WORD_ATOM(705, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(687, 12, "match");
+    WORD_ATOM(705, 12, "match");
     switch (get_top_data_tag()) {
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(688, 19, "pack2");
+            WORD_ATOM(706, 19, "pack2");
             mw_pack2();
-            WORD_ATOM(688, 25, "SOME");
+            WORD_ATOM(706, 25, "SOME");
             mw_SOME();
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(689, 19, "swap");
+            WORD_ATOM(707, 19, "swap");
             mw_prim_swap();
-            WORD_ATOM(689, 24, "force-cons?!");
+            WORD_ATOM(707, 24, "force-cons?!");
             mw_StackType_2E_force_cons_3F__21_();
-            WORD_ATOM(689, 37, "map");
+            WORD_ATOM(707, 37, "map");
             push_u64(0);
             push_fnptr(&mb_StackType_2E_force_cons_3F__21__3);
             mw_prim_pack_cons();
             mw_Maybe_2E_map();
-            WORD_ATOM(689, 73, "nip");
+            WORD_ATOM(707, 73, "nip");
             mw_nip();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(691, 13, "dip");
+            WORD_ATOM(709, 13, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(691, 17, "MetaVar.new!");
+                WORD_ATOM(709, 17, "MetaVar.new!");
                 mw_MetaVar_2E_new_21_();
-                WORD_ATOM(691, 30, "STMeta");
+                WORD_ATOM(709, 30, "STMeta");
                 mw_STMeta();
-                WORD_ATOM(692, 17, "MetaVar.new!");
+                WORD_ATOM(710, 17, "MetaVar.new!");
                 mw_MetaVar_2E_new_21_();
-                WORD_ATOM(692, 30, "TMeta");
+                WORD_ATOM(710, 30, "TMeta");
                 mw_TMeta();
-                WORD_ATOM(693, 17, "dup2");
+                WORD_ATOM(711, 17, "dup2");
                 mw_dup2();
-                WORD_ATOM(693, 22, "STCons");
+                WORD_ATOM(711, 22, "STCons");
                 mw_STCons();
-                WORD_ATOM(693, 29, ">Type");
+                WORD_ATOM(711, 29, ">Type");
                 mw_StackType_3E_Type();
-                WORD_ATOM(693, 35, "SOME");
+                WORD_ATOM(711, 35, "SOME");
                 mw_SOME();
                 push_value(d4);
             }
-            WORD_ATOM(693, 41, "~type?");
+            WORD_ATOM(711, 41, "~type?");
             mw_MetaVar_7E_type_3F_();
-            WORD_ATOM(693, 48, "!");
+            WORD_ATOM(711, 48, "!");
             mw_prim_mut_set();
-            WORD_ATOM(694, 13, "pack2");
+            WORD_ATOM(712, 13, "pack2");
             mw_pack2();
-            WORD_ATOM(694, 19, "SOME");
+            WORD_ATOM(712, 19, "SOME");
             mw_SOME();
             break;
         default:
-            WORD_ATOM(695, 14, "drop");
+            WORD_ATOM(713, 14, "drop");
             mw_prim_drop();
-            WORD_ATOM(695, 19, "NONE");
+            WORD_ATOM(713, 19, "NONE");
             mw_NONE();
             break;
     
 }    WORD_EXIT(mw_StackType_2E_force_cons_3F__21_);
 }
 static void mw_StackType_2E_force_with_3F__21_ (void){
-    WORD_ENTER(mw_StackType_2E_force_with_3F__21_, "StackType.force-with?!", "src/mirth/data/type.mth", 699, 5);
-    WORD_ATOM(699, 5, "expand");
+    WORD_ENTER(mw_StackType_2E_force_with_3F__21_, "StackType.force-with?!", "src/mirth/data/type.mth", 717, 5);
+    WORD_ATOM(717, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(699, 12, "match");
+    WORD_ATOM(717, 12, "match");
     switch (get_top_data_tag()) {
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(700, 19, "pack2");
+            WORD_ATOM(718, 19, "pack2");
             mw_pack2();
-            WORD_ATOM(700, 25, "SOME");
+            WORD_ATOM(718, 25, "SOME");
             mw_SOME();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(701, 19, "swap");
+            WORD_ATOM(719, 19, "swap");
             mw_prim_swap();
-            WORD_ATOM(701, 24, "force-with?!");
+            WORD_ATOM(719, 24, "force-with?!");
             mw_StackType_2E_force_with_3F__21_();
-            WORD_ATOM(701, 37, "map");
+            WORD_ATOM(719, 37, "map");
             push_u64(0);
             push_fnptr(&mb_StackType_2E_force_with_3F__21__3);
             mw_prim_pack_cons();
             mw_Maybe_2E_map();
-            WORD_ATOM(701, 73, "nip");
+            WORD_ATOM(719, 73, "nip");
             mw_nip();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(703, 13, "dip");
+            WORD_ATOM(721, 13, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(703, 17, "MetaVar.new!");
+                WORD_ATOM(721, 17, "MetaVar.new!");
                 mw_MetaVar_2E_new_21_();
-                WORD_ATOM(703, 30, "STMeta");
+                WORD_ATOM(721, 30, "STMeta");
                 mw_STMeta();
-                WORD_ATOM(704, 17, "MetaVar.new!");
+                WORD_ATOM(722, 17, "MetaVar.new!");
                 mw_MetaVar_2E_new_21_();
-                WORD_ATOM(704, 30, "TMeta");
+                WORD_ATOM(722, 30, "TMeta");
                 mw_TMeta();
-                WORD_ATOM(704, 36, "RESOURCE");
+                WORD_ATOM(722, 36, "RESOURCE");
                 mw_RESOURCE();
-                WORD_ATOM(705, 17, "dup2");
+                WORD_ATOM(723, 17, "dup2");
                 mw_dup2();
-                WORD_ATOM(705, 22, "STWith");
+                WORD_ATOM(723, 22, "STWith");
                 mw_STWith();
-                WORD_ATOM(705, 29, ">Type");
+                WORD_ATOM(723, 29, ">Type");
                 mw_StackType_3E_Type();
-                WORD_ATOM(705, 35, "SOME");
+                WORD_ATOM(723, 35, "SOME");
                 mw_SOME();
                 push_value(d4);
             }
-            WORD_ATOM(705, 41, "~type?");
+            WORD_ATOM(723, 41, "~type?");
             mw_MetaVar_7E_type_3F_();
-            WORD_ATOM(705, 48, "!");
+            WORD_ATOM(723, 48, "!");
             mw_prim_mut_set();
-            WORD_ATOM(706, 13, "pack2");
+            WORD_ATOM(724, 13, "pack2");
             mw_pack2();
-            WORD_ATOM(706, 19, "SOME");
+            WORD_ATOM(724, 19, "SOME");
             mw_SOME();
             break;
         default:
-            WORD_ATOM(707, 14, "drop");
+            WORD_ATOM(725, 14, "drop");
             mw_prim_drop();
-            WORD_ATOM(707, 19, "NONE");
+            WORD_ATOM(725, 19, "NONE");
             mw_NONE();
             break;
     
 }    WORD_EXIT(mw_StackType_2E_force_with_3F__21_);
 }
 static void mw_StackType_2E_trace_dom_21_ (void){
-    WORD_ENTER(mw_StackType_2E_trace_dom_21_, "StackType.trace-dom!", "src/mirth/data/type.mth", 711, 5);
-    WORD_ATOM(711, 5, "expand");
+    WORD_ENTER(mw_StackType_2E_trace_dom_21_, "StackType.trace-dom!", "src/mirth/data/type.mth", 729, 5);
+    WORD_ATOM(729, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(711, 12, "dup");
+    WORD_ATOM(729, 12, "dup");
     mw_prim_dup();
-    WORD_ATOM(711, 16, "unit?");
+    WORD_ATOM(729, 16, "unit?");
     mw_StackType_2E_unit_3F_();
-    WORD_ATOM(711, 22, "if");
+    WORD_ATOM(729, 22, "if");
     if (pop_u64()) {
-        WORD_ATOM(712, 9, "drop");
+        WORD_ATOM(730, 9, "drop");
         mw_prim_drop();
     } else {
-        WORD_ATOM(713, 9, "trace!");
+        WORD_ATOM(731, 9, "trace!");
         mw_StackType_2E_trace_21_();
-        WORD_ATOM(714, 9, "");
+        WORD_ATOM(732, 9, "");
         {
             static bool vready = false;
             static VAL v;
@@ -27632,25 +27949,25 @@ static void mw_StackType_2E_trace_dom_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(714, 13, "trace!");
+        WORD_ATOM(732, 13, "trace!");
         mw_Str_2E_trace_21_();
     }
     WORD_EXIT(mw_StackType_2E_trace_dom_21_);
 }
 static void mw_StackType_2E_trace_cod_21_ (void){
-    WORD_ENTER(mw_StackType_2E_trace_cod_21_, "StackType.trace-cod!", "src/mirth/data/type.mth", 718, 5);
-    WORD_ATOM(718, 5, "expand");
+    WORD_ENTER(mw_StackType_2E_trace_cod_21_, "StackType.trace-cod!", "src/mirth/data/type.mth", 736, 5);
+    WORD_ATOM(736, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(718, 12, "dup");
+    WORD_ATOM(736, 12, "dup");
     mw_prim_dup();
-    WORD_ATOM(718, 16, "unit?");
+    WORD_ATOM(736, 16, "unit?");
     mw_StackType_2E_unit_3F_();
-    WORD_ATOM(718, 22, "if");
+    WORD_ATOM(736, 22, "if");
     if (pop_u64()) {
-        WORD_ATOM(719, 9, "drop");
+        WORD_ATOM(737, 9, "drop");
         mw_prim_drop();
     } else {
-        WORD_ATOM(720, 9, "");
+        WORD_ATOM(738, 9, "");
         {
             static bool vready = false;
             static VAL v;
@@ -27661,27 +27978,27 @@ static void mw_StackType_2E_trace_cod_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(720, 13, "trace!");
+        WORD_ATOM(738, 13, "trace!");
         mw_Str_2E_trace_21_();
-        WORD_ATOM(721, 9, "trace!");
+        WORD_ATOM(739, 9, "trace!");
         mw_StackType_2E_trace_21_();
     }
     WORD_EXIT(mw_StackType_2E_trace_cod_21_);
 }
 static void mw_StackType_2E_trace_base_21_ (void){
-    WORD_ENTER(mw_StackType_2E_trace_base_21_, "StackType.trace-base!", "src/mirth/data/type.mth", 725, 5);
-    WORD_ATOM(725, 5, "match");
+    WORD_ENTER(mw_StackType_2E_trace_base_21_, "StackType.trace-base!", "src/mirth/data/type.mth", 743, 5);
+    WORD_ATOM(743, 5, "match");
     switch (get_top_data_tag()) {
         case 2LL:
             mw_prim_drop();
-            WORD_ATOM(726, 28, "id");
+            WORD_ATOM(744, 28, "id");
             mw_prim_id();
-            WORD_ATOM(726, 31, "F");
+            WORD_ATOM(744, 31, "F");
             mw_F();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(727, 19, "");
+            WORD_ATOM(745, 19, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -27692,107 +28009,107 @@ static void mw_StackType_2E_trace_base_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(727, 23, "trace!");
+            WORD_ATOM(745, 23, "trace!");
             mw_Str_2E_trace_21_();
-            WORD_ATOM(727, 30, "trace!");
+            WORD_ATOM(745, 30, "trace!");
             mw_MetaVar_2E_trace_21_();
-            WORD_ATOM(727, 37, "T");
+            WORD_ATOM(745, 37, "T");
             mw_T();
             break;
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(728, 18, "dup");
+            WORD_ATOM(746, 18, "dup");
             mw_prim_dup();
-            WORD_ATOM(728, 22, "trace!");
+            WORD_ATOM(746, 22, "trace!");
             mw_Var_2E_trace_21_();
-            WORD_ATOM(728, 29, "is-stack?");
+            WORD_ATOM(746, 29, "is-stack?");
             mw_Var_2E_is_stack_3F_();
-            WORD_ATOM(728, 39, "else");
+            WORD_ATOM(746, 39, "else");
             push_u64(0);
             push_fnptr(&mb_StackType_2E_trace_base_21__4);
             mw_prim_pack_cons();
             mw_Bool_2E_else();
-            WORD_ATOM(728, 57, "T");
+            WORD_ATOM(746, 57, "T");
             mw_T();
             break;
         default:
-            WORD_ATOM(729, 14, ">Type");
+            WORD_ATOM(747, 14, ">Type");
             mw_StackType_3E_Type();
-            WORD_ATOM(729, 20, "trace!");
+            WORD_ATOM(747, 20, "trace!");
             mw_Type_2E_trace_21_();
-            WORD_ATOM(729, 27, "T");
+            WORD_ATOM(747, 27, "T");
             mw_T();
             break;
     
 }    WORD_EXIT(mw_StackType_2E_trace_base_21_);
 }
 static void mw_StackType_2E_trace_21_ (void){
-    WORD_ENTER(mw_StackType_2E_trace_21_, "StackType.trace!", "src/mirth/data/type.mth", 733, 5);
-    WORD_ATOM(733, 5, "split3");
+    WORD_ENTER(mw_StackType_2E_trace_21_, "StackType.trace!", "src/mirth/data/type.mth", 751, 5);
+    WORD_ATOM(751, 5, "split3");
     mw_StackType_2E_split3();
-    WORD_ATOM(734, 5, "dip2");
+    WORD_ATOM(752, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_StackType_2E_trace_21__1);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(735, 5, "dip");
+    WORD_ATOM(753, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(735, 9, "for");
+        WORD_ATOM(753, 9, "for");
         push_u64(0);
         push_fnptr(&mb_StackType_2E_trace_21__3);
         mw_prim_pack_cons();
         mw_List_2E_for();
         push_value(d2);
     }
-    WORD_ATOM(736, 5, "for");
+    WORD_ATOM(754, 5, "for");
     push_u64(0);
     push_fnptr(&mb_StackType_2E_trace_21__5);
     mw_prim_pack_cons();
     mw_List_2E_for();
-    WORD_ATOM(736, 41, "drop");
+    WORD_ATOM(754, 41, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_StackType_2E_trace_21_);
 }
 static void mw_StackType_2E_semifreshen (void){
-    WORD_ENTER(mw_StackType_2E_semifreshen, "StackType.semifreshen", "src/mirth/data/type.mth", 757, 5);
-    WORD_ATOM(757, 5, "expand");
+    WORD_ENTER(mw_StackType_2E_semifreshen, "StackType.semifreshen", "src/mirth/data/type.mth", 775, 5);
+    WORD_ATOM(775, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(757, 12, "match");
+    WORD_ATOM(775, 12, "match");
     switch (get_top_data_tag()) {
         case 2LL:
             mw_prim_drop();
-            WORD_ATOM(758, 28, "dup");
+            WORD_ATOM(776, 28, "dup");
             mw_prim_dup();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(759, 19, "dip");
+            WORD_ATOM(777, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(759, 23, "semifreshen");
+                WORD_ATOM(777, 23, "semifreshen");
                 mw_StackType_2E_semifreshen();
                 push_value(d4);
             }
-            WORD_ATOM(759, 36, "STCons");
+            WORD_ATOM(777, 36, "STCons");
             mw_STCons();
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(760, 19, "dip");
+            WORD_ATOM(778, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(760, 23, "semifreshen");
+                WORD_ATOM(778, 23, "semifreshen");
                 mw_StackType_2E_semifreshen();
                 push_value(d4);
             }
-            WORD_ATOM(760, 36, "STWith");
+            WORD_ATOM(778, 36, "STWith");
             mw_STWith();
             break;
         default:
-            WORD_ATOM(761, 14, "");
+            WORD_ATOM(779, 14, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -27803,159 +28120,159 @@ static void mw_StackType_2E_semifreshen (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(761, 58, "panic!");
+            WORD_ATOM(779, 58, "panic!");
             mw_prim_panic();
             break;
     
 }    WORD_EXIT(mw_StackType_2E_semifreshen);
 }
 static void mw_StackType_2E_freshen (void){
-    WORD_ENTER(mw_StackType_2E_freshen, "StackType.freshen", "src/mirth/data/type.mth", 765, 5);
-    WORD_ATOM(765, 5, "expand");
+    WORD_ENTER(mw_StackType_2E_freshen, "StackType.freshen", "src/mirth/data/type.mth", 783, 5);
+    WORD_ATOM(783, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(765, 12, "match");
+    WORD_ATOM(783, 12, "match");
     switch (get_top_data_tag()) {
         case 2LL:
             mw_prim_drop();
-            WORD_ATOM(766, 28, "STACK_TYPE_UNIT");
+            WORD_ATOM(784, 28, "STACK_TYPE_UNIT");
             mw_STACK_5F_TYPE_5F_UNIT();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(767, 19, "dip");
+            WORD_ATOM(785, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(767, 23, "freshen");
+                WORD_ATOM(785, 23, "freshen");
                 mw_StackType_2E_freshen();
                 push_value(d4);
             }
-            WORD_ATOM(767, 32, "swap");
+            WORD_ATOM(785, 32, "swap");
             mw_prim_swap();
-            WORD_ATOM(767, 37, "dip");
+            WORD_ATOM(785, 37, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(767, 41, "freshen");
+                WORD_ATOM(785, 41, "freshen");
                 mw_Type_2E_freshen();
                 push_value(d4);
             }
-            WORD_ATOM(767, 50, "swap");
+            WORD_ATOM(785, 50, "swap");
             mw_prim_swap();
-            WORD_ATOM(767, 55, "STCons");
+            WORD_ATOM(785, 55, "STCons");
             mw_STCons();
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(768, 19, "dip");
+            WORD_ATOM(786, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(768, 23, "freshen");
+                WORD_ATOM(786, 23, "freshen");
                 mw_StackType_2E_freshen();
                 push_value(d4);
             }
-            WORD_ATOM(768, 32, "swap");
+            WORD_ATOM(786, 32, "swap");
             mw_prim_swap();
-            WORD_ATOM(768, 37, "dip");
+            WORD_ATOM(786, 37, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(768, 41, "freshen");
+                WORD_ATOM(786, 41, "freshen");
                 mw_Resource_2E_freshen();
                 push_value(d4);
             }
-            WORD_ATOM(768, 50, "swap");
+            WORD_ATOM(786, 50, "swap");
             mw_prim_swap();
-            WORD_ATOM(768, 55, "STWith");
+            WORD_ATOM(786, 55, "STWith");
             mw_STWith();
             break;
         default:
-            WORD_ATOM(769, 14, ">Type");
+            WORD_ATOM(787, 14, ">Type");
             mw_StackType_3E_Type();
-            WORD_ATOM(769, 20, "freshen");
+            WORD_ATOM(787, 20, "freshen");
             mw_Type_2E_freshen();
-            WORD_ATOM(769, 28, ">StackType");
+            WORD_ATOM(787, 28, ">StackType");
             mw_Type_3E_StackType();
             break;
     
 }    WORD_EXIT(mw_StackType_2E_freshen);
 }
 static void mw_StackType_2E_freshen_aux (void){
-    WORD_ENTER(mw_StackType_2E_freshen_aux, "StackType.freshen-aux", "src/mirth/data/type.mth", 773, 5);
-    WORD_ATOM(773, 5, "expand");
+    WORD_ENTER(mw_StackType_2E_freshen_aux, "StackType.freshen-aux", "src/mirth/data/type.mth", 791, 5);
+    WORD_ATOM(791, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(773, 12, "match");
+    WORD_ATOM(791, 12, "match");
     switch (get_top_data_tag()) {
         case 2LL:
             mw_prim_drop();
-            WORD_ATOM(774, 28, "over");
+            WORD_ATOM(792, 28, "over");
             mw_over();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(775, 19, "dip");
+            WORD_ATOM(793, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(775, 23, "freshen-aux");
+                WORD_ATOM(793, 23, "freshen-aux");
                 mw_StackType_2E_freshen_aux();
                 push_value(d4);
             }
-            WORD_ATOM(775, 36, "swap");
+            WORD_ATOM(793, 36, "swap");
             mw_prim_swap();
-            WORD_ATOM(775, 41, "dip");
+            WORD_ATOM(793, 41, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(775, 45, "freshen");
+                WORD_ATOM(793, 45, "freshen");
                 mw_Type_2E_freshen();
                 push_value(d4);
             }
-            WORD_ATOM(775, 54, "swap");
+            WORD_ATOM(793, 54, "swap");
             mw_prim_swap();
-            WORD_ATOM(775, 59, "STCons");
+            WORD_ATOM(793, 59, "STCons");
             mw_STCons();
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(776, 19, "dip");
+            WORD_ATOM(794, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(776, 23, "freshen-aux");
+                WORD_ATOM(794, 23, "freshen-aux");
                 mw_StackType_2E_freshen_aux();
                 push_value(d4);
             }
-            WORD_ATOM(776, 36, "swap");
+            WORD_ATOM(794, 36, "swap");
             mw_prim_swap();
-            WORD_ATOM(776, 41, "dip");
+            WORD_ATOM(794, 41, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(776, 45, "freshen");
+                WORD_ATOM(794, 45, "freshen");
                 mw_Resource_2E_freshen();
                 push_value(d4);
             }
-            WORD_ATOM(776, 54, "swap");
+            WORD_ATOM(794, 54, "swap");
             mw_prim_swap();
-            WORD_ATOM(776, 59, "STWith");
+            WORD_ATOM(794, 59, "STWith");
             mw_STWith();
             break;
         default:
-            WORD_ATOM(777, 14, ">Type");
+            WORD_ATOM(795, 14, ">Type");
             mw_StackType_3E_Type();
-            WORD_ATOM(777, 20, "freshen");
+            WORD_ATOM(795, 20, "freshen");
             mw_Type_2E_freshen();
-            WORD_ATOM(777, 28, ">StackType");
+            WORD_ATOM(795, 28, ">StackType");
             mw_Type_3E_StackType();
             break;
     
 }    WORD_EXIT(mw_StackType_2E_freshen_aux);
 }
 static void mw_StackType_2E_num_morphisms_on_top (void){
-    WORD_ENTER(mw_StackType_2E_num_morphisms_on_top, "StackType.num-morphisms-on-top", "src/mirth/data/type.mth", 790, 5);
-    WORD_ATOM(790, 5, "STMeta");
+    WORD_ENTER(mw_StackType_2E_num_morphisms_on_top, "StackType.num-morphisms-on-top", "src/mirth/data/type.mth", 808, 5);
+    WORD_ATOM(808, 5, "STMeta");
     switch (get_top_data_tag()) {
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(790, 15, "expand-if");
+            WORD_ATOM(808, 15, "expand-if");
             push_u64(0);
             push_fnptr(&mb_StackType_2E_num_morphisms_on_top_2);
             mw_prim_pack_cons();
@@ -27967,9 +28284,9 @@ static void mw_StackType_2E_num_morphisms_on_top (void){
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(791, 15, "morphism?");
+            WORD_ATOM(809, 15, "morphism?");
             mw_Type_2E_morphism_3F_();
-            WORD_ATOM(791, 25, ".if");
+            WORD_ATOM(809, 25, ".if");
             push_u64(0);
             push_fnptr(&mb_StackType_2E_num_morphisms_on_top_5);
             mw_prim_pack_cons();
@@ -27981,34 +28298,34 @@ static void mw_StackType_2E_num_morphisms_on_top (void){
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(792, 15, "drop");
+            WORD_ATOM(810, 15, "drop");
             mw_prim_drop();
-            WORD_ATOM(792, 20, "num-morphisms-on-top");
+            WORD_ATOM(810, 20, "num-morphisms-on-top");
             mw_StackType_2E_num_morphisms_on_top();
             break;
         default:
-            WORD_ATOM(793, 10, "drop");
+            WORD_ATOM(811, 10, "drop");
             mw_prim_drop();
-            WORD_ATOM(793, 15, "");
+            WORD_ATOM(811, 15, "");
             push_i64(0LL);
             break;
     
 }    WORD_EXIT(mw_StackType_2E_num_morphisms_on_top);
 }
 static void mw_ArrowType_3E_Type (void){
-    WORD_ENTER(mw_ArrowType_3E_Type, "ArrowType>Type", "src/mirth/data/type.mth", 800, 40);
-    WORD_ATOM(800, 40, "TMorphism");
+    WORD_ENTER(mw_ArrowType_3E_Type, "ArrowType>Type", "src/mirth/data/type.mth", 818, 40);
+    WORD_ATOM(818, 40, "TMorphism");
     mw_TMorphism();
     WORD_EXIT(mw_ArrowType_3E_Type);
 }
 static void mw_ArrowType_2E_unpack (void){
-    WORD_ENTER(mw_ArrowType_2E_unpack, "ArrowType.unpack", "src/mirth/data/type.mth", 802, 57);
-    WORD_ATOM(802, 57, "ARROW_TYPE");
+    WORD_ENTER(mw_ArrowType_2E_unpack, "ArrowType.unpack", "src/mirth/data/type.mth", 820, 57);
+    WORD_ATOM(820, 57, "ARROW_TYPE");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(802, 71, "id");
+            WORD_ATOM(820, 71, "id");
             mw_prim_id();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -28016,87 +28333,87 @@ static void mw_ArrowType_2E_unpack (void){
 }    WORD_EXIT(mw_ArrowType_2E_unpack);
 }
 static void mw_ArrowType_2E_dom (void){
-    WORD_ENTER(mw_ArrowType_2E_dom, "ArrowType.dom", "src/mirth/data/type.mth", 803, 44);
-    WORD_ATOM(803, 44, "unpack");
+    WORD_ENTER(mw_ArrowType_2E_dom, "ArrowType.dom", "src/mirth/data/type.mth", 821, 44);
+    WORD_ATOM(821, 44, "unpack");
     mw_ArrowType_2E_unpack();
-    WORD_ATOM(803, 51, "drop");
+    WORD_ATOM(821, 51, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_ArrowType_2E_dom);
 }
 static void mw_ArrowType_2E_unify_21_ (void){
-    WORD_ENTER(mw_ArrowType_2E_unify_21_, "ArrowType.unify!", "src/mirth/data/type.mth", 806, 5);
-    WORD_ATOM(806, 5, "dip");
+    WORD_ENTER(mw_ArrowType_2E_unify_21_, "ArrowType.unify!", "src/mirth/data/type.mth", 824, 5);
+    WORD_ATOM(824, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(806, 9, "unpack");
+        WORD_ATOM(824, 9, "unpack");
         mw_ArrowType_2E_unpack();
         push_value(d2);
     }
-    WORD_ATOM(806, 17, "unpack");
+    WORD_ATOM(824, 17, "unpack");
     mw_ArrowType_2E_unpack();
-    WORD_ATOM(807, 5, "dip");
+    WORD_ATOM(825, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(807, 9, "swap");
+        WORD_ATOM(825, 9, "swap");
         mw_prim_swap();
-        WORD_ATOM(807, 14, "dip");
+        WORD_ATOM(825, 14, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(807, 18, "unify!");
+            WORD_ATOM(825, 18, "unify!");
             mw_StackType_2E_unify_21_();
             push_value(d3);
         }
         push_value(d2);
     }
-    WORD_ATOM(807, 27, "rotl");
+    WORD_ATOM(825, 27, "rotl");
     mw_rotl();
-    WORD_ATOM(808, 5, "dip");
+    WORD_ATOM(826, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(808, 9, "unify!");
+        WORD_ATOM(826, 9, "unify!");
         mw_StackType_2E_unify_21_();
         push_value(d2);
     }
-    WORD_ATOM(808, 17, "swap");
+    WORD_ATOM(826, 17, "swap");
     mw_prim_swap();
-    WORD_ATOM(809, 5, "ARROW_TYPE");
+    WORD_ATOM(827, 5, "ARROW_TYPE");
     mw_ARROW_5F_TYPE();
     WORD_EXIT(mw_ArrowType_2E_unify_21_);
 }
 static void mw_ArrowType_2E_has_meta_3F_ (void){
-    WORD_ENTER(mw_ArrowType_2E_has_meta_3F_, "ArrowType.has-meta?", "src/mirth/data/type.mth", 811, 5);
-    WORD_ATOM(811, 5, "unpack");
+    WORD_ENTER(mw_ArrowType_2E_has_meta_3F_, "ArrowType.has-meta?", "src/mirth/data/type.mth", 829, 5);
+    WORD_ATOM(829, 5, "unpack");
     mw_ArrowType_2E_unpack();
-    WORD_ATOM(811, 12, "dip");
+    WORD_ATOM(829, 12, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(811, 16, "over");
+        WORD_ATOM(829, 16, "over");
         mw_over();
         push_value(d2);
     }
-    WORD_ATOM(811, 22, "has-meta?");
+    WORD_ATOM(829, 22, "has-meta?");
     mw_StackType_2E_has_meta_3F_();
-    WORD_ATOM(811, 32, "if");
+    WORD_ATOM(829, 32, "if");
     if (pop_u64()) {
-        WORD_ATOM(811, 35, "drop2");
+        WORD_ATOM(829, 35, "drop2");
         mw_drop2();
-        WORD_ATOM(811, 41, "T");
+        WORD_ATOM(829, 41, "T");
         mw_T();
     } else {
-        WORD_ATOM(811, 44, "has-meta?");
+        WORD_ATOM(829, 44, "has-meta?");
         mw_StackType_2E_has_meta_3F_();
     }
     WORD_EXIT(mw_ArrowType_2E_has_meta_3F_);
 }
 static void mw_ArrowType_2E_trace_21_ (void){
-    WORD_ENTER(mw_ArrowType_2E_trace_21_, "ArrowType.trace!", "src/mirth/data/type.mth", 814, 5);
-    WORD_ATOM(814, 5, "unpack");
+    WORD_ENTER(mw_ArrowType_2E_trace_21_, "ArrowType.trace!", "src/mirth/data/type.mth", 832, 5);
+    WORD_ATOM(832, 5, "unpack");
     mw_ArrowType_2E_unpack();
-    WORD_ATOM(814, 12, "swap");
+    WORD_ATOM(832, 12, "swap");
     mw_prim_swap();
-    WORD_ATOM(815, 5, "trace-dom!");
+    WORD_ATOM(833, 5, "trace-dom!");
     mw_StackType_2E_trace_dom_21_();
-    WORD_ATOM(816, 5, "");
+    WORD_ATOM(834, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -28107,19 +28424,19 @@ static void mw_ArrowType_2E_trace_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(816, 10, "trace!");
+    WORD_ATOM(834, 10, "trace!");
     mw_Str_2E_trace_21_();
-    WORD_ATOM(817, 5, "trace-cod!");
+    WORD_ATOM(835, 5, "trace-cod!");
     mw_StackType_2E_trace_cod_21_();
     WORD_EXIT(mw_ArrowType_2E_trace_21_);
 }
 static void mw_ArrowType_2E_semifreshen_sig (void){
-    WORD_ENTER(mw_ArrowType_2E_semifreshen_sig, "ArrowType.semifreshen-sig", "src/mirth/data/type.mth", 821, 5);
-    WORD_ATOM(821, 5, "dup");
+    WORD_ENTER(mw_ArrowType_2E_semifreshen_sig, "ArrowType.semifreshen-sig", "src/mirth/data/type.mth", 839, 5);
+    WORD_ATOM(839, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(821, 9, "needs-fresh-stack-rest?");
+    WORD_ATOM(839, 9, "needs-fresh-stack-rest?");
     mw_ArrowType_2E_needs_fresh_stack_rest_3F_();
-    WORD_ATOM(821, 33, "then");
+    WORD_ATOM(839, 33, "then");
     push_u64(0);
     push_fnptr(&mb_ArrowType_2E_semifreshen_sig_1);
     mw_prim_pack_cons();
@@ -28127,92 +28444,20 @@ static void mw_ArrowType_2E_semifreshen_sig (void){
     WORD_EXIT(mw_ArrowType_2E_semifreshen_sig);
 }
 static void mw_ArrowType_2E_semifreshen_aux (void){
-    WORD_ENTER(mw_ArrowType_2E_semifreshen_aux, "ArrowType.semifreshen-aux", "src/mirth/data/type.mth", 824, 5);
-    WORD_ATOM(824, 5, "MetaVar.new!");
-    mw_MetaVar_2E_new_21_();
-    WORD_ATOM(824, 18, "STMeta");
-    mw_STMeta();
-    WORD_ATOM(824, 25, "swap");
-    mw_prim_swap();
-    WORD_ATOM(824, 30, "unpack");
-    mw_ArrowType_2E_unpack();
-    WORD_ATOM(825, 5, "dip");
-    {
-        VAL d2 = pop_value();
-        WORD_ATOM(825, 9, "semifreshen");
-        mw_StackType_2E_semifreshen();
-        push_value(d2);
-    }
-    WORD_ATOM(825, 22, "swap");
-    mw_prim_swap();
-    WORD_ATOM(826, 5, "dip");
-    {
-        VAL d2 = pop_value();
-        WORD_ATOM(826, 9, "semifreshen");
-        mw_StackType_2E_semifreshen();
-        push_value(d2);
-    }
-    WORD_ATOM(826, 22, "swap");
-    mw_prim_swap();
-    WORD_ATOM(827, 5, "ARROW_TYPE");
-    mw_ARROW_5F_TYPE();
-    WORD_ATOM(827, 16, "nip");
-    mw_nip();
-    WORD_EXIT(mw_ArrowType_2E_semifreshen_aux);
-}
-static void mw_ArrowType_2E_needs_fresh_stack_rest_3F_ (void){
-    WORD_ENTER(mw_ArrowType_2E_needs_fresh_stack_rest_3F_, "ArrowType.needs-fresh-stack-rest?", "src/mirth/data/type.mth", 830, 5);
-    WORD_ATOM(830, 5, "unpack");
-    mw_ArrowType_2E_unpack();
-    WORD_ATOM(830, 12, "base");
-    mw_StackType_2E_base();
-    WORD_ATOM(830, 17, "unit?");
-    mw_StackType_2E_unit_3F_();
-    WORD_ATOM(830, 23, "if");
-    if (pop_u64()) {
-        WORD_ATOM(831, 9, "base");
-        mw_StackType_2E_base();
-        WORD_ATOM(831, 14, "unit?");
-        mw_StackType_2E_unit_3F_();
-    } else {
-        WORD_ATOM(832, 9, "drop");
-        mw_prim_drop();
-        WORD_ATOM(832, 14, "F");
-        mw_F();
-    }
-    WORD_EXIT(mw_ArrowType_2E_needs_fresh_stack_rest_3F_);
-}
-static void mw_ArrowType_2E_freshen_sig (void){
-    WORD_ENTER(mw_ArrowType_2E_freshen_sig, "ArrowType.freshen-sig", "src/mirth/data/type.mth", 836, 5);
-    WORD_ATOM(836, 5, "dup");
-    mw_prim_dup();
-    WORD_ATOM(836, 9, "needs-fresh-stack-rest?");
-    mw_ArrowType_2E_needs_fresh_stack_rest_3F_();
-    WORD_ATOM(836, 33, "if");
-    if (pop_u64()) {
-        WORD_ATOM(837, 9, "freshen-sig-aux");
-        mw_ArrowType_2E_freshen_sig_aux();
-    } else {
-        WORD_ATOM(838, 9, "freshen");
-        mw_ArrowType_2E_freshen();
-    }
-    WORD_EXIT(mw_ArrowType_2E_freshen_sig);
-}
-static void mw_ArrowType_2E_freshen_sig_aux (void){
-    WORD_ENTER(mw_ArrowType_2E_freshen_sig_aux, "ArrowType.freshen-sig-aux", "src/mirth/data/type.mth", 842, 5);
+    WORD_ENTER(mw_ArrowType_2E_semifreshen_aux, "ArrowType.semifreshen-aux", "src/mirth/data/type.mth", 842, 5);
     WORD_ATOM(842, 5, "MetaVar.new!");
     mw_MetaVar_2E_new_21_();
     WORD_ATOM(842, 18, "STMeta");
     mw_STMeta();
-    WORD_ATOM(842, 25, "rotr");
-    mw_rotr();
+    WORD_ATOM(842, 25, "swap");
+    mw_prim_swap();
     WORD_ATOM(842, 30, "unpack");
     mw_ArrowType_2E_unpack();
     WORD_ATOM(843, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(843, 9, "freshen-aux");
-        mw_StackType_2E_freshen_aux();
+        WORD_ATOM(843, 9, "semifreshen");
+        mw_StackType_2E_semifreshen();
         push_value(d2);
     }
     WORD_ATOM(843, 22, "swap");
@@ -28220,100 +28465,172 @@ static void mw_ArrowType_2E_freshen_sig_aux (void){
     WORD_ATOM(844, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(844, 9, "freshen-aux");
-        mw_StackType_2E_freshen_aux();
+        WORD_ATOM(844, 9, "semifreshen");
+        mw_StackType_2E_semifreshen();
         push_value(d2);
     }
     WORD_ATOM(844, 22, "swap");
     mw_prim_swap();
     WORD_ATOM(845, 5, "ARROW_TYPE");
     mw_ARROW_5F_TYPE();
-    WORD_ATOM(845, 16, "dip");
+    WORD_ATOM(845, 16, "nip");
+    mw_nip();
+    WORD_EXIT(mw_ArrowType_2E_semifreshen_aux);
+}
+static void mw_ArrowType_2E_needs_fresh_stack_rest_3F_ (void){
+    WORD_ENTER(mw_ArrowType_2E_needs_fresh_stack_rest_3F_, "ArrowType.needs-fresh-stack-rest?", "src/mirth/data/type.mth", 848, 5);
+    WORD_ATOM(848, 5, "unpack");
+    mw_ArrowType_2E_unpack();
+    WORD_ATOM(848, 12, "base");
+    mw_StackType_2E_base();
+    WORD_ATOM(848, 17, "unit?");
+    mw_StackType_2E_unit_3F_();
+    WORD_ATOM(848, 23, "if");
+    if (pop_u64()) {
+        WORD_ATOM(849, 9, "base");
+        mw_StackType_2E_base();
+        WORD_ATOM(849, 14, "unit?");
+        mw_StackType_2E_unit_3F_();
+    } else {
+        WORD_ATOM(850, 9, "drop");
+        mw_prim_drop();
+        WORD_ATOM(850, 14, "F");
+        mw_F();
+    }
+    WORD_EXIT(mw_ArrowType_2E_needs_fresh_stack_rest_3F_);
+}
+static void mw_ArrowType_2E_freshen_sig (void){
+    WORD_ENTER(mw_ArrowType_2E_freshen_sig, "ArrowType.freshen-sig", "src/mirth/data/type.mth", 854, 5);
+    WORD_ATOM(854, 5, "dup");
+    mw_prim_dup();
+    WORD_ATOM(854, 9, "needs-fresh-stack-rest?");
+    mw_ArrowType_2E_needs_fresh_stack_rest_3F_();
+    WORD_ATOM(854, 33, "if");
+    if (pop_u64()) {
+        WORD_ATOM(855, 9, "freshen-sig-aux");
+        mw_ArrowType_2E_freshen_sig_aux();
+    } else {
+        WORD_ATOM(856, 9, "freshen");
+        mw_ArrowType_2E_freshen();
+    }
+    WORD_EXIT(mw_ArrowType_2E_freshen_sig);
+}
+static void mw_ArrowType_2E_freshen_sig_aux (void){
+    WORD_ENTER(mw_ArrowType_2E_freshen_sig_aux, "ArrowType.freshen-sig-aux", "src/mirth/data/type.mth", 860, 5);
+    WORD_ATOM(860, 5, "MetaVar.new!");
+    mw_MetaVar_2E_new_21_();
+    WORD_ATOM(860, 18, "STMeta");
+    mw_STMeta();
+    WORD_ATOM(860, 25, "rotr");
+    mw_rotr();
+    WORD_ATOM(860, 30, "unpack");
+    mw_ArrowType_2E_unpack();
+    WORD_ATOM(861, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(845, 20, "nip");
+        WORD_ATOM(861, 9, "freshen-aux");
+        mw_StackType_2E_freshen_aux();
+        push_value(d2);
+    }
+    WORD_ATOM(861, 22, "swap");
+    mw_prim_swap();
+    WORD_ATOM(862, 5, "dip");
+    {
+        VAL d2 = pop_value();
+        WORD_ATOM(862, 9, "freshen-aux");
+        mw_StackType_2E_freshen_aux();
+        push_value(d2);
+    }
+    WORD_ATOM(862, 22, "swap");
+    mw_prim_swap();
+    WORD_ATOM(863, 5, "ARROW_TYPE");
+    mw_ARROW_5F_TYPE();
+    WORD_ATOM(863, 16, "dip");
+    {
+        VAL d2 = pop_value();
+        WORD_ATOM(863, 20, "nip");
         mw_nip();
         push_value(d2);
     }
     WORD_EXIT(mw_ArrowType_2E_freshen_sig_aux);
 }
 static void mw_ArrowType_2E_freshen (void){
-    WORD_ENTER(mw_ArrowType_2E_freshen, "ArrowType.freshen", "src/mirth/data/type.mth", 848, 5);
-    WORD_ATOM(848, 5, "unpack");
+    WORD_ENTER(mw_ArrowType_2E_freshen, "ArrowType.freshen", "src/mirth/data/type.mth", 866, 5);
+    WORD_ATOM(866, 5, "unpack");
     mw_ArrowType_2E_unpack();
-    WORD_ATOM(849, 5, "dip");
+    WORD_ATOM(867, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(849, 9, "freshen");
+        WORD_ATOM(867, 9, "freshen");
         mw_StackType_2E_freshen();
         push_value(d2);
     }
-    WORD_ATOM(849, 18, "swap");
+    WORD_ATOM(867, 18, "swap");
     mw_prim_swap();
-    WORD_ATOM(850, 5, "dip");
+    WORD_ATOM(868, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(850, 9, "freshen");
+        WORD_ATOM(868, 9, "freshen");
         mw_StackType_2E_freshen();
         push_value(d2);
     }
-    WORD_ATOM(850, 18, "swap");
+    WORD_ATOM(868, 18, "swap");
     mw_prim_swap();
-    WORD_ATOM(851, 5, "ARROW_TYPE");
+    WORD_ATOM(869, 5, "ARROW_TYPE");
     mw_ARROW_5F_TYPE();
     WORD_EXIT(mw_ArrowType_2E_freshen);
 }
 static void mw_ArrowType_2E_max_num_params (void){
-    WORD_ENTER(mw_ArrowType_2E_max_num_params, "ArrowType.max-num-params", "src/mirth/data/type.mth", 860, 5);
-    WORD_ATOM(860, 5, "dom");
+    WORD_ENTER(mw_ArrowType_2E_max_num_params, "ArrowType.max-num-params", "src/mirth/data/type.mth", 878, 5);
+    WORD_ATOM(878, 5, "dom");
     mw_ArrowType_2E_dom();
-    WORD_ATOM(860, 9, "num-morphisms-on-top");
+    WORD_ATOM(878, 9, "num-morphisms-on-top");
     mw_StackType_2E_num_morphisms_on_top();
     WORD_EXIT(mw_ArrowType_2E_max_num_params);
 }
 static void mw_Subst_2E_nil (void){
-    WORD_ENTER(mw_Subst_2E_nil, "Subst.nil", "src/mirth/data/type.mth", 876, 23);
-    WORD_ATOM(876, 23, "SUBST_NIL");
+    WORD_ENTER(mw_Subst_2E_nil, "Subst.nil", "src/mirth/data/type.mth", 894, 23);
+    WORD_ATOM(894, 23, "SUBST_NIL");
     mw_SUBST_5F_NIL();
     WORD_EXIT(mw_Subst_2E_nil);
 }
 static void mw_Subst_2E_cons (void){
-    WORD_ENTER(mw_Subst_2E_cons, "Subst.cons", "src/mirth/data/type.mth", 877, 42);
-    WORD_ATOM(877, 42, "rotr");
+    WORD_ENTER(mw_Subst_2E_cons, "Subst.cons", "src/mirth/data/type.mth", 895, 42);
+    WORD_ATOM(895, 42, "rotr");
     mw_rotr();
-    WORD_ATOM(877, 47, "SUBST_CON");
+    WORD_ATOM(895, 47, "SUBST_CON");
     mw_SUBST_5F_CON();
     WORD_EXIT(mw_Subst_2E_cons);
 }
 static void mw_Subst_2E_has_var_3F_ (void){
-    WORD_ENTER(mw_Subst_2E_has_var_3F_, "Subst.has-var?", "src/mirth/data/type.mth", 879, 5);
-    WORD_ATOM(879, 5, "SUBST_NIL");
+    WORD_ENTER(mw_Subst_2E_has_var_3F_, "Subst.has-var?", "src/mirth/data/type.mth", 897, 5);
+    WORD_ATOM(897, 5, "SUBST_NIL");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(879, 18, "drop");
+            WORD_ATOM(897, 18, "drop");
             mw_prim_drop();
-            WORD_ATOM(879, 23, "F");
+            WORD_ATOM(897, 23, "F");
             mw_F();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(880, 18, "nip");
+            WORD_ATOM(898, 18, "nip");
             mw_nip();
-            WORD_ATOM(880, 22, "over2");
+            WORD_ATOM(898, 22, "over2");
             mw_over2();
-            WORD_ATOM(880, 28, "=");
+            WORD_ATOM(898, 28, "=");
             mw_Var_3D_();
-            WORD_ATOM(880, 30, "if");
+            WORD_ATOM(898, 30, "if");
             if (pop_u64()) {
-                WORD_ATOM(880, 33, "drop2");
+                WORD_ATOM(898, 33, "drop2");
                 mw_drop2();
-                WORD_ATOM(880, 39, "T");
+                WORD_ATOM(898, 39, "T");
                 mw_T();
             } else {
-                WORD_ATOM(880, 42, "has-var?");
+                WORD_ATOM(898, 42, "has-var?");
                 mw_Subst_2E_has_var_3F_();
             }
             break;
@@ -28322,37 +28639,37 @@ static void mw_Subst_2E_has_var_3F_ (void){
 }    WORD_EXIT(mw_Subst_2E_has_var_3F_);
 }
 static void mw_Subst_2E_get_var (void){
-    WORD_ENTER(mw_Subst_2E_get_var, "Subst.get-var", "src/mirth/data/type.mth", 882, 5);
-    WORD_ATOM(882, 5, "SUBST_NIL");
+    WORD_ENTER(mw_Subst_2E_get_var, "Subst.get-var", "src/mirth/data/type.mth", 900, 5);
+    WORD_ATOM(900, 5, "SUBST_NIL");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(882, 18, "drop");
+            WORD_ATOM(900, 18, "drop");
             mw_prim_drop();
-            WORD_ATOM(882, 23, "TYPE_ERROR");
+            WORD_ATOM(900, 23, "TYPE_ERROR");
             mw_TYPE_5F_ERROR();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(883, 18, "over3");
+            WORD_ATOM(901, 18, "over3");
             mw_over3();
-            WORD_ATOM(883, 24, "=");
+            WORD_ATOM(901, 24, "=");
             mw_Var_3D_();
-            WORD_ATOM(883, 26, "if");
+            WORD_ATOM(901, 26, "if");
             if (pop_u64()) {
-                WORD_ATOM(883, 29, "dip");
+                WORD_ATOM(901, 29, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(883, 33, "drop2");
+                    WORD_ATOM(901, 33, "drop2");
                     mw_drop2();
                     push_value(d5);
                 }
             } else {
-                WORD_ATOM(883, 41, "drop");
+                WORD_ATOM(901, 41, "drop");
                 mw_prim_drop();
-                WORD_ATOM(883, 46, "get-var");
+                WORD_ATOM(901, 46, "get-var");
                 mw_Subst_2E_get_var();
             }
             break;
@@ -33444,6 +33761,98 @@ static void mw_Def_2E_typecheck_21_ (void){
     
 }    WORD_EXIT(mw_Def_2E_typecheck_21_);
 }
+static void mw_Def_2E_callable_3F_ (void){
+    WORD_ENTER(mw_Def_2E_callable_3F_, "Def.callable?", "src/mirth/data/def.mth", 73, 5);
+    WORD_ATOM(73, 5, "DEF_NONE");
+    switch (get_top_data_tag()) {
+        case 0LL:
+            mw_prim_drop();
+            WORD_ATOM(73, 17, "F");
+            mw_F();
+            break;
+        case 1LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(74, 18, "target");
+            mw_Alias_2E_target();
+            WORD_ATOM(74, 25, ">Def");
+            mw_Name_3E_Def();
+            WORD_ATOM(74, 30, "callable?");
+            mw_Def_2E_callable_3F_();
+            break;
+        case 2LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(75, 19, "drop");
+            mw_prim_drop();
+            WORD_ATOM(75, 24, "F");
+            mw_F();
+            break;
+        case 7LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(76, 19, "drop");
+            mw_prim_drop();
+            WORD_ATOM(76, 24, "T");
+            mw_T();
+            break;
+        case 5LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(77, 17, "drop");
+            mw_prim_drop();
+            WORD_ATOM(77, 22, "T");
+            mw_T();
+            break;
+        case 3LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(78, 17, "drop");
+            mw_prim_drop();
+            WORD_ATOM(78, 22, "F");
+            mw_F();
+            break;
+        case 10LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(79, 21, "drop");
+            mw_prim_drop();
+            WORD_ATOM(79, 26, "T");
+            mw_T();
+            break;
+        case 6LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(80, 17, "drop");
+            mw_prim_drop();
+            WORD_ATOM(80, 22, "T");
+            mw_T();
+            break;
+        case 11LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(81, 18, "drop");
+            mw_prim_drop();
+            WORD_ATOM(81, 23, "T");
+            mw_T();
+            break;
+        case 4LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(82, 16, "drop");
+            mw_prim_drop();
+            WORD_ATOM(82, 21, "T");
+            mw_T();
+            break;
+        case 8LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(83, 21, "drop");
+            mw_prim_drop();
+            WORD_ATOM(83, 26, "T");
+            mw_T();
+            break;
+        case 9LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(84, 21, "drop");
+            mw_prim_drop();
+            WORD_ATOM(84, 26, "T");
+            mw_T();
+            break;
+        default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
+    
+}    WORD_EXIT(mw_Def_2E_callable_3F_);
+}
 static void mw_Name_2E_id (void){
     WORD_ENTER(mw_Name_2E_id, "Name.id", "src/mirth/data/name.mth", 16, 7);
     WORD_ATOM(16, 7, "Name");
@@ -33964,47 +34373,6 @@ static void mw_Name_2E_mangle_compute_21_ (void){
     mw_prim_pack_cons();
     mw_build_str_21_();
     WORD_EXIT(mw_Name_2E_mangle_compute_21_);
-}
-static void mw_Name_2E_could_be_relative (void){
-    WORD_ENTER(mw_Name_2E_could_be_relative, "Name.could-be-relative", "src/mirth/data/name.mth", 113, 5);
-    WORD_ATOM(113, 5, "head");
-    mw_Name_2E_head();
-    WORD_ATOM(113, 10, "is-overload-trigger");
-    mw_Byte_2E_is_overload_trigger();
-    WORD_EXIT(mw_Name_2E_could_be_relative);
-}
-static void mw_Name_2E_to_overload_suffix (void){
-    WORD_ENTER(mw_Name_2E_to_overload_suffix, "Name.to-overload-suffix", "src/mirth/data/name.mth", 116, 5);
-    WORD_ATOM(116, 5, "dup");
-    mw_prim_dup();
-    WORD_ATOM(116, 9, "head");
-    mw_Name_2E_head();
-    WORD_ATOM(116, 14, "is-alpha");
-    mw_Byte_2E_is_alpha();
-    WORD_ATOM(116, 23, "if");
-    if (pop_u64()) {
-        WORD_ATOM(117, 9, "");
-        {
-            static bool vready = false;
-            static VAL v;
-            if (! vready) {
-                v = mkstr(".", 1);
-                vready = true;
-            }
-            push_value(v);
-            incref(v);
-        }
-        WORD_ATOM(117, 13, "swap");
-        mw_prim_swap();
-        WORD_ATOM(117, 18, ">Str");
-        mw_Name_3E_Str();
-        WORD_ATOM(117, 23, "cat");
-        mw_prim_str_cat();
-    } else {
-        WORD_ATOM(118, 9, ">Str");
-        mw_Name_3E_Str();
-    }
-    WORD_EXIT(mw_Name_2E_to_overload_suffix);
 }
 static void mw_name_undefined_3F_ (void){
     WORD_ENTER(mw_name_undefined_3F_, "name-undefined?", "src/mirth/data/name.mth", 125, 41);
@@ -34653,19 +35021,19 @@ static void mb_init_prims_21__16 (void) {
 }
 
 static void mb_typecheck_everything_21__1 (void) {
-    WORD_ENTER(mb_typecheck_everything_21__1, "typecheck-everything! block", "src/mirth/elab.mth", 1012, 14);
+    WORD_ENTER(mb_typecheck_everything_21__1, "typecheck-everything! block", "src/mirth/elab.mth", 1025, 14);
     mw_prim_drop();
-    WORD_ATOM(1012, 14, ">Def");
+    WORD_ATOM(1025, 14, ">Def");
     mw_Name_3E_Def();
-    WORD_ATOM(1012, 19, "typecheck!");
+    WORD_ATOM(1025, 19, "typecheck!");
     mw_Def_2E_typecheck_21_();
     WORD_EXIT(mb_typecheck_everything_21__1);
 }
 
 static void mb_typecheck_everything_21__2 (void) {
-    WORD_ENTER(mb_typecheck_everything_21__2, "typecheck-everything! block", "src/mirth/elab.mth", 1013, 15);
+    WORD_ENTER(mb_typecheck_everything_21__2, "typecheck-everything! block", "src/mirth/elab.mth", 1026, 15);
     mw_prim_drop();
-    WORD_ATOM(1013, 15, "typecheck!");
+    WORD_ATOM(1026, 15, "typecheck!");
     mw_Block_2E_typecheck_21_();
     WORD_EXIT(mb_typecheck_everything_21__2);
 }
@@ -34850,20 +35218,20 @@ static void mb_List_2E_cat_2B__1 (void) {
     WORD_EXIT(mb_List_2E_cat_2B__1);
 }
 
-static void mb_first_1 (void) {
-    WORD_ENTER(mb_first_1, "first block", "src/data/list.mth", 168, 48);
+static void mb_List_2E_first_1 (void) {
+    WORD_ENTER(mb_List_2E_first_1, "List.first block", "src/data/list.mth", 168, 53);
     mw_prim_drop();
-    WORD_ATOM(168, 48, "first+");
-    mw_first_2B_();
-    WORD_EXIT(mb_first_1);
+    WORD_ATOM(168, 53, "first");
+    mw_List_2B__2E_first();
+    WORD_EXIT(mb_List_2E_first_1);
 }
 
-static void mb_last_1 (void) {
-    WORD_ENTER(mb_last_1, "last block", "src/data/list.mth", 169, 47);
+static void mb_List_2E_last_1 (void) {
+    WORD_ENTER(mb_List_2E_last_1, "List.last block", "src/data/list.mth", 169, 52);
     mw_prim_drop();
-    WORD_ATOM(169, 47, "last+");
-    mw_last_2B_();
-    WORD_EXIT(mb_last_1);
+    WORD_ATOM(169, 52, "last");
+    mw_List_2B__2E_last();
+    WORD_EXIT(mb_List_2E_last_1);
 }
 
 static void mb_List_2B__2E_filter_5 (void) {
@@ -34892,15 +35260,74 @@ static void mb_List_2B__2E_filter_10 (void) {
     WORD_EXIT(mb_List_2B__2E_filter_10);
 }
 
+static void mb_List_2E_filter_some_2 (void) {
+    WORD_ENTER(mb_List_2E_filter_some_2, "List.filter-some block", "src/data/list.mth", 279, 24);
+    mw_prim_pack_uncons();
+    VAL var_p = pop_value();
+    mw_prim_drop();
+    WORD_ATOM(279, 24, "filter-some");
+    incref(var_p);
+    push_value(var_p);
+    mw_List_2B__2E_filter_some();
+    decref(var_p);
+    WORD_EXIT(mb_List_2E_filter_some_2);
+}
+
+static void mb_List_2E_filter_some_4 (void) {
+    WORD_ENTER(mb_List_2E_filter_some_4, "List.filter-some block", "src/data/list.mth", 279, 40);
+    mw_prim_pack_uncons();
+    VAL var_p = pop_value();
+    mw_prim_drop();
+    WORD_ATOM(279, 40, "L0");
+    mw_L0();
+    decref(var_p);
+    WORD_EXIT(mb_List_2E_filter_some_4);
+}
+
+static void mb_List_2B__2E_filter_some_5 (void) {
+    WORD_ENTER(mb_List_2B__2E_filter_some_5, "List+.filter-some block", "src/data/list.mth", 282, 44);
+    mw_prim_pack_uncons();
+    VAL var_p = pop_value();
+    mw_prim_drop();
+    WORD_ATOM(282, 44, "filter-some");
+    incref(var_p);
+    push_value(var_p);
+    mw_List_2B__2E_filter_some();
+    decref(var_p);
+    WORD_EXIT(mb_List_2B__2E_filter_some_5);
+}
+
+static void mb_List_2B__2E_filter_some_11 (void) {
+    WORD_ENTER(mb_List_2B__2E_filter_some_11, "List+.filter-some block", "src/data/list.mth", 283, 53);
+    mw_prim_pack_uncons();
+    VAL var_p = pop_value();
+    mw_prim_drop();
+    WORD_ATOM(283, 53, "snoc");
+    mw_snoc();
+    decref(var_p);
+    WORD_EXIT(mb_List_2B__2E_filter_some_11);
+}
+
+static void mb_List_2B__2E_filter_some_12 (void) {
+    WORD_ENTER(mb_List_2B__2E_filter_some_12, "List+.filter-some block", "src/data/list.mth", 283, 59);
+    mw_prim_pack_uncons();
+    VAL var_p = pop_value();
+    mw_prim_drop();
+    WORD_ATOM(283, 59, "id");
+    mw_prim_id();
+    decref(var_p);
+    WORD_EXIT(mb_List_2B__2E_filter_some_12);
+}
+
 static void mb_List_2E_all_2 (void) {
-    WORD_ENTER(mb_List_2E_all_2, "List.all block", "src/data/list.mth", 322, 10);
+    WORD_ENTER(mb_List_2E_all_2, "List.all block", "src/data/list.mth", 329, 10);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(322, 10, "f");
+    WORD_ATOM(329, 10, "f");
     incref(var_f);
     run_value(var_f);
-    WORD_ATOM(322, 12, "not");
+    WORD_ATOM(329, 12, "not");
     mw_Bool_2E_not();
     decref(var_f);
     WORD_EXIT(mb_List_2E_all_2);
@@ -35185,6 +35612,30 @@ static void mb_str_bytes_for_3 (void) {
     mw_prim_ptr_add();
     decref(var_f);
     WORD_EXIT(mb_str_bytes_for_3);
+}
+
+static void mb_Str_2E_first_byte_1 (void) {
+    WORD_ENTER(mb_Str_2E_first_byte_1, "Str.first-byte block", "src/data/str.mth", 102, 9);
+    mw_prim_drop();
+    WORD_ATOM(102, 9, "");
+    push_i64(1LL);
+    WORD_ATOM(102, 11, ">=");
+    mw_Int_3E__3D_();
+    WORD_ATOM(102, 14, "if");
+    if (pop_u64()) {
+        WORD_ATOM(103, 13, "@U8");
+        mw_prim_u8_get();
+        WORD_ATOM(103, 17, "U8>Byte");
+        mw_U8_3E_Byte();
+        WORD_ATOM(103, 25, "SOME");
+        mw_SOME();
+    } else {
+        WORD_ATOM(104, 13, "drop");
+        mw_prim_drop();
+        WORD_ATOM(104, 18, "NONE");
+        mw_NONE();
+    }
+    WORD_EXIT(mb_Str_2E_first_byte_1);
 }
 
 static void mb_Int_3E_Byte_1 (void) {
@@ -35839,25 +36290,25 @@ static void mb_Token_2E_sig_stack_end_3F__1 (void) {
 }
 
 static void mb_elab_module_import_21__1 (void) {
-    WORD_ENTER(mb_elab_module_import_21__1, "elab-module-import! block", "src/mirth/elab.mth", 784, 9);
+    WORD_ENTER(mb_elab_module_import_21__1, "elab-module-import! block", "src/mirth/elab.mth", 797, 9);
     mw_prim_drop();
-    WORD_ATOM(784, 9, "next");
+    WORD_ATOM(797, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_module_import_21__1);
 }
 
 static void mb_elab_alias_21__1 (void) {
-    WORD_ENTER(mb_elab_alias_21__1, "elab-alias! block", "src/mirth/elab.mth", 882, 9);
+    WORD_ENTER(mb_elab_alias_21__1, "elab-alias! block", "src/mirth/elab.mth", 895, 9);
     mw_prim_drop();
-    WORD_ATOM(882, 9, "next");
+    WORD_ATOM(895, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_alias_21__1);
 }
 
 static void mb_elab_alias_21__2 (void) {
-    WORD_ENTER(mb_elab_alias_21__2, "elab-alias! block", "src/mirth/elab.mth", 883, 25);
+    WORD_ENTER(mb_elab_alias_21__2, "elab-alias! block", "src/mirth/elab.mth", 896, 25);
     mw_prim_drop();
-    WORD_ATOM(883, 25, "");
+    WORD_ATOM(896, 25, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35868,17 +36319,17 @@ static void mb_elab_alias_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(883, 46, "emit-fatal-error!");
+    WORD_ATOM(896, 46, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_alias_21__2);
 }
 
 static void mb_elab_alias_21__4 (void) {
-    WORD_ENTER(mb_elab_alias_21__4, "elab-alias! block", "src/mirth/elab.mth", 884, 26);
+    WORD_ENTER(mb_elab_alias_21__4, "elab-alias! block", "src/mirth/elab.mth", 897, 26);
     mw_prim_drop();
-    WORD_ATOM(884, 26, "drop");
+    WORD_ATOM(897, 26, "drop");
     mw_prim_drop();
-    WORD_ATOM(884, 31, "");
+    WORD_ATOM(897, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35889,15 +36340,15 @@ static void mb_elab_alias_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(884, 54, "emit-fatal-error!");
+    WORD_ATOM(897, 54, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_alias_21__4);
 }
 
 static void mb_elab_alias_21__5 (void) {
-    WORD_ENTER(mb_elab_alias_21__5, "elab-alias! block", "src/mirth/elab.mth", 885, 25);
+    WORD_ENTER(mb_elab_alias_21__5, "elab-alias! block", "src/mirth/elab.mth", 898, 25);
     mw_prim_drop();
-    WORD_ATOM(885, 25, "");
+    WORD_ATOM(898, 25, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35908,23 +36359,23 @@ static void mb_elab_alias_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(885, 46, "emit-fatal-error!");
+    WORD_ATOM(898, 46, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_alias_21__5);
 }
 
 static void mb_elab_def_21__1 (void) {
-    WORD_ENTER(mb_elab_def_21__1, "elab-def! block", "src/mirth/elab.mth", 898, 9);
+    WORD_ENTER(mb_elab_def_21__1, "elab-def! block", "src/mirth/elab.mth", 911, 9);
     mw_prim_drop();
-    WORD_ATOM(898, 9, "next");
+    WORD_ATOM(911, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_def_21__1);
 }
 
 static void mb_elab_def_21__6 (void) {
-    WORD_ENTER(mb_elab_def_21__6, "elab-def! block", "src/mirth/elab.mth", 902, 30);
+    WORD_ENTER(mb_elab_def_21__6, "elab-def! block", "src/mirth/elab.mth", 915, 30);
     mw_prim_drop();
-    WORD_ATOM(902, 30, "");
+    WORD_ATOM(915, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35935,51 +36386,51 @@ static void mb_elab_def_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(902, 51, "emit-fatal-error!");
+    WORD_ATOM(915, 51, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_21__6);
 }
 
 static void mb_elab_def_21__9 (void) {
-    WORD_ENTER(mb_elab_def_21__9, "elab-def! block", "src/mirth/elab.mth", 909, 9);
+    WORD_ENTER(mb_elab_def_21__9, "elab-def! block", "src/mirth/elab.mth", 922, 9);
     mw_prim_drop();
-    WORD_ATOM(909, 9, "type-elab-default");
+    WORD_ATOM(922, 9, "type-elab-default");
     mw_type_elab_default();
-    WORD_ATOM(910, 9, "over");
+    WORD_ATOM(923, 9, "over");
     mw_over();
-    WORD_ATOM(910, 14, "sig");
+    WORD_ATOM(923, 14, "sig");
     mw_Word_2E_sig();
-    WORD_ATOM(910, 18, "unwrap-or");
+    WORD_ATOM(923, 18, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_def_21__10);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(911, 9, "elab-type-sig!");
+    WORD_ATOM(924, 9, "elab-type-sig!");
     mw_elab_type_sig_21_();
-    WORD_ATOM(911, 24, "drop");
+    WORD_ATOM(924, 24, "drop");
     mw_prim_drop();
-    WORD_ATOM(911, 29, "dip");
+    WORD_ATOM(924, 29, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(911, 33, "type-elab-ctx");
+        WORD_ATOM(924, 33, "type-elab-ctx");
         mw_type_elab_ctx();
         push_value(d2);
     }
-    WORD_ATOM(912, 9, "pack2");
+    WORD_ATOM(925, 9, "pack2");
     mw_pack2();
-    WORD_ATOM(912, 15, "nip");
+    WORD_ATOM(925, 15, "nip");
     mw_nip();
     WORD_EXIT(mb_elab_def_21__9);
 }
 
 static void mb_elab_def_21__10 (void) {
-    WORD_ENTER(mb_elab_def_21__10, "elab-def! block", "src/mirth/elab.mth", 910, 28);
+    WORD_ENTER(mb_elab_def_21__10, "elab-def! block", "src/mirth/elab.mth", 923, 28);
     mw_prim_drop();
-    WORD_ATOM(910, 28, "over");
+    WORD_ATOM(923, 28, "over");
     mw_over();
-    WORD_ATOM(910, 33, "head");
+    WORD_ATOM(923, 33, "head");
     mw_Word_2E_head();
-    WORD_ATOM(910, 38, "");
+    WORD_ATOM(923, 38, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35990,25 +36441,25 @@ static void mb_elab_def_21__10 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(910, 60, "emit-fatal-error!");
+    WORD_ATOM(923, 60, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_21__10);
 }
 
 static void mb_elab_def_21__12 (void) {
-    WORD_ENTER(mb_elab_def_21__12, "elab-def! block", "src/mirth/elab.mth", 914, 15);
+    WORD_ENTER(mb_elab_def_21__12, "elab-def! block", "src/mirth/elab.mth", 927, 15);
     mw_prim_drop();
-    WORD_ATOM(914, 15, "elab-def-params!");
+    WORD_ATOM(927, 15, "elab-def-params!");
     mw_elab_def_params_21_();
     WORD_EXIT(mb_elab_def_21__12);
 }
 
 static void mb_elab_def_21__13 (void) {
-    WORD_ENTER(mb_elab_def_21__13, "elab-def! block", "src/mirth/elab.mth", 916, 9);
+    WORD_ENTER(mb_elab_def_21__13, "elab-def! block", "src/mirth/elab.mth", 929, 9);
     mw_prim_drop();
-    WORD_ATOM(916, 9, "dup");
+    WORD_ATOM(929, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(916, 13, "ab-build-word-arrow!");
+    WORD_ATOM(929, 13, "ab-build-word-arrow!");
     push_u64(0);
     push_fnptr(&mb_elab_def_21__14);
     mw_prim_pack_cons();
@@ -36017,24 +36468,24 @@ static void mb_elab_def_21__13 (void) {
 }
 
 static void mb_elab_def_21__14 (void) {
-    WORD_ENTER(mb_elab_def_21__14, "elab-def! block", "src/mirth/elab.mth", 917, 13);
+    WORD_ENTER(mb_elab_def_21__14, "elab-def! block", "src/mirth/elab.mth", 930, 13);
     mw_prim_drop();
-    WORD_ATOM(917, 13, "swap");
+    WORD_ATOM(930, 13, "swap");
     mw_prim_swap();
-    WORD_ATOM(917, 18, "params");
+    WORD_ATOM(930, 18, "params");
     mw_Word_2E_params();
-    WORD_ATOM(917, 25, "dup");
+    WORD_ATOM(930, 25, "dup");
     mw_prim_dup();
-    WORD_ATOM(917, 29, "is-empty");
+    WORD_ATOM(930, 29, "is-empty");
     mw_List_2E_is_empty();
-    WORD_ATOM(917, 38, "if");
+    WORD_ATOM(930, 38, "if");
     if (pop_u64()) {
-        WORD_ATOM(918, 17, "drop");
+        WORD_ATOM(931, 17, "drop");
         mw_prim_drop();
-        WORD_ATOM(918, 22, "elab-def-body!");
+        WORD_ATOM(931, 22, "elab-def-body!");
         mw_elab_def_body_21_();
     } else {
-        WORD_ATOM(919, 17, "ab-lambda!");
+        WORD_ATOM(932, 17, "ab-lambda!");
         push_u64(0);
         push_fnptr(&mb_elab_def_21__17);
         mw_prim_pack_cons();
@@ -36044,17 +36495,17 @@ static void mb_elab_def_21__14 (void) {
 }
 
 static void mb_elab_def_21__17 (void) {
-    WORD_ENTER(mb_elab_def_21__17, "elab-def! block", "src/mirth/elab.mth", 919, 28);
+    WORD_ENTER(mb_elab_def_21__17, "elab-def! block", "src/mirth/elab.mth", 932, 28);
     mw_prim_drop();
-    WORD_ATOM(919, 28, "elab-def-body!");
+    WORD_ATOM(932, 28, "elab-def-body!");
     mw_elab_def_body_21_();
     WORD_EXIT(mb_elab_def_21__17);
 }
 
 static void mb_elab_def_missing_21__1 (void) {
-    WORD_ENTER(mb_elab_def_missing_21__1, "elab-def-missing! block", "src/mirth/elab.mth", 891, 39);
+    WORD_ENTER(mb_elab_def_missing_21__1, "elab-def-missing! block", "src/mirth/elab.mth", 904, 39);
     mw_prim_drop();
-    WORD_ATOM(891, 39, "");
+    WORD_ATOM(904, 39, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36065,23 +36516,23 @@ static void mb_elab_def_missing_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(891, 55, "emit-fatal-error!");
+    WORD_ATOM(904, 55, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_missing_21__1);
 }
 
 static void mb_elab_def_external_21__1 (void) {
-    WORD_ENTER(mb_elab_def_external_21__1, "elab-def-external! block", "src/mirth/elab.mth", 948, 9);
+    WORD_ENTER(mb_elab_def_external_21__1, "elab-def-external! block", "src/mirth/elab.mth", 961, 9);
     mw_prim_drop();
-    WORD_ATOM(948, 9, "next");
+    WORD_ATOM(961, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_def_external_21__1);
 }
 
 static void mb_elab_def_external_21__2 (void) {
-    WORD_ENTER(mb_elab_def_external_21__2, "elab-def-external! block", "src/mirth/elab.mth", 949, 30);
+    WORD_ENTER(mb_elab_def_external_21__2, "elab-def-external! block", "src/mirth/elab.mth", 962, 30);
     mw_prim_drop();
-    WORD_ATOM(949, 30, "");
+    WORD_ATOM(962, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36092,17 +36543,17 @@ static void mb_elab_def_external_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(949, 51, "emit-fatal-error!");
+    WORD_ATOM(962, 51, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_external_21__2);
 }
 
 static void mb_elab_def_external_21__3 (void) {
-    WORD_ENTER(mb_elab_def_external_21__3, "elab-def-external! block", "src/mirth/elab.mth", 950, 26);
+    WORD_ENTER(mb_elab_def_external_21__3, "elab-def-external! block", "src/mirth/elab.mth", 963, 26);
     mw_prim_drop();
-    WORD_ATOM(950, 26, "drop");
+    WORD_ATOM(963, 26, "drop");
     mw_prim_drop();
-    WORD_ATOM(950, 31, "");
+    WORD_ATOM(963, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36113,48 +36564,48 @@ static void mb_elab_def_external_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(950, 54, "emit-fatal-error!");
+    WORD_ATOM(963, 54, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_external_21__3);
 }
 
 static void mb_elab_def_external_21__4 (void) {
-    WORD_ENTER(mb_elab_def_external_21__4, "elab-def-external! block", "src/mirth/elab.mth", 957, 9);
+    WORD_ENTER(mb_elab_def_external_21__4, "elab-def-external! block", "src/mirth/elab.mth", 970, 9);
     mw_prim_drop();
-    WORD_ATOM(957, 9, "type-elab-default");
+    WORD_ATOM(970, 9, "type-elab-default");
     mw_type_elab_default();
-    WORD_ATOM(957, 27, "swap");
+    WORD_ATOM(970, 27, "swap");
     mw_prim_swap();
-    WORD_ATOM(957, 32, "sig");
+    WORD_ATOM(970, 32, "sig");
     mw_External_2E_sig();
-    WORD_ATOM(958, 9, "elab-type-sig!");
+    WORD_ATOM(971, 9, "elab-type-sig!");
     mw_elab_type_sig_21_();
-    WORD_ATOM(958, 24, "drop");
+    WORD_ATOM(971, 24, "drop");
     mw_prim_drop();
-    WORD_ATOM(958, 29, "dip");
+    WORD_ATOM(971, 29, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(958, 33, "type-elab-ctx");
+        WORD_ATOM(971, 33, "type-elab-ctx");
         mw_type_elab_ctx();
         push_value(d2);
     }
-    WORD_ATOM(958, 48, "pack2");
+    WORD_ATOM(971, 48, "pack2");
     mw_pack2();
     WORD_EXIT(mb_elab_def_external_21__4);
 }
 
 static void mb_elab_def_type_21__1 (void) {
-    WORD_ENTER(mb_elab_def_type_21__1, "elab-def-type! block", "src/mirth/elab.mth", 963, 9);
+    WORD_ENTER(mb_elab_def_type_21__1, "elab-def-type! block", "src/mirth/elab.mth", 976, 9);
     mw_prim_drop();
-    WORD_ATOM(963, 9, "next");
+    WORD_ATOM(976, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_def_type_21__1);
 }
 
 static void mb_elab_def_type_21__2 (void) {
-    WORD_ENTER(mb_elab_def_type_21__2, "elab-def-type! block", "src/mirth/elab.mth", 964, 33);
+    WORD_ENTER(mb_elab_def_type_21__2, "elab-def-type! block", "src/mirth/elab.mth", 977, 33);
     mw_prim_drop();
-    WORD_ATOM(964, 33, "");
+    WORD_ATOM(977, 33, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36165,17 +36616,17 @@ static void mb_elab_def_type_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(964, 61, "emit-fatal-error!");
+    WORD_ATOM(977, 61, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_type_21__2);
 }
 
 static void mb_elab_def_type_21__3 (void) {
-    WORD_ENTER(mb_elab_def_type_21__3, "elab-def-type! block", "src/mirth/elab.mth", 965, 43);
+    WORD_ENTER(mb_elab_def_type_21__3, "elab-def-type! block", "src/mirth/elab.mth", 978, 43);
     mw_prim_drop();
-    WORD_ATOM(965, 43, "drop");
+    WORD_ATOM(978, 43, "drop");
     mw_prim_drop();
-    WORD_ATOM(965, 48, "");
+    WORD_ATOM(978, 48, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36186,23 +36637,23 @@ static void mb_elab_def_type_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(965, 76, "emit-fatal-error!");
+    WORD_ATOM(978, 76, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_type_21__3);
 }
 
 static void mb_elab_buffer_21__1 (void) {
-    WORD_ENTER(mb_elab_buffer_21__1, "elab-buffer! block", "src/mirth/elab.mth", 970, 9);
+    WORD_ENTER(mb_elab_buffer_21__1, "elab-buffer! block", "src/mirth/elab.mth", 983, 9);
     mw_prim_drop();
-    WORD_ATOM(970, 9, "next");
+    WORD_ATOM(983, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_buffer_21__1);
 }
 
 static void mb_elab_buffer_21__2 (void) {
-    WORD_ENTER(mb_elab_buffer_21__2, "elab-buffer! block", "src/mirth/elab.mth", 971, 30);
+    WORD_ENTER(mb_elab_buffer_21__2, "elab-buffer! block", "src/mirth/elab.mth", 984, 30);
     mw_prim_drop();
-    WORD_ATOM(971, 30, "");
+    WORD_ATOM(984, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36213,17 +36664,17 @@ static void mb_elab_buffer_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(971, 53, "emit-fatal-error!");
+    WORD_ATOM(984, 53, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_buffer_21__2);
 }
 
 static void mb_elab_buffer_21__3 (void) {
-    WORD_ENTER(mb_elab_buffer_21__3, "elab-buffer! block", "src/mirth/elab.mth", 972, 26);
+    WORD_ENTER(mb_elab_buffer_21__3, "elab-buffer! block", "src/mirth/elab.mth", 985, 26);
     mw_prim_drop();
-    WORD_ATOM(972, 26, "drop");
+    WORD_ATOM(985, 26, "drop");
     mw_prim_drop();
-    WORD_ATOM(972, 31, "");
+    WORD_ATOM(985, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36234,15 +36685,15 @@ static void mb_elab_buffer_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(972, 61, "emit-fatal-error!");
+    WORD_ATOM(985, 61, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_buffer_21__3);
 }
 
 static void mb_elab_buffer_21__4 (void) {
-    WORD_ENTER(mb_elab_buffer_21__4, "elab-buffer! block", "src/mirth/elab.mth", 973, 29);
+    WORD_ENTER(mb_elab_buffer_21__4, "elab-buffer! block", "src/mirth/elab.mth", 986, 29);
     mw_prim_drop();
-    WORD_ATOM(973, 29, "");
+    WORD_ATOM(986, 29, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36253,23 +36704,23 @@ static void mb_elab_buffer_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(973, 52, "emit-fatal-error!");
+    WORD_ATOM(986, 52, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_buffer_21__4);
 }
 
 static void mb_elab_variable_21__1 (void) {
-    WORD_ENTER(mb_elab_variable_21__1, "elab-variable! block", "src/mirth/elab.mth", 978, 9);
+    WORD_ENTER(mb_elab_variable_21__1, "elab-variable! block", "src/mirth/elab.mth", 991, 9);
     mw_prim_drop();
-    WORD_ATOM(978, 9, "next");
+    WORD_ATOM(991, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_variable_21__1);
 }
 
 static void mb_elab_variable_21__2 (void) {
-    WORD_ENTER(mb_elab_variable_21__2, "elab-variable! block", "src/mirth/elab.mth", 979, 30);
+    WORD_ENTER(mb_elab_variable_21__2, "elab-variable! block", "src/mirth/elab.mth", 992, 30);
     mw_prim_drop();
-    WORD_ATOM(979, 30, "");
+    WORD_ATOM(992, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36280,17 +36731,17 @@ static void mb_elab_variable_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(979, 55, "emit-fatal-error!");
+    WORD_ATOM(992, 55, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_variable_21__2);
 }
 
 static void mb_elab_variable_21__3 (void) {
-    WORD_ENTER(mb_elab_variable_21__3, "elab-variable! block", "src/mirth/elab.mth", 980, 26);
+    WORD_ENTER(mb_elab_variable_21__3, "elab-variable! block", "src/mirth/elab.mth", 993, 26);
     mw_prim_drop();
-    WORD_ATOM(980, 26, "drop");
+    WORD_ATOM(993, 26, "drop");
     mw_prim_drop();
-    WORD_ATOM(980, 31, "");
+    WORD_ATOM(993, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36301,31 +36752,31 @@ static void mb_elab_variable_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(980, 63, "emit-fatal-error!");
+    WORD_ATOM(993, 63, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_variable_21__3);
 }
 
 static void mb_elab_variable_21__4 (void) {
-    WORD_ENTER(mb_elab_variable_21__4, "elab-variable! block", "src/mirth/elab.mth", 981, 16);
+    WORD_ENTER(mb_elab_variable_21__4, "elab-variable! block", "src/mirth/elab.mth", 994, 16);
     mw_prim_drop();
-    WORD_ATOM(981, 16, "elab-simple-type-arg!");
+    WORD_ATOM(994, 16, "elab-simple-type-arg!");
     mw_elab_simple_type_arg_21_();
     WORD_EXIT(mb_elab_variable_21__4);
 }
 
 static void mb_elab_table_21__1 (void) {
-    WORD_ENTER(mb_elab_table_21__1, "elab-table! block", "src/mirth/elab.mth", 986, 9);
+    WORD_ENTER(mb_elab_table_21__1, "elab-table! block", "src/mirth/elab.mth", 999, 9);
     mw_prim_drop();
-    WORD_ATOM(986, 9, "next");
+    WORD_ATOM(999, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_table_21__1);
 }
 
 static void mb_elab_table_21__2 (void) {
-    WORD_ENTER(mb_elab_table_21__2, "elab-table! block", "src/mirth/elab.mth", 987, 28);
+    WORD_ENTER(mb_elab_table_21__2, "elab-table! block", "src/mirth/elab.mth", 1000, 28);
     mw_prim_drop();
-    WORD_ATOM(987, 28, "");
+    WORD_ATOM(1000, 28, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36336,17 +36787,17 @@ static void mb_elab_table_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(987, 49, "emit-fatal-error!");
+    WORD_ATOM(1000, 49, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_table_21__2);
 }
 
 static void mb_elab_table_21__3 (void) {
-    WORD_ENTER(mb_elab_table_21__3, "elab-table! block", "src/mirth/elab.mth", 988, 43);
+    WORD_ENTER(mb_elab_table_21__3, "elab-table! block", "src/mirth/elab.mth", 1001, 43);
     mw_prim_drop();
-    WORD_ATOM(988, 43, "drop");
+    WORD_ATOM(1001, 43, "drop");
     mw_prim_drop();
-    WORD_ATOM(988, 48, "");
+    WORD_ATOM(1001, 48, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36357,75 +36808,75 @@ static void mb_elab_table_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(988, 77, "emit-fatal-error!");
+    WORD_ATOM(1001, 77, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_table_21__3);
 }
 
 static void mb_elab_field_21__1 (void) {
-    WORD_ENTER(mb_elab_field_21__1, "elab-field! block", "src/mirth/elab.mth", 1195, 9);
+    WORD_ENTER(mb_elab_field_21__1, "elab-field! block", "src/mirth/elab.mth", 1208, 9);
     mw_prim_drop();
-    WORD_ATOM(1195, 9, "next");
+    WORD_ATOM(1208, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_field_21__1);
 }
 
 static void mb_elab_data_21__1 (void) {
-    WORD_ENTER(mb_elab_data_21__1, "elab-data! block", "src/mirth/elab.mth", 810, 9);
+    WORD_ENTER(mb_elab_data_21__1, "elab-data! block", "src/mirth/elab.mth", 823, 9);
     mw_prim_drop();
-    WORD_ATOM(810, 9, "Data.alloc!");
+    WORD_ATOM(823, 9, "Data.alloc!");
     mw_Data_2E_alloc_21_();
-    WORD_ATOM(811, 9, "L0");
+    WORD_ATOM(824, 9, "L0");
     mw_L0();
-    WORD_ATOM(811, 12, "over");
+    WORD_ATOM(824, 12, "over");
     mw_over();
-    WORD_ATOM(811, 17, "~tags");
+    WORD_ATOM(824, 17, "~tags");
     mw_Data_7E_tags();
-    WORD_ATOM(811, 23, "!");
+    WORD_ATOM(824, 23, "!");
     mw_prim_mut_set();
-    WORD_ATOM(812, 9, "swap");
+    WORD_ATOM(825, 9, "swap");
     mw_prim_swap();
-    WORD_ATOM(812, 14, "args+");
+    WORD_ATOM(825, 14, "args+");
     mw_Token_2E_args_2B_();
-    WORD_ATOM(813, 9, "uncons");
+    WORD_ATOM(826, 9, "uncons");
     mw_List_2B__2E_uncons();
-    WORD_ATOM(813, 16, "dip");
+    WORD_ATOM(826, 16, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(813, 20, "elab-data-header!");
+        WORD_ATOM(826, 20, "elab-data-header!");
         mw_elab_data_header_21_();
         push_value(d2);
     }
-    WORD_ATOM(814, 9, "for");
+    WORD_ATOM(827, 9, "for");
     push_u64(0);
     push_fnptr(&mb_elab_data_21__3);
     mw_prim_pack_cons();
     mw_List_2E_for();
-    WORD_ATOM(815, 9, "drop");
+    WORD_ATOM(828, 9, "drop");
     mw_prim_drop();
     WORD_EXIT(mb_elab_data_21__1);
 }
 
 static void mb_elab_data_21__3 (void) {
-    WORD_ENTER(mb_elab_data_21__3, "elab-data! block", "src/mirth/elab.mth", 814, 13);
+    WORD_ENTER(mb_elab_data_21__3, "elab-data! block", "src/mirth/elab.mth", 827, 13);
     mw_prim_drop();
-    WORD_ATOM(814, 13, "elab-data-tag!");
+    WORD_ATOM(827, 13, "elab-data-tag!");
     mw_elab_data_tag_21_();
     WORD_EXIT(mb_elab_data_21__3);
 }
 
 static void mb_elab_target_c99_21__1 (void) {
-    WORD_ENTER(mb_elab_target_c99_21__1, "elab-target-c99! block", "src/mirth/elab.mth", 994, 9);
+    WORD_ENTER(mb_elab_target_c99_21__1, "elab-target-c99! block", "src/mirth/elab.mth", 1007, 9);
     mw_prim_drop();
-    WORD_ATOM(994, 9, "next");
+    WORD_ATOM(1007, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_target_c99_21__1);
 }
 
 static void mb_elab_target_c99_21__3 (void) {
-    WORD_ENTER(mb_elab_target_c99_21__3, "elab-target-c99! block", "src/mirth/elab.mth", 995, 28);
+    WORD_ENTER(mb_elab_target_c99_21__3, "elab-target-c99! block", "src/mirth/elab.mth", 1008, 28);
     mw_prim_drop();
-    WORD_ATOM(995, 28, "");
+    WORD_ATOM(1008, 28, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36436,23 +36887,23 @@ static void mb_elab_target_c99_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(995, 51, "emit-fatal-error!");
+    WORD_ATOM(1008, 51, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_target_c99_21__3);
 }
 
 static void mb_elab_embed_str_21__1 (void) {
-    WORD_ENTER(mb_elab_embed_str_21__1, "elab-embed-str! block", "src/mirth/elab.mth", 1003, 9);
+    WORD_ENTER(mb_elab_embed_str_21__1, "elab-embed-str! block", "src/mirth/elab.mth", 1016, 9);
     mw_prim_drop();
-    WORD_ATOM(1003, 9, "next");
+    WORD_ATOM(1016, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_embed_str_21__1);
 }
 
 static void mb_elab_embed_str_21__2 (void) {
-    WORD_ENTER(mb_elab_embed_str_21__2, "elab-embed-str! block", "src/mirth/elab.mth", 1004, 25);
+    WORD_ENTER(mb_elab_embed_str_21__2, "elab-embed-str! block", "src/mirth/elab.mth", 1017, 25);
     mw_prim_drop();
-    WORD_ATOM(1004, 25, "");
+    WORD_ATOM(1017, 25, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36463,17 +36914,17 @@ static void mb_elab_embed_str_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1004, 59, "emit-fatal-error!");
+    WORD_ATOM(1017, 59, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_embed_str_21__2);
 }
 
 static void mb_elab_embed_str_21__3 (void) {
-    WORD_ENTER(mb_elab_embed_str_21__3, "elab-embed-str! block", "src/mirth/elab.mth", 1005, 26);
+    WORD_ENTER(mb_elab_embed_str_21__3, "elab-embed-str! block", "src/mirth/elab.mth", 1018, 26);
     mw_prim_drop();
-    WORD_ATOM(1005, 26, "drop");
+    WORD_ATOM(1018, 26, "drop");
     mw_prim_drop();
-    WORD_ATOM(1005, 31, "");
+    WORD_ATOM(1018, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36484,15 +36935,15 @@ static void mb_elab_embed_str_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1005, 72, "emit-fatal-error!");
+    WORD_ATOM(1018, 72, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_embed_str_21__3);
 }
 
 static void mb_elab_embed_str_21__4 (void) {
-    WORD_ENTER(mb_elab_embed_str_21__4, "elab-embed-str! block", "src/mirth/elab.mth", 1006, 29);
+    WORD_ENTER(mb_elab_embed_str_21__4, "elab-embed-str! block", "src/mirth/elab.mth", 1019, 29);
     mw_prim_drop();
-    WORD_ATOM(1006, 29, "");
+    WORD_ATOM(1019, 29, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36503,25 +36954,25 @@ static void mb_elab_embed_str_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1006, 52, "emit-fatal-error!");
+    WORD_ATOM(1019, 52, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_embed_str_21__4);
 }
 
 static void mb_elab_embed_str_21__5 (void) {
-    WORD_ENTER(mb_elab_embed_str_21__5, "elab-embed-str! block", "src/mirth/elab.mth", 1007, 21);
+    WORD_ENTER(mb_elab_embed_str_21__5, "elab-embed-str! block", "src/mirth/elab.mth", 1020, 21);
     mw_prim_drop();
-    WORD_ATOM(1007, 21, "read-file!");
+    WORD_ATOM(1020, 21, "read-file!");
     mw_read_file_21_();
-    WORD_ATOM(1007, 32, "nip");
+    WORD_ATOM(1020, 32, "nip");
     mw_nip();
     WORD_EXIT(mb_elab_embed_str_21__5);
 }
 
 static void mb_elab_embed_str_21__6 (void) {
-    WORD_ENTER(mb_elab_embed_str_21__6, "elab-embed-str! block", "src/mirth/elab.mth", 1007, 37);
+    WORD_ENTER(mb_elab_embed_str_21__6, "elab-embed-str! block", "src/mirth/elab.mth", 1020, 37);
     mw_prim_drop();
-    WORD_ATOM(1007, 37, "");
+    WORD_ATOM(1020, 37, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36532,57 +36983,57 @@ static void mb_elab_embed_str_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1007, 66, "emit-fatal-error!");
+    WORD_ATOM(1020, 66, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_embed_str_21__6);
 }
 
 static void mb_Type_2E_tycon_name_5 (void) {
-    WORD_ENTER(mb_Type_2E_tycon_name_5, "Type.tycon-name block", "src/mirth/data/type.mth", 59, 24);
+    WORD_ENTER(mb_Type_2E_tycon_name_5, "Type.tycon-name block", "src/mirth/data/type.mth", 61, 24);
     mw_prim_drop();
-    WORD_ATOM(59, 24, "tycon-name");
+    WORD_ATOM(61, 24, "tycon-name");
     mw_Type_2E_tycon_name();
     WORD_EXIT(mb_Type_2E_tycon_name_5);
 }
 
 static void mb_Type_2E_tycon_name_6 (void) {
-    WORD_ENTER(mb_Type_2E_tycon_name_6, "Type.tycon-name block", "src/mirth/data/type.mth", 59, 36);
+    WORD_ENTER(mb_Type_2E_tycon_name_6, "Type.tycon-name block", "src/mirth/data/type.mth", 61, 36);
     mw_prim_drop();
-    WORD_ATOM(59, 36, "drop");
+    WORD_ATOM(61, 36, "drop");
     mw_prim_drop();
-    WORD_ATOM(59, 41, "NONE");
+    WORD_ATOM(61, 41, "NONE");
     mw_NONE();
     WORD_EXIT(mb_Type_2E_tycon_name_6);
 }
 
 static void mb_PrimType_3D__1 (void) {
-    WORD_ENTER(mb_PrimType_3D__1, "PrimType= block", "src/mirth/data/type.mth", 86, 48);
+    WORD_ENTER(mb_PrimType_3D__1, "PrimType= block", "src/mirth/data/type.mth", 89, 48);
     mw_prim_drop();
-    WORD_ATOM(86, 48, ">Int");
+    WORD_ATOM(89, 48, ">Int");
     mw_PrimType_3E_Int();
     WORD_EXIT(mb_PrimType_3D__1);
 }
 
 static void mb_TT_1 (void) {
-    WORD_ENTER(mb_TT_1, "TT block", "src/mirth/data/type.mth", 105, 46);
+    WORD_ENTER(mb_TT_1, "TT block", "src/mirth/data/type.mth", 109, 46);
     mw_prim_drop();
-    WORD_ATOM(105, 46, "T*");
+    WORD_ATOM(109, 46, "T*");
     mw_T_2A_();
     WORD_EXIT(mb_TT_1);
 }
 
 static void mb_Type_2E_is_physical_3F__2 (void) {
-    WORD_ENTER(mb_Type_2E_is_physical_3F__2, "Type.is-physical? block", "src/mirth/data/type.mth", 142, 24);
+    WORD_ENTER(mb_Type_2E_is_physical_3F__2, "Type.is-physical? block", "src/mirth/data/type.mth", 146, 24);
     mw_prim_drop();
-    WORD_ATOM(142, 24, "is-physical?");
+    WORD_ATOM(146, 24, "is-physical?");
     mw_Type_2E_is_physical_3F_();
     WORD_EXIT(mb_Type_2E_is_physical_3F__2);
 }
 
 static void mb_Type_2E_is_physical_3F__3 (void) {
-    WORD_ENTER(mb_Type_2E_is_physical_3F__3, "Type.is-physical? block", "src/mirth/data/type.mth", 142, 38);
+    WORD_ENTER(mb_Type_2E_is_physical_3F__3, "Type.is-physical? block", "src/mirth/data/type.mth", 146, 38);
     mw_prim_drop();
-    WORD_ATOM(142, 38, "");
+    WORD_ATOM(146, 38, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36593,307 +37044,317 @@ static void mb_Type_2E_is_physical_3F__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(142, 74, "panic!");
+    WORD_ATOM(146, 74, "panic!");
     mw_prim_panic();
     WORD_EXIT(mb_Type_2E_is_physical_3F__3);
 }
 
 static void mb_Type_2E_unify_failed_21__2 (void) {
-    WORD_ENTER(mb_Type_2E_unify_failed_21__2, "Type.unify-failed! block", "src/mirth/data/type.mth", 178, 23);
+    WORD_ENTER(mb_Type_2E_unify_failed_21__2, "Type.unify-failed! block", "src/mirth/data/type.mth", 184, 23);
     mw_prim_drop();
-    WORD_ATOM(178, 23, "1+");
+    WORD_ATOM(184, 23, "1+");
     mw_prim_int_succ();
     WORD_EXIT(mb_Type_2E_unify_failed_21__2);
 }
 
 static void mb_Type_2E_unify_21__1 (void) {
-    WORD_ENTER(mb_Type_2E_unify_21__1, "Type.unify! block", "src/mirth/data/type.mth", 228, 10);
+    WORD_ENTER(mb_Type_2E_unify_21__1, "Type.unify! block", "src/mirth/data/type.mth", 234, 10);
     mw_prim_drop();
-    WORD_ATOM(228, 10, "expand");
+    WORD_ATOM(234, 10, "expand");
     mw_Type_2E_expand();
     WORD_EXIT(mb_Type_2E_unify_21__1);
 }
 
 static void mb_PrimType_2E_unify_21__3 (void) {
-    WORD_ENTER(mb_PrimType_2E_unify_21__3, "PrimType.unify! block", "src/mirth/data/type.mth", 289, 32);
+    WORD_ENTER(mb_PrimType_2E_unify_21__3, "PrimType.unify! block", "src/mirth/data/type.mth", 295, 32);
     mw_prim_drop();
-    WORD_ATOM(289, 32, "TPrim");
+    WORD_ATOM(295, 32, "TPrim");
     mw_TPrim();
     WORD_EXIT(mb_PrimType_2E_unify_21__3);
 }
 
 static void mb_Data_2E_unify_21__3 (void) {
-    WORD_ENTER(mb_Data_2E_unify_21__3, "Data.unify! block", "src/mirth/data/type.mth", 291, 32);
+    WORD_ENTER(mb_Data_2E_unify_21__3, "Data.unify! block", "src/mirth/data/type.mth", 297, 32);
     mw_prim_drop();
-    WORD_ATOM(291, 32, "TData");
+    WORD_ATOM(297, 32, "TData");
     mw_TData();
     WORD_EXIT(mb_Data_2E_unify_21__3);
 }
 
 static void mb_Table_2E_unify_21__3 (void) {
-    WORD_ENTER(mb_Table_2E_unify_21__3, "Table.unify! block", "src/mirth/data/type.mth", 293, 33);
+    WORD_ENTER(mb_Table_2E_unify_21__3, "Table.unify! block", "src/mirth/data/type.mth", 299, 33);
     mw_prim_drop();
-    WORD_ATOM(293, 33, "TTable");
+    WORD_ATOM(299, 33, "TTable");
     mw_TTable();
     WORD_EXIT(mb_Table_2E_unify_21__3);
 }
 
 static void mb_Var_2E_unify_21__3 (void) {
-    WORD_ENTER(mb_Var_2E_unify_21__3, "Var.unify! block", "src/mirth/data/type.mth", 295, 31);
+    WORD_ENTER(mb_Var_2E_unify_21__3, "Var.unify! block", "src/mirth/data/type.mth", 301, 31);
     mw_prim_drop();
-    WORD_ATOM(295, 31, "TVar");
+    WORD_ATOM(301, 31, "TVar");
     mw_TVar();
     WORD_EXIT(mb_Var_2E_unify_21__3);
 }
 
 static void mb_Type_2E_trace_sig_21__2 (void) {
-    WORD_ENTER(mb_Type_2E_trace_sig_21__2, "Type.trace-sig! block", "src/mirth/data/type.mth", 319, 24);
+    WORD_ENTER(mb_Type_2E_trace_sig_21__2, "Type.trace-sig! block", "src/mirth/data/type.mth", 325, 24);
     mw_prim_drop();
-    WORD_ATOM(319, 24, "trace-sig!");
+    WORD_ATOM(325, 24, "trace-sig!");
     mw_Type_2E_trace_sig_21_();
     WORD_EXIT(mb_Type_2E_trace_sig_21__2);
 }
 
 static void mb_Type_2E_trace_sig_21__3 (void) {
-    WORD_ENTER(mb_Type_2E_trace_sig_21__3, "Type.trace-sig! block", "src/mirth/data/type.mth", 319, 36);
+    WORD_ENTER(mb_Type_2E_trace_sig_21__3, "Type.trace-sig! block", "src/mirth/data/type.mth", 325, 36);
     mw_prim_drop();
-    WORD_ATOM(319, 36, "trace!");
+    WORD_ATOM(325, 36, "trace!");
     mw_MetaVar_2E_trace_21_();
     WORD_EXIT(mb_Type_2E_trace_sig_21__3);
 }
 
 static void mb_MetaVar_2E_freshen_1 (void) {
-    WORD_ENTER(mb_MetaVar_2E_freshen_1, "MetaVar.freshen block", "src/mirth/data/type.mth", 392, 15);
+    WORD_ENTER(mb_MetaVar_2E_freshen_1, "MetaVar.freshen block", "src/mirth/data/type.mth", 399, 15);
     mw_prim_drop();
-    WORD_ATOM(392, 15, "freshen");
+    WORD_ATOM(399, 15, "freshen");
     mw_Type_2E_freshen();
     WORD_EXIT(mb_MetaVar_2E_freshen_1);
 }
 
 static void mb_MetaVar_2E_freshen_2 (void) {
-    WORD_ENTER(mb_MetaVar_2E_freshen_2, "MetaVar.freshen block", "src/mirth/data/type.mth", 392, 24);
+    WORD_ENTER(mb_MetaVar_2E_freshen_2, "MetaVar.freshen block", "src/mirth/data/type.mth", 399, 24);
     mw_prim_drop();
-    WORD_ATOM(392, 24, "drop");
+    WORD_ATOM(399, 24, "drop");
     mw_prim_drop();
-    WORD_ATOM(392, 29, "MetaVar.new!");
+    WORD_ATOM(399, 29, "MetaVar.new!");
     mw_MetaVar_2E_new_21_();
-    WORD_ATOM(392, 42, "TMeta");
+    WORD_ATOM(399, 42, "TMeta");
     mw_TMeta();
     WORD_EXIT(mb_MetaVar_2E_freshen_2);
 }
 
 static void mb_Type_2E_arity_2 (void) {
-    WORD_ENTER(mb_Type_2E_arity_2, "Type.arity block", "src/mirth/data/type.mth", 438, 24);
+    WORD_ENTER(mb_Type_2E_arity_2, "Type.arity block", "src/mirth/data/type.mth", 445, 24);
     mw_prim_drop();
-    WORD_ATOM(438, 24, "arity");
+    WORD_ATOM(445, 24, "arity");
     mw_Type_2E_arity();
     WORD_EXIT(mb_Type_2E_arity_2);
 }
 
 static void mb_Type_2E_arity_3 (void) {
-    WORD_ENTER(mb_Type_2E_arity_3, "Type.arity block", "src/mirth/data/type.mth", 438, 31);
+    WORD_ENTER(mb_Type_2E_arity_3, "Type.arity block", "src/mirth/data/type.mth", 445, 31);
     mw_prim_drop();
-    WORD_ATOM(438, 31, "drop");
+    WORD_ATOM(445, 31, "drop");
     mw_prim_drop();
-    WORD_ATOM(438, 36, "");
+    WORD_ATOM(445, 36, "");
     push_i64(0LL);
     WORD_EXIT(mb_Type_2E_arity_3);
 }
 
 static void mb_MetaVar_2E_expand_1 (void) {
-    WORD_ENTER(mb_MetaVar_2E_expand_1, "MetaVar.expand block", "src/mirth/data/type.mth", 494, 15);
+    WORD_ENTER(mb_MetaVar_2E_expand_1, "MetaVar.expand block", "src/mirth/data/type.mth", 501, 15);
     mw_prim_drop();
-    WORD_ATOM(494, 15, "id");
+    WORD_ATOM(501, 15, "id");
     mw_prim_id();
     WORD_EXIT(mb_MetaVar_2E_expand_1);
 }
 
 static void mb_MetaVar_2E_expand_2 (void) {
-    WORD_ENTER(mb_MetaVar_2E_expand_2, "MetaVar.expand block", "src/mirth/data/type.mth", 494, 19);
+    WORD_ENTER(mb_MetaVar_2E_expand_2, "MetaVar.expand block", "src/mirth/data/type.mth", 501, 19);
     mw_prim_drop();
-    WORD_ATOM(494, 19, "TMeta");
+    WORD_ATOM(501, 19, "TMeta");
     mw_TMeta();
     WORD_EXIT(mb_MetaVar_2E_expand_2);
 }
 
 static void mb_MetaVar_3D__1 (void) {
-    WORD_ENTER(mb_MetaVar_3D__1, "MetaVar= block", "src/mirth/data/type.mth", 512, 45);
+    WORD_ENTER(mb_MetaVar_3D__1, "MetaVar= block", "src/mirth/data/type.mth", 519, 45);
     mw_prim_drop();
-    WORD_ATOM(512, 45, ".id");
+    WORD_ATOM(519, 45, ".id");
     mw_MetaVar_2E_id();
     WORD_EXIT(mb_MetaVar_3D__1);
 }
 
 static void mb_Resource_2E_unify_21__1 (void) {
-    WORD_ENTER(mb_Resource_2E_unify_21__1, "Resource.unify! block", "src/mirth/data/type.mth", 552, 10);
+    WORD_ENTER(mb_Resource_2E_unify_21__1, "Resource.unify! block", "src/mirth/data/type.mth", 559, 10);
     mw_prim_drop();
-    WORD_ATOM(552, 10, ">Type");
+    WORD_ATOM(559, 10, ">Type");
     mw_Resource_3E_Type();
     WORD_EXIT(mb_Resource_2E_unify_21__1);
 }
 
 static void mb_StackType_2E_top_tycon_name_1 (void) {
-    WORD_ENTER(mb_StackType_2E_top_tycon_name_1, "StackType.top-tycon-name block", "src/mirth/data/type.mth", 625, 19);
+    WORD_ENTER(mb_StackType_2E_top_tycon_name_1, "StackType.top-tycon-name block", "src/mirth/data/type.mth", 631, 19);
     mw_prim_drop();
-    WORD_ATOM(625, 19, "tycon-name");
+    WORD_ATOM(631, 19, "tycon-name");
     mw_Type_2E_tycon_name();
     WORD_EXIT(mb_StackType_2E_top_tycon_name_1);
 }
 
-static void mb_StackType_2E_unify_failed_21__1 (void) {
-    WORD_ENTER(mb_StackType_2E_unify_failed_21__1, "StackType.unify-failed! block", "src/mirth/data/type.mth", 640, 9);
+static void mb_StackType_2E_top_resource_name_1 (void) {
+    WORD_ENTER(mb_StackType_2E_top_resource_name_1, "StackType.top-resource-name block", "src/mirth/data/type.mth", 643, 23);
     mw_prim_drop();
-    WORD_ATOM(640, 9, ">Type");
+    WORD_ATOM(643, 23, ">Type");
+    mw_Resource_3E_Type();
+    WORD_ATOM(643, 29, "tycon-name");
+    mw_Type_2E_tycon_name();
+    WORD_EXIT(mb_StackType_2E_top_resource_name_1);
+}
+
+static void mb_StackType_2E_unify_failed_21__1 (void) {
+    WORD_ENTER(mb_StackType_2E_unify_failed_21__1, "StackType.unify-failed! block", "src/mirth/data/type.mth", 658, 9);
+    mw_prim_drop();
+    WORD_ATOM(658, 9, ">Type");
     mw_StackType_3E_Type();
     WORD_EXIT(mb_StackType_2E_unify_failed_21__1);
 }
 
 static void mb_StackType_2E_unify_21__30 (void) {
-    WORD_ENTER(mb_StackType_2E_unify_21__30, "StackType.unify! block", "src/mirth/data/type.mth", 671, 17);
+    WORD_ENTER(mb_StackType_2E_unify_21__30, "StackType.unify! block", "src/mirth/data/type.mth", 689, 17);
     mw_prim_drop();
-    WORD_ATOM(671, 17, "nip");
+    WORD_ATOM(689, 17, "nip");
     mw_nip();
-    WORD_ATOM(671, 21, "unpack2");
+    WORD_ATOM(689, 21, "unpack2");
     mw_unpack2();
-    WORD_ATOM(671, 29, "dip");
+    WORD_ATOM(689, 29, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(671, 33, "swap");
+        WORD_ATOM(689, 33, "swap");
         mw_prim_swap();
-        WORD_ATOM(671, 38, "dip");
+        WORD_ATOM(689, 38, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(671, 42, "unify!");
+            WORD_ATOM(689, 42, "unify!");
             mw_StackType_2E_unify_21_();
-            WORD_ATOM(671, 49, "swap");
+            WORD_ATOM(689, 49, "swap");
             mw_prim_swap();
             push_value(d3);
         }
         push_value(d2);
     }
-    WORD_ATOM(671, 56, "unify!");
+    WORD_ATOM(689, 56, "unify!");
     mw_Type_2E_unify_21_();
-    WORD_ATOM(671, 63, "dip");
+    WORD_ATOM(689, 63, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(671, 67, "swap");
+        WORD_ATOM(689, 67, "swap");
         mw_prim_swap();
         push_value(d2);
     }
-    WORD_ATOM(671, 73, "STCons");
+    WORD_ATOM(689, 73, "STCons");
     mw_STCons();
     WORD_EXIT(mb_StackType_2E_unify_21__30);
 }
 
 static void mb_StackType_2E_unify_21__34 (void) {
-    WORD_ENTER(mb_StackType_2E_unify_21__34, "StackType.unify! block", "src/mirth/data/type.mth", 672, 17);
+    WORD_ENTER(mb_StackType_2E_unify_21__34, "StackType.unify! block", "src/mirth/data/type.mth", 690, 17);
     mw_prim_drop();
-    WORD_ATOM(672, 17, "dip");
+    WORD_ATOM(690, 17, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(672, 21, "STCons");
+        WORD_ATOM(690, 21, "STCons");
         mw_STCons();
         push_value(d2);
     }
-    WORD_ATOM(672, 29, "unify-failed!");
+    WORD_ATOM(690, 29, "unify-failed!");
     mw_StackType_2E_unify_failed_21_();
     WORD_EXIT(mb_StackType_2E_unify_21__34);
 }
 
 static void mb_StackType_2E_unify_21__42 (void) {
-    WORD_ENTER(mb_StackType_2E_unify_21__42, "StackType.unify! block", "src/mirth/data/type.mth", 680, 17);
+    WORD_ENTER(mb_StackType_2E_unify_21__42, "StackType.unify! block", "src/mirth/data/type.mth", 698, 17);
     mw_prim_drop();
-    WORD_ATOM(680, 17, "nip");
+    WORD_ATOM(698, 17, "nip");
     mw_nip();
-    WORD_ATOM(680, 21, "unpack2");
+    WORD_ATOM(698, 21, "unpack2");
     mw_unpack2();
-    WORD_ATOM(680, 29, "dip");
+    WORD_ATOM(698, 29, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(680, 33, "swap");
+        WORD_ATOM(698, 33, "swap");
         mw_prim_swap();
-        WORD_ATOM(680, 38, "dip");
+        WORD_ATOM(698, 38, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(680, 42, "unify!");
+            WORD_ATOM(698, 42, "unify!");
             mw_StackType_2E_unify_21_();
-            WORD_ATOM(680, 49, "swap");
+            WORD_ATOM(698, 49, "swap");
             mw_prim_swap();
             push_value(d3);
         }
         push_value(d2);
     }
-    WORD_ATOM(680, 56, "unify!");
+    WORD_ATOM(698, 56, "unify!");
     mw_Resource_2E_unify_21_();
-    WORD_ATOM(680, 63, "dip");
+    WORD_ATOM(698, 63, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(680, 67, "swap");
+        WORD_ATOM(698, 67, "swap");
         mw_prim_swap();
         push_value(d2);
     }
-    WORD_ATOM(680, 73, "STWith");
+    WORD_ATOM(698, 73, "STWith");
     mw_STWith();
     WORD_EXIT(mb_StackType_2E_unify_21__42);
 }
 
 static void mb_StackType_2E_unify_21__46 (void) {
-    WORD_ENTER(mb_StackType_2E_unify_21__46, "StackType.unify! block", "src/mirth/data/type.mth", 681, 17);
+    WORD_ENTER(mb_StackType_2E_unify_21__46, "StackType.unify! block", "src/mirth/data/type.mth", 699, 17);
     mw_prim_drop();
-    WORD_ATOM(681, 17, "dip");
+    WORD_ATOM(699, 17, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(681, 21, "STWith");
+        WORD_ATOM(699, 21, "STWith");
         mw_STWith();
         push_value(d2);
     }
-    WORD_ATOM(681, 29, "unify-failed!");
+    WORD_ATOM(699, 29, "unify-failed!");
     mw_StackType_2E_unify_failed_21_();
     WORD_EXIT(mb_StackType_2E_unify_21__46);
 }
 
 static void mb_StackType_2E_force_cons_3F__21__3 (void) {
-    WORD_ENTER(mb_StackType_2E_force_cons_3F__21__3, "StackType.force-cons?! block", "src/mirth/data/type.mth", 689, 41);
+    WORD_ENTER(mb_StackType_2E_force_cons_3F__21__3, "StackType.force-cons?! block", "src/mirth/data/type.mth", 707, 41);
     mw_prim_drop();
-    WORD_ATOM(689, 41, "unpack2");
+    WORD_ATOM(707, 41, "unpack2");
     mw_unpack2();
-    WORD_ATOM(689, 49, "dip");
+    WORD_ATOM(707, 49, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(689, 53, "over");
+        WORD_ATOM(707, 53, "over");
         mw_over();
-        WORD_ATOM(689, 58, "STWith");
+        WORD_ATOM(707, 58, "STWith");
         mw_STWith();
         push_value(d2);
     }
-    WORD_ATOM(689, 66, "pack2");
+    WORD_ATOM(707, 66, "pack2");
     mw_pack2();
     WORD_EXIT(mb_StackType_2E_force_cons_3F__21__3);
 }
 
 static void mb_StackType_2E_force_with_3F__21__3 (void) {
-    WORD_ENTER(mb_StackType_2E_force_with_3F__21__3, "StackType.force-with?! block", "src/mirth/data/type.mth", 701, 41);
+    WORD_ENTER(mb_StackType_2E_force_with_3F__21__3, "StackType.force-with?! block", "src/mirth/data/type.mth", 719, 41);
     mw_prim_drop();
-    WORD_ATOM(701, 41, "unpack2");
+    WORD_ATOM(719, 41, "unpack2");
     mw_unpack2();
-    WORD_ATOM(701, 49, "dip");
+    WORD_ATOM(719, 49, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(701, 53, "over");
+        WORD_ATOM(719, 53, "over");
         mw_over();
-        WORD_ATOM(701, 58, "STCons");
+        WORD_ATOM(719, 58, "STCons");
         mw_STCons();
         push_value(d2);
     }
-    WORD_ATOM(701, 66, "pack2");
+    WORD_ATOM(719, 66, "pack2");
     mw_pack2();
     WORD_EXIT(mb_StackType_2E_force_with_3F__21__3);
 }
 
 static void mb_StackType_2E_trace_base_21__4 (void) {
-    WORD_ENTER(mb_StackType_2E_trace_base_21__4, "StackType.trace-base! block", "src/mirth/data/type.mth", 728, 44);
+    WORD_ENTER(mb_StackType_2E_trace_base_21__4, "StackType.trace-base! block", "src/mirth/data/type.mth", 746, 44);
     mw_prim_drop();
-    WORD_ATOM(728, 44, "");
+    WORD_ATOM(746, 44, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36904,40 +37365,40 @@ static void mb_StackType_2E_trace_base_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(728, 49, "trace!");
+    WORD_ATOM(746, 49, "trace!");
     mw_Str_2E_trace_21_();
     WORD_EXIT(mb_StackType_2E_trace_base_21__4);
 }
 
 static void mb_StackType_2E_trace_21__1 (void) {
-    WORD_ENTER(mb_StackType_2E_trace_21__1, "StackType.trace! block", "src/mirth/data/type.mth", 734, 10);
+    WORD_ENTER(mb_StackType_2E_trace_21__1, "StackType.trace! block", "src/mirth/data/type.mth", 752, 10);
     mw_prim_drop();
-    WORD_ATOM(734, 10, "trace-base!");
+    WORD_ATOM(752, 10, "trace-base!");
     mw_StackType_2E_trace_base_21_();
     WORD_EXIT(mb_StackType_2E_trace_21__1);
 }
 
 static void mb_StackType_2E_trace_21__3 (void) {
-    WORD_ENTER(mb_StackType_2E_trace_21__3, "StackType.trace! block", "src/mirth/data/type.mth", 735, 13);
+    WORD_ENTER(mb_StackType_2E_trace_21__3, "StackType.trace! block", "src/mirth/data/type.mth", 753, 13);
     mw_prim_drop();
-    WORD_ATOM(735, 13, "swap");
+    WORD_ATOM(753, 13, "swap");
     mw_prim_swap();
-    WORD_ATOM(735, 18, "then");
+    WORD_ATOM(753, 18, "then");
     push_u64(0);
     push_fnptr(&mb_StackType_2E_trace_21__4);
     mw_prim_pack_cons();
     mw_Bool_2E_then();
-    WORD_ATOM(735, 35, "trace!");
+    WORD_ATOM(753, 35, "trace!");
     mw_Type_2E_trace_21_();
-    WORD_ATOM(735, 42, "T");
+    WORD_ATOM(753, 42, "T");
     mw_T();
     WORD_EXIT(mb_StackType_2E_trace_21__3);
 }
 
 static void mb_StackType_2E_trace_21__4 (void) {
-    WORD_ENTER(mb_StackType_2E_trace_21__4, "StackType.trace! block", "src/mirth/data/type.mth", 735, 23);
+    WORD_ENTER(mb_StackType_2E_trace_21__4, "StackType.trace! block", "src/mirth/data/type.mth", 753, 23);
     mw_prim_drop();
-    WORD_ATOM(735, 23, "");
+    WORD_ATOM(753, 23, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36948,32 +37409,32 @@ static void mb_StackType_2E_trace_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(735, 27, "trace!");
+    WORD_ATOM(753, 27, "trace!");
     mw_Str_2E_trace_21_();
     WORD_EXIT(mb_StackType_2E_trace_21__4);
 }
 
 static void mb_StackType_2E_trace_21__5 (void) {
-    WORD_ENTER(mb_StackType_2E_trace_21__5, "StackType.trace! block", "src/mirth/data/type.mth", 736, 9);
+    WORD_ENTER(mb_StackType_2E_trace_21__5, "StackType.trace! block", "src/mirth/data/type.mth", 754, 9);
     mw_prim_drop();
-    WORD_ATOM(736, 9, "swap");
+    WORD_ATOM(754, 9, "swap");
     mw_prim_swap();
-    WORD_ATOM(736, 14, "then");
+    WORD_ATOM(754, 14, "then");
     push_u64(0);
     push_fnptr(&mb_StackType_2E_trace_21__6);
     mw_prim_pack_cons();
     mw_Bool_2E_then();
-    WORD_ATOM(736, 31, "trace!");
+    WORD_ATOM(754, 31, "trace!");
     mw_Resource_2E_trace_21_();
-    WORD_ATOM(736, 38, "T");
+    WORD_ATOM(754, 38, "T");
     mw_T();
     WORD_EXIT(mb_StackType_2E_trace_21__5);
 }
 
 static void mb_StackType_2E_trace_21__6 (void) {
-    WORD_ENTER(mb_StackType_2E_trace_21__6, "StackType.trace! block", "src/mirth/data/type.mth", 736, 19);
+    WORD_ENTER(mb_StackType_2E_trace_21__6, "StackType.trace! block", "src/mirth/data/type.mth", 754, 19);
     mw_prim_drop();
-    WORD_ATOM(736, 19, "");
+    WORD_ATOM(754, 19, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36984,55 +37445,55 @@ static void mb_StackType_2E_trace_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(736, 23, "trace!");
+    WORD_ATOM(754, 23, "trace!");
     mw_Str_2E_trace_21_();
     WORD_EXIT(mb_StackType_2E_trace_21__6);
 }
 
 static void mb_StackType_2E_num_morphisms_on_top_2 (void) {
-    WORD_ENTER(mb_StackType_2E_num_morphisms_on_top_2, "StackType.num-morphisms-on-top block", "src/mirth/data/type.mth", 790, 25);
+    WORD_ENTER(mb_StackType_2E_num_morphisms_on_top_2, "StackType.num-morphisms-on-top block", "src/mirth/data/type.mth", 808, 25);
     mw_prim_drop();
-    WORD_ATOM(790, 25, ">StackType");
+    WORD_ATOM(808, 25, ">StackType");
     mw_Type_3E_StackType();
-    WORD_ATOM(790, 36, "num-morphisms-on-top");
+    WORD_ATOM(808, 36, "num-morphisms-on-top");
     mw_StackType_2E_num_morphisms_on_top();
     WORD_EXIT(mb_StackType_2E_num_morphisms_on_top_2);
 }
 
 static void mb_StackType_2E_num_morphisms_on_top_3 (void) {
-    WORD_ENTER(mb_StackType_2E_num_morphisms_on_top_3, "StackType.num-morphisms-on-top block", "src/mirth/data/type.mth", 790, 58);
+    WORD_ENTER(mb_StackType_2E_num_morphisms_on_top_3, "StackType.num-morphisms-on-top block", "src/mirth/data/type.mth", 808, 58);
     mw_prim_drop();
-    WORD_ATOM(790, 58, "drop");
+    WORD_ATOM(808, 58, "drop");
     mw_prim_drop();
-    WORD_ATOM(790, 63, "");
+    WORD_ATOM(808, 63, "");
     push_i64(0LL);
     WORD_EXIT(mb_StackType_2E_num_morphisms_on_top_3);
 }
 
 static void mb_StackType_2E_num_morphisms_on_top_5 (void) {
-    WORD_ENTER(mb_StackType_2E_num_morphisms_on_top_5, "StackType.num-morphisms-on-top block", "src/mirth/data/type.mth", 791, 29);
+    WORD_ENTER(mb_StackType_2E_num_morphisms_on_top_5, "StackType.num-morphisms-on-top block", "src/mirth/data/type.mth", 809, 29);
     mw_prim_drop();
-    WORD_ATOM(791, 29, "num-morphisms-on-top");
+    WORD_ATOM(809, 29, "num-morphisms-on-top");
     mw_StackType_2E_num_morphisms_on_top();
-    WORD_ATOM(791, 50, "1+");
+    WORD_ATOM(809, 50, "1+");
     mw_prim_int_succ();
     WORD_EXIT(mb_StackType_2E_num_morphisms_on_top_5);
 }
 
 static void mb_StackType_2E_num_morphisms_on_top_6 (void) {
-    WORD_ENTER(mb_StackType_2E_num_morphisms_on_top_6, "StackType.num-morphisms-on-top block", "src/mirth/data/type.mth", 791, 54);
+    WORD_ENTER(mb_StackType_2E_num_morphisms_on_top_6, "StackType.num-morphisms-on-top block", "src/mirth/data/type.mth", 809, 54);
     mw_prim_drop();
-    WORD_ATOM(791, 54, "drop");
+    WORD_ATOM(809, 54, "drop");
     mw_prim_drop();
-    WORD_ATOM(791, 59, "");
+    WORD_ATOM(809, 59, "");
     push_i64(0LL);
     WORD_EXIT(mb_StackType_2E_num_morphisms_on_top_6);
 }
 
 static void mb_ArrowType_2E_semifreshen_sig_1 (void) {
-    WORD_ENTER(mb_ArrowType_2E_semifreshen_sig_1, "ArrowType.semifreshen-sig block", "src/mirth/data/type.mth", 821, 38);
+    WORD_ENTER(mb_ArrowType_2E_semifreshen_sig_1, "ArrowType.semifreshen-sig block", "src/mirth/data/type.mth", 839, 38);
     mw_prim_drop();
-    WORD_ATOM(821, 38, "semifreshen-aux");
+    WORD_ATOM(839, 38, "semifreshen-aux");
     mw_ArrowType_2E_semifreshen_aux();
     WORD_EXIT(mb_ArrowType_2E_semifreshen_sig_1);
 }
@@ -37468,11 +37929,11 @@ static void mb_Pattern_2E_tag_3D__2 (void) {
 }
 
 static void mb_elab_type_sig_21__1 (void) {
-    WORD_ENTER(mb_elab_type_sig_21__1, "elab-type-sig! block", "src/mirth/elab.mth", 48, 23);
+    WORD_ENTER(mb_elab_type_sig_21__1, "elab-type-sig! block", "src/mirth/elab.mth", 49, 23);
     mw_prim_drop();
-    WORD_ATOM(48, 23, "dup");
+    WORD_ATOM(49, 23, "dup");
     mw_prim_dup();
-    WORD_ATOM(48, 27, "");
+    WORD_ATOM(49, 27, "");
     {
         static bool vready = false;
         static VAL v;
@@ -37483,17 +37944,17 @@ static void mb_elab_type_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(48, 53, "emit-error!");
+    WORD_ATOM(49, 53, "emit-error!");
     mw_emit_error_21_();
     WORD_EXIT(mb_elab_type_sig_21__1);
 }
 
 static void mb_elab_type_sig_21__8 (void) {
-    WORD_ENTER(mb_elab_type_sig_21__8, "elab-type-sig! block", "src/mirth/elab.mth", 54, 23);
+    WORD_ENTER(mb_elab_type_sig_21__8, "elab-type-sig! block", "src/mirth/elab.mth", 55, 23);
     mw_prim_drop();
-    WORD_ATOM(54, 23, "dup");
+    WORD_ATOM(55, 23, "dup");
     mw_prim_dup();
-    WORD_ATOM(54, 27, "");
+    WORD_ATOM(55, 27, "");
     {
         static bool vready = false;
         static VAL v;
@@ -37504,41 +37965,41 @@ static void mb_elab_type_sig_21__8 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(54, 59, "emit-error!");
+    WORD_ATOM(55, 59, "emit-error!");
     mw_emit_error_21_();
     WORD_EXIT(mb_elab_type_sig_21__8);
 }
 
 static void mb_elab_type_sig_21__11 (void) {
-    WORD_ENTER(mb_elab_type_sig_21__11, "elab-type-sig! block", "src/mirth/elab.mth", 55, 28);
+    WORD_ENTER(mb_elab_type_sig_21__11, "elab-type-sig! block", "src/mirth/elab.mth", 56, 28);
     mw_prim_drop();
-    WORD_ATOM(55, 28, "T*");
+    WORD_ATOM(56, 28, "T*");
     mw_T_2A_();
     WORD_EXIT(mb_elab_type_sig_21__11);
 }
 
 static void mb_elab_type_sig_params_21__1 (void) {
-    WORD_ENTER(mb_elab_type_sig_params_21__1, "elab-type-sig-params! block", "src/mirth/elab.mth", 59, 9);
+    WORD_ENTER(mb_elab_type_sig_params_21__1, "elab-type-sig-params! block", "src/mirth/elab.mth", 60, 9);
     mw_prim_drop();
-    WORD_ATOM(59, 9, "dup");
+    WORD_ATOM(60, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(59, 13, "next");
+    WORD_ATOM(60, 13, "next");
     mw_Token_2E_next();
-    WORD_ATOM(59, 18, "dip");
+    WORD_ATOM(60, 18, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(60, 13, "L0");
+        WORD_ATOM(61, 13, "L0");
         mw_L0();
-        WORD_ATOM(60, 16, "rotr");
+        WORD_ATOM(61, 16, "rotr");
         mw_rotr();
-        WORD_ATOM(60, 21, "args");
+        WORD_ATOM(61, 21, "args");
         mw_Token_2E_args();
-        WORD_ATOM(61, 13, "for");
+        WORD_ATOM(62, 13, "for");
         push_u64(0);
         push_fnptr(&mb_elab_type_sig_params_21__3);
         mw_prim_pack_cons();
         mw_List_2E_for();
-        WORD_ATOM(62, 13, "swap");
+        WORD_ATOM(63, 13, "swap");
         mw_prim_swap();
         push_value(d2);
     }
@@ -37546,30 +38007,30 @@ static void mb_elab_type_sig_params_21__1 (void) {
 }
 
 static void mb_elab_type_sig_params_21__5 (void) {
-    WORD_ENTER(mb_elab_type_sig_params_21__5, "elab-type-sig-params! block", "src/mirth/elab.mth", 64, 9);
+    WORD_ENTER(mb_elab_type_sig_params_21__5, "elab-type-sig-params! block", "src/mirth/elab.mth", 65, 9);
     mw_prim_drop();
-    WORD_ATOM(64, 9, "L0");
+    WORD_ATOM(65, 9, "L0");
     mw_L0();
-    WORD_ATOM(64, 12, "swap");
+    WORD_ATOM(65, 12, "swap");
     mw_prim_swap();
     WORD_EXIT(mb_elab_type_sig_params_21__5);
 }
 
 static void mb_elab_type_sig_params_21__3 (void) {
-    WORD_ENTER(mb_elab_type_sig_params_21__3, "elab-type-sig-params! block", "src/mirth/elab.mth", 61, 17);
+    WORD_ENTER(mb_elab_type_sig_params_21__3, "elab-type-sig-params! block", "src/mirth/elab.mth", 62, 17);
     mw_prim_drop();
-    WORD_ATOM(61, 17, "elab-type-sig!");
+    WORD_ATOM(62, 17, "elab-type-sig!");
     mw_elab_type_sig_21_();
-    WORD_ATOM(61, 32, "drop");
+    WORD_ATOM(62, 32, "drop");
     mw_prim_drop();
-    WORD_ATOM(61, 37, "ArrowType>Type");
+    WORD_ATOM(62, 37, "ArrowType>Type");
     mw_ArrowType_3E_Type();
-    WORD_ATOM(61, 52, "swap");
+    WORD_ATOM(62, 52, "swap");
     mw_prim_swap();
-    WORD_ATOM(61, 57, "dip");
+    WORD_ATOM(62, 57, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(61, 61, "snoc");
+        WORD_ATOM(62, 61, "snoc");
         mw_snoc();
         push_value(d2);
     }
@@ -37577,14 +38038,14 @@ static void mb_elab_type_sig_params_21__3 (void) {
 }
 
 static void mb_elab_type_atom_21__19 (void) {
-    WORD_ENTER(mb_elab_type_atom_21__19, "elab-type-atom! block", "src/mirth/elab.mth", 112, 9);
+    WORD_ENTER(mb_elab_type_atom_21__19, "elab-type-atom! block", "src/mirth/elab.mth", 113, 9);
     mw_prim_drop();
-    WORD_ATOM(112, 9, "elab-type-quote!");
+    WORD_ATOM(113, 9, "elab-type-quote!");
     mw_elab_type_quote_21_();
-    WORD_ATOM(112, 26, "dip");
+    WORD_ATOM(113, 26, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(112, 30, "LEFT");
+        WORD_ATOM(113, 30, "LEFT");
         mw_LEFT();
         push_value(d2);
     }
@@ -37592,11 +38053,11 @@ static void mb_elab_type_atom_21__19 (void) {
 }
 
 static void mb_elab_type_atom_21__21 (void) {
-    WORD_ENTER(mb_elab_type_atom_21__21, "elab-type-atom! block", "src/mirth/elab.mth", 114, 9);
+    WORD_ENTER(mb_elab_type_atom_21__21, "elab-type-atom! block", "src/mirth/elab.mth", 115, 9);
     mw_prim_drop();
-    WORD_ATOM(114, 9, "dup");
+    WORD_ATOM(115, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(114, 13, "");
+    WORD_ATOM(115, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -37607,132 +38068,132 @@ static void mb_elab_type_atom_21__21 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(114, 49, "emit-error!");
+    WORD_ATOM(115, 49, "emit-error!");
     mw_emit_error_21_();
-    WORD_ATOM(115, 9, "dip");
+    WORD_ATOM(116, 9, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(115, 13, "TYPE_ERROR");
+        WORD_ATOM(116, 13, "TYPE_ERROR");
         mw_TYPE_5F_ERROR();
-        WORD_ATOM(115, 24, "LEFT");
+        WORD_ATOM(116, 24, "LEFT");
         mw_LEFT();
         push_value(d2);
     }
-    WORD_ATOM(115, 30, "next");
+    WORD_ATOM(116, 30, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_type_atom_21__21);
 }
 
 static void mb_elab_implicit_var_21__1 (void) {
-    WORD_ENTER(mb_elab_implicit_var_21__1, "elab-implicit-var! block", "src/mirth/elab.mth", 128, 10);
+    WORD_ENTER(mb_elab_implicit_var_21__1, "elab-implicit-var! block", "src/mirth/elab.mth", 129, 10);
     mw_prim_drop();
-    WORD_ATOM(128, 10, "type-elab-ctx?");
+    WORD_ATOM(129, 10, "type-elab-ctx?");
     mw_type_elab_ctx_3F_();
     WORD_EXIT(mb_elab_implicit_var_21__1);
 }
 
 static void mb_elab_implicit_var_21__2 (void) {
-    WORD_ENTER(mb_elab_implicit_var_21__2, "elab-implicit-var! block", "src/mirth/elab.mth", 129, 10);
+    WORD_ENTER(mb_elab_implicit_var_21__2, "elab-implicit-var! block", "src/mirth/elab.mth", 130, 10);
     mw_prim_drop();
-    WORD_ATOM(129, 10, "name?");
+    WORD_ATOM(130, 10, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(129, 16, "unwrap");
+    WORD_ATOM(130, 16, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(129, 23, "dup2");
+    WORD_ATOM(130, 23, "dup2");
     mw_dup2();
-    WORD_ATOM(129, 28, "swap");
+    WORD_ATOM(130, 28, "swap");
     mw_prim_swap();
-    WORD_ATOM(129, 33, "lookup");
+    WORD_ATOM(130, 33, "lookup");
     mw_Ctx_2E_lookup();
     WORD_EXIT(mb_elab_implicit_var_21__2);
 }
 
 static void mb_elab_implicit_var_21__4 (void) {
-    WORD_ENTER(mb_elab_implicit_var_21__4, "elab-implicit-var! block", "src/mirth/elab.mth", 132, 23);
+    WORD_ENTER(mb_elab_implicit_var_21__4, "elab-implicit-var! block", "src/mirth/elab.mth", 133, 23);
     mw_prim_drop();
-    WORD_ATOM(132, 23, "nip");
+    WORD_ATOM(133, 23, "nip");
     mw_nip();
-    WORD_ATOM(132, 27, "dup");
+    WORD_ATOM(133, 27, "dup");
     mw_prim_dup();
-    WORD_ATOM(132, 31, "type");
+    WORD_ATOM(133, 31, "type");
     mw_Var_2E_type();
     WORD_EXIT(mb_elab_implicit_var_21__4);
 }
 
 static void mb_elab_implicit_var_21__7 (void) {
-    WORD_ENTER(mb_elab_implicit_var_21__7, "elab-implicit-var! block", "src/mirth/elab.mth", 137, 21);
+    WORD_ENTER(mb_elab_implicit_var_21__7, "elab-implicit-var! block", "src/mirth/elab.mth", 138, 21);
     mw_prim_drop();
-    WORD_ATOM(137, 21, "Ctx.new");
+    WORD_ATOM(138, 21, "Ctx.new");
     mw_Ctx_2E_new();
     WORD_EXIT(mb_elab_implicit_var_21__7);
 }
 
 static void mb_elab_implicit_var_21__8 (void) {
-    WORD_ENTER(mb_elab_implicit_var_21__8, "elab-implicit-var! block", "src/mirth/elab.mth", 141, 10);
+    WORD_ENTER(mb_elab_implicit_var_21__8, "elab-implicit-var! block", "src/mirth/elab.mth", 142, 10);
     mw_prim_drop();
-    WORD_ATOM(141, 10, "type-elab-ctx-replace");
+    WORD_ATOM(142, 10, "type-elab-ctx-replace");
     mw_type_elab_ctx_replace();
     WORD_EXIT(mb_elab_implicit_var_21__8);
 }
 
 static void mb_elab_type_unify_21__1 (void) {
-    WORD_ENTER(mb_elab_type_unify_21__1, "elab-type-unify! block", "src/mirth/elab.mth", 204, 9);
+    WORD_ENTER(mb_elab_type_unify_21__1, "elab-type-unify! block", "src/mirth/elab.mth", 205, 9);
     mw_prim_drop();
-    WORD_ATOM(204, 9, "GAMMA");
+    WORD_ATOM(205, 9, "GAMMA");
     mw_GAMMA();
-    WORD_ATOM(204, 15, "rotr");
+    WORD_ATOM(205, 15, "rotr");
     mw_rotr();
-    WORD_ATOM(204, 20, "unify!");
+    WORD_ATOM(205, 20, "unify!");
     mw_Type_2E_unify_21_();
-    WORD_ATOM(204, 27, "nip");
+    WORD_ATOM(205, 27, "nip");
     mw_nip();
     WORD_EXIT(mb_elab_type_unify_21__1);
 }
 
 static void mb_elab_stack_type_unify_21__1 (void) {
-    WORD_ENTER(mb_elab_stack_type_unify_21__1, "elab-stack-type-unify! block", "src/mirth/elab.mth", 206, 9);
+    WORD_ENTER(mb_elab_stack_type_unify_21__1, "elab-stack-type-unify! block", "src/mirth/elab.mth", 207, 9);
     mw_prim_drop();
-    WORD_ATOM(206, 9, "GAMMA");
+    WORD_ATOM(207, 9, "GAMMA");
     mw_GAMMA();
-    WORD_ATOM(206, 15, "rotr");
+    WORD_ATOM(207, 15, "rotr");
     mw_rotr();
-    WORD_ATOM(206, 20, "unify!");
+    WORD_ATOM(207, 20, "unify!");
     mw_StackType_2E_unify_21_();
-    WORD_ATOM(206, 27, "nip");
+    WORD_ATOM(207, 27, "nip");
     mw_nip();
     WORD_EXIT(mb_elab_stack_type_unify_21__1);
 }
 
 static void mb_ab_build_21__2 (void) {
-    WORD_ENTER(mb_ab_build_21__2, "ab-build! block", "src/mirth/elab.mth", 231, 9);
+    WORD_ENTER(mb_ab_build_21__2, "ab-build! block", "src/mirth/elab.mth", 232, 9);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(231, 9, "Arrow.alloc!");
+    WORD_ATOM(232, 9, "Arrow.alloc!");
     mw_Arrow_2E_alloc_21_();
-    WORD_ATOM(232, 9, "ab-home");
+    WORD_ATOM(233, 9, "ab-home");
     mw_ab_home();
-    WORD_ATOM(232, 17, "@");
+    WORD_ATOM(233, 17, "@");
     mw_prim_mut_get();
-    WORD_ATOM(232, 19, "over");
+    WORD_ATOM(233, 19, "over");
     mw_over();
-    WORD_ATOM(232, 24, "~home");
+    WORD_ATOM(233, 24, "~home");
     mw_Arrow_7E_home();
-    WORD_ATOM(232, 30, "!");
-    mw_prim_mut_set();
-    WORD_ATOM(233, 9, "ab-homeidx");
-    mw_ab_homeidx();
-    WORD_ATOM(233, 20, "@");
-    mw_prim_mut_get();
-    WORD_ATOM(233, 22, "over");
-    mw_over();
-    WORD_ATOM(233, 27, "~homeidx");
-    mw_Arrow_7E_homeidx();
-    WORD_ATOM(233, 36, "!");
+    WORD_ATOM(233, 30, "!");
     mw_prim_mut_set();
     WORD_ATOM(234, 9, "ab-homeidx");
     mw_ab_homeidx();
-    WORD_ATOM(234, 20, "modify");
+    WORD_ATOM(234, 20, "@");
+    mw_prim_mut_get();
+    WORD_ATOM(234, 22, "over");
+    mw_over();
+    WORD_ATOM(234, 27, "~homeidx");
+    mw_Arrow_7E_homeidx();
+    WORD_ATOM(234, 36, "!");
+    mw_prim_mut_set();
+    WORD_ATOM(235, 9, "ab-homeidx");
+    mw_ab_homeidx();
+    WORD_ATOM(235, 20, "modify");
     push_u64(0);
     incref(var_f);
     push_value(var_f);
@@ -37740,101 +38201,101 @@ static void mb_ab_build_21__2 (void) {
     push_fnptr(&mb_ab_build_21__3);
     mw_prim_pack_cons();
     mw_modify();
-    WORD_ATOM(235, 9, "tuck");
-    mw_tuck();
-    WORD_ATOM(235, 14, "dup2");
-    mw_dup2();
-    WORD_ATOM(235, 19, "~token-start");
-    mw_Arrow_7E_token_start();
-    WORD_ATOM(235, 32, "!");
-    mw_prim_mut_set();
-    WORD_ATOM(235, 34, "~token-end");
-    mw_Arrow_7E_token_end();
-    WORD_ATOM(235, 45, "!");
-    mw_prim_mut_set();
     WORD_ATOM(236, 9, "tuck");
     mw_tuck();
     WORD_ATOM(236, 14, "dup2");
     mw_dup2();
-    WORD_ATOM(236, 19, "~dom");
-    mw_Arrow_7E_dom();
-    WORD_ATOM(236, 24, "!");
+    WORD_ATOM(236, 19, "~token-start");
+    mw_Arrow_7E_token_start();
+    WORD_ATOM(236, 32, "!");
     mw_prim_mut_set();
-    WORD_ATOM(236, 26, "~cod");
-    mw_Arrow_7E_cod();
-    WORD_ATOM(236, 31, "!");
+    WORD_ATOM(236, 34, "~token-end");
+    mw_Arrow_7E_token_end();
+    WORD_ATOM(236, 45, "!");
     mw_prim_mut_set();
     WORD_ATOM(237, 9, "tuck");
     mw_tuck();
-    WORD_ATOM(237, 14, "~ctx");
+    WORD_ATOM(237, 14, "dup2");
+    mw_dup2();
+    WORD_ATOM(237, 19, "~dom");
+    mw_Arrow_7E_dom();
+    WORD_ATOM(237, 24, "!");
+    mw_prim_mut_set();
+    WORD_ATOM(237, 26, "~cod");
+    mw_Arrow_7E_cod();
+    WORD_ATOM(237, 31, "!");
+    mw_prim_mut_set();
+    WORD_ATOM(238, 9, "tuck");
+    mw_tuck();
+    WORD_ATOM(238, 14, "~ctx");
     mw_Arrow_7E_ctx();
-    WORD_ATOM(237, 19, "!");
+    WORD_ATOM(238, 19, "!");
     mw_prim_mut_set();
-    WORD_ATOM(238, 9, "L0");
+    WORD_ATOM(239, 9, "L0");
     mw_L0();
-    WORD_ATOM(238, 12, "over");
+    WORD_ATOM(239, 12, "over");
     mw_over();
-    WORD_ATOM(238, 17, "~atoms");
+    WORD_ATOM(239, 17, "~atoms");
     mw_Arrow_7E_atoms();
-    WORD_ATOM(238, 24, "!");
+    WORD_ATOM(239, 24, "!");
     mw_prim_mut_set();
-    WORD_ATOM(239, 9, "ab-arrow");
+    WORD_ATOM(240, 9, "ab-arrow");
     mw_ab_arrow();
-    WORD_ATOM(239, 18, "!");
+    WORD_ATOM(240, 18, "!");
     mw_prim_mut_set();
-    WORD_ATOM(240, 9, "f");
+    WORD_ATOM(241, 9, "f");
     incref(var_f);
     run_value(var_f);
-    WORD_ATOM(241, 9, "ab-arrow");
+    WORD_ATOM(242, 9, "ab-arrow");
     mw_ab_arrow();
-    WORD_ATOM(241, 18, "@");
+    WORD_ATOM(242, 18, "@");
     mw_prim_mut_get();
     decref(var_f);
     WORD_EXIT(mb_ab_build_21__2);
 }
 
 static void mb_ab_build_21__3 (void) {
-    WORD_ENTER(mb_ab_build_21__3, "ab-build! block", "src/mirth/elab.mth", 234, 27);
+    WORD_ENTER(mb_ab_build_21__3, "ab-build! block", "src/mirth/elab.mth", 235, 27);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(234, 27, "1+");
+    WORD_ATOM(235, 27, "1+");
     mw_prim_int_succ();
     decref(var_f);
     WORD_EXIT(mb_ab_build_21__3);
 }
 
 static void mb_ab_build_hom_21__3 (void) {
-    WORD_ENTER(mb_ab_build_hom_21__3, "ab-build-hom! block", "src/mirth/elab.mth", 249, 15);
+    WORD_ENTER(mb_ab_build_hom_21__3, "ab-build-hom! block", "src/mirth/elab.mth", 250, 15);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(249, 15, "f");
+    WORD_ATOM(250, 15, "f");
     incref(var_f);
     run_value(var_f);
-    WORD_ATOM(249, 17, "ab-unify-type!");
+    WORD_ATOM(250, 17, "ab-unify-type!");
     mw_ab_unify_type_21_();
     decref(var_f);
     WORD_EXIT(mb_ab_build_hom_21__3);
 }
 
 static void mb_ab_build_word_arrow_21__2 (void) {
-    WORD_ENTER(mb_ab_build_word_arrow_21__2, "ab-build-word-arrow! block", "src/mirth/elab.mth", 252, 9);
+    WORD_ENTER(mb_ab_build_word_arrow_21__2, "ab-build-word-arrow! block", "src/mirth/elab.mth", 253, 9);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(252, 9, "elab-word-ctx-type-weak!");
+    WORD_ATOM(253, 9, "elab-word-ctx-type-weak!");
     mw_elab_word_ctx_type_weak_21_();
     decref(var_f);
     WORD_EXIT(mb_ab_build_word_arrow_21__2);
 }
 
 static void mb_ab_build_word_21__2 (void) {
-    WORD_ENTER(mb_ab_build_word_21__2, "ab-build-word! block", "src/mirth/elab.mth", 256, 9);
+    WORD_ENTER(mb_ab_build_word_21__2, "ab-build-word! block", "src/mirth/elab.mth", 257, 9);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(256, 9, "ab-build-word-arrow!");
+    WORD_ATOM(257, 9, "ab-build-word-arrow!");
     push_u64(0);
     incref(var_f);
     push_value(var_f);
@@ -37842,21 +38303,21 @@ static void mb_ab_build_word_21__2 (void) {
     push_fnptr(&mb_ab_build_word_21__3);
     mw_prim_pack_cons();
     mw_ab_build_word_arrow_21_();
-    WORD_ATOM(256, 38, "ready");
+    WORD_ATOM(257, 38, "ready");
     mw_ready();
     decref(var_f);
     WORD_EXIT(mb_ab_build_word_21__2);
 }
 
 static void mb_ab_build_word_21__3 (void) {
-    WORD_ENTER(mb_ab_build_word_21__3, "ab-build-word! block", "src/mirth/elab.mth", 256, 30);
+    WORD_ENTER(mb_ab_build_word_21__3, "ab-build-word! block", "src/mirth/elab.mth", 257, 30);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(256, 30, "dip");
+    WORD_ATOM(257, 30, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(256, 34, "f");
+        WORD_ATOM(257, 34, "f");
         incref(var_f);
         run_value(var_f);
         push_value(d2);
@@ -37866,194 +38327,163 @@ static void mb_ab_build_word_21__3 (void) {
 }
 
 static void mb_ab_optimized_snoc_21__2 (void) {
-    WORD_ENTER(mb_ab_optimized_snoc_21__2, "ab-optimized-snoc! block", "src/mirth/elab.mth", 274, 16);
+    WORD_ENTER(mb_ab_optimized_snoc_21__2, "ab-optimized-snoc! block", "src/mirth/elab.mth", 275, 16);
     mw_prim_drop();
-    WORD_ATOM(274, 16, "atoms-has-last-block?");
+    WORD_ATOM(275, 16, "atoms-has-last-block?");
     mw_atoms_has_last_block_3F_();
     WORD_EXIT(mb_ab_optimized_snoc_21__2);
 }
 
 static void mb_ab_optimized_snoc_21__3 (void) {
-    WORD_ENTER(mb_ab_optimized_snoc_21__3, "ab-optimized-snoc! block", "src/mirth/elab.mth", 274, 43);
+    WORD_ENTER(mb_ab_optimized_snoc_21__3, "ab-optimized-snoc! block", "src/mirth/elab.mth", 275, 43);
     mw_prim_drop();
-    WORD_ATOM(274, 43, "atom-accepts-args?");
+    WORD_ATOM(275, 43, "atom-accepts-args?");
     mw_atom_accepts_args_3F_();
     WORD_EXIT(mb_ab_optimized_snoc_21__3);
 }
 
 static void mb_ab_lambda_21__3 (void) {
-    WORD_ENTER(mb_ab_lambda_21__3, "ab-lambda! block", "src/mirth/elab.mth", 390, 9);
+    WORD_ENTER(mb_ab_lambda_21__3, "ab-lambda! block", "src/mirth/elab.mth", 391, 9);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(390, 9, "swap");
+    WORD_ATOM(391, 9, "swap");
     mw_prim_swap();
-    WORD_ATOM(390, 14, "dip");
+    WORD_ATOM(391, 14, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(390, 18, ">Var");
+        WORD_ATOM(391, 18, ">Var");
         mw_Param_3E_Var();
-        WORD_ATOM(390, 23, "dup");
+        WORD_ATOM(391, 23, "dup");
         mw_prim_dup();
-        WORD_ATOM(390, 27, "dip");
+        WORD_ATOM(391, 27, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(390, 31, "Ctx.new");
+            WORD_ATOM(391, 31, "Ctx.new");
             mw_Ctx_2E_new();
             push_value(d3);
         }
         push_value(d2);
     }
-    WORD_ATOM(391, 9, "ab-token");
+    WORD_ATOM(392, 9, "ab-token");
     mw_ab_token();
-    WORD_ATOM(391, 18, "@");
+    WORD_ATOM(392, 18, "@");
     mw_prim_mut_get();
-    WORD_ATOM(391, 20, "elab-expand-tensor!");
+    WORD_ATOM(392, 20, "elab-expand-tensor!");
     mw_elab_expand_tensor_21_();
-    WORD_ATOM(392, 9, "dip");
+    WORD_ATOM(393, 9, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(392, 13, "rotl");
+        WORD_ATOM(393, 13, "rotl");
         mw_rotl();
-        WORD_ATOM(392, 18, "type");
+        WORD_ATOM(393, 18, "type");
         mw_Var_2E_type();
         push_value(d2);
     }
-    WORD_ATOM(392, 24, "elab-type-unify!");
+    WORD_ATOM(393, 24, "elab-type-unify!");
     mw_elab_type_unify_21_();
-    WORD_ATOM(392, 41, "drop2");
+    WORD_ATOM(393, 41, "drop2");
     mw_drop2();
     decref(var_f);
     WORD_EXIT(mb_ab_lambda_21__3);
 }
 
 static void mb_ab_lambda_21__7 (void) {
-    WORD_ENTER(mb_ab_lambda_21__7, "ab-lambda! block", "src/mirth/elab.mth", 403, 9);
+    WORD_ENTER(mb_ab_lambda_21__7, "ab-lambda! block", "src/mirth/elab.mth", 404, 9);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(403, 9, "dip");
+    WORD_ATOM(404, 9, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(403, 13, "f");
+        WORD_ATOM(404, 13, "f");
         incref(var_f);
         run_value(var_f);
         push_value(d2);
     }
-    WORD_ATOM(404, 9, "ab-type");
+    WORD_ATOM(405, 9, "ab-type");
     mw_ab_type();
-    WORD_ATOM(404, 17, "@");
+    WORD_ATOM(405, 17, "@");
     mw_prim_mut_get();
-    WORD_ATOM(404, 19, "over");
+    WORD_ATOM(405, 19, "over");
     mw_over();
-    WORD_ATOM(404, 24, "~cod");
+    WORD_ATOM(405, 24, "~cod");
     mw_Lambda_7E_cod();
-    WORD_ATOM(404, 29, "!");
+    WORD_ATOM(405, 29, "!");
     mw_prim_mut_set();
     decref(var_f);
     WORD_EXIT(mb_ab_lambda_21__7);
 }
 
 static void mb_elab_match_sig_21__1 (void) {
-    WORD_ENTER(mb_elab_match_sig_21__1, "elab-match-sig! block", "src/mirth/elab.mth", 437, 9);
+    WORD_ENTER(mb_elab_match_sig_21__1, "elab-match-sig! block", "src/mirth/elab.mth", 438, 9);
     mw_prim_drop();
-    WORD_ATOM(437, 9, "dom");
+    WORD_ATOM(438, 9, "dom");
     mw_Match_2E_dom();
     WORD_EXIT(mb_elab_match_sig_21__1);
 }
 
 static void mb_elab_lambda_sig_21__1 (void) {
-    WORD_ENTER(mb_elab_lambda_sig_21__1, "elab-lambda-sig! block", "src/mirth/elab.mth", 440, 9);
+    WORD_ENTER(mb_elab_lambda_sig_21__1, "elab-lambda-sig! block", "src/mirth/elab.mth", 441, 9);
     mw_prim_drop();
-    WORD_ATOM(440, 9, "dom");
+    WORD_ATOM(441, 9, "dom");
     mw_Lambda_2E_dom();
     WORD_EXIT(mb_elab_lambda_sig_21__1);
 }
 
 static void mb_elab_arrow_fwd_21__1 (void) {
-    WORD_ENTER(mb_elab_arrow_fwd_21__1, "elab-arrow-fwd! block", "src/mirth/elab.mth", 469, 15);
+    WORD_ENTER(mb_elab_arrow_fwd_21__1, "elab-arrow-fwd! block", "src/mirth/elab.mth", 470, 15);
     mw_prim_drop();
-    WORD_ATOM(469, 15, "elab-atoms!");
+    WORD_ATOM(470, 15, "elab-atoms!");
     mw_elab_atoms_21_();
     WORD_EXIT(mb_elab_arrow_fwd_21__1);
 }
 
 static void mb_elab_atoms_21__3 (void) {
-    WORD_ENTER(mb_elab_atoms_21__3, "elab-atoms! block", "src/mirth/elab.mth", 474, 36);
+    WORD_ENTER(mb_elab_atoms_21__3, "elab-atoms! block", "src/mirth/elab.mth", 475, 36);
     mw_prim_drop();
-    WORD_ATOM(474, 36, "next");
+    WORD_ATOM(475, 36, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_atoms_21__3);
 }
 
 static void mb_elab_args_21__1 (void) {
-    WORD_ENTER(mb_elab_args_21__1, "elab-args! block", "src/mirth/elab.mth", 497, 25);
+    WORD_ENTER(mb_elab_args_21__1, "elab-args! block", "src/mirth/elab.mth", 498, 25);
     mw_prim_drop();
-    WORD_ATOM(497, 25, "elab-block-at!");
+    WORD_ATOM(498, 25, "elab-block-at!");
     mw_elab_block_at_21_();
     WORD_EXIT(mb_elab_args_21__1);
 }
 
 static void mb_elab_relativize_name_21__1 (void) {
-    WORD_ENTER(mb_elab_relativize_name_21__1, "elab-relativize-name! block", "src/mirth/elab.mth", 512, 25);
+    WORD_ENTER(mb_elab_relativize_name_21__1, "elab-relativize-name! block", "src/mirth/elab.mth", 535, 44);
     mw_prim_drop();
-    WORD_ATOM(512, 25, "dup");
-    mw_prim_dup();
-    WORD_ATOM(512, 29, "could-be-relative");
-    mw_Name_2E_could_be_relative();
+    WORD_ATOM(535, 44, "nip");
+    mw_nip();
     WORD_EXIT(mb_elab_relativize_name_21__1);
 }
 
-static void mb_elab_relativize_name_21__3 (void) {
-    WORD_ENTER(mb_elab_relativize_name_21__3, "elab-relativize-name! block", "src/mirth/elab.mth", 514, 13);
+static void mb_elab_relativize_name_21__2 (void) {
+    WORD_ENTER(mb_elab_relativize_name_21__2, "elab-relativize-name! block", "src/mirth/elab.mth", 535, 49);
     mw_prim_drop();
-    WORD_ATOM(514, 13, ">Str");
-    mw_Name_3E_Str();
-    WORD_ATOM(514, 18, "over");
-    mw_over();
-    WORD_ATOM(514, 23, "to-overload-suffix");
-    mw_Name_2E_to_overload_suffix();
-    WORD_ATOM(514, 42, "cat");
-    mw_prim_str_cat();
-    WORD_ATOM(514, 46, "Name.search");
-    mw_Name_2E_search();
-    WORD_ATOM(514, 58, "for");
-    push_u64(0);
-    push_fnptr(&mb_elab_relativize_name_21__4);
-    mw_prim_pack_cons();
-    mw_Maybe_2E_for();
-    WORD_EXIT(mb_elab_relativize_name_21__3);
-}
-
-static void mb_elab_relativize_name_21__4 (void) {
-    WORD_ENTER(mb_elab_relativize_name_21__4, "elab-relativize-name! block", "src/mirth/elab.mth", 515, 17);
-    mw_prim_drop();
-    WORD_ATOM(515, 17, "name-defined?");
-    mw_name_defined_3F_();
-    WORD_ATOM(515, 31, "if");
-    if (pop_u64()) {
-        WORD_ATOM(516, 21, "nip");
-        mw_nip();
-    } else {
-        WORD_ATOM(517, 21, "drop");
-        mw_prim_drop();
-    }
-    WORD_EXIT(mb_elab_relativize_name_21__4);
+    WORD_ATOM(535, 49, "id");
+    mw_prim_id();
+    WORD_EXIT(mb_elab_relativize_name_21__2);
 }
 
 static void mb_elab_check_name_visible_21__1 (void) {
-    WORD_ENTER(mb_elab_check_name_visible_21__1, "elab-check-name-visible! block", "src/mirth/elab.mth", 526, 9);
+    WORD_ENTER(mb_elab_check_name_visible_21__1, "elab-check-name-visible! block", "src/mirth/elab.mth", 539, 9);
     mw_prim_drop();
-    WORD_ATOM(526, 9, "dup");
+    WORD_ATOM(539, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(526, 13, "elab-module-is-visible");
+    WORD_ATOM(539, 13, "elab-module-is-visible");
     mw_elab_module_is_visible();
-    WORD_ATOM(526, 36, "if");
+    WORD_ATOM(539, 36, "if");
     if (pop_u64()) {
-        WORD_ATOM(526, 39, "drop");
+        WORD_ATOM(539, 39, "drop");
         mw_prim_drop();
     } else {
-        WORD_ATOM(527, 13, "");
+        WORD_ATOM(540, 13, "");
         {
             static bool vready = false;
             static VAL v;
@@ -38064,34 +38494,140 @@ static void mb_elab_check_name_visible_21__1 (void) {
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(527, 46, "swap");
+        WORD_ATOM(540, 46, "swap");
         mw_prim_swap();
-        WORD_ATOM(527, 51, "name");
+        WORD_ATOM(540, 51, "name");
         mw_Module_2E_name();
-        WORD_ATOM(527, 56, ">Str");
+        WORD_ATOM(540, 56, ">Str");
         mw_Name_3E_Str();
-        WORD_ATOM(527, 61, "cat");
+        WORD_ATOM(540, 61, "cat");
         mw_prim_str_cat();
-        WORD_ATOM(528, 13, "ab-token");
+        WORD_ATOM(541, 13, "ab-token");
         mw_ab_token();
-        WORD_ATOM(528, 22, "@");
+        WORD_ATOM(541, 22, "@");
         mw_prim_mut_get();
-        WORD_ATOM(528, 24, "swap");
+        WORD_ATOM(541, 24, "swap");
         mw_prim_swap();
-        WORD_ATOM(528, 29, "emit-error!");
+        WORD_ATOM(541, 29, "emit-error!");
         mw_emit_error_21_();
     }
     WORD_EXIT(mb_elab_check_name_visible_21__1);
 }
 
-static void mb_elab_match_exhaustive_21__1 (void) {
-    WORD_ENTER(mb_elab_match_exhaustive_21__1, "elab-match-exhaustive! block", "src/mirth/elab.mth", 675, 9);
+static void mb_elab_needs_dot_1 (void) {
+    WORD_ENTER(mb_elab_needs_dot_1, "elab-needs-dot block", "src/mirth/elab.mth", 514, 24);
     mw_prim_drop();
-    WORD_ATOM(675, 9, "dup");
+    WORD_ATOM(514, 24, "is-alpha");
+    mw_Byte_2E_is_alpha();
+    WORD_EXIT(mb_elab_needs_dot_1);
+}
+
+static void mb_elab_needs_dot_2 (void) {
+    WORD_ENTER(mb_elab_needs_dot_2, "elab-needs-dot block", "src/mirth/elab.mth", 514, 34);
+    mw_prim_drop();
+    WORD_ATOM(514, 34, "F");
+    mw_F();
+    WORD_EXIT(mb_elab_needs_dot_2);
+}
+
+static void mb_elab_combine_prefix_1 (void) {
+    WORD_ENTER(mb_elab_combine_prefix_1, "elab-combine-prefix block", "src/mirth/elab.mth", 517, 30);
+    mw_prim_drop();
+    WORD_ATOM(517, 30, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr(".", 1);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(517, 34, "cat");
+    mw_prim_str_cat();
+    WORD_EXIT(mb_elab_combine_prefix_1);
+}
+
+static void mb_elab_combine_prefixes_1 (void) {
+    WORD_ENTER(mb_elab_combine_prefixes_1, "elab-combine-prefixes block", "src/mirth/elab.mth", 521, 9);
+    mw_prim_drop();
+    WORD_ATOM(521, 9, "over");
+    mw_over();
+    WORD_ATOM(521, 14, "map");
+    push_u64(0);
+    push_fnptr(&mb_elab_combine_prefixes_2);
+    mw_prim_pack_cons();
+    mw_List_2B__2E_map();
+    WORD_ATOM(521, 44, "nip");
+    mw_nip();
+    WORD_ATOM(521, 48, "cat+");
+    mw_List_2B__2E_cat_2B_();
+    WORD_EXIT(mb_elab_combine_prefixes_1);
+}
+
+static void mb_elab_combine_prefixes_3 (void) {
+    WORD_ENTER(mb_elab_combine_prefixes_3, "elab-combine-prefixes block", "src/mirth/elab.mth", 522, 9);
+    mw_prim_drop();
+    WORD_ATOM(522, 9, "id");
+    mw_prim_id();
+    WORD_EXIT(mb_elab_combine_prefixes_3);
+}
+
+static void mb_elab_combine_prefixes_2 (void) {
+    WORD_ENTER(mb_elab_combine_prefixes_2, "elab-combine-prefixes block", "src/mirth/elab.mth", 521, 18);
+    mw_prim_drop();
+    WORD_ATOM(521, 18, "over");
+    mw_over();
+    WORD_ATOM(521, 23, "elab-combine-prefix");
+    mw_elab_combine_prefix();
+    WORD_EXIT(mb_elab_combine_prefixes_2);
+}
+
+static void mb_elab_word_search_1 (void) {
+    WORD_ENTER(mb_elab_word_search_1, "elab-word-search block", "src/mirth/elab.mth", 526, 24);
+    mw_prim_drop();
+    WORD_ATOM(526, 24, "dup");
     mw_prim_dup();
-    WORD_ATOM(675, 13, "token");
+    WORD_ATOM(526, 28, ">Def");
+    mw_Name_3E_Def();
+    WORD_ATOM(526, 33, "callable?");
+    mw_Def_2E_callable_3F_();
+    WORD_EXIT(mb_elab_word_search_1);
+}
+
+static void mb_elab_name_candidates_1 (void) {
+    WORD_ENTER(mb_elab_name_candidates_1, "elab-name-candidates block", "src/mirth/elab.mth", 530, 37);
+    mw_prim_drop();
+    WORD_ATOM(530, 37, ">Str");
+    mw_Name_3E_Str();
+    WORD_EXIT(mb_elab_name_candidates_1);
+}
+
+static void mb_elab_name_candidates_2 (void) {
+    WORD_ENTER(mb_elab_name_candidates_2, "elab-name-candidates block", "src/mirth/elab.mth", 531, 34);
+    mw_prim_drop();
+    WORD_ATOM(531, 34, ">Str");
+    mw_Name_3E_Str();
+    WORD_EXIT(mb_elab_name_candidates_2);
+}
+
+static void mb_elab_name_candidates_3 (void) {
+    WORD_ENTER(mb_elab_name_candidates_3, "elab-name-candidates block", "src/mirth/elab.mth", 532, 17);
+    mw_prim_drop();
+    WORD_ATOM(532, 17, "elab-word-search");
+    mw_elab_word_search();
+    WORD_EXIT(mb_elab_name_candidates_3);
+}
+
+static void mb_elab_match_exhaustive_21__1 (void) {
+    WORD_ENTER(mb_elab_match_exhaustive_21__1, "elab-match-exhaustive! block", "src/mirth/elab.mth", 688, 9);
+    mw_prim_drop();
+    WORD_ATOM(688, 9, "dup");
+    mw_prim_dup();
+    WORD_ATOM(688, 13, "token");
     mw_Match_2E_token();
-    WORD_ATOM(675, 19, "");
+    WORD_ATOM(688, 19, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38102,43 +38638,43 @@ static void mb_elab_match_exhaustive_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(675, 51, "emit-error!");
+    WORD_ATOM(688, 51, "emit-error!");
     mw_emit_error_21_();
     WORD_EXIT(mb_elab_match_exhaustive_21__1);
 }
 
 static void mb_elab_lambda_params_21__5 (void) {
-    WORD_ENTER(mb_elab_lambda_params_21__5, "elab-lambda-params! block", "src/mirth/elab.mth", 649, 13);
+    WORD_ENTER(mb_elab_lambda_params_21__5, "elab-lambda-params! block", "src/mirth/elab.mth", 662, 13);
     mw_prim_drop();
-    WORD_ATOM(649, 13, "dup");
+    WORD_ATOM(662, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(649, 17, "sig-type-var?");
+    WORD_ATOM(662, 17, "sig-type-var?");
     mw_Token_2E_sig_type_var_3F_();
-    WORD_ATOM(649, 31, "if");
+    WORD_ATOM(662, 31, "if");
     if (pop_u64()) {
-        WORD_ATOM(650, 17, "name?");
+        WORD_ATOM(663, 17, "name?");
         mw_Token_2E_name_3F_();
-        WORD_ATOM(650, 23, "unwrap");
+        WORD_ATOM(663, 23, "unwrap");
         mw_Maybe_2E_unwrap();
-        WORD_ATOM(650, 30, "Var.new!");
+        WORD_ATOM(663, 30, "Var.new!");
         mw_Var_2E_new_21_();
     } else {
-        WORD_ATOM(652, 17, "succ");
+        WORD_ATOM(665, 17, "succ");
         mw_Token_2E_succ();
-        WORD_ATOM(652, 22, "dip");
+        WORD_ATOM(665, 22, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(652, 26, "expand");
+            WORD_ATOM(665, 26, "expand");
             mw_Type_2E_expand();
-            WORD_ATOM(652, 33, "dup");
+            WORD_ATOM(665, 33, "dup");
             mw_prim_dup();
-            WORD_ATOM(652, 37, "morphism?");
+            WORD_ATOM(665, 37, "morphism?");
             mw_Type_2E_morphism_3F_();
             push_value(d3);
         }
-        WORD_ATOM(652, 48, "swap");
+        WORD_ATOM(665, 48, "swap");
         mw_prim_swap();
-        WORD_ATOM(652, 53, ".if");
+        WORD_ATOM(665, 53, ".if");
         push_u64(0);
         push_fnptr(&mb_elab_lambda_params_21__9);
         mw_prim_pack_cons();
@@ -38147,56 +38683,56 @@ static void mb_elab_lambda_params_21__5 (void) {
         mw_prim_pack_cons();
         mw_Maybe_2E_if();
     }
-    WORD_ATOM(658, 13, "dip");
+    WORD_ATOM(671, 13, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(658, 17, "dup");
+        WORD_ATOM(671, 17, "dup");
         mw_prim_dup();
-        WORD_ATOM(658, 21, "params");
+        WORD_ATOM(671, 21, "params");
         mw_Lambda_2E_params();
         push_value(d2);
     }
-    WORD_ATOM(658, 29, "sip");
+    WORD_ATOM(671, 29, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_lambda_params_21__12);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(659, 13, "dip");
+    WORD_ATOM(672, 13, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(659, 17, "dup");
+        WORD_ATOM(672, 17, "dup");
         mw_prim_dup();
-        WORD_ATOM(659, 21, "inner-ctx");
+        WORD_ATOM(672, 21, "inner-ctx");
         mw_Lambda_2E_inner_ctx();
         push_value(d2);
     }
-    WORD_ATOM(659, 32, "Ctx.new");
+    WORD_ATOM(672, 32, "Ctx.new");
     mw_Ctx_2E_new();
-    WORD_ATOM(659, 40, "over");
+    WORD_ATOM(672, 40, "over");
     mw_over();
-    WORD_ATOM(659, 45, "~inner-ctx");
+    WORD_ATOM(672, 45, "~inner-ctx");
     mw_Lambda_7E_inner_ctx();
-    WORD_ATOM(659, 56, "!");
+    WORD_ATOM(672, 56, "!");
     mw_prim_mut_set();
     WORD_EXIT(mb_elab_lambda_params_21__5);
 }
 
 static void mb_elab_lambda_params_21__9 (void) {
-    WORD_ENTER(mb_elab_lambda_params_21__9, "elab-lambda-params! block", "src/mirth/elab.mth", 653, 21);
+    WORD_ENTER(mb_elab_lambda_params_21__9, "elab-lambda-params! block", "src/mirth/elab.mth", 666, 21);
     mw_prim_drop();
-    WORD_ATOM(653, 21, "name?");
+    WORD_ATOM(666, 21, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(653, 27, "unwrap");
+    WORD_ATOM(666, 27, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(653, 34, "Var.new-auto-run!");
+    WORD_ATOM(666, 34, "Var.new-auto-run!");
     mw_Var_2E_new_auto_run_21_();
     WORD_EXIT(mb_elab_lambda_params_21__9);
 }
 
 static void mb_elab_lambda_params_21__10 (void) {
-    WORD_ENTER(mb_elab_lambda_params_21__10, "elab-lambda-params! block", "src/mirth/elab.mth", 655, 21);
+    WORD_ENTER(mb_elab_lambda_params_21__10, "elab-lambda-params! block", "src/mirth/elab.mth", 668, 21);
     mw_prim_drop();
-    WORD_ATOM(655, 21, "");
+    WORD_ATOM(668, 21, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38207,93 +38743,93 @@ static void mb_elab_lambda_params_21__10 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(655, 59, "emit-fatal-error!");
+    WORD_ATOM(668, 59, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_lambda_params_21__10);
 }
 
 static void mb_elab_lambda_params_21__12 (void) {
-    WORD_ENTER(mb_elab_lambda_params_21__12, "elab-lambda-params! block", "src/mirth/elab.mth", 658, 33);
+    WORD_ENTER(mb_elab_lambda_params_21__12, "elab-lambda-params! block", "src/mirth/elab.mth", 671, 33);
     mw_prim_drop();
-    WORD_ATOM(658, 33, "Var>Param");
+    WORD_ATOM(671, 33, "Var>Param");
     mw_Var_3E_Param();
-    WORD_ATOM(658, 43, "swap");
+    WORD_ATOM(671, 43, "swap");
     mw_prim_swap();
-    WORD_ATOM(658, 48, "cons");
+    WORD_ATOM(671, 48, "cons");
     mw_List_2E_cons();
-    WORD_ATOM(658, 53, "over");
+    WORD_ATOM(671, 53, "over");
     mw_over();
-    WORD_ATOM(658, 58, "~params");
+    WORD_ATOM(671, 58, "~params");
     mw_Lambda_7E_params();
-    WORD_ATOM(658, 66, "!");
+    WORD_ATOM(671, 66, "!");
     mw_prim_mut_set();
     WORD_EXIT(mb_elab_lambda_params_21__12);
 }
 
 static void mb_elab_lambda_pop_from_mid_21__2 (void) {
-    WORD_ENTER(mb_elab_lambda_pop_from_mid_21__2, "elab-lambda-pop-from-mid! block", "src/mirth/elab.mth", 627, 10);
+    WORD_ENTER(mb_elab_lambda_pop_from_mid_21__2, "elab-lambda-pop-from-mid! block", "src/mirth/elab.mth", 640, 10);
     mw_prim_drop();
-    WORD_ATOM(627, 10, "over");
+    WORD_ATOM(640, 10, "over");
     mw_over();
-    WORD_ATOM(627, 15, "~mid");
+    WORD_ATOM(640, 15, "~mid");
     mw_Lambda_7E_mid();
-    WORD_ATOM(627, 20, "!");
+    WORD_ATOM(640, 20, "!");
     mw_prim_mut_set();
     WORD_EXIT(mb_elab_lambda_pop_from_mid_21__2);
 }
 
 static void mb_token_is_lambda_param_3F__3 (void) {
-    WORD_ENTER(mb_token_is_lambda_param_3F__3, "token-is-lambda-param? block", "src/mirth/elab.mth", 633, 9);
+    WORD_ENTER(mb_token_is_lambda_param_3F__3, "token-is-lambda-param? block", "src/mirth/elab.mth", 646, 9);
     mw_prim_drop();
-    WORD_ATOM(633, 9, "dup");
+    WORD_ATOM(646, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(633, 13, "T");
+    WORD_ATOM(646, 13, "T");
     mw_T();
-    WORD_ATOM(634, 9, "dip");
+    WORD_ATOM(647, 9, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(634, 13, "succ");
+        WORD_ATOM(647, 13, "succ");
         mw_Token_2E_succ();
-        WORD_ATOM(634, 18, "dup");
+        WORD_ATOM(647, 18, "dup");
         mw_prim_dup();
-        WORD_ATOM(634, 22, "sig-type-var?");
+        WORD_ATOM(647, 22, "sig-type-var?");
         mw_Token_2E_sig_type_var_3F_();
         push_value(d2);
     }
-    WORD_ATOM(634, 37, "&&");
+    WORD_ATOM(647, 37, "&&");
     mw_Bool_26__26_();
-    WORD_ATOM(635, 9, "dip");
+    WORD_ATOM(648, 9, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(635, 13, "succ");
+        WORD_ATOM(648, 13, "succ");
         mw_Token_2E_succ();
-        WORD_ATOM(635, 18, "dup");
+        WORD_ATOM(648, 18, "dup");
         mw_prim_dup();
-        WORD_ATOM(635, 22, "rsquare?");
+        WORD_ATOM(648, 22, "rsquare?");
         mw_Token_2E_rsquare_3F_();
-        WORD_ATOM(635, 31, "some?");
+        WORD_ATOM(648, 31, "some?");
         mw_Maybe_2E_some_3F_();
         push_value(d2);
     }
-    WORD_ATOM(635, 38, "&&");
+    WORD_ATOM(648, 38, "&&");
     mw_Bool_26__26_();
-    WORD_ATOM(636, 9, "nip");
+    WORD_ATOM(649, 9, "nip");
     mw_nip();
     WORD_EXIT(mb_token_is_lambda_param_3F__3);
 }
 
 static void mb_token_is_lambda_param_3F__6 (void) {
-    WORD_ENTER(mb_token_is_lambda_param_3F__6, "token-is-lambda-param? block", "src/mirth/elab.mth", 637, 9);
+    WORD_ENTER(mb_token_is_lambda_param_3F__6, "token-is-lambda-param? block", "src/mirth/elab.mth", 650, 9);
     mw_prim_drop();
-    WORD_ATOM(637, 9, "F");
+    WORD_ATOM(650, 9, "F");
     mw_F();
     WORD_EXIT(mb_token_is_lambda_param_3F__6);
 }
 
 static void mb_expect_token_arrow_1 (void) {
-    WORD_ENTER(mb_expect_token_arrow_1, "expect-token-arrow block", "src/mirth/elab.mth", 861, 25);
+    WORD_ENTER(mb_expect_token_arrow_1, "expect-token-arrow block", "src/mirth/elab.mth", 874, 25);
     mw_prim_drop();
-    WORD_ATOM(861, 25, "");
+    WORD_ATOM(874, 25, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38304,105 +38840,105 @@ static void mb_expect_token_arrow_1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(861, 43, "emit-fatal-error!");
+    WORD_ATOM(874, 43, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_expect_token_arrow_1);
 }
 
 static void mb_elab_match_case_21__3 (void) {
-    WORD_ENTER(mb_elab_match_case_21__3, "elab-match-case! block", "src/mirth/elab.mth", 694, 21);
+    WORD_ENTER(mb_elab_match_case_21__3, "elab-match-case! block", "src/mirth/elab.mth", 707, 21);
     mw_prim_drop();
-    WORD_ATOM(694, 21, "succ");
+    WORD_ATOM(707, 21, "succ");
     mw_Token_2E_succ();
     WORD_EXIT(mb_elab_match_case_21__3);
 }
 
 static void mb_elab_case_pattern_21__6 (void) {
-    WORD_ENTER(mb_elab_case_pattern_21__6, "elab-case-pattern! block", "src/mirth/elab.mth", 710, 9);
+    WORD_ENTER(mb_elab_case_pattern_21__6, "elab-case-pattern! block", "src/mirth/elab.mth", 723, 9);
     mw_prim_drop();
-    WORD_ATOM(710, 9, ">Def");
+    WORD_ATOM(723, 9, ">Def");
     mw_Name_3E_Def();
-    WORD_ATOM(710, 14, "match");
+    WORD_ATOM(723, 14, "match");
     switch (get_top_data_tag()) {
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(714, 17, "dup");
+            WORD_ATOM(727, 17, "dup");
             mw_prim_dup();
-            WORD_ATOM(714, 21, "PATTERN_TAG");
+            WORD_ATOM(727, 21, "PATTERN_TAG");
             mw_PATTERN_5F_TAG();
-            WORD_ATOM(714, 33, "rotr");
+            WORD_ATOM(727, 33, "rotr");
             mw_rotr();
-            WORD_ATOM(715, 17, "dip2");
+            WORD_ATOM(728, 17, "dip2");
             push_u64(0);
             push_fnptr(&mb_elab_case_pattern_21__8);
             mw_prim_pack_cons();
             mw_dip2();
-            WORD_ATOM(718, 17, "dip2");
+            WORD_ATOM(731, 17, "dip2");
             push_u64(0);
             push_fnptr(&mb_elab_case_pattern_21__9);
             mw_prim_pack_cons();
             mw_dip2();
-            WORD_ATOM(719, 17, "type");
+            WORD_ATOM(732, 17, "type");
             mw_Tag_2E_type();
-            WORD_ATOM(719, 22, "Subst.nil");
+            WORD_ATOM(732, 22, "Subst.nil");
             mw_Subst_2E_nil();
-            WORD_ATOM(719, 32, "swap");
+            WORD_ATOM(732, 32, "swap");
             mw_prim_swap();
-            WORD_ATOM(719, 37, "freshen-sig");
+            WORD_ATOM(732, 37, "freshen-sig");
             mw_ArrowType_2E_freshen_sig();
-            WORD_ATOM(720, 17, "rotr");
+            WORD_ATOM(733, 17, "rotr");
             mw_rotr();
-            WORD_ATOM(720, 22, "dip");
+            WORD_ATOM(733, 22, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(721, 21, "dip");
+                WORD_ATOM(734, 21, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(721, 25, "unpack");
+                    WORD_ATOM(734, 25, "unpack");
                     mw_ArrowType_2E_unpack();
                     push_value(d5);
                 }
-                WORD_ATOM(722, 21, "dip2");
+                WORD_ATOM(735, 21, "dip2");
                 push_u64(0);
                 push_fnptr(&mb_elab_case_pattern_21__12);
                 mw_prim_pack_cons();
                 mw_dip2();
-                WORD_ATOM(722, 32, "elab-stack-type-unify!");
+                WORD_ATOM(735, 32, "elab-stack-type-unify!");
                 mw_elab_stack_type_unify_21_();
-                WORD_ATOM(722, 55, "nip");
+                WORD_ATOM(735, 55, "nip");
                 mw_nip();
-                WORD_ATOM(723, 21, "dip");
+                WORD_ATOM(736, 21, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(723, 25, "over");
+                    WORD_ATOM(736, 25, "over");
                     mw_over();
-                    WORD_ATOM(723, 30, "~mid");
+                    WORD_ATOM(736, 30, "~mid");
                     mw_Case_7E_mid();
-                    WORD_ATOM(723, 35, "!");
+                    WORD_ATOM(736, 35, "!");
                     mw_prim_mut_set();
                     push_value(d5);
                 }
                 push_value(d4);
             }
-            WORD_ATOM(725, 17, "swap");
+            WORD_ATOM(738, 17, "swap");
             mw_prim_swap();
-            WORD_ATOM(725, 22, "dip");
+            WORD_ATOM(738, 22, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(725, 26, "over");
+                WORD_ATOM(738, 26, "over");
                 mw_over();
-                WORD_ATOM(725, 31, "~subst");
+                WORD_ATOM(738, 31, "~subst");
                 mw_Case_7E_subst();
-                WORD_ATOM(725, 38, "!");
+                WORD_ATOM(738, 38, "!");
                 mw_prim_mut_set();
                 push_value(d4);
             }
-            WORD_ATOM(728, 17, "succ");
+            WORD_ATOM(741, 17, "succ");
             mw_Token_2E_succ();
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(731, 17, "");
+            WORD_ATOM(744, 17, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -38413,13 +38949,13 @@ static void mb_elab_case_pattern_21__6 (void) {
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(731, 40, "emit-fatal-error!");
+            WORD_ATOM(744, 40, "emit-fatal-error!");
             mw_emit_fatal_error_21_();
             break;
         default:
-            WORD_ATOM(734, 17, "drop");
+            WORD_ATOM(747, 17, "drop");
             mw_prim_drop();
-            WORD_ATOM(734, 22, "");
+            WORD_ATOM(747, 22, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -38430,7 +38966,7 @@ static void mb_elab_case_pattern_21__6 (void) {
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(734, 43, "emit-fatal-error!");
+            WORD_ATOM(747, 43, "emit-fatal-error!");
             mw_emit_fatal_error_21_();
             break;
     
@@ -38438,9 +38974,9 @@ static void mb_elab_case_pattern_21__6 (void) {
 }
 
 static void mb_elab_case_pattern_21__17 (void) {
-    WORD_ENTER(mb_elab_case_pattern_21__17, "elab-case-pattern! block", "src/mirth/elab.mth", 737, 9);
+    WORD_ENTER(mb_elab_case_pattern_21__17, "elab-case-pattern! block", "src/mirth/elab.mth", 750, 9);
     mw_prim_drop();
-    WORD_ATOM(737, 9, "");
+    WORD_ATOM(750, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38451,79 +38987,79 @@ static void mb_elab_case_pattern_21__17 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(737, 38, "emit-fatal-error!");
+    WORD_ATOM(750, 38, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_case_pattern_21__17);
 }
 
 static void mb_elab_case_pattern_21__8 (void) {
-    WORD_ENTER(mb_elab_case_pattern_21__8, "elab-case-pattern! block", "src/mirth/elab.mth", 715, 22);
+    WORD_ENTER(mb_elab_case_pattern_21__8, "elab-case-pattern! block", "src/mirth/elab.mth", 728, 22);
     mw_prim_drop();
-    WORD_ATOM(715, 22, "over");
+    WORD_ATOM(728, 22, "over");
     mw_over();
-    WORD_ATOM(715, 27, "~pattern");
+    WORD_ATOM(728, 27, "~pattern");
     mw_Case_7E_pattern();
-    WORD_ATOM(715, 36, "!");
+    WORD_ATOM(728, 36, "!");
     mw_prim_mut_set();
     WORD_EXIT(mb_elab_case_pattern_21__8);
 }
 
 static void mb_elab_case_pattern_21__9 (void) {
-    WORD_ENTER(mb_elab_case_pattern_21__9, "elab-case-pattern! block", "src/mirth/elab.mth", 718, 22);
+    WORD_ENTER(mb_elab_case_pattern_21__9, "elab-case-pattern! block", "src/mirth/elab.mth", 731, 22);
     mw_prim_drop();
-    WORD_ATOM(718, 22, "dup");
+    WORD_ATOM(731, 22, "dup");
     mw_prim_dup();
-    WORD_ATOM(718, 26, ".match");
+    WORD_ATOM(731, 26, ".match");
     mw_Case_2E_match();
-    WORD_ATOM(718, 33, "dom");
+    WORD_ATOM(731, 33, "dom");
     mw_Match_2E_dom();
     WORD_EXIT(mb_elab_case_pattern_21__9);
 }
 
 static void mb_elab_case_pattern_21__12 (void) {
-    WORD_ENTER(mb_elab_case_pattern_21__12, "elab-case-pattern! block", "src/mirth/elab.mth", 722, 26);
+    WORD_ENTER(mb_elab_case_pattern_21__12, "elab-case-pattern! block", "src/mirth/elab.mth", 735, 26);
     mw_prim_drop();
-    WORD_ATOM(722, 26, "swap");
+    WORD_ATOM(735, 26, "swap");
     mw_prim_swap();
     WORD_EXIT(mb_elab_case_pattern_21__12);
 }
 
 static void mb_elab_case_body_21__4 (void) {
-    WORD_ENTER(mb_elab_case_body_21__4, "elab-case-body! block", "src/mirth/elab.mth", 744, 10);
+    WORD_ENTER(mb_elab_case_body_21__4, "elab-case-body! block", "src/mirth/elab.mth", 757, 10);
     mw_prim_drop();
-    WORD_ATOM(744, 10, "over");
+    WORD_ATOM(757, 10, "over");
     mw_over();
-    WORD_ATOM(744, 15, "~body");
+    WORD_ATOM(757, 15, "~body");
     mw_Case_7E_body();
-    WORD_ATOM(744, 21, "!");
+    WORD_ATOM(757, 21, "!");
     mw_prim_mut_set();
     WORD_EXIT(mb_elab_case_body_21__4);
 }
 
 static void mb_elab_case_body_21__5 (void) {
-    WORD_ENTER(mb_elab_case_body_21__5, "elab-case-body! block", "src/mirth/elab.mth", 745, 10);
+    WORD_ENTER(mb_elab_case_body_21__5, "elab-case-body! block", "src/mirth/elab.mth", 758, 10);
     mw_prim_drop();
-    WORD_ATOM(745, 10, "dup");
+    WORD_ATOM(758, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(745, 14, ".match");
+    WORD_ATOM(758, 14, ".match");
     mw_Case_2E_match();
-    WORD_ATOM(745, 21, "cod");
+    WORD_ATOM(758, 21, "cod");
     mw_Match_2E_cod();
     WORD_EXIT(mb_elab_case_body_21__5);
 }
 
 static void mb_elab_module_header_21__2 (void) {
-    WORD_ENTER(mb_elab_module_header_21__2, "elab-module-header! block", "src/mirth/elab.mth", 762, 13);
+    WORD_ENTER(mb_elab_module_header_21__2, "elab-module-header! block", "src/mirth/elab.mth", 775, 13);
     mw_prim_drop();
-    WORD_ATOM(762, 13, "next");
+    WORD_ATOM(775, 13, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_module_header_21__2);
 }
 
 static void mb_elab_module_header_21__3 (void) {
-    WORD_ENTER(mb_elab_module_header_21__3, "elab-module-header! block", "src/mirth/elab.mth", 763, 29);
+    WORD_ENTER(mb_elab_module_header_21__3, "elab-module-header! block", "src/mirth/elab.mth", 776, 29);
     mw_prim_drop();
-    WORD_ATOM(763, 29, "");
+    WORD_ATOM(776, 29, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38534,17 +39070,17 @@ static void mb_elab_module_header_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(763, 53, "emit-fatal-error!");
+    WORD_ATOM(776, 53, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_module_header_21__3);
 }
 
 static void mb_elab_module_header_21__4 (void) {
-    WORD_ENTER(mb_elab_module_header_21__4, "elab-module-header! block", "src/mirth/elab.mth", 764, 28);
+    WORD_ENTER(mb_elab_module_header_21__4, "elab-module-header! block", "src/mirth/elab.mth", 777, 28);
     mw_prim_drop();
-    WORD_ATOM(764, 28, "drop");
+    WORD_ATOM(777, 28, "drop");
     mw_prim_drop();
-    WORD_ATOM(764, 33, "");
+    WORD_ATOM(777, 33, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38555,15 +39091,15 @@ static void mb_elab_module_header_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(764, 62, "emit-fatal-error!");
+    WORD_ATOM(777, 62, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_module_header_21__4);
 }
 
 static void mb_elab_module_decl_21__1 (void) {
-    WORD_ENTER(mb_elab_module_decl_21__1, "elab-module-decl! block", "src/mirth/elab.mth", 777, 21);
+    WORD_ENTER(mb_elab_module_decl_21__1, "elab-module-decl! block", "src/mirth/elab.mth", 790, 21);
     mw_prim_drop();
-    WORD_ATOM(777, 21, "");
+    WORD_ATOM(790, 21, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38574,15 +39110,15 @@ static void mb_elab_module_decl_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(777, 43, "emit-fatal-error!");
+    WORD_ATOM(790, 43, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_module_decl_21__1);
 }
 
 static void mb_elab_module_decl_21__2 (void) {
-    WORD_ENTER(mb_elab_module_decl_21__2, "elab-module-decl! block", "src/mirth/elab.mth", 778, 26);
+    WORD_ENTER(mb_elab_module_decl_21__2, "elab-module-decl! block", "src/mirth/elab.mth", 791, 26);
     mw_prim_drop();
-    WORD_ATOM(778, 26, "");
+    WORD_ATOM(791, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38593,15 +39129,15 @@ static void mb_elab_module_decl_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(778, 48, "emit-fatal-error!");
+    WORD_ATOM(791, 48, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_module_decl_21__2);
 }
 
 static void mb_elab_module_decl_21__3 (void) {
-    WORD_ENTER(mb_elab_module_decl_21__3, "elab-module-decl! block", "src/mirth/elab.mth", 779, 20);
+    WORD_ENTER(mb_elab_module_decl_21__3, "elab-module-decl! block", "src/mirth/elab.mth", 792, 20);
     mw_prim_drop();
-    WORD_ATOM(779, 20, "");
+    WORD_ATOM(792, 20, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38612,25 +39148,25 @@ static void mb_elab_module_decl_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(779, 42, "emit-fatal-error!");
+    WORD_ATOM(792, 42, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_module_decl_21__3);
 }
 
 static void mb_elab_data_header_21__1 (void) {
-    WORD_ENTER(mb_elab_data_header_21__1, "elab-data-header! block", "src/mirth/elab.mth", 821, 26);
+    WORD_ENTER(mb_elab_data_header_21__1, "elab-data-header! block", "src/mirth/elab.mth", 834, 26);
     mw_prim_drop();
-    WORD_ATOM(821, 26, "dup");
+    WORD_ATOM(834, 26, "dup");
     mw_prim_dup();
-    WORD_ATOM(821, 30, "sig-resource-con?");
+    WORD_ATOM(834, 30, "sig-resource-con?");
     mw_Token_2E_sig_resource_con_3F_();
     WORD_EXIT(mb_elab_data_header_21__1);
 }
 
 static void mb_elab_data_header_21__2 (void) {
-    WORD_ENTER(mb_elab_data_header_21__2, "elab-data-header! block", "src/mirth/elab.mth", 821, 54);
+    WORD_ENTER(mb_elab_data_header_21__2, "elab-data-header! block", "src/mirth/elab.mth", 834, 54);
     mw_prim_drop();
-    WORD_ATOM(821, 54, "");
+    WORD_ATOM(834, 54, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38641,17 +39177,17 @@ static void mb_elab_data_header_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(821, 76, "emit-fatal-error!");
+    WORD_ATOM(834, 76, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_data_header_21__2);
 }
 
 static void mb_elab_data_header_21__3 (void) {
-    WORD_ENTER(mb_elab_data_header_21__3, "elab-data-header! block", "src/mirth/elab.mth", 822, 44);
+    WORD_ENTER(mb_elab_data_header_21__3, "elab-data-header! block", "src/mirth/elab.mth", 835, 44);
     mw_prim_drop();
-    WORD_ATOM(822, 44, "drop2");
+    WORD_ATOM(835, 44, "drop2");
     mw_drop2();
-    WORD_ATOM(822, 50, "");
+    WORD_ATOM(835, 50, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38662,15 +39198,15 @@ static void mb_elab_data_header_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(822, 79, "emit-fatal-error!");
+    WORD_ATOM(835, 79, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_data_header_21__3);
 }
 
 static void mb_elab_data_tag_21__1 (void) {
-    WORD_ENTER(mb_elab_data_tag_21__1, "elab-data-tag! block", "src/mirth/elab.mth", 831, 25);
+    WORD_ENTER(mb_elab_data_tag_21__1, "elab-data-tag! block", "src/mirth/elab.mth", 844, 25);
     mw_prim_drop();
-    WORD_ATOM(831, 25, "");
+    WORD_ATOM(844, 25, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38681,17 +39217,17 @@ static void mb_elab_data_tag_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(831, 54, "emit-fatal-error!");
+    WORD_ATOM(844, 54, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_data_tag_21__1);
 }
 
 static void mb_elab_data_tag_21__2 (void) {
-    WORD_ENTER(mb_elab_data_tag_21__2, "elab-data-tag! block", "src/mirth/elab.mth", 832, 26);
+    WORD_ENTER(mb_elab_data_tag_21__2, "elab-data-tag! block", "src/mirth/elab.mth", 845, 26);
     mw_prim_drop();
-    WORD_ATOM(832, 26, "drop");
+    WORD_ATOM(845, 26, "drop");
     mw_prim_drop();
-    WORD_ATOM(832, 31, "");
+    WORD_ATOM(845, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38702,90 +39238,90 @@ static void mb_elab_data_tag_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(832, 67, "emit-fatal-error!");
+    WORD_ATOM(845, 67, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_data_tag_21__2);
 }
 
 static void mb_elab_data_tag_21__9 (void) {
-    WORD_ENTER(mb_elab_data_tag_21__9, "elab-data-tag! block", "src/mirth/elab.mth", 849, 9);
+    WORD_ENTER(mb_elab_data_tag_21__9, "elab-data-tag! block", "src/mirth/elab.mth", 862, 9);
     mw_prim_drop();
-    WORD_ATOM(849, 9, "type-elab-default");
+    WORD_ATOM(862, 9, "type-elab-default");
     mw_type_elab_default();
-    WORD_ATOM(850, 9, "over");
+    WORD_ATOM(863, 9, "over");
     mw_over();
-    WORD_ATOM(850, 14, ".data");
+    WORD_ATOM(863, 14, ".data");
     mw_Tag_2E_data();
-    WORD_ATOM(850, 20, "head?");
+    WORD_ATOM(863, 20, "head?");
     mw_Data_2E_head_3F_();
-    WORD_ATOM(850, 26, "unwrap");
+    WORD_ATOM(863, 26, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(850, 33, "elab-type-atom!");
+    WORD_ATOM(863, 33, "elab-type-atom!");
     mw_elab_type_atom_21_();
-    WORD_ATOM(850, 49, "drop");
+    WORD_ATOM(863, 49, "drop");
     mw_prim_drop();
-    WORD_ATOM(850, 54, "dip");
+    WORD_ATOM(863, 54, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(850, 58, "T0");
+        WORD_ATOM(863, 58, "T0");
         mw_T0();
         push_value(d2);
     }
-    WORD_ATOM(850, 62, "T*+");
+    WORD_ATOM(863, 62, "T*+");
     mw_T_2A__2B_();
-    WORD_ATOM(851, 9, "dip");
+    WORD_ATOM(864, 9, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(851, 13, "T0");
+        WORD_ATOM(864, 13, "T0");
         mw_T0();
-        WORD_ATOM(851, 16, "rotl");
+        WORD_ATOM(864, 16, "rotl");
         mw_rotl();
-        WORD_ATOM(851, 21, "sig?");
+        WORD_ATOM(864, 21, "sig?");
         mw_Tag_2E_sig_3F_();
-        WORD_ATOM(851, 26, "for");
+        WORD_ATOM(864, 26, "for");
         push_u64(0);
         push_fnptr(&mb_elab_data_tag_21__12);
         mw_prim_pack_cons();
         mw_Maybe_2E_for();
         push_value(d2);
     }
-    WORD_ATOM(855, 9, "T->");
+    WORD_ATOM(868, 9, "T->");
     mw_T__3E_();
-    WORD_ATOM(855, 13, "dip");
+    WORD_ATOM(868, 13, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(855, 17, "type-elab-ctx");
+        WORD_ATOM(868, 17, "type-elab-ctx");
         mw_type_elab_ctx();
         push_value(d2);
     }
-    WORD_ATOM(855, 32, "pack2");
+    WORD_ATOM(868, 32, "pack2");
     mw_pack2();
     WORD_EXIT(mb_elab_data_tag_21__9);
 }
 
 static void mb_elab_data_tag_21__12 (void) {
-    WORD_ENTER(mb_elab_data_tag_21__12, "elab-data-tag! block", "src/mirth/elab.mth", 852, 13);
+    WORD_ENTER(mb_elab_data_tag_21__12, "elab-data-tag! block", "src/mirth/elab.mth", 865, 13);
     mw_prim_drop();
-    WORD_ATOM(852, 13, "elab-type-stack-rest!");
+    WORD_ATOM(865, 13, "elab-type-stack-rest!");
     mw_elab_type_stack_rest_21_();
-    WORD_ATOM(853, 13, "dup");
+    WORD_ATOM(866, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(853, 17, "run-end?");
+    WORD_ATOM(866, 17, "run-end?");
     mw_Token_2E_run_end_3F_();
-    WORD_ATOM(853, 26, "else");
+    WORD_ATOM(866, 26, "else");
     push_u64(0);
     push_fnptr(&mb_elab_data_tag_21__13);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(853, 65, "drop");
+    WORD_ATOM(866, 65, "drop");
     mw_prim_drop();
     WORD_EXIT(mb_elab_data_tag_21__12);
 }
 
 static void mb_elab_data_tag_21__13 (void) {
-    WORD_ENTER(mb_elab_data_tag_21__13, "elab-data-tag! block", "src/mirth/elab.mth", 853, 31);
+    WORD_ENTER(mb_elab_data_tag_21__13, "elab-data-tag! block", "src/mirth/elab.mth", 866, 31);
     mw_prim_drop();
-    WORD_ATOM(853, 31, "");
+    WORD_ATOM(866, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38796,42 +39332,42 @@ static void mb_elab_data_tag_21__13 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(853, 46, "emit-fatal-error!");
+    WORD_ATOM(866, 46, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_data_tag_21__13);
 }
 
 static void mb_elab_data_tag_21__15 (void) {
-    WORD_ENTER(mb_elab_data_tag_21__15, "elab-data-tag! block", "src/mirth/elab.mth", 858, 9);
+    WORD_ENTER(mb_elab_data_tag_21__15, "elab-data-tag! block", "src/mirth/elab.mth", 871, 9);
     mw_prim_drop();
-    WORD_ATOM(858, 9, "num-inputs-from-sig");
+    WORD_ATOM(871, 9, "num-inputs-from-sig");
     mw_Tag_2E_num_inputs_from_sig();
     WORD_EXIT(mb_elab_data_tag_21__15);
 }
 
 static void mb_token_def_args_3 (void) {
-    WORD_ENTER(mb_token_def_args_3, "token-def-args block", "src/mirth/elab.mth", 873, 9);
+    WORD_ENTER(mb_token_def_args_3, "token-def-args block", "src/mirth/elab.mth", 886, 9);
     mw_prim_drop();
-    WORD_ATOM(873, 9, "over");
+    WORD_ATOM(886, 9, "over");
     mw_over();
-    WORD_ATOM(873, 14, "run-has-arrow?");
+    WORD_ATOM(886, 14, "run-has-arrow?");
     mw_Token_2E_run_has_arrow_3F_();
-    WORD_ATOM(873, 29, "if");
+    WORD_ATOM(886, 29, "if");
     if (pop_u64()) {
-        WORD_ATOM(874, 13, "cons+");
+        WORD_ATOM(887, 13, "cons+");
         mw_List_2B__2E_cons_2B_();
-        WORD_ATOM(874, 19, "dip");
+        WORD_ATOM(887, 19, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(874, 23, "NONE");
+            WORD_ATOM(887, 23, "NONE");
             mw_NONE();
             push_value(d3);
         }
     } else {
-        WORD_ATOM(875, 13, "dip");
+        WORD_ATOM(888, 13, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(875, 17, "SOME");
+            WORD_ATOM(888, 17, "SOME");
             mw_SOME();
             push_value(d3);
         }
@@ -38840,14 +39376,14 @@ static void mb_token_def_args_3 (void) {
 }
 
 static void mb_token_def_args_8 (void) {
-    WORD_ENTER(mb_token_def_args_8, "token-def-args block", "src/mirth/elab.mth", 877, 9);
+    WORD_ENTER(mb_token_def_args_8, "token-def-args block", "src/mirth/elab.mth", 890, 9);
     mw_prim_drop();
-    WORD_ATOM(877, 9, "L1+");
+    WORD_ATOM(890, 9, "L1+");
     mw_L1_2B_();
-    WORD_ATOM(877, 13, "dip");
+    WORD_ATOM(890, 13, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(877, 17, "NONE");
+        WORD_ATOM(890, 17, "NONE");
         mw_NONE();
         push_value(d2);
     }
@@ -38855,31 +39391,31 @@ static void mb_token_def_args_8 (void) {
 }
 
 static void mb_elab_def_params_21__2 (void) {
-    WORD_ENTER(mb_elab_def_params_21__2, "elab-def-params! block", "src/mirth/elab.mth", 929, 9);
+    WORD_ENTER(mb_elab_def_params_21__2, "elab-def-params! block", "src/mirth/elab.mth", 942, 9);
     mw_prim_drop();
-    WORD_ATOM(929, 9, "dup");
+    WORD_ATOM(942, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(929, 13, "sig-param-name?");
+    WORD_ATOM(942, 13, "sig-param-name?");
     mw_Token_2E_sig_param_name_3F_();
-    WORD_ATOM(929, 29, "else");
+    WORD_ATOM(942, 29, "else");
     push_u64(0);
     push_fnptr(&mb_elab_def_params_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(930, 9, "dup");
+    WORD_ATOM(943, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(930, 13, "succ");
+    WORD_ATOM(943, 13, "succ");
     mw_Token_2E_succ();
-    WORD_ATOM(930, 18, "dup");
+    WORD_ATOM(943, 18, "dup");
     mw_prim_dup();
-    WORD_ATOM(930, 22, "run-end?");
+    WORD_ATOM(943, 22, "run-end?");
     mw_Token_2E_run_end_3F_();
-    WORD_ATOM(930, 31, "if");
+    WORD_ATOM(943, 31, "if");
     if (pop_u64()) {
-        WORD_ATOM(930, 34, "drop");
+        WORD_ATOM(943, 34, "drop");
         mw_prim_drop();
     } else {
-        WORD_ATOM(930, 40, "");
+        WORD_ATOM(943, 40, "");
         {
             static bool vready = false;
             static VAL v;
@@ -38890,34 +39426,34 @@ static void mb_elab_def_params_21__2 (void) {
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(930, 72, "emit-fatal-error!");
+        WORD_ATOM(943, 72, "emit-fatal-error!");
         mw_emit_fatal_error_21_();
     }
-    WORD_ATOM(931, 9, "elab-expand-tensor!");
+    WORD_ATOM(944, 9, "elab-expand-tensor!");
     mw_elab_expand_tensor_21_();
-    WORD_ATOM(932, 9, "over");
+    WORD_ATOM(945, 9, "over");
     mw_over();
-    WORD_ATOM(932, 14, "morphism?");
+    WORD_ATOM(945, 14, "morphism?");
     mw_Type_2E_morphism_3F_();
-    WORD_ATOM(932, 24, "else");
+    WORD_ATOM(945, 24, "else");
     push_u64(0);
     push_fnptr(&mb_elab_def_params_21__6);
     mw_prim_pack_cons();
     mw_Maybe_2E_else();
-    WORD_ATOM(934, 9, "name?");
+    WORD_ATOM(947, 9, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(934, 15, "unwrap");
+    WORD_ATOM(947, 15, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(934, 22, "Var.new-auto-run!");
+    WORD_ATOM(947, 22, "Var.new-auto-run!");
     mw_Var_2E_new_auto_run_21_();
-    WORD_ATOM(935, 9, "PARAM");
+    WORD_ATOM(948, 9, "PARAM");
     mw_PARAM();
-    WORD_ATOM(935, 15, "rotr");
+    WORD_ATOM(948, 15, "rotr");
     mw_rotr();
-    WORD_ATOM(935, 20, "dip");
+    WORD_ATOM(948, 20, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(935, 24, "cons");
+        WORD_ATOM(948, 24, "cons");
         mw_List_2E_cons();
         push_value(d2);
     }
@@ -38925,9 +39461,9 @@ static void mb_elab_def_params_21__2 (void) {
 }
 
 static void mb_elab_def_params_21__3 (void) {
-    WORD_ENTER(mb_elab_def_params_21__3, "elab-def-params! block", "src/mirth/elab.mth", 929, 34);
+    WORD_ENTER(mb_elab_def_params_21__3, "elab-def-params! block", "src/mirth/elab.mth", 942, 34);
     mw_prim_drop();
-    WORD_ATOM(929, 34, "");
+    WORD_ATOM(942, 34, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38938,15 +39474,15 @@ static void mb_elab_def_params_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(929, 60, "emit-fatal-error!");
+    WORD_ATOM(942, 60, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_params_21__3);
 }
 
 static void mb_elab_def_params_21__6 (void) {
-    WORD_ENTER(mb_elab_def_params_21__6, "elab-def-params! block", "src/mirth/elab.mth", 933, 13);
+    WORD_ENTER(mb_elab_def_params_21__6, "elab-def-params! block", "src/mirth/elab.mth", 946, 13);
     mw_prim_drop();
-    WORD_ATOM(933, 13, "");
+    WORD_ATOM(946, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38957,171 +39493,171 @@ static void mb_elab_def_params_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(933, 44, "emit-fatal-error!");
+    WORD_ATOM(946, 44, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_params_21__6);
 }
 
 static void mb_table_new_21__1 (void) {
-    WORD_ENTER(mb_table_new_21__1, "table-new! block", "src/mirth/elab.mth", 1040, 9);
+    WORD_ENTER(mb_table_new_21__1, "table-new! block", "src/mirth/elab.mth", 1053, 9);
     mw_prim_drop();
-    WORD_ATOM(1040, 9, "dup");
+    WORD_ATOM(1053, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1040, 13, "head");
+    WORD_ATOM(1053, 13, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1040, 18, "ab-token");
+    WORD_ATOM(1053, 18, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1040, 27, "!");
+    WORD_ATOM(1053, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1041, 9, "TABLE_MAX_SIZE");
+    WORD_ATOM(1054, 9, "TABLE_MAX_SIZE");
     mw_TABLE_5F_MAX_5F_SIZE();
-    WORD_ATOM(1041, 24, "ab-int!");
+    WORD_ATOM(1054, 24, "ab-int!");
     mw_ab_int_21_();
     WORD_EXIT(mb_table_new_21__1);
 }
 
 static void mb_table_new_21__2 (void) {
-    WORD_ENTER(mb_table_new_21__2, "table-new! block", "src/mirth/elab.mth", 1052, 9);
+    WORD_ENTER(mb_table_new_21__2, "table-new! block", "src/mirth/elab.mth", 1065, 9);
     mw_prim_drop();
-    WORD_ATOM(1052, 9, "dup");
+    WORD_ATOM(1065, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1052, 13, "head");
+    WORD_ATOM(1065, 13, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1052, 18, "ab-token");
+    WORD_ATOM(1065, 18, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1052, 27, "!");
+    WORD_ATOM(1065, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1053, 9, "");
+    WORD_ATOM(1066, 9, "");
     push_i64(0LL);
-    WORD_ATOM(1053, 11, "ab-int!");
+    WORD_ATOM(1066, 11, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1054, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1067, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1054, 26, "ab-prim!");
+    WORD_ATOM(1067, 26, "ab-prim!");
     mw_ab_prim_21_();
     WORD_EXIT(mb_table_new_21__2);
 }
 
 static void mb_table_new_21__3 (void) {
-    WORD_ENTER(mb_table_new_21__3, "table-new! block", "src/mirth/elab.mth", 1071, 9);
+    WORD_ENTER(mb_table_new_21__3, "table-new! block", "src/mirth/elab.mth", 1084, 9);
     mw_prim_drop();
-    WORD_ATOM(1071, 9, "dup");
+    WORD_ATOM(1084, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1071, 13, "head");
+    WORD_ATOM(1084, 13, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1071, 18, "ab-token");
+    WORD_ATOM(1084, 18, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1071, 27, "!");
+    WORD_ATOM(1084, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1072, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1085, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1072, 26, "ab-prim!");
+    WORD_ATOM(1085, 26, "ab-prim!");
     mw_ab_prim_21_();
     WORD_EXIT(mb_table_new_21__3);
 }
 
 static void mb_table_new_21__4 (void) {
-    WORD_ENTER(mb_table_new_21__4, "table-new! block", "src/mirth/elab.mth", 1083, 9);
+    WORD_ENTER(mb_table_new_21__4, "table-new! block", "src/mirth/elab.mth", 1096, 9);
     mw_prim_drop();
-    WORD_ATOM(1083, 9, "dup");
+    WORD_ATOM(1096, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1083, 13, "head");
+    WORD_ATOM(1096, 13, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1083, 18, "ab-token");
+    WORD_ATOM(1096, 18, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1083, 27, "!");
+    WORD_ATOM(1096, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1084, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1097, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1084, 26, "ab-prim!");
+    WORD_ATOM(1097, 26, "ab-prim!");
     mw_ab_prim_21_();
     WORD_EXIT(mb_table_new_21__4);
 }
 
 static void mb_table_new_21__5 (void) {
-    WORD_ENTER(mb_table_new_21__5, "table-new! block", "src/mirth/elab.mth", 1095, 9);
+    WORD_ENTER(mb_table_new_21__5, "table-new! block", "src/mirth/elab.mth", 1108, 9);
     mw_prim_drop();
-    WORD_ATOM(1095, 9, "dup");
+    WORD_ATOM(1108, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1095, 13, "head");
+    WORD_ATOM(1108, 13, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1095, 18, "ab-token");
+    WORD_ATOM(1108, 18, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1095, 27, "!");
+    WORD_ATOM(1108, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1096, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1109, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1096, 26, "ab-prim!");
+    WORD_ATOM(1109, 26, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1097, 9, "");
+    WORD_ATOM(1110, 9, "");
     push_i64(1LL);
-    WORD_ATOM(1097, 11, "ab-int!");
+    WORD_ATOM(1110, 11, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1098, 9, "PRIM_INT_ADD");
+    WORD_ATOM(1111, 9, "PRIM_INT_ADD");
     mw_PRIM_5F_INT_5F_ADD();
-    WORD_ATOM(1098, 22, "ab-prim!");
+    WORD_ATOM(1111, 22, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1099, 9, "dup");
+    WORD_ATOM(1112, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1099, 13, "num-buffer");
+    WORD_ATOM(1112, 13, "num-buffer");
     mw_Table_2E_num_buffer();
-    WORD_ATOM(1099, 24, "ab-buffer!");
+    WORD_ATOM(1112, 24, "ab-buffer!");
     mw_ab_buffer_21_();
-    WORD_ATOM(1100, 9, "PRIM_U64_GET");
+    WORD_ATOM(1113, 9, "PRIM_U64_GET");
     mw_PRIM_5F_U64_5F_GET();
-    WORD_ATOM(1100, 22, "ab-prim!");
+    WORD_ATOM(1113, 22, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1101, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1114, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1101, 26, "ab-prim!");
+    WORD_ATOM(1114, 26, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1102, 9, "");
+    WORD_ATOM(1115, 9, "");
     push_i64(1LL);
-    WORD_ATOM(1102, 11, "ab-int!");
+    WORD_ATOM(1115, 11, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1103, 9, "PRIM_INT_ADD");
+    WORD_ATOM(1116, 9, "PRIM_INT_ADD");
     mw_PRIM_5F_INT_5F_ADD();
-    WORD_ATOM(1103, 22, "ab-prim!");
+    WORD_ATOM(1116, 22, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1104, 9, "PRIM_INT_MOD");
+    WORD_ATOM(1117, 9, "PRIM_INT_MOD");
     mw_PRIM_5F_INT_5F_MOD();
-    WORD_ATOM(1104, 22, "ab-prim!");
+    WORD_ATOM(1117, 22, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1105, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1118, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1105, 26, "ab-prim!");
+    WORD_ATOM(1118, 26, "ab-prim!");
     mw_ab_prim_21_();
     WORD_EXIT(mb_table_new_21__5);
 }
 
 static void mb_table_new_21__6 (void) {
-    WORD_ENTER(mb_table_new_21__6, "table-new! block", "src/mirth/elab.mth", 1116, 9);
+    WORD_ENTER(mb_table_new_21__6, "table-new! block", "src/mirth/elab.mth", 1129, 9);
     mw_prim_drop();
-    WORD_ATOM(1116, 9, "dup");
+    WORD_ATOM(1129, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1116, 13, "head");
+    WORD_ATOM(1129, 13, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1116, 18, "ab-token");
+    WORD_ATOM(1129, 18, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1116, 27, "!");
+    WORD_ATOM(1129, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1117, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1130, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1117, 26, "ab-prim!");
+    WORD_ATOM(1130, 26, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1118, 9, "PRIM_CORE_DUP");
+    WORD_ATOM(1131, 9, "PRIM_CORE_DUP");
     mw_PRIM_5F_CORE_5F_DUP();
-    WORD_ATOM(1118, 23, "ab-prim!");
+    WORD_ATOM(1131, 23, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1119, 9, "");
+    WORD_ATOM(1132, 9, "");
     push_i64(0LL);
-    WORD_ATOM(1119, 11, "ab-int!");
+    WORD_ATOM(1132, 11, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1120, 9, "PRIM_INT_EQ");
+    WORD_ATOM(1133, 9, "PRIM_INT_EQ");
     mw_PRIM_5F_INT_5F_EQ();
-    WORD_ATOM(1120, 21, "ab-prim!");
+    WORD_ATOM(1133, 21, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1121, 9, "ab-if!");
+    WORD_ATOM(1134, 9, "ab-if!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__7);
     mw_prim_pack_cons();
@@ -39129,37 +39665,37 @@ static void mb_table_new_21__6 (void) {
     push_fnptr(&mb_table_new_21__8);
     mw_prim_pack_cons();
     mw_ab_if_21_();
-    WORD_ATOM(1126, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1139, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1126, 26, "ab-prim!");
+    WORD_ATOM(1139, 26, "ab-prim!");
     mw_ab_prim_21_();
     WORD_EXIT(mb_table_new_21__6);
 }
 
 static void mb_table_new_21__7 (void) {
-    WORD_ENTER(mb_table_new_21__7, "table-new! block", "src/mirth/elab.mth", 1122, 13);
+    WORD_ENTER(mb_table_new_21__7, "table-new! block", "src/mirth/elab.mth", 1135, 13);
     mw_prim_drop();
-    WORD_ATOM(1122, 13, "id");
+    WORD_ATOM(1135, 13, "id");
     mw_prim_id();
     WORD_EXIT(mb_table_new_21__7);
 }
 
 static void mb_table_new_21__8 (void) {
-    WORD_ENTER(mb_table_new_21__8, "table-new! block", "src/mirth/elab.mth", 1123, 13);
+    WORD_ENTER(mb_table_new_21__8, "table-new! block", "src/mirth/elab.mth", 1136, 13);
     mw_prim_drop();
-    WORD_ATOM(1123, 13, "");
+    WORD_ATOM(1136, 13, "");
     push_i64(1LL);
-    WORD_ATOM(1123, 15, "ab-int!");
+    WORD_ATOM(1136, 15, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1124, 13, "PRIM_INT_SUB");
+    WORD_ATOM(1137, 13, "PRIM_INT_SUB");
     mw_PRIM_5F_INT_5F_SUB();
-    WORD_ATOM(1124, 26, "ab-prim!");
+    WORD_ATOM(1137, 26, "ab-prim!");
     mw_ab_prim_21_();
     WORD_EXIT(mb_table_new_21__8);
 }
 
 static void mb_table_new_21__11 (void) {
-    WORD_ENTER(mb_table_new_21__11, "table-new! block", "src/mirth/elab.mth", 1140, 13);
+    WORD_ENTER(mb_table_new_21__11, "table-new! block", "src/mirth/elab.mth", 1153, 13);
     mw_prim_pack_uncons();
     VAL var_x = pop_value();
     mw_prim_pack_uncons();
@@ -39171,23 +39707,23 @@ static void mb_table_new_21__11 (void) {
     mw_prim_pack_uncons();
     VAL var_a = pop_value();
     mw_prim_drop();
-    WORD_ATOM(1140, 13, "t");
+    WORD_ATOM(1153, 13, "t");
     incref(var_t);
     push_value(var_t);
-    WORD_ATOM(1140, 15, "head");
+    WORD_ATOM(1153, 15, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1140, 20, "ab-token");
+    WORD_ATOM(1153, 20, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1140, 29, "!");
+    WORD_ATOM(1153, 29, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1141, 13, "x");
+    WORD_ATOM(1154, 13, "x");
     incref(var_x);
     push_value(var_x);
-    WORD_ATOM(1141, 15, "Var>Param");
+    WORD_ATOM(1154, 15, "Var>Param");
     mw_Var_3E_Param();
-    WORD_ATOM(1141, 25, "L1");
+    WORD_ATOM(1154, 25, "L1");
     mw_L1();
-    WORD_ATOM(1141, 28, "ab-lambda!");
+    WORD_ATOM(1154, 28, "ab-lambda!");
     push_u64(0);
     incref(var_a);
     push_value(var_a);
@@ -39216,7 +39752,7 @@ static void mb_table_new_21__11 (void) {
 }
 
 static void mb_table_new_21__12 (void) {
-    WORD_ENTER(mb_table_new_21__12, "table-new! block", "src/mirth/elab.mth", 1142, 17);
+    WORD_ENTER(mb_table_new_21__12, "table-new! block", "src/mirth/elab.mth", 1155, 17);
     mw_prim_pack_uncons();
     VAL var_x = pop_value();
     mw_prim_pack_uncons();
@@ -39228,11 +39764,11 @@ static void mb_table_new_21__12 (void) {
     mw_prim_pack_uncons();
     VAL var_a = pop_value();
     mw_prim_drop();
-    WORD_ATOM(1142, 17, "");
+    WORD_ATOM(1155, 17, "");
     push_i64(1LL);
-    WORD_ATOM(1142, 19, "ab-int!");
+    WORD_ATOM(1155, 19, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1143, 17, "ab-while!");
+    WORD_ATOM(1156, 17, "ab-while!");
     push_u64(0);
     incref(var_a);
     push_value(var_a);
@@ -39270,9 +39806,9 @@ static void mb_table_new_21__12 (void) {
     push_fnptr(&mb_table_new_21__14);
     mw_prim_pack_cons();
     mw_ab_while_21_();
-    WORD_ATOM(1160, 17, "PRIM_CORE_DROP");
+    WORD_ATOM(1173, 17, "PRIM_CORE_DROP");
     mw_PRIM_5F_CORE_5F_DROP();
-    WORD_ATOM(1160, 32, "ab-prim!");
+    WORD_ATOM(1173, 32, "ab-prim!");
     mw_ab_prim_21_();
     decref(var_x);
     decref(var_t);
@@ -39283,7 +39819,7 @@ static void mb_table_new_21__12 (void) {
 }
 
 static void mb_table_new_21__13 (void) {
-    WORD_ENTER(mb_table_new_21__13, "table-new! block", "src/mirth/elab.mth", 1144, 21);
+    WORD_ENTER(mb_table_new_21__13, "table-new! block", "src/mirth/elab.mth", 1157, 21);
     mw_prim_pack_uncons();
     VAL var_x = pop_value();
     mw_prim_pack_uncons();
@@ -39295,36 +39831,36 @@ static void mb_table_new_21__13 (void) {
     mw_prim_pack_uncons();
     VAL var_a = pop_value();
     mw_prim_drop();
-    WORD_ATOM(1144, 21, "PRIM_CORE_DUP");
+    WORD_ATOM(1157, 21, "PRIM_CORE_DUP");
     mw_PRIM_5F_CORE_5F_DUP();
-    WORD_ATOM(1144, 35, "ab-prim!");
+    WORD_ATOM(1157, 35, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1145, 21, "t");
+    WORD_ATOM(1158, 21, "t");
     incref(var_t);
     push_value(var_t);
-    WORD_ATOM(1145, 23, "num-buffer");
+    WORD_ATOM(1158, 23, "num-buffer");
     mw_Table_2E_num_buffer();
-    WORD_ATOM(1145, 34, "ab-buffer!");
+    WORD_ATOM(1158, 34, "ab-buffer!");
     mw_ab_buffer_21_();
-    WORD_ATOM(1146, 21, "PRIM_U64_GET");
+    WORD_ATOM(1159, 21, "PRIM_U64_GET");
     mw_PRIM_5F_U64_5F_GET();
-    WORD_ATOM(1146, 34, "ab-prim!");
+    WORD_ATOM(1159, 34, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1147, 21, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1160, 21, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1147, 38, "ab-prim!");
+    WORD_ATOM(1160, 38, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1148, 21, "");
+    WORD_ATOM(1161, 21, "");
     push_i64(1LL);
-    WORD_ATOM(1148, 23, "ab-int!");
+    WORD_ATOM(1161, 23, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1149, 21, "PRIM_INT_ADD");
+    WORD_ATOM(1162, 21, "PRIM_INT_ADD");
     mw_PRIM_5F_INT_5F_ADD();
-    WORD_ATOM(1149, 34, "ab-prim!");
+    WORD_ATOM(1162, 34, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1150, 21, "PRIM_INT_LT");
+    WORD_ATOM(1163, 21, "PRIM_INT_LT");
     mw_PRIM_5F_INT_5F_LT();
-    WORD_ATOM(1150, 33, "ab-prim!");
+    WORD_ATOM(1163, 33, "ab-prim!");
     mw_ab_prim_21_();
     decref(var_x);
     decref(var_t);
@@ -39335,7 +39871,7 @@ static void mb_table_new_21__13 (void) {
 }
 
 static void mb_table_new_21__14 (void) {
-    WORD_ENTER(mb_table_new_21__14, "table-new! block", "src/mirth/elab.mth", 1152, 21);
+    WORD_ENTER(mb_table_new_21__14, "table-new! block", "src/mirth/elab.mth", 1165, 21);
     mw_prim_pack_uncons();
     VAL var_x = pop_value();
     mw_prim_pack_uncons();
@@ -39347,11 +39883,11 @@ static void mb_table_new_21__14 (void) {
     mw_prim_pack_uncons();
     VAL var_a = pop_value();
     mw_prim_drop();
-    WORD_ATOM(1152, 21, "PRIM_CORE_DUP");
+    WORD_ATOM(1165, 21, "PRIM_CORE_DUP");
     mw_PRIM_5F_CORE_5F_DUP();
-    WORD_ATOM(1152, 35, "ab-prim!");
+    WORD_ATOM(1165, 35, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1153, 21, "ab-dip!");
+    WORD_ATOM(1166, 21, "ab-dip!");
     push_u64(0);
     incref(var_a);
     push_value(var_a);
@@ -39371,13 +39907,13 @@ static void mb_table_new_21__14 (void) {
     push_fnptr(&mb_table_new_21__15);
     mw_prim_pack_cons();
     mw_ab_dip_21_();
-    WORD_ATOM(1157, 21, "");
+    WORD_ATOM(1170, 21, "");
     push_i64(1LL);
-    WORD_ATOM(1157, 23, "ab-int!");
+    WORD_ATOM(1170, 23, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1158, 21, "PRIM_INT_ADD");
+    WORD_ATOM(1171, 21, "PRIM_INT_ADD");
     mw_PRIM_5F_INT_5F_ADD();
-    WORD_ATOM(1158, 34, "ab-prim!");
+    WORD_ATOM(1171, 34, "ab-prim!");
     mw_ab_prim_21_();
     decref(var_x);
     decref(var_t);
@@ -39388,7 +39924,7 @@ static void mb_table_new_21__14 (void) {
 }
 
 static void mb_table_new_21__15 (void) {
-    WORD_ENTER(mb_table_new_21__15, "table-new! block", "src/mirth/elab.mth", 1154, 25);
+    WORD_ENTER(mb_table_new_21__15, "table-new! block", "src/mirth/elab.mth", 1167, 25);
     mw_prim_pack_uncons();
     VAL var_x = pop_value();
     mw_prim_pack_uncons();
@@ -39400,14 +39936,14 @@ static void mb_table_new_21__15 (void) {
     mw_prim_pack_uncons();
     VAL var_a = pop_value();
     mw_prim_drop();
-    WORD_ATOM(1154, 25, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1167, 25, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1154, 42, "ab-prim!");
+    WORD_ATOM(1167, 42, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1155, 25, "x");
+    WORD_ATOM(1168, 25, "x");
     incref(var_x);
     push_value(var_x);
-    WORD_ATOM(1155, 27, "ab-var!");
+    WORD_ATOM(1168, 27, "ab-var!");
     mw_ab_var_21_();
     decref(var_x);
     decref(var_t);
@@ -39418,75 +39954,75 @@ static void mb_table_new_21__15 (void) {
 }
 
 static void mb_table_new_21__16 (void) {
-    WORD_ENTER(mb_table_new_21__16, "table-new! block", "src/mirth/elab.mth", 1174, 9);
+    WORD_ENTER(mb_table_new_21__16, "table-new! block", "src/mirth/elab.mth", 1187, 9);
     mw_prim_drop();
-    WORD_ATOM(1174, 9, "dup");
+    WORD_ATOM(1187, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1174, 13, "head");
+    WORD_ATOM(1187, 13, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1174, 18, "ab-token");
+    WORD_ATOM(1187, 18, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1174, 27, "!");
+    WORD_ATOM(1187, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1175, 9, "dup");
+    WORD_ATOM(1188, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1175, 13, "num-buffer");
+    WORD_ATOM(1188, 13, "num-buffer");
     mw_Table_2E_num_buffer();
-    WORD_ATOM(1175, 24, "ab-buffer!");
+    WORD_ATOM(1188, 24, "ab-buffer!");
     mw_ab_buffer_21_();
-    WORD_ATOM(1176, 9, "PRIM_U64_GET");
+    WORD_ATOM(1189, 9, "PRIM_U64_GET");
     mw_PRIM_5F_U64_5F_GET();
-    WORD_ATOM(1176, 22, "ab-prim!");
+    WORD_ATOM(1189, 22, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1177, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1190, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1177, 26, "ab-prim!");
+    WORD_ATOM(1190, 26, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1178, 9, "");
+    WORD_ATOM(1191, 9, "");
     push_i64(1LL);
-    WORD_ATOM(1178, 11, "ab-int!");
+    WORD_ATOM(1191, 11, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1179, 9, "PRIM_INT_ADD");
+    WORD_ATOM(1192, 9, "PRIM_INT_ADD");
     mw_PRIM_5F_INT_5F_ADD();
-    WORD_ATOM(1179, 22, "ab-prim!");
+    WORD_ATOM(1192, 22, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1180, 9, "PRIM_CORE_DUP");
+    WORD_ATOM(1193, 9, "PRIM_CORE_DUP");
     mw_PRIM_5F_CORE_5F_DUP();
-    WORD_ATOM(1180, 23, "ab-prim!");
+    WORD_ATOM(1193, 23, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1181, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1194, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1181, 26, "ab-prim!");
+    WORD_ATOM(1194, 26, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1182, 9, "dup");
+    WORD_ATOM(1195, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1182, 13, "num-buffer");
+    WORD_ATOM(1195, 13, "num-buffer");
     mw_Table_2E_num_buffer();
-    WORD_ATOM(1182, 24, "ab-buffer!");
+    WORD_ATOM(1195, 24, "ab-buffer!");
     mw_ab_buffer_21_();
-    WORD_ATOM(1183, 9, "PRIM_U64_SET");
+    WORD_ATOM(1196, 9, "PRIM_U64_SET");
     mw_PRIM_5F_U64_5F_SET();
-    WORD_ATOM(1183, 22, "ab-prim!");
+    WORD_ATOM(1196, 22, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1184, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1197, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1184, 26, "ab-prim!");
+    WORD_ATOM(1197, 26, "ab-prim!");
     mw_ab_prim_21_();
     WORD_EXIT(mb_table_new_21__16);
 }
 
 static void mb_field_new_21__1 (void) {
-    WORD_ENTER(mb_field_new_21__1, "field-new! block", "src/mirth/elab.mth", 1209, 16);
+    WORD_ENTER(mb_field_new_21__1, "field-new! block", "src/mirth/elab.mth", 1222, 16);
     mw_prim_drop();
-    WORD_ATOM(1209, 16, "elab-simple-type-arg!");
+    WORD_ATOM(1222, 16, "elab-simple-type-arg!");
     mw_elab_simple_type_arg_21_();
     WORD_EXIT(mb_field_new_21__1);
 }
 
 static void mb_field_new_21__2 (void) {
-    WORD_ENTER(mb_field_new_21__2, "field-new! block", "src/mirth/elab.mth", 1210, 16);
+    WORD_ENTER(mb_field_new_21__2, "field-new! block", "src/mirth/elab.mth", 1223, 16);
     mw_prim_drop();
-    WORD_ATOM(1210, 16, "elab-simple-type-arg!");
+    WORD_ATOM(1223, 16, "elab-simple-type-arg!");
     mw_elab_simple_type_arg_21_();
     WORD_EXIT(mb_field_new_21__2);
 }

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -257,6 +257,12 @@ static void value_uncons(VAL val, VAL* car, VAL* cdr) {
         *cdr = val;
     }
 }
+static void value_uncons_c(VAL val, VAL* car, VAL* cdr) {
+    value_uncons(val, car, cdr);
+    incref(*car);
+    incref(*cdr);
+    decref(val);
+}
 
 static void* value_ptr (VAL v) {
     ASSERT(IS_PTR(v));
@@ -372,35 +378,6 @@ static USIZE get_top_data_tag(void) {
 
 static USIZE get_top_resource_data_tag(void) {
     return get_data_tag(top_resource());
-}
-
-static int value_cmp_(VAL v1, VAL v2) {
-    while (IS_CONS(v1) || IS_CONS(v2)) {
-        VAL v1car, v1cdr; value_uncons(v1, &v1car, &v1cdr);
-        VAL v2car, v2cdr; value_uncons(v2, &v2car, &v2cdr);
-        int r = value_cmp_(v1cdr, v2cdr);
-        if (r) return r;
-        v1 = v1car;
-        v2 = v2car;
-    }
-    if (IS_INT(v1) && IS_INT(v2)) {
-        if (VINT(v1) < VINT(v2)) return -1;
-        if (VINT(v1) > VINT(v2)) return 1;
-        return 0;
-    } else if (IS_STR(v1) && IS_STR(v2)) {
-        ASSERT2(VSTR(v1) && VSTR(v2), v1, v2);
-        USIZE n1 = VSTR(v1)->size;
-        USIZE n2 = VSTR(v2)->size;
-        USIZE n = (n1 < n2 ? n1 : n2);
-        ASSERT(n < SIZE_MAX);
-        int r = memcmp(VSTR(v1)->data, VSTR(v2)->data, (size_t)n);
-        if (r) return r;
-        if (n1 < n2) return -1;
-        if (n1 > n2) return 1;
-        return 0;
-    }
-    ASSERT2(0, v1, v2);
-    return 0;
 }
 
 static int str_cmp_(STR* s1, STR* s2) {
@@ -1124,7 +1101,7 @@ static void mw_prim_str_cat (void) {
         decref(v2);
     } else {
         USIZE m2 = n1 + n2 + 4;
-        if (m2 < m*2) m2 = m*2;
+        if ((s1->refs == 1) && (m2 < m*2)) m2 = m*2;
         STR* str = str_alloc(m2);
         str->size = n1+n2;
         ASSERT(n1 <= SIZE_MAX);
@@ -1217,1664 +1194,4964 @@ static void mw_prim_mut_is_set (void) {
 /* GENERATED C99 */
 
 static void mw_F (void) {
-    push_u64(0LL);
+    VAL tag = MKU64(0LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_F() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_T (void) {
-    push_u64(1LL);
+    VAL tag = MKU64(1LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_T() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Int_3E_U64_unsafe (void) {
 }
+void co_Int_3E_U64_unsafe() {
+}
 static void mw_Int_3E_U32_unsafe (void) {
+}
+void co_Int_3E_U32_unsafe() {
 }
 static void mw_Int_3E_U16_unsafe (void) {
 }
+void co_Int_3E_U16_unsafe() {
+}
 static void mw_Int_3E_U8_unsafe (void) {
+}
+void co_Int_3E_U8_unsafe() {
 }
 static void mw_Int_3E_I64_unsafe (void) {
 }
+void co_Int_3E_I64_unsafe() {
+}
 static void mw_Int_3E_I32_unsafe (void) {
+}
+void co_Int_3E_I32_unsafe() {
 }
 static void mw_Int_3E_I16_unsafe (void) {
 }
+void co_Int_3E_I16_unsafe() {
+}
 static void mw_Int_3E_I8_unsafe (void) {
 }
+void co_Int_3E_I8_unsafe() {
+}
 static void mw_L0 (void) {
-    push_u64(0LL);
+    VAL tag = MKU64(0LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_L0() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_L1 (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(1LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_L1() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_L2 (void) {
-    VAL car = pop_value();
-    car = mkcons(car, pop_value());
     VAL tag = MKU64(2LL);
+    VAL car = (pop_value());
+    car = mkcons(car, pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_L2() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
     push_value(car);
 }
 static void mw_L3 (void) {
-    VAL car = pop_value();
-    car = mkcons(car, pop_value());
-    car = mkcons(car, pop_value());
     VAL tag = MKU64(3LL);
+    VAL car = (pop_value());
+    car = mkcons(car, pop_value());
+    car = mkcons(car, pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_L3() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
     push_value(car);
 }
 static void mw_LCAT (void) {
-    VAL car = pop_value();
-    car = mkcons(car, pop_value());
-    car = mkcons(car, pop_value());
     VAL tag = MKU64(4LL);
+    VAL car = (pop_value());
+    car = mkcons(car, pop_value());
+    car = mkcons(car, pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_LCAT() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
     push_value(car);
 }
 static void mw_L1_2B_ (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(0LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_L1_2B_() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_L2_2B_ (void) {
-    VAL car = pop_value();
-    car = mkcons(car, pop_value());
     VAL tag = MKU64(1LL);
+    VAL car = (pop_value());
+    car = mkcons(car, pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_L2_2B_() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
     push_value(car);
 }
 static void mw_L3_2B_ (void) {
-    VAL car = pop_value();
-    car = mkcons(car, pop_value());
-    car = mkcons(car, pop_value());
     VAL tag = MKU64(2LL);
+    VAL car = (pop_value());
+    car = mkcons(car, pop_value());
+    car = mkcons(car, pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_L3_2B_() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
     push_value(car);
 }
 static void mw_LCAT_2B_ (void) {
-    VAL car = pop_value();
-    car = mkcons(car, pop_value());
-    car = mkcons(car, pop_value());
     VAL tag = MKU64(3LL);
+    VAL car = (pop_value());
+    car = mkcons(car, pop_value());
+    car = mkcons(car, pop_value());
     car = mkcons(car, tag);
     push_value(car);
 }
+void co_LCAT_2B_() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
+    push_value(car);
+}
 static void mw_NONE (void) {
-    push_u64(0LL);
+    VAL tag = MKU64(0LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_NONE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_SOME (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(1LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_SOME() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_Int_3E_RawPtr (void) {
 }
+void co_Int_3E_RawPtr() {
+}
 static void mw_OS_5F_UNKNOWN (void) {
-    push_u64(0LL);
+    VAL tag = MKU64(0LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_OS_5F_UNKNOWN() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_OS_5F_WINDOWS (void) {
-    push_u64(1LL);
+    VAL tag = MKU64(1LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_OS_5F_WINDOWS() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_OS_5F_LINUX (void) {
-    push_u64(2LL);
+    VAL tag = MKU64(2LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_OS_5F_LINUX() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_OS_5F_MACOS (void) {
-    push_u64(3LL);
+    VAL tag = MKU64(3LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_OS_5F_MACOS() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_LT (void) {
-    push_u64(0LL);
+    VAL tag = MKU64(0LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_LT() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_EQ (void) {
-    push_u64(1LL);
+    VAL tag = MKU64(1LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_EQ() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_GT (void) {
-    push_u64(2LL);
+    VAL tag = MKU64(2LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_GT() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BNUL (void) {
-    push_u64(0LL);
+    VAL tag = MKU64(0LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BNUL() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BSOH (void) {
-    push_u64(1LL);
+    VAL tag = MKU64(1LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BSOH() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BSTX (void) {
-    push_u64(2LL);
+    VAL tag = MKU64(2LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BSTX() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BETX (void) {
-    push_u64(3LL);
+    VAL tag = MKU64(3LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BETX() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BEOT (void) {
-    push_u64(4LL);
+    VAL tag = MKU64(4LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BEOT() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BENQ (void) {
-    push_u64(5LL);
+    VAL tag = MKU64(5LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BENQ() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BACK (void) {
-    push_u64(6LL);
+    VAL tag = MKU64(6LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BACK() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BBEL (void) {
-    push_u64(7LL);
+    VAL tag = MKU64(7LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BBEL() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BBS (void) {
-    push_u64(8LL);
+    VAL tag = MKU64(8LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BBS() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BHT (void) {
-    push_u64(9LL);
+    VAL tag = MKU64(9LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BHT() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BLF (void) {
-    push_u64(10LL);
+    VAL tag = MKU64(10LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BLF() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BVT (void) {
-    push_u64(11LL);
+    VAL tag = MKU64(11LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BVT() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BFF (void) {
-    push_u64(12LL);
+    VAL tag = MKU64(12LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BFF() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BCR (void) {
-    push_u64(13LL);
+    VAL tag = MKU64(13LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BCR() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BSO (void) {
-    push_u64(14LL);
+    VAL tag = MKU64(14LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BSO() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BSI (void) {
-    push_u64(15LL);
+    VAL tag = MKU64(15LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BSI() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BDLE (void) {
-    push_u64(16LL);
+    VAL tag = MKU64(16LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BDLE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BDC1 (void) {
-    push_u64(17LL);
+    VAL tag = MKU64(17LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BDC1() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BDC2 (void) {
-    push_u64(18LL);
+    VAL tag = MKU64(18LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BDC2() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BDC3 (void) {
-    push_u64(19LL);
+    VAL tag = MKU64(19LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BDC3() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BDC4 (void) {
-    push_u64(20LL);
+    VAL tag = MKU64(20LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BDC4() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BNAK (void) {
-    push_u64(21LL);
+    VAL tag = MKU64(21LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BNAK() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BSYN (void) {
-    push_u64(22LL);
+    VAL tag = MKU64(22LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BSYN() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BETB (void) {
-    push_u64(23LL);
+    VAL tag = MKU64(23LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BETB() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BCAN (void) {
-    push_u64(24LL);
+    VAL tag = MKU64(24LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BCAN() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BEM (void) {
-    push_u64(25LL);
+    VAL tag = MKU64(25LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BEM() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BSUB (void) {
-    push_u64(26LL);
+    VAL tag = MKU64(26LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BSUB() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BESC (void) {
-    push_u64(27LL);
+    VAL tag = MKU64(27LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BESC() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BFS (void) {
-    push_u64(28LL);
+    VAL tag = MKU64(28LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BFS() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BGS (void) {
-    push_u64(29LL);
+    VAL tag = MKU64(29LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BGS() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BRS (void) {
-    push_u64(30LL);
+    VAL tag = MKU64(30LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BRS() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BUS (void) {
-    push_u64(31LL);
+    VAL tag = MKU64(31LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BUS() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BSPACE (void) {
-    push_u64(32LL);
+    VAL tag = MKU64(32LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BSPACE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27__21__27_ (void) {
-    push_u64(33LL);
+    VAL tag = MKU64(33LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27__21__27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BQUOTE (void) {
-    push_u64(34LL);
+    VAL tag = MKU64(34LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BQUOTE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BHASH (void) {
-    push_u64(35LL);
+    VAL tag = MKU64(35LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BHASH() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27__24__27_ (void) {
-    push_u64(36LL);
+    VAL tag = MKU64(36LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27__24__27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27__25__27_ (void) {
-    push_u64(37LL);
+    VAL tag = MKU64(37LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27__25__27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27__26__27_ (void) {
-    push_u64(38LL);
+    VAL tag = MKU64(38LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27__26__27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BTICK (void) {
-    push_u64(39LL);
+    VAL tag = MKU64(39LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BTICK() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BLPAREN (void) {
-    push_u64(40LL);
+    VAL tag = MKU64(40LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BLPAREN() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BRPAREN (void) {
-    push_u64(41LL);
+    VAL tag = MKU64(41LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BRPAREN() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27__2A__27_ (void) {
-    push_u64(42LL);
+    VAL tag = MKU64(42LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27__2A__27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27__2B__27_ (void) {
-    push_u64(43LL);
+    VAL tag = MKU64(43LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27__2B__27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BCOMMA (void) {
-    push_u64(44LL);
+    VAL tag = MKU64(44LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BCOMMA() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27___27_ (void) {
-    push_u64(45LL);
+    VAL tag = MKU64(45LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27___27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27__2E__27_ (void) {
-    push_u64(46LL);
+    VAL tag = MKU64(46LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27__2E__27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27__2F__27_ (void) {
-    push_u64(47LL);
+    VAL tag = MKU64(47LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27__2F__27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_0_27_ (void) {
-    push_u64(48LL);
+    VAL tag = MKU64(48LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_0_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_1_27_ (void) {
-    push_u64(49LL);
+    VAL tag = MKU64(49LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_1_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_2_27_ (void) {
-    push_u64(50LL);
+    VAL tag = MKU64(50LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_2_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_3_27_ (void) {
-    push_u64(51LL);
+    VAL tag = MKU64(51LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_3_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_4_27_ (void) {
-    push_u64(52LL);
+    VAL tag = MKU64(52LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_4_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_5_27_ (void) {
-    push_u64(53LL);
+    VAL tag = MKU64(53LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_5_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_6_27_ (void) {
-    push_u64(54LL);
+    VAL tag = MKU64(54LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_6_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_7_27_ (void) {
-    push_u64(55LL);
+    VAL tag = MKU64(55LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_7_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_8_27_ (void) {
-    push_u64(56LL);
+    VAL tag = MKU64(56LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_8_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_9_27_ (void) {
-    push_u64(57LL);
+    VAL tag = MKU64(57LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_9_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BCOLON (void) {
-    push_u64(58LL);
+    VAL tag = MKU64(58LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BCOLON() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27__3B__27_ (void) {
-    push_u64(59LL);
+    VAL tag = MKU64(59LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27__3B__27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27__3C__27_ (void) {
-    push_u64(60LL);
+    VAL tag = MKU64(60LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27__3C__27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27__3D__27_ (void) {
-    push_u64(61LL);
+    VAL tag = MKU64(61LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27__3D__27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27__3E__27_ (void) {
-    push_u64(62LL);
+    VAL tag = MKU64(62LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27__3E__27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27__3F__27_ (void) {
-    push_u64(63LL);
+    VAL tag = MKU64(63LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27__3F__27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27__40__27_ (void) {
-    push_u64(64LL);
+    VAL tag = MKU64(64LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27__40__27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_A_27_ (void) {
-    push_u64(65LL);
+    VAL tag = MKU64(65LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_A_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_B_27_ (void) {
-    push_u64(66LL);
+    VAL tag = MKU64(66LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_B_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_C_27_ (void) {
-    push_u64(67LL);
+    VAL tag = MKU64(67LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_C_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_D_27_ (void) {
-    push_u64(68LL);
+    VAL tag = MKU64(68LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_D_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_E_27_ (void) {
-    push_u64(69LL);
+    VAL tag = MKU64(69LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_E_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_F_27_ (void) {
-    push_u64(70LL);
+    VAL tag = MKU64(70LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_F_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_G_27_ (void) {
-    push_u64(71LL);
+    VAL tag = MKU64(71LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_G_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_H_27_ (void) {
-    push_u64(72LL);
+    VAL tag = MKU64(72LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_H_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_I_27_ (void) {
-    push_u64(73LL);
+    VAL tag = MKU64(73LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_I_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_J_27_ (void) {
-    push_u64(74LL);
+    VAL tag = MKU64(74LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_J_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_K_27_ (void) {
-    push_u64(75LL);
+    VAL tag = MKU64(75LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_K_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_L_27_ (void) {
-    push_u64(76LL);
+    VAL tag = MKU64(76LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_L_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_M_27_ (void) {
-    push_u64(77LL);
+    VAL tag = MKU64(77LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_M_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_N_27_ (void) {
-    push_u64(78LL);
+    VAL tag = MKU64(78LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_N_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_O_27_ (void) {
-    push_u64(79LL);
+    VAL tag = MKU64(79LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_O_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_P_27_ (void) {
-    push_u64(80LL);
+    VAL tag = MKU64(80LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_P_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_Q_27_ (void) {
-    push_u64(81LL);
+    VAL tag = MKU64(81LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_Q_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_R_27_ (void) {
-    push_u64(82LL);
+    VAL tag = MKU64(82LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_R_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_S_27_ (void) {
-    push_u64(83LL);
+    VAL tag = MKU64(83LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_S_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_T_27_ (void) {
-    push_u64(84LL);
+    VAL tag = MKU64(84LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_T_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_U_27_ (void) {
-    push_u64(85LL);
+    VAL tag = MKU64(85LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_U_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_V_27_ (void) {
-    push_u64(86LL);
+    VAL tag = MKU64(86LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_V_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_W_27_ (void) {
-    push_u64(87LL);
+    VAL tag = MKU64(87LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_W_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_X_27_ (void) {
-    push_u64(88LL);
+    VAL tag = MKU64(88LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_X_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_Y_27_ (void) {
-    push_u64(89LL);
+    VAL tag = MKU64(89LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_Y_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_Z_27_ (void) {
-    push_u64(90LL);
+    VAL tag = MKU64(90LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_Z_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BLSQUARE (void) {
-    push_u64(91LL);
+    VAL tag = MKU64(91LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BLSQUARE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27__5C__27_ (void) {
-    push_u64(92LL);
+    VAL tag = MKU64(92LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27__5C__27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BRSQUARE (void) {
-    push_u64(93LL);
+    VAL tag = MKU64(93LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BRSQUARE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27__5E__27_ (void) {
-    push_u64(94LL);
+    VAL tag = MKU64(94LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27__5E__27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27__5F__27_ (void) {
-    push_u64(95LL);
+    VAL tag = MKU64(95LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27__5F__27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27__60__27_ (void) {
-    push_u64(96LL);
+    VAL tag = MKU64(96LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27__60__27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_a_27_ (void) {
-    push_u64(97LL);
+    VAL tag = MKU64(97LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_a_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_b_27_ (void) {
-    push_u64(98LL);
+    VAL tag = MKU64(98LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_b_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_c_27_ (void) {
-    push_u64(99LL);
+    VAL tag = MKU64(99LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_c_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_d_27_ (void) {
-    push_u64(100LL);
+    VAL tag = MKU64(100LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_d_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_e_27_ (void) {
-    push_u64(101LL);
+    VAL tag = MKU64(101LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_e_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_f_27_ (void) {
-    push_u64(102LL);
+    VAL tag = MKU64(102LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_f_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_g_27_ (void) {
-    push_u64(103LL);
+    VAL tag = MKU64(103LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_g_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_h_27_ (void) {
-    push_u64(104LL);
+    VAL tag = MKU64(104LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_h_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_i_27_ (void) {
-    push_u64(105LL);
+    VAL tag = MKU64(105LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_i_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_j_27_ (void) {
-    push_u64(106LL);
+    VAL tag = MKU64(106LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_j_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_k_27_ (void) {
-    push_u64(107LL);
+    VAL tag = MKU64(107LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_k_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_l_27_ (void) {
-    push_u64(108LL);
+    VAL tag = MKU64(108LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_l_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_m_27_ (void) {
-    push_u64(109LL);
+    VAL tag = MKU64(109LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_m_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_n_27_ (void) {
-    push_u64(110LL);
+    VAL tag = MKU64(110LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_n_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_o_27_ (void) {
-    push_u64(111LL);
+    VAL tag = MKU64(111LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_o_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_p_27_ (void) {
-    push_u64(112LL);
+    VAL tag = MKU64(112LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_p_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_q_27_ (void) {
-    push_u64(113LL);
+    VAL tag = MKU64(113LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_q_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_r_27_ (void) {
-    push_u64(114LL);
+    VAL tag = MKU64(114LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_r_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_s_27_ (void) {
-    push_u64(115LL);
+    VAL tag = MKU64(115LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_s_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_t_27_ (void) {
-    push_u64(116LL);
+    VAL tag = MKU64(116LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_t_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_u_27_ (void) {
-    push_u64(117LL);
+    VAL tag = MKU64(117LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_u_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_v_27_ (void) {
-    push_u64(118LL);
+    VAL tag = MKU64(118LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_v_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_w_27_ (void) {
-    push_u64(119LL);
+    VAL tag = MKU64(119LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_w_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_x_27_ (void) {
-    push_u64(120LL);
+    VAL tag = MKU64(120LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_x_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_y_27_ (void) {
-    push_u64(121LL);
+    VAL tag = MKU64(121LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_y_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27_z_27_ (void) {
-    push_u64(122LL);
+    VAL tag = MKU64(122LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27_z_27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BLCURLY (void) {
-    push_u64(123LL);
+    VAL tag = MKU64(123LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BLCURLY() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27__7C__27_ (void) {
-    push_u64(124LL);
+    VAL tag = MKU64(124LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27__7C__27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BRCURLY (void) {
-    push_u64(125LL);
+    VAL tag = MKU64(125LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BRCURLY() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_B_27__7E__27_ (void) {
-    push_u64(126LL);
+    VAL tag = MKU64(126LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_B_27__7E__27_() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BDEL (void) {
-    push_u64(127LL);
+    VAL tag = MKU64(127LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BDEL() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx80 (void) {
-    push_u64(128LL);
+    VAL tag = MKU64(128LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx80() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx81 (void) {
-    push_u64(129LL);
+    VAL tag = MKU64(129LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx81() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx82 (void) {
-    push_u64(130LL);
+    VAL tag = MKU64(130LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx82() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx83 (void) {
-    push_u64(131LL);
+    VAL tag = MKU64(131LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx83() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx84 (void) {
-    push_u64(132LL);
+    VAL tag = MKU64(132LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx84() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx85 (void) {
-    push_u64(133LL);
+    VAL tag = MKU64(133LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx85() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx86 (void) {
-    push_u64(134LL);
+    VAL tag = MKU64(134LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx86() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx87 (void) {
-    push_u64(135LL);
+    VAL tag = MKU64(135LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx87() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx88 (void) {
-    push_u64(136LL);
+    VAL tag = MKU64(136LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx88() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx89 (void) {
-    push_u64(137LL);
+    VAL tag = MKU64(137LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx89() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx8A (void) {
-    push_u64(138LL);
+    VAL tag = MKU64(138LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx8A() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx8B (void) {
-    push_u64(139LL);
+    VAL tag = MKU64(139LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx8B() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx8C (void) {
-    push_u64(140LL);
+    VAL tag = MKU64(140LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx8C() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx8D (void) {
-    push_u64(141LL);
+    VAL tag = MKU64(141LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx8D() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx8E (void) {
-    push_u64(142LL);
+    VAL tag = MKU64(142LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx8E() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx8F (void) {
-    push_u64(143LL);
+    VAL tag = MKU64(143LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx8F() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx90 (void) {
-    push_u64(144LL);
+    VAL tag = MKU64(144LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx90() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx91 (void) {
-    push_u64(145LL);
+    VAL tag = MKU64(145LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx91() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx92 (void) {
-    push_u64(146LL);
+    VAL tag = MKU64(146LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx92() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx93 (void) {
-    push_u64(147LL);
+    VAL tag = MKU64(147LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx93() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx94 (void) {
-    push_u64(148LL);
+    VAL tag = MKU64(148LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx94() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx95 (void) {
-    push_u64(149LL);
+    VAL tag = MKU64(149LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx95() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx96 (void) {
-    push_u64(150LL);
+    VAL tag = MKU64(150LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx96() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx97 (void) {
-    push_u64(151LL);
+    VAL tag = MKU64(151LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx97() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx98 (void) {
-    push_u64(152LL);
+    VAL tag = MKU64(152LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx98() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx99 (void) {
-    push_u64(153LL);
+    VAL tag = MKU64(153LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx99() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx9A (void) {
-    push_u64(154LL);
+    VAL tag = MKU64(154LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx9A() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx9B (void) {
-    push_u64(155LL);
+    VAL tag = MKU64(155LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx9B() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx9C (void) {
-    push_u64(156LL);
+    VAL tag = MKU64(156LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx9C() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx9D (void) {
-    push_u64(157LL);
+    VAL tag = MKU64(157LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx9D() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx9E (void) {
-    push_u64(158LL);
+    VAL tag = MKU64(158LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx9E() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Bx9F (void) {
-    push_u64(159LL);
+    VAL tag = MKU64(159LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_Bx9F() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxA0 (void) {
-    push_u64(160LL);
+    VAL tag = MKU64(160LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxA0() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxA1 (void) {
-    push_u64(161LL);
+    VAL tag = MKU64(161LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxA1() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxA2 (void) {
-    push_u64(162LL);
+    VAL tag = MKU64(162LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxA2() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxA3 (void) {
-    push_u64(163LL);
+    VAL tag = MKU64(163LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxA3() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxA4 (void) {
-    push_u64(164LL);
+    VAL tag = MKU64(164LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxA4() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxA5 (void) {
-    push_u64(165LL);
+    VAL tag = MKU64(165LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxA5() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxA6 (void) {
-    push_u64(166LL);
+    VAL tag = MKU64(166LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxA6() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxA7 (void) {
-    push_u64(167LL);
+    VAL tag = MKU64(167LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxA7() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxA8 (void) {
-    push_u64(168LL);
+    VAL tag = MKU64(168LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxA8() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxA9 (void) {
-    push_u64(169LL);
+    VAL tag = MKU64(169LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxA9() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxAA (void) {
-    push_u64(170LL);
+    VAL tag = MKU64(170LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxAA() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxAB (void) {
-    push_u64(171LL);
+    VAL tag = MKU64(171LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxAB() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxAC (void) {
-    push_u64(172LL);
+    VAL tag = MKU64(172LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxAC() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxAD (void) {
-    push_u64(173LL);
+    VAL tag = MKU64(173LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxAD() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxAE (void) {
-    push_u64(174LL);
+    VAL tag = MKU64(174LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxAE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxAF (void) {
-    push_u64(175LL);
+    VAL tag = MKU64(175LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxAF() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxB0 (void) {
-    push_u64(176LL);
+    VAL tag = MKU64(176LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxB0() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxB1 (void) {
-    push_u64(177LL);
+    VAL tag = MKU64(177LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxB1() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxB2 (void) {
-    push_u64(178LL);
+    VAL tag = MKU64(178LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxB2() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxB3 (void) {
-    push_u64(179LL);
+    VAL tag = MKU64(179LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxB3() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxB4 (void) {
-    push_u64(180LL);
+    VAL tag = MKU64(180LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxB4() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxB5 (void) {
-    push_u64(181LL);
+    VAL tag = MKU64(181LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxB5() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxB6 (void) {
-    push_u64(182LL);
+    VAL tag = MKU64(182LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxB6() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxB7 (void) {
-    push_u64(183LL);
+    VAL tag = MKU64(183LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxB7() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxB8 (void) {
-    push_u64(184LL);
+    VAL tag = MKU64(184LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxB8() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxB9 (void) {
-    push_u64(185LL);
+    VAL tag = MKU64(185LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxB9() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxBA (void) {
-    push_u64(186LL);
+    VAL tag = MKU64(186LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxBA() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxBB (void) {
-    push_u64(187LL);
+    VAL tag = MKU64(187LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxBB() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxBC (void) {
-    push_u64(188LL);
+    VAL tag = MKU64(188LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxBC() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxBD (void) {
-    push_u64(189LL);
+    VAL tag = MKU64(189LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxBD() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxBE (void) {
-    push_u64(190LL);
+    VAL tag = MKU64(190LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxBE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxBF (void) {
-    push_u64(191LL);
+    VAL tag = MKU64(191LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxBF() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxC0 (void) {
-    push_u64(192LL);
+    VAL tag = MKU64(192LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxC0() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxC1 (void) {
-    push_u64(193LL);
+    VAL tag = MKU64(193LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxC1() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxC2 (void) {
-    push_u64(194LL);
+    VAL tag = MKU64(194LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxC2() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxC3 (void) {
-    push_u64(195LL);
+    VAL tag = MKU64(195LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxC3() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxC4 (void) {
-    push_u64(196LL);
+    VAL tag = MKU64(196LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxC4() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxC5 (void) {
-    push_u64(197LL);
+    VAL tag = MKU64(197LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxC5() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxC6 (void) {
-    push_u64(198LL);
+    VAL tag = MKU64(198LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxC6() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxC7 (void) {
-    push_u64(199LL);
+    VAL tag = MKU64(199LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxC7() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxC8 (void) {
-    push_u64(200LL);
+    VAL tag = MKU64(200LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxC8() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxC9 (void) {
-    push_u64(201LL);
+    VAL tag = MKU64(201LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxC9() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxCA (void) {
-    push_u64(202LL);
+    VAL tag = MKU64(202LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxCA() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxCB (void) {
-    push_u64(203LL);
+    VAL tag = MKU64(203LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxCB() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxCC (void) {
-    push_u64(204LL);
+    VAL tag = MKU64(204LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxCC() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxCD (void) {
-    push_u64(205LL);
+    VAL tag = MKU64(205LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxCD() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxCE (void) {
-    push_u64(206LL);
+    VAL tag = MKU64(206LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxCE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxCF (void) {
-    push_u64(207LL);
+    VAL tag = MKU64(207LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxCF() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxD0 (void) {
-    push_u64(208LL);
+    VAL tag = MKU64(208LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxD0() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxD1 (void) {
-    push_u64(209LL);
+    VAL tag = MKU64(209LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxD1() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxD2 (void) {
-    push_u64(210LL);
+    VAL tag = MKU64(210LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxD2() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxD3 (void) {
-    push_u64(211LL);
+    VAL tag = MKU64(211LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxD3() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxD4 (void) {
-    push_u64(212LL);
+    VAL tag = MKU64(212LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxD4() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxD5 (void) {
-    push_u64(213LL);
+    VAL tag = MKU64(213LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxD5() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxD6 (void) {
-    push_u64(214LL);
+    VAL tag = MKU64(214LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxD6() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxD7 (void) {
-    push_u64(215LL);
+    VAL tag = MKU64(215LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxD7() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxD8 (void) {
-    push_u64(216LL);
+    VAL tag = MKU64(216LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxD8() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxD9 (void) {
-    push_u64(217LL);
+    VAL tag = MKU64(217LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxD9() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxDA (void) {
-    push_u64(218LL);
+    VAL tag = MKU64(218LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxDA() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxDB (void) {
-    push_u64(219LL);
+    VAL tag = MKU64(219LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxDB() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxDC (void) {
-    push_u64(220LL);
+    VAL tag = MKU64(220LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxDC() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxDD (void) {
-    push_u64(221LL);
+    VAL tag = MKU64(221LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxDD() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxDE (void) {
-    push_u64(222LL);
+    VAL tag = MKU64(222LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxDE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxDF (void) {
-    push_u64(223LL);
+    VAL tag = MKU64(223LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxDF() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxE0 (void) {
-    push_u64(224LL);
+    VAL tag = MKU64(224LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxE0() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxE1 (void) {
-    push_u64(225LL);
+    VAL tag = MKU64(225LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxE1() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxE2 (void) {
-    push_u64(226LL);
+    VAL tag = MKU64(226LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxE2() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxE3 (void) {
-    push_u64(227LL);
+    VAL tag = MKU64(227LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxE3() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxE4 (void) {
-    push_u64(228LL);
+    VAL tag = MKU64(228LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxE4() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxE5 (void) {
-    push_u64(229LL);
+    VAL tag = MKU64(229LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxE5() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxE6 (void) {
-    push_u64(230LL);
+    VAL tag = MKU64(230LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxE6() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxE7 (void) {
-    push_u64(231LL);
+    VAL tag = MKU64(231LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxE7() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxE8 (void) {
-    push_u64(232LL);
+    VAL tag = MKU64(232LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxE8() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxE9 (void) {
-    push_u64(233LL);
+    VAL tag = MKU64(233LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxE9() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxEA (void) {
-    push_u64(234LL);
+    VAL tag = MKU64(234LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxEA() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxEB (void) {
-    push_u64(235LL);
+    VAL tag = MKU64(235LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxEB() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxEC (void) {
-    push_u64(236LL);
+    VAL tag = MKU64(236LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxEC() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxED (void) {
-    push_u64(237LL);
+    VAL tag = MKU64(237LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxED() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxEE (void) {
-    push_u64(238LL);
+    VAL tag = MKU64(238LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxEE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxEF (void) {
-    push_u64(239LL);
+    VAL tag = MKU64(239LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxEF() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxF0 (void) {
-    push_u64(240LL);
+    VAL tag = MKU64(240LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxF0() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxF1 (void) {
-    push_u64(241LL);
+    VAL tag = MKU64(241LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxF1() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxF2 (void) {
-    push_u64(242LL);
+    VAL tag = MKU64(242LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxF2() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxF3 (void) {
-    push_u64(243LL);
+    VAL tag = MKU64(243LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxF3() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxF4 (void) {
-    push_u64(244LL);
+    VAL tag = MKU64(244LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxF4() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxF5 (void) {
-    push_u64(245LL);
+    VAL tag = MKU64(245LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxF5() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxF6 (void) {
-    push_u64(246LL);
+    VAL tag = MKU64(246LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxF6() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxF7 (void) {
-    push_u64(247LL);
+    VAL tag = MKU64(247LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxF7() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxF8 (void) {
-    push_u64(248LL);
+    VAL tag = MKU64(248LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxF8() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxF9 (void) {
-    push_u64(249LL);
+    VAL tag = MKU64(249LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxF9() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxFA (void) {
-    push_u64(250LL);
+    VAL tag = MKU64(250LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxFA() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxFB (void) {
-    push_u64(251LL);
+    VAL tag = MKU64(251LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxFB() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxFC (void) {
-    push_u64(252LL);
+    VAL tag = MKU64(252LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxFC() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxFD (void) {
-    push_u64(253LL);
+    VAL tag = MKU64(253LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxFD() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxFE (void) {
-    push_u64(254LL);
+    VAL tag = MKU64(254LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxFE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_BxFF (void) {
-    push_u64(255LL);
+    VAL tag = MKU64(255LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_BxFF() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_Str_3E_Path (void) {
 }
+void co_Str_3E_Path() {
+}
 static void mw_FILE (void) {
 }
+void co_FILE() {
+}
 static void mw_LAZY_5F_READY (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(0LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_LAZY_5F_READY() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_LAZY_5F_DELAY (void) {
-    VAL car = pop_value();
-    car = mkcons(car, pop_value());
     VAL tag = MKU64(1LL);
+    VAL car = (pop_value());
+    car = mkcons(car, pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_LAZY_5F_DELAY() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
     push_value(car);
 }
 static void mw_LAZY_5F_WAIT (void) {
-    push_u64(2LL);
+    VAL tag = MKU64(2LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_LAZY_5F_WAIT() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_CTX (void) {
 }
+void co_CTX() {
+}
 static void mw_PATTERN_5F_UNDERSCORE (void) {
-    push_u64(0LL);
+    VAL tag = MKU64(0LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PATTERN_5F_UNDERSCORE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PATTERN_5F_TAG (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(1LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_PATTERN_5F_TAG() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_LEFT (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(0LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_LEFT() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_RIGHT (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(1LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_RIGHT() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_STACK_5F_NIL (void) {
-    push_u64(0LL);
+    VAL tag = MKU64(0LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_STACK_5F_NIL() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_STACK_5F_CONS (void) {
-    VAL car = pop_value();
-    car = mkcons(car, pop_value());
     VAL tag = MKU64(1LL);
+    VAL car = (pop_value());
+    car = mkcons(car, pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_STACK_5F_CONS() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
     push_value(car);
 }
 static void mw_NEED_5F_WORD (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(0LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_NEED_5F_WORD() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_NEED_5F_BLOCK (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(1LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
     push_value(car);
 }
-static void mw_TYPE_5F_ELAB (void) {
+void co_NEED_5F_BLOCK() {
     VAL car = pop_value();
-    car = mkcons(car, pop_value());
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
+    push_value(car);
+}
+static void mw_MKC99_unsafe (void) {
     VAL tag = MKU64(0LL);
+    VAL car = (tag);
+    push_resource(car);
+}
+void co_MKC99_unsafe() {
+    VAL car = pop_resource();
+    VAL cdr;
+    decref(car);
+}
+static void mw_TYPE_5F_ELAB (void) {
+    VAL tag = MKU64(0LL);
+    VAL car = (pop_value());
+    car = mkcons(car, pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_TYPE_5F_ELAB() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
     push_value(car);
 }
 static void mw_OPSIG_5F_ID (void) {
-    push_u64(0LL);
+    VAL tag = MKU64(0LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_OPSIG_5F_ID() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_OPSIG_5F_PUSH (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(1LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
     push_value(car);
 }
-static void mw_OPSIG_5F_APPLY (void) {
+void co_OPSIG_5F_PUSH() {
     VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
+    push_value(car);
+}
+static void mw_OPSIG_5F_APPLY (void) {
     VAL tag = MKU64(2LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_OPSIG_5F_APPLY() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_ARG_5F_BLOCK (void) {
 }
+void co_ARG_5F_BLOCK() {
+}
 static void mw_OP_5F_NONE (void) {
-    push_u64(0LL);
+    VAL tag = MKU64(0LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_OP_5F_NONE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_OP_5F_PRIM (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(1LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_OP_5F_PRIM() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_OP_5F_WORD (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(2LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_OP_5F_WORD() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_OP_5F_EXTERNAL (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(3LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_OP_5F_EXTERNAL() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_OP_5F_BUFFER (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(4LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_OP_5F_BUFFER() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_OP_5F_VARIABLE (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(5LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_OP_5F_VARIABLE() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_OP_5F_CONSTANT (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(6LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_OP_5F_CONSTANT() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_OP_5F_FIELD (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(7LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_OP_5F_FIELD() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_OP_5F_INT (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(8LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_OP_5F_INT() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_OP_5F_STR (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(9LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_OP_5F_STR() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_OP_5F_TAG (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(10LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_OP_5F_TAG() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_OP_5F_MATCH (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(11LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_OP_5F_MATCH() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_OP_5F_LAMBDA (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(12LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_OP_5F_LAMBDA() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_OP_5F_VAR (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(13LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
     push_value(car);
 }
-static void mw_OP_5F_BLOCK (void) {
+void co_OP_5F_VAR() {
     VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
+    push_value(car);
+}
+static void mw_OP_5F_BLOCK (void) {
     VAL tag = MKU64(14LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_OP_5F_BLOCK() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_PARAM (void) {
 }
+void co_PARAM() {
+}
 static void mw_TYPE_5F_ERROR (void) {
-    push_u64(0LL);
+    VAL tag = MKU64(0LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_TYPE_5F_ERROR() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_TYPE_5F_DONT_5F_CARE (void) {
-    push_u64(1LL);
+    VAL tag = MKU64(1LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_TYPE_5F_DONT_5F_CARE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_TPrim (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(2LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_TPrim() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_TMeta (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(3LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_TMeta() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_THole (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(4LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_THole() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_TVar (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(5LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_TVar() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_TTable (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(6LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_TTable() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_TData (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(7LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_TData() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_TTensor (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(8LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_TTensor() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_TMorphism (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(9LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_TMorphism() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_TApp (void) {
-    VAL car = pop_value();
-    car = mkcons(car, pop_value());
     VAL tag = MKU64(10LL);
+    VAL car = (pop_value());
+    car = mkcons(car, pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_TApp() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
     push_value(car);
 }
 static void mw_TMut (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(11LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_TMut() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_TValue (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(12LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_TValue() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_VALUE_5F_INT (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(0LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_VALUE_5F_INT() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_VALUE_5F_STR (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(1LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_VALUE_5F_STR() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_VALUE_5F_BLOCK (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(2LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_VALUE_5F_BLOCK() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_PRIM_5F_TYPE_5F_TYPE (void) {
-    push_u64(0LL);
+    VAL tag = MKU64(0LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_TYPE_5F_TYPE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_TYPE_5F_STACK (void) {
-    push_u64(1LL);
+    VAL tag = MKU64(1LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_TYPE_5F_STACK() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_TYPE_5F_RESOURCE (void) {
-    push_u64(2LL);
+    VAL tag = MKU64(2LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_TYPE_5F_RESOURCE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_TYPE_5F_INT (void) {
-    push_u64(3LL);
+    VAL tag = MKU64(3LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_TYPE_5F_INT() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_TYPE_5F_PTR (void) {
-    push_u64(4LL);
+    VAL tag = MKU64(4LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_TYPE_5F_PTR() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_TYPE_5F_STR (void) {
-    push_u64(5LL);
+    VAL tag = MKU64(5LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_TYPE_5F_STR() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_TYPE_5F__2B_PLATFORM (void) {
-    push_u64(6LL);
+    VAL tag = MKU64(6LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_TYPE_5F__2B_PLATFORM() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_GAMMA (void) {
 }
+void co_GAMMA() {
+}
 static void mw_RESOURCE (void) {
 }
+void co_RESOURCE() {
+}
 static void mw_STACK_5F_TYPE_5F_ERROR (void) {
-    push_u64(0LL);
+    VAL tag = MKU64(0LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_STACK_5F_TYPE_5F_ERROR() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_STACK_5F_TYPE_5F_DONT_5F_CARE (void) {
-    push_u64(1LL);
+    VAL tag = MKU64(1LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_STACK_5F_TYPE_5F_DONT_5F_CARE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_STACK_5F_TYPE_5F_UNIT (void) {
-    push_u64(2LL);
+    VAL tag = MKU64(2LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_STACK_5F_TYPE_5F_UNIT() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_STVar (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(3LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_STVar() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_STMeta (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(4LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_STMeta() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_STCons (void) {
-    VAL car = pop_value();
-    car = mkcons(car, pop_value());
     VAL tag = MKU64(5LL);
+    VAL car = (pop_value());
+    car = mkcons(car, pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_STCons() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
     push_value(car);
 }
 static void mw_STWith (void) {
-    VAL car = pop_value();
-    car = mkcons(car, pop_value());
     VAL tag = MKU64(6LL);
+    VAL car = (pop_value());
+    car = mkcons(car, pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_STWith() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
     push_value(car);
 }
 static void mw_ARROW_5F_TYPE (void) {
-    VAL car = pop_value();
-    car = mkcons(car, pop_value());
     VAL tag = MKU64(0LL);
+    VAL car = (pop_value());
+    car = mkcons(car, pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_ARROW_5F_TYPE() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
     push_value(car);
 }
 static void mw_SUBST_5F_NIL (void) {
-    push_u64(0LL);
+    VAL tag = MKU64(0LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_SUBST_5F_NIL() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_SUBST_5F_CON (void) {
-    VAL car = pop_value();
-    car = mkcons(car, pop_value());
-    car = mkcons(car, pop_value());
     VAL tag = MKU64(1LL);
+    VAL car = (pop_value());
+    car = mkcons(car, pop_value());
+    car = mkcons(car, pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_SUBST_5F_CON() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
     push_value(car);
 }
 static void mw_PRIM_5F_CORE_5F_ID (void) {
-    push_u64(0LL);
+    VAL tag = MKU64(0LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_CORE_5F_ID() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_DUP (void) {
-    push_u64(1LL);
+    VAL tag = MKU64(1LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_CORE_5F_DUP() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_DROP (void) {
-    push_u64(2LL);
+    VAL tag = MKU64(2LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_CORE_5F_DROP() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_SWAP (void) {
-    push_u64(3LL);
+    VAL tag = MKU64(3LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_CORE_5F_SWAP() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_DIP (void) {
-    push_u64(4LL);
+    VAL tag = MKU64(4LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_CORE_5F_DIP() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_IF (void) {
-    push_u64(5LL);
+    VAL tag = MKU64(5LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_CORE_5F_IF() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_WHILE (void) {
-    push_u64(6LL);
+    VAL tag = MKU64(6LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_CORE_5F_WHILE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_DEBUG (void) {
-    push_u64(7LL);
+    VAL tag = MKU64(7LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_CORE_5F_DEBUG() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_PANIC (void) {
-    push_u64(8LL);
+    VAL tag = MKU64(8LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_CORE_5F_PANIC() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_RUN (void) {
-    push_u64(9LL);
+    VAL tag = MKU64(9LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_CORE_5F_RUN() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_MATCH (void) {
-    push_u64(10LL);
+    VAL tag = MKU64(10LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_CORE_5F_MATCH() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_LAMBDA (void) {
-    push_u64(11LL);
+    VAL tag = MKU64(11LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_CORE_5F_LAMBDA() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_RSWAP (void) {
-    push_u64(12LL);
+    VAL tag = MKU64(12LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_CORE_5F_RSWAP() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_CORE_5F_RDIP (void) {
-    push_u64(13LL);
+    VAL tag = MKU64(13LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_CORE_5F_RDIP() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_UNSAFE_5F_CAST (void) {
-    push_u64(14LL);
+    VAL tag = MKU64(14LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_UNSAFE_5F_CAST() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_INT_5F_EQ (void) {
-    push_u64(15LL);
+    VAL tag = MKU64(15LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_INT_5F_EQ() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_INT_5F_LT (void) {
-    push_u64(16LL);
+    VAL tag = MKU64(16LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_INT_5F_LT() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_INT_5F_ADD (void) {
-    push_u64(17LL);
+    VAL tag = MKU64(17LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_INT_5F_ADD() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_INT_5F_SUB (void) {
-    push_u64(18LL);
+    VAL tag = MKU64(18LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_INT_5F_SUB() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_INT_5F_MUL (void) {
-    push_u64(19LL);
+    VAL tag = MKU64(19LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_INT_5F_MUL() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_INT_5F_DIV (void) {
-    push_u64(20LL);
+    VAL tag = MKU64(20LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_INT_5F_DIV() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_INT_5F_MOD (void) {
-    push_u64(21LL);
+    VAL tag = MKU64(21LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_INT_5F_MOD() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_INT_5F_AND (void) {
-    push_u64(22LL);
+    VAL tag = MKU64(22LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_INT_5F_AND() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_INT_5F_OR (void) {
-    push_u64(23LL);
+    VAL tag = MKU64(23LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_INT_5F_OR() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_INT_5F_XOR (void) {
-    push_u64(24LL);
+    VAL tag = MKU64(24LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_INT_5F_XOR() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_INT_5F_SHL (void) {
-    push_u64(25LL);
+    VAL tag = MKU64(25LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_INT_5F_SHL() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_INT_5F_SHR (void) {
-    push_u64(26LL);
+    VAL tag = MKU64(26LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_INT_5F_SHR() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_INT_5F_TO_5F_STR (void) {
-    push_u64(27LL);
+    VAL tag = MKU64(27LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_INT_5F_TO_5F_STR() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_PACK_5F_NIL (void) {
-    push_u64(28LL);
+    VAL tag = MKU64(28LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_PACK_5F_NIL() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_PACK_5F_CONS (void) {
-    push_u64(29LL);
+    VAL tag = MKU64(29LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_PACK_5F_CONS() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_PACK_5F_UNCONS (void) {
-    push_u64(30LL);
+    VAL tag = MKU64(30LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_PACK_5F_UNCONS() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_MUT_5F_NEW (void) {
-    push_u64(31LL);
+    VAL tag = MKU64(31LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_MUT_5F_NEW() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_MUT_5F_GET (void) {
-    push_u64(32LL);
+    VAL tag = MKU64(32LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_MUT_5F_GET() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_MUT_5F_SET (void) {
-    push_u64(33LL);
+    VAL tag = MKU64(33LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_MUT_5F_SET() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_MUT_5F_IS_5F_SET (void) {
-    push_u64(34LL);
+    VAL tag = MKU64(34LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_MUT_5F_IS_5F_SET() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_PTR_5F_NIL (void) {
-    push_u64(35LL);
+    VAL tag = MKU64(35LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_PTR_5F_NIL() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_PTR_5F_ADD (void) {
-    push_u64(36LL);
+    VAL tag = MKU64(36LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_PTR_5F_ADD() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_PTR_5F_SIZE (void) {
-    push_u64(37LL);
+    VAL tag = MKU64(37LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_PTR_5F_SIZE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_PTR_5F_GET (void) {
-    push_u64(38LL);
+    VAL tag = MKU64(38LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_PTR_5F_GET() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_PTR_5F_SET (void) {
-    push_u64(39LL);
+    VAL tag = MKU64(39LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_PTR_5F_SET() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_PTR_5F_ALLOC (void) {
-    push_u64(40LL);
+    VAL tag = MKU64(40LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_PTR_5F_ALLOC() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_PTR_5F_REALLOC (void) {
-    push_u64(41LL);
+    VAL tag = MKU64(41LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_PTR_5F_REALLOC() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_PTR_5F_COPY (void) {
-    push_u64(42LL);
+    VAL tag = MKU64(42LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_PTR_5F_COPY() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_PTR_5F_FILL (void) {
-    push_u64(43LL);
+    VAL tag = MKU64(43LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_PTR_5F_FILL() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_PTR_5F_RAW (void) {
-    push_u64(44LL);
+    VAL tag = MKU64(44LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_PTR_5F_RAW() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_STR_5F_CMP (void) {
-    push_u64(45LL);
+    VAL tag = MKU64(45LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_STR_5F_CMP() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_STR_5F_ALLOC (void) {
-    push_u64(46LL);
+    VAL tag = MKU64(46LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_STR_5F_ALLOC() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_STR_5F_COPY (void) {
-    push_u64(47LL);
+    VAL tag = MKU64(47LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_STR_5F_COPY() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_STR_5F_NUM_5F_BYTES (void) {
-    push_u64(48LL);
+    VAL tag = MKU64(48LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_STR_5F_NUM_5F_BYTES() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_STR_5F_BASE (void) {
-    push_u64(49LL);
+    VAL tag = MKU64(49LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_STR_5F_BASE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_STR_5F_CAT (void) {
-    push_u64(50LL);
+    VAL tag = MKU64(50LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_STR_5F_CAT() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_U8_5F_GET (void) {
-    push_u64(51LL);
+    VAL tag = MKU64(51LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_U8_5F_GET() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_U8_5F_SET (void) {
-    push_u64(52LL);
+    VAL tag = MKU64(52LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_U8_5F_SET() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_U16_5F_GET (void) {
-    push_u64(53LL);
+    VAL tag = MKU64(53LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_U16_5F_GET() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_U16_5F_SET (void) {
-    push_u64(54LL);
+    VAL tag = MKU64(54LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_U16_5F_SET() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_U32_5F_GET (void) {
-    push_u64(55LL);
+    VAL tag = MKU64(55LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_U32_5F_GET() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_U32_5F_SET (void) {
-    push_u64(56LL);
+    VAL tag = MKU64(56LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_U32_5F_SET() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_U64_5F_GET (void) {
-    push_u64(57LL);
+    VAL tag = MKU64(57LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_U64_5F_GET() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_U64_5F_SET (void) {
-    push_u64(58LL);
+    VAL tag = MKU64(58LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_U64_5F_SET() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_I8_5F_GET (void) {
-    push_u64(59LL);
+    VAL tag = MKU64(59LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_I8_5F_GET() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_I8_5F_SET (void) {
-    push_u64(60LL);
+    VAL tag = MKU64(60LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_I8_5F_SET() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_I16_5F_GET (void) {
-    push_u64(61LL);
+    VAL tag = MKU64(61LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_I16_5F_GET() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_I16_5F_SET (void) {
-    push_u64(62LL);
+    VAL tag = MKU64(62LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_I16_5F_SET() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_I32_5F_GET (void) {
-    push_u64(63LL);
+    VAL tag = MKU64(63LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_I32_5F_GET() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_I32_5F_SET (void) {
-    push_u64(64LL);
+    VAL tag = MKU64(64LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_I32_5F_SET() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_I64_5F_GET (void) {
-    push_u64(65LL);
+    VAL tag = MKU64(65LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_I64_5F_GET() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_I64_5F_SET (void) {
-    push_u64(66LL);
+    VAL tag = MKU64(66LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_I64_5F_SET() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_SYS_5F_OS (void) {
-    push_u64(67LL);
+    VAL tag = MKU64(67LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_SYS_5F_OS() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_SYS_5F_ARGC (void) {
-    push_u64(68LL);
+    VAL tag = MKU64(68LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_SYS_5F_ARGC() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_SYS_5F_ARGV (void) {
-    push_u64(69LL);
+    VAL tag = MKU64(69LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_SYS_5F_ARGV() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_POSIX_5F_READ (void) {
-    push_u64(70LL);
+    VAL tag = MKU64(70LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_POSIX_5F_READ() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_POSIX_5F_WRITE (void) {
-    push_u64(71LL);
+    VAL tag = MKU64(71LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_POSIX_5F_WRITE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_POSIX_5F_OPEN (void) {
-    push_u64(72LL);
+    VAL tag = MKU64(72LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_POSIX_5F_OPEN() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_POSIX_5F_CLOSE (void) {
-    push_u64(73LL);
+    VAL tag = MKU64(73LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_POSIX_5F_CLOSE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_POSIX_5F_EXIT (void) {
-    push_u64(74LL);
+    VAL tag = MKU64(74LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_POSIX_5F_EXIT() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_POSIX_5F_MMAP (void) {
-    push_u64(75LL);
+    VAL tag = MKU64(75LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_POSIX_5F_MMAP() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_MODULE (void) {
-    push_u64(76LL);
+    VAL tag = MKU64(76LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_SYNTAX_5F_MODULE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_IMPORT (void) {
-    push_u64(77LL);
+    VAL tag = MKU64(77LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_SYNTAX_5F_IMPORT() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_ALIAS (void) {
-    push_u64(78LL);
+    VAL tag = MKU64(78LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_SYNTAX_5F_ALIAS() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_DEF (void) {
-    push_u64(79LL);
+    VAL tag = MKU64(79LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_SYNTAX_5F_DEF() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_DEF_5F_MISSING (void) {
-    push_u64(80LL);
+    VAL tag = MKU64(80LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_SYNTAX_5F_DEF_5F_MISSING() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_DEF_5F_TYPE (void) {
-    push_u64(81LL);
+    VAL tag = MKU64(81LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_SYNTAX_5F_DEF_5F_TYPE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_BUFFER (void) {
-    push_u64(82LL);
+    VAL tag = MKU64(82LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_SYNTAX_5F_BUFFER() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_VARIABLE (void) {
-    push_u64(83LL);
+    VAL tag = MKU64(83LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_SYNTAX_5F_VARIABLE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_DEF_5F_EXTERNAL (void) {
-    push_u64(84LL);
+    VAL tag = MKU64(84LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_SYNTAX_5F_DEF_5F_EXTERNAL() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_TARGET_5F_C99 (void) {
-    push_u64(85LL);
+    VAL tag = MKU64(85LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_SYNTAX_5F_TARGET_5F_C99() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_EMBED_5F_STR (void) {
-    push_u64(86LL);
+    VAL tag = MKU64(86LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_SYNTAX_5F_EMBED_5F_STR() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_TABLE (void) {
-    push_u64(87LL);
+    VAL tag = MKU64(87LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_SYNTAX_5F_TABLE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_FIELD (void) {
-    push_u64(88LL);
+    VAL tag = MKU64(88LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_SYNTAX_5F_FIELD() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_DATA (void) {
-    push_u64(89LL);
+    VAL tag = MKU64(89LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_SYNTAX_5F_DATA() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_DASHES (void) {
-    push_u64(90LL);
+    VAL tag = MKU64(90LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_SYNTAX_5F_DASHES() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_PRIM_5F_SYNTAX_5F_ARROW (void) {
-    push_u64(91LL);
+    VAL tag = MKU64(91LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_PRIM_5F_SYNTAX_5F_ARROW() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_TOKEN_5F_NONE (void) {
-    push_u64(0LL);
+    VAL tag = MKU64(0LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_TOKEN_5F_NONE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_TOKEN_5F_COMMA (void) {
-    push_u64(1LL);
+    VAL tag = MKU64(1LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_TOKEN_5F_COMMA() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_TOKEN_5F_LPAREN_5F_OPEN (void) {
-    push_u64(2LL);
+    VAL tag = MKU64(2LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_TOKEN_5F_LPAREN_5F_OPEN() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_TOKEN_5F_LPAREN (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(3LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_TOKEN_5F_LPAREN() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_TOKEN_5F_RPAREN (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(4LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_TOKEN_5F_RPAREN() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_TOKEN_5F_LSQUARE_5F_OPEN (void) {
-    push_u64(5LL);
+    VAL tag = MKU64(5LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_TOKEN_5F_LSQUARE_5F_OPEN() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_TOKEN_5F_LSQUARE (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(6LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_TOKEN_5F_LSQUARE() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_TOKEN_5F_RSQUARE (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(7LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_TOKEN_5F_RSQUARE() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_TOKEN_5F_LCURLY_5F_OPEN (void) {
-    push_u64(8LL);
+    VAL tag = MKU64(8LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_TOKEN_5F_LCURLY_5F_OPEN() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_TOKEN_5F_LCURLY (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(9LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_TOKEN_5F_LCURLY() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_TOKEN_5F_RCURLY (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(10LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_TOKEN_5F_RCURLY() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_TOKEN_5F_INT (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(11LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_TOKEN_5F_INT() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_TOKEN_5F_STR (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(12LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_TOKEN_5F_STR() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_TOKEN_5F_NAME (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(13LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_TOKEN_5F_NAME() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_DEF_5F_NONE (void) {
-    push_u64(0LL);
+    VAL tag = MKU64(0LL);
+    VAL car = (tag);
+    push_value(car);
+}
+void co_DEF_5F_NONE() {
+    VAL car = pop_value();
+    VAL cdr;
+    decref(car);
 }
 static void mw_DEF_5F_ALIAS (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(1LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_DEF_5F_ALIAS() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_DEF_5F_MODULE (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(2LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_DEF_5F_MODULE() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_DEF_5F_TYPE (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(3LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_DEF_5F_TYPE() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_DEF_5F_TAG (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(4LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_DEF_5F_TAG() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_DEF_5F_PRIM (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(5LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_DEF_5F_PRIM() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_DEF_5F_WORD (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(6LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_DEF_5F_WORD() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_DEF_5F_BUFFER (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(7LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_DEF_5F_BUFFER() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_DEF_5F_VARIABLE (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(8LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_DEF_5F_VARIABLE() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_DEF_5F_CONSTANT (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(9LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_DEF_5F_CONSTANT() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_DEF_5F_EXTERNAL (void) {
-    VAL car = pop_value();
     VAL tag = MKU64(10LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
     push_value(car);
 }
-static void mw_DEF_5F_FIELD (void) {
+void co_DEF_5F_EXTERNAL() {
     VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
+    push_value(car);
+}
+static void mw_DEF_5F_FIELD (void) {
     VAL tag = MKU64(11LL);
+    VAL car = (pop_value());
     car = mkcons(car, tag);
+    push_value(car);
+}
+void co_DEF_5F_FIELD() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
     push_value(car);
 }
 static void mw_HASH (void) {
 }
+void co_HASH() {
+}
 static void mw_ROW (void) {
+}
+void co_ROW() {
 }
 static void mw_COL (void) {
 }
+void co_COL() {
+}
 static void mw_LOCATION (void) {
-    VAL car = pop_value();
-    car = mkcons(car, pop_value());
-    car = mkcons(car, pop_value());
     VAL tag = MKU64(0LL);
+    VAL car = (pop_value());
+    car = mkcons(car, pop_value());
+    car = mkcons(car, pop_value());
     car = mkcons(car, tag);
     push_value(car);
 }
+void co_LOCATION() {
+    VAL car = pop_value();
+    VAL cdr;
+    value_uncons_c(car, &car, &cdr);
+    decref(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
+    value_uncons_c(car, &car, &cdr);
+    push_value(cdr);
+    push_value(car);
+}
 
+static void mw_BYTE_5F_ASCII_5F_BUF (void) {
+    static uint8_t b[8] = {0};
+    push_ptr(&b);
+}
 static void mw_STR_5F_BUF (void) {
     static uint8_t b[8192] = {0};
     push_ptr(&b);
@@ -2937,10 +6214,6 @@ static void mw_Field_2E_NUM (void) {
 }
 static void mw_INPUT_5F_BUFFER (void) {
     static uint8_t b[8208] = {0};
-    push_ptr(&b);
-}
-static void mw_CODEGEN_5F_BUF (void) {
-    static uint8_t b[8192] = {0};
     push_ptr(&b);
 }
 static void mw_Atom_2E_NUM (void) {
@@ -3104,19 +6377,19 @@ void mw_lexer_stack() {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_codegen_file() {
-    static VAL v = {0};
-    push_ptr(&v);
-}
-void mw_codegen_length() {
-    static VAL v = {0};
-    push_ptr(&v);
-}
 void mw_needs_stack() {
     static VAL v = {0};
     push_ptr(&v);
 }
-void mw_c99_depth() {
+void mw_c99_file_var() {
+    static VAL v = {0};
+    push_ptr(&v);
+}
+void mw_c99_depth_var() {
+    static VAL v = {0};
+    push_ptr(&v);
+}
+void mw_c99_buffer_var() {
     static VAL v = {0};
     push_ptr(&v);
 }
@@ -3288,6 +6561,7 @@ static void mw_Byte_2E_is_digit (void);
 static void mw_Byte_2E_is_alpha (void);
 static void mw_Byte_2E_is_alnum (void);
 static void mw_Byte_2E_is_hexdigit (void);
+static void mw_Byte_2E_to_ascii_str (void);
 static void mw_Byte_2E_is_string_end (void);
 static void mw_Byte_2E_to_lower (void);
 static void mw_Byte_2E_to_hexdigits (void);
@@ -3326,7 +6600,6 @@ static void mw_Path_2E_trace_21_ (void);
 static void mw_Int_3E_File (void);
 static void mw_File_3E_Int (void);
 static void mw_STDIN (void);
-static void mw_STDOUT (void);
 static void mw_STDERR (void);
 static void mw_Str_2E_write_21_ (void);
 static void mw_slice_write_21_ (void);
@@ -3373,16 +6646,6 @@ static void mw_Data_2E_head_3F_ (void);
 static void mw_Data_2E_name (void);
 static void mw_Data_2E_arity (void);
 static void mw_Data_2E_tags (void);
-static void mw_Tag_2E_id (void);
-static void mw_Tag_2E_for (void);
-static void mw_Tag_2E_alloc_21_ (void);
-static void mw_Tag_2E_data (void);
-static void mw_Tag_2E_name (void);
-static void mw_Tag_2E_value (void);
-static void mw_Tag_2E_num_inputs (void);
-static void mw_Tag_2E_sig_3F_ (void);
-static void mw_Tag_2E_ctx_type (void);
-static void mw_Tag_2E_type (void);
 static void mw_TYPE_5F_BOOL (void);
 static void mw_TYPE_5F_U64 (void);
 static void mw_TYPE_5F_U32 (void);
@@ -3400,8 +6663,21 @@ static void mw_Data_2E_num_tags (void);
 static void mw_Data_2E_add_tag_21_ (void);
 static void mw_Data_2E_is_transparent_3F_ (void);
 static void mw_Data_2E_is_resource_3F_ (void);
-static void mw_Tag_2E_num_inputs_from_sig (void);
+static void mw_Tag_2E_id (void);
+static void mw_Tag_2E_for (void);
+static void mw_Tag_2E_alloc_21_ (void);
+static void mw_Tag_2E_data (void);
+static void mw_Tag_2E_name (void);
+static void mw_Tag_2E_value (void);
+static void mw_Tag_2E_num_type_inputs (void);
+static void mw_Tag_2E_num_resource_inputs (void);
+static void mw_Tag_2E_sig_3F_ (void);
+static void mw_Tag_2E_ctx_type (void);
+static void mw_Tag_2E_type (void);
+static void mw_Tag_2E_num_type_inputs_from_sig (void);
+static void mw_Tag_2E_num_resource_inputs_from_sig (void);
 static void mw_Tag_2E_is_transparent_3F_ (void);
+static void mw_Tag_2E_outputs_resource_3F_ (void);
 static void mw_Tag_3D_ (void);
 static void mw_Match_2E_alloc_21_ (void);
 static void mw_Match_2E_ctx (void);
@@ -3521,7 +6797,6 @@ static void mw_lexer_move_21_ (void);
 static void mw_lexer_location (void);
 static void mw_lexer_emit_warning_21_ (void);
 static void mw_lexer_emit_fatal_error_21_ (void);
-static void mw_CODEGEN_5F_BUF_5F_SIZE (void);
 static void mw_reset_needs_21_ (void);
 static void mw_for_needed_words (void);
 static void mw_for_needed_blocks (void);
@@ -3539,19 +6814,21 @@ static void mw_need_match (void);
 static void mw_need_lambda (void);
 static void mw_need_block_push (void);
 static void mw_need_block_run (void);
-static void mw_codegen_full_3F_ (void);
-static void mw_codegen_flush_21_ (void);
-static void mw__2E_b (void);
-static void mw__2E_ (void);
+static void mw_Str_2B_C99_2E_ (void);
+static void mw_Int_2B_C99_2E_n (void);
+static void mw_Byte_2B_C99_2E_b (void);
+static void mw__2B_C99_2E_depth_40_ (void);
+static void mw__2B_C99_2E_depth_21_ (void);
 static void mw_codegen_start_21_ (void);
+static void mw_codegen_flush_21_ (void);
 static void mw_codegen_end_21_ (void);
+static void mw_with_c99 (void);
 static void mw_run_output_c99_21_ (void);
-static void mw__2E_lf (void);
-static void mw__3B_ (void);
-static void mw__3B__3B_ (void);
-static void mw__2E_n (void);
-static void mw__2E_name (void);
-static void mw__2E_w (void);
+static void mw__2B_C99_2E_lf (void);
+static void mw_Str_2B_C99_3B_ (void);
+static void mw_Str_2B_C99_3B__3B_ (void);
+static void mw_Name_2B_C99_2E_name (void);
+static void mw_Name_2B_C99_2E_w (void);
 static void mw_c99_header_21_ (void);
 static void mw_c99_buffers_21_ (void);
 static void mw_c99_buffer_21_ (void);
@@ -3580,8 +6857,8 @@ static void mw_c99_args_push_21_ (void);
 static void mw_c99_arg_push_21_ (void);
 static void mw_c99_arg_run_21_ (void);
 static void mw_c99_block_run_21_ (void);
-static void mw__2E_var (void);
-static void mw__2E_param (void);
+static void mw_Var_2B_C99_2E_var (void);
+static void mw_Param_2B_C99_2E_param (void);
 static void mw_c99_pack_ctx_21_ (void);
 static void mw_c99_unpack_ctx_21_ (void);
 static void mw_c99_decref_ctx_21_ (void);
@@ -3603,7 +6880,7 @@ static void mw_c99_block_enter_21_ (void);
 static void mw_c99_block_exit_21_ (void);
 static void mw_c99_block_defs_21_ (void);
 static void mw_c99_block_def_21_ (void);
-static void mw__2E_block (void);
+static void mw_Block_2B_C99_2E_block (void);
 static void mw_c99_word_enter_21_ (void);
 static void mw_c99_word_exit_21_ (void);
 static void mw_c99_word_defs_21_ (void);
@@ -4281,9 +7558,15 @@ static void mb_make_tag_21__3 (void);
 static void mb_make_tag_21__4 (void);
 static void mb_make_tag_21__5 (void);
 static void mb_make_tag_21__6 (void);
+static void mb_make_tag_21__7 (void);
 static void mb_Data_3D__1 (void);
-static void mb_Tag_2E_num_inputs_from_sig_1 (void);
-static void mb_Tag_2E_num_inputs_from_sig_2 (void);
+static void mb_Tag_2E_num_type_inputs_from_sig_1 (void);
+static void mb_Tag_2E_num_type_inputs_from_sig_2 (void);
+static void mb_Tag_2E_num_resource_inputs_from_sig_1 (void);
+static void mb_Tag_2E_num_resource_inputs_from_sig_5 (void);
+static void mb_Tag_2E_num_resource_inputs_from_sig_2 (void);
+static void mb_Tag_2E_num_resource_inputs_from_sig_3 (void);
+static void mb_Tag_2E_num_resource_inputs_from_sig_4 (void);
 static void mb_Tag_3D__1 (void);
 static void mb_Match_2E_is_exhaustive_3F__1 (void);
 static void mb_Match_2E_has_default_case_3F__1 (void);
@@ -4375,6 +7658,9 @@ static void mb_elab_data_tag_21__9 (void);
 static void mb_elab_data_tag_21__12 (void);
 static void mb_elab_data_tag_21__13 (void);
 static void mb_elab_data_tag_21__15 (void);
+static void mb_elab_data_tag_21__16 (void);
+static void mb_elab_data_tag_21__17 (void);
+static void mb_elab_data_tag_21__18 (void);
 static void mb_token_def_args_3 (void);
 static void mb_token_def_args_8 (void);
 static void mb_elab_def_params_21__2 (void);
@@ -4394,6 +7680,7 @@ static void mb_table_new_21__13 (void);
 static void mb_table_new_21__14 (void);
 static void mb_table_new_21__15 (void);
 static void mb_table_new_21__16 (void);
+static void mb_run_output_c99_21__3 (void);
 static void mb_field_new_21__1 (void);
 static void mb_field_new_21__2 (void);
 static void mb_Word_2E_ctx_type_1 (void);
@@ -4420,13 +7707,9 @@ static void mb_determine_transitive_needs_21__2 (void);
 static void mb_need_atom_run_1 (void);
 static void mb_need_args_push_1 (void);
 static void mb_need_match_1 (void);
-static void mb_codegen_flush_21__2 (void);
-static void mb_codegen_flush_21__3 (void);
-static void mb_codegen_flush_21__4 (void);
-static void mb_codegen_flush_21__5 (void);
-static void mb__2E_b_3 (void);
-static void mb__2E__6 (void);
-static void mb__2E__7 (void);
+static void mb_Str_2B_C99_2E__1 (void);
+static void mb_Str_2B_C99_2E__2 (void);
+static void mb_codegen_flush_21__1 (void);
 static void mb_c99_tags_21__1 (void);
 static void mb_c99_buffers_21__1 (void);
 static void mb_c99_variables_21__1 (void);
@@ -4445,15 +7728,16 @@ static void mb_c99_main_21__8 (void);
 static void mb_c99_field_defs_21__1 (void);
 static void mb_c99_word_defs_21__1 (void);
 static void mb_c99_block_defs_21__1 (void);
-static void mb_c99_tag_21__5 (void);
+static void mb_c99_tag_21__3 (void);
+static void mb_c99_tag_21__4 (void);
+static void mb_c99_tag_21__11 (void);
+static void mb_c99_tag_21__12 (void);
 static void mb_c99_external_21__5 (void);
 static void mb_c99_external_21__7 (void);
 static void mb_c99_external_21__9 (void);
 static void mb_c99_external_21__10 (void);
 static void mb_c99_external_21__13 (void);
 static void mb_c99_external_21__16 (void);
-static void mb_c99_nest_2 (void);
-static void mb_c99_nest_3 (void);
 static void mb_c99_indent_1 (void);
 static void mb_c99_call_21__2 (void);
 static void mb_c99_args_push_21__1 (void);
@@ -4534,10 +7818,7 @@ static void mb_c99_case_21__2 (void);
 static void mb_c99_pattern_21__2 (void);
 static void mb_c99_pattern_21__4 (void);
 static void mb_c99_pattern_21__5 (void);
-static void mb_c99_pattern_21__7 (void);
-static void mb_c99_pattern_21__8 (void);
-static void mb_c99_pattern_21__9 (void);
-static void mb_c99_pattern_21__11 (void);
+static void mb_c99_pattern_21__6 (void);
 static void mb_c99_word_sig_21__1 (void);
 static void mb_c99_block_sig_21__1 (void);
 static void mb_c99_field_sig_21__1 (void);
@@ -4562,7 +7843,8 @@ static void mw_Data_7E_tags (void);
 static void mw_Tag_7E_data (void);
 static void mw_Tag_7E_name (void);
 static void mw_Tag_7E_value (void);
-static void mw_Tag_7E_num_inputs (void);
+static void mw_Tag_7E_num_type_inputs (void);
+static void mw_Tag_7E_num_resource_inputs (void);
 static void mw_Tag_7E_sig_3F_ (void);
 static void mw_Tag_7E_ctx_type (void);
 static void mw_Match_7E_ctx (void);
@@ -4804,7 +8086,7 @@ static void mw_Tag_7E_value (void){
     push_ptr(v);
 }
 
-static VAL* fieldptr_Tag_7E_num_inputs (size_t i) {
+static VAL* fieldptr_Tag_7E_num_type_inputs (size_t i) {
     static struct VAL * p = 0;
     size_t m = 65536;
     if (! p) { p = calloc(m, sizeof *p); }
@@ -4812,9 +8094,23 @@ static VAL* fieldptr_Tag_7E_num_inputs (size_t i) {
     return p+i;
 }
 
-static void mw_Tag_7E_num_inputs (void){
+static void mw_Tag_7E_num_type_inputs (void){
     size_t index = (size_t)pop_u64();
-    VAL *v = fieldptr_Tag_7E_num_inputs(index);
+    VAL *v = fieldptr_Tag_7E_num_type_inputs(index);
+    push_ptr(v);
+}
+
+static VAL* fieldptr_Tag_7E_num_resource_inputs (size_t i) {
+    static struct VAL * p = 0;
+    size_t m = 65536;
+    if (! p) { p = calloc(m, sizeof *p); }
+    if (i>=m) { write(2,"table too big\n",14); exit(123); }
+    return p+i;
+}
+
+static void mw_Tag_7E_num_resource_inputs (void){
+    size_t index = (size_t)pop_u64();
+    VAL *v = fieldptr_Tag_7E_num_resource_inputs(index);
     push_ptr(v);
 }
 
@@ -6094,83 +9390,78 @@ static void mw_Module_7E_imports (void){
 
 
 static void mw_L4_2B_ (void){
-    WORD_ENTER(mw_L4_2B_, "L4+", "src/data/list.mth", 28, 50);
-    WORD_ATOM(28, 50, "L2+");
+    WORD_ENTER(mw_L4_2B_, "L4+", "src/data/list.mth", 33, 50);
+    WORD_ATOM(33, 50, "L2+");
     mw_L2_2B_();
-    WORD_ATOM(28, 54, "dip");
+    WORD_ATOM(33, 54, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(28, 58, "L2+");
+        WORD_ATOM(33, 58, "L2+");
         mw_L2_2B_();
         push_value(d2);
     }
-    WORD_ATOM(28, 63, "");
+    WORD_ATOM(33, 63, "");
     push_i64(4LL);
-    WORD_ATOM(28, 66, "LCAT+");
+    WORD_ATOM(33, 66, "LCAT+");
     mw_LCAT_2B_();
     WORD_EXIT(mw_L4_2B_);
 }
 static void mw_L5_2B_ (void){
-    WORD_ENTER(mw_L5_2B_, "L5+", "src/data/list.mth", 29, 50);
-    WORD_ATOM(29, 50, "L3+");
+    WORD_ENTER(mw_L5_2B_, "L5+", "src/data/list.mth", 34, 50);
+    WORD_ATOM(34, 50, "L3+");
     mw_L3_2B_();
-    WORD_ATOM(29, 54, "dip");
+    WORD_ATOM(34, 54, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(29, 58, "L2+");
+        WORD_ATOM(34, 58, "L2+");
         mw_L2_2B_();
         push_value(d2);
     }
-    WORD_ATOM(29, 63, "");
+    WORD_ATOM(34, 63, "");
     push_i64(5LL);
-    WORD_ATOM(29, 66, "LCAT+");
+    WORD_ATOM(34, 66, "LCAT+");
     mw_LCAT_2B_();
     WORD_EXIT(mw_L5_2B_);
 }
 static void mw_L6_2B_ (void){
-    WORD_ENTER(mw_L6_2B_, "L6+", "src/data/list.mth", 30, 50);
-    WORD_ATOM(30, 50, "L3+");
+    WORD_ENTER(mw_L6_2B_, "L6+", "src/data/list.mth", 35, 50);
+    WORD_ATOM(35, 50, "L3+");
     mw_L3_2B_();
-    WORD_ATOM(30, 54, "dip");
+    WORD_ATOM(35, 54, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(30, 58, "L3+");
+        WORD_ATOM(35, 58, "L3+");
         mw_L3_2B_();
         push_value(d2);
     }
-    WORD_ATOM(30, 63, "");
+    WORD_ATOM(35, 63, "");
     push_i64(6LL);
-    WORD_ATOM(30, 66, "LCAT+");
+    WORD_ATOM(35, 66, "LCAT+");
     mw_LCAT_2B_();
     WORD_EXIT(mw_L6_2B_);
 }
 static void mw_List_2B__3E_List (void){
-    WORD_ENTER(mw_List_2B__3E_List, "List+>List", "src/data/list.mth", 39, 5);
-    WORD_ATOM(39, 5, "L1+");
+    WORD_ENTER(mw_List_2B__3E_List, "List+>List", "src/data/list.mth", 44, 5);
+    WORD_ATOM(44, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(39, 12, "L1");
+            co_L1_2B_();
+            WORD_ATOM(44, 12, "L1");
             mw_L1();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(40, 12, "L2");
+            co_L2_2B_();
+            WORD_ATOM(45, 12, "L2");
             mw_L2();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(41, 12, "L3");
+            co_L3_2B_();
+            WORD_ATOM(46, 12, "L3");
             mw_L3();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(42, 14, "LCAT");
+            co_LCAT_2B_();
+            WORD_ATOM(47, 14, "LCAT");
             mw_LCAT();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -6178,45 +9469,40 @@ static void mw_List_2B__3E_List (void){
 }    WORD_EXIT(mw_List_2B__3E_List);
 }
 static void mw_List_3E_List_2B_ (void){
-    WORD_ENTER(mw_List_3E_List_2B_, "List>List+", "src/data/list.mth", 45, 5);
-    WORD_ATOM(45, 5, "L0");
+    WORD_ENTER(mw_List_3E_List_2B_, "List>List+", "src/data/list.mth", 50, 5);
+    WORD_ATOM(50, 5, "L0");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
-            WORD_ATOM(45, 11, "NONE");
+            co_L0();
+            WORD_ATOM(50, 11, "NONE");
             mw_NONE();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(46, 11, "L1+");
+            co_L1();
+            WORD_ATOM(51, 11, "L1+");
             mw_L1_2B_();
-            WORD_ATOM(46, 15, "SOME");
+            WORD_ATOM(51, 15, "SOME");
             mw_SOME();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(47, 11, "L2+");
+            co_L2();
+            WORD_ATOM(52, 11, "L2+");
             mw_L2_2B_();
-            WORD_ATOM(47, 15, "SOME");
+            WORD_ATOM(52, 15, "SOME");
             mw_SOME();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(48, 11, "L3+");
+            co_L3();
+            WORD_ATOM(53, 11, "L3+");
             mw_L3_2B_();
-            WORD_ATOM(48, 15, "SOME");
+            WORD_ATOM(53, 15, "SOME");
             mw_SOME();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(49, 13, "LCAT+");
+            co_LCAT();
+            WORD_ATOM(54, 13, "LCAT+");
             mw_LCAT_2B_();
-            WORD_ATOM(49, 19, "SOME");
+            WORD_ATOM(54, 19, "SOME");
             mw_SOME();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -6224,64 +9510,59 @@ static void mw_List_3E_List_2B_ (void){
 }    WORD_EXIT(mw_List_3E_List_2B_);
 }
 static void mw_List_2E_is_empty (void){
-    WORD_ENTER(mw_List_2E_is_empty, "List.is-empty", "src/data/list.mth", 52, 5);
-    WORD_ATOM(52, 5, "L0");
+    WORD_ENTER(mw_List_2E_is_empty, "List.is-empty", "src/data/list.mth", 57, 5);
+    WORD_ATOM(57, 5, "L0");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
-            WORD_ATOM(52, 11, "T");
+            co_L0();
+            WORD_ATOM(57, 11, "T");
             mw_T();
             break;
         default:
-            WORD_ATOM(53, 10, "drop");
+            WORD_ATOM(58, 10, "drop");
             mw_prim_drop();
-            WORD_ATOM(53, 15, "F");
+            WORD_ATOM(58, 15, "F");
             mw_F();
             break;
     
 }    WORD_EXIT(mw_List_2E_is_empty);
 }
 static void mw_List_2E_len (void){
-    WORD_ENTER(mw_List_2E_len, "List.len", "src/data/list.mth", 56, 5);
-    WORD_ATOM(56, 5, "L0");
+    WORD_ENTER(mw_List_2E_len, "List.len", "src/data/list.mth", 61, 5);
+    WORD_ATOM(61, 5, "L0");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
-            WORD_ATOM(56, 11, "");
+            co_L0();
+            WORD_ATOM(61, 11, "");
             push_i64(0LL);
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(57, 11, "drop");
+            co_L1();
+            WORD_ATOM(62, 11, "drop");
             mw_prim_drop();
-            WORD_ATOM(57, 16, "");
+            WORD_ATOM(62, 16, "");
             push_i64(1LL);
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(58, 11, "drop2");
+            co_L2();
+            WORD_ATOM(63, 11, "drop2");
             mw_drop2();
-            WORD_ATOM(58, 17, "");
+            WORD_ATOM(63, 17, "");
             push_i64(2LL);
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(59, 11, "drop3");
+            co_L3();
+            WORD_ATOM(64, 11, "drop3");
             mw_drop3();
-            WORD_ATOM(59, 17, "");
+            WORD_ATOM(64, 17, "");
             push_i64(3LL);
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(60, 13, "dip");
+            co_LCAT();
+            WORD_ATOM(65, 13, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(60, 17, "drop2");
+                WORD_ATOM(65, 17, "drop2");
                 mw_drop2();
                 push_value(d4);
             }
@@ -6291,41 +9572,36 @@ static void mw_List_2E_len (void){
 }    WORD_EXIT(mw_List_2E_len);
 }
 static void mw_List_2B__2E_len (void){
-    WORD_ENTER(mw_List_2B__2E_len, "List+.len", "src/data/list.mth", 63, 5);
-    WORD_ATOM(63, 5, "L1+");
+    WORD_ENTER(mw_List_2B__2E_len, "List+.len", "src/data/list.mth", 68, 5);
+    WORD_ATOM(68, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(63, 12, "drop");
+            co_L1_2B_();
+            WORD_ATOM(68, 12, "drop");
             mw_prim_drop();
-            WORD_ATOM(63, 17, "");
+            WORD_ATOM(68, 17, "");
             push_i64(1LL);
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(64, 12, "drop2");
+            co_L2_2B_();
+            WORD_ATOM(69, 12, "drop2");
             mw_drop2();
-            WORD_ATOM(64, 18, "");
+            WORD_ATOM(69, 18, "");
             push_i64(2LL);
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(65, 12, "drop3");
+            co_L3_2B_();
+            WORD_ATOM(70, 12, "drop3");
             mw_drop3();
-            WORD_ATOM(65, 18, "");
+            WORD_ATOM(70, 18, "");
             push_i64(3LL);
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(66, 14, "dip");
+            co_LCAT_2B_();
+            WORD_ATOM(71, 14, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(66, 18, "drop2");
+                WORD_ATOM(71, 18, "drop2");
                 mw_drop2();
                 push_value(d4);
             }
@@ -6335,53 +9611,48 @@ static void mw_List_2B__2E_len (void){
 }    WORD_EXIT(mw_List_2B__2E_len);
 }
 static void mw_List_2E_cons_2B_ (void){
-    WORD_ENTER(mw_List_2E_cons_2B_, "List.cons+", "src/data/list.mth", 72, 5);
-    WORD_ATOM(72, 5, "L0");
+    WORD_ENTER(mw_List_2E_cons_2B_, "List.cons+", "src/data/list.mth", 77, 5);
+    WORD_ATOM(77, 5, "L0");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
-            WORD_ATOM(72, 11, "L1+");
+            co_L0();
+            WORD_ATOM(77, 11, "L1+");
             mw_L1_2B_();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(73, 11, "L2+");
+            co_L1();
+            WORD_ATOM(78, 11, "L2+");
             mw_L2_2B_();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(74, 11, "L3+");
+            co_L2();
+            WORD_ATOM(79, 11, "L3+");
             mw_L3_2B_();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(75, 11, "L4+");
+            co_L3();
+            WORD_ATOM(80, 11, "L4+");
             mw_L4_2B_();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(76, 13, "1+");
+            co_LCAT();
+            WORD_ATOM(81, 13, "1+");
             mw_prim_int_succ();
-            WORD_ATOM(76, 16, "dip");
+            WORD_ATOM(81, 16, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(76, 20, "dip");
+                WORD_ATOM(81, 20, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(76, 24, "cons+");
+                    WORD_ATOM(81, 24, "cons+");
                     mw_List_2B__2E_cons_2B_();
                     push_value(d5);
                 }
-                WORD_ATOM(76, 31, "rebalance");
+                WORD_ATOM(81, 31, "rebalance");
                 mw_List_2B__2E_rebalance();
                 push_value(d4);
             }
-            WORD_ATOM(76, 42, "LCAT+");
+            WORD_ATOM(81, 42, "LCAT+");
             mw_LCAT_2B_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -6389,58 +9660,53 @@ static void mw_List_2E_cons_2B_ (void){
 }    WORD_EXIT(mw_List_2E_cons_2B_);
 }
 static void mw_snoc_2B_ (void){
-    WORD_ENTER(mw_snoc_2B_, "snoc+", "src/data/list.mth", 79, 5);
-    WORD_ATOM(79, 5, "swap");
+    WORD_ENTER(mw_snoc_2B_, "snoc+", "src/data/list.mth", 84, 5);
+    WORD_ATOM(84, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(79, 10, "match");
+    WORD_ATOM(84, 10, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
-            WORD_ATOM(80, 15, "L1+");
+            co_L0();
+            WORD_ATOM(85, 15, "L1+");
             mw_L1_2B_();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(81, 15, "swap");
+            co_L1();
+            WORD_ATOM(86, 15, "swap");
             mw_prim_swap();
-            WORD_ATOM(81, 20, "L2+");
+            WORD_ATOM(86, 20, "L2+");
             mw_L2_2B_();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(82, 15, "rotl");
+            co_L2();
+            WORD_ATOM(87, 15, "rotl");
             mw_rotl();
-            WORD_ATOM(82, 20, "L3+");
+            WORD_ATOM(87, 20, "L3+");
             mw_L3_2B_();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(83, 15, "rot4l");
+            co_L3();
+            WORD_ATOM(88, 15, "rot4l");
             mw_rot4l();
-            WORD_ATOM(83, 21, "L4+");
+            WORD_ATOM(88, 21, "L4+");
             mw_L4_2B_();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(84, 17, "1+");
+            co_LCAT();
+            WORD_ATOM(89, 17, "1+");
             mw_prim_int_succ();
-            WORD_ATOM(84, 20, "dip");
+            WORD_ATOM(89, 20, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(84, 24, "rotl");
+                WORD_ATOM(89, 24, "rotl");
                 mw_rotl();
-                WORD_ATOM(84, 29, "snoc++");
+                WORD_ATOM(89, 29, "snoc++");
                 mw_snoc_2B__2B_();
-                WORD_ATOM(84, 36, "rebalance");
+                WORD_ATOM(89, 36, "rebalance");
                 mw_List_2B__2E_rebalance();
                 push_value(d4);
             }
-            WORD_ATOM(84, 47, "LCAT+");
+            WORD_ATOM(89, 47, "LCAT+");
             mw_LCAT_2B_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -6448,80 +9714,75 @@ static void mw_snoc_2B_ (void){
 }    WORD_EXIT(mw_snoc_2B_);
 }
 static void mw_List_2B__2E_cons_2B_ (void){
-    WORD_ENTER(mw_List_2B__2E_cons_2B_, "List+.cons+", "src/data/list.mth", 87, 42);
-    WORD_ATOM(87, 42, ">List");
+    WORD_ENTER(mw_List_2B__2E_cons_2B_, "List+.cons+", "src/data/list.mth", 92, 42);
+    WORD_ATOM(92, 42, ">List");
     mw_List_2B__3E_List();
-    WORD_ATOM(87, 48, "cons+");
+    WORD_ATOM(92, 48, "cons+");
     mw_List_2E_cons_2B_();
     WORD_EXIT(mw_List_2B__2E_cons_2B_);
 }
 static void mw_List_2E_cons (void){
-    WORD_ENTER(mw_List_2E_cons, "List.cons", "src/data/list.mth", 88, 38);
-    WORD_ATOM(88, 38, "cons+");
+    WORD_ENTER(mw_List_2E_cons, "List.cons", "src/data/list.mth", 93, 38);
+    WORD_ATOM(93, 38, "cons+");
     mw_List_2E_cons_2B_();
-    WORD_ATOM(88, 44, ">List");
+    WORD_ATOM(93, 44, ">List");
     mw_List_2B__3E_List();
     WORD_EXIT(mw_List_2E_cons);
 }
 static void mw_snoc_2B__2B_ (void){
-    WORD_ENTER(mw_snoc_2B__2B_, "snoc++", "src/data/list.mth", 89, 37);
-    WORD_ATOM(89, 37, "dip");
+    WORD_ENTER(mw_snoc_2B__2B_, "snoc++", "src/data/list.mth", 94, 37);
+    WORD_ATOM(94, 37, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(89, 41, "List+>List");
+        WORD_ATOM(94, 41, "List+>List");
         mw_List_2B__3E_List();
         push_value(d2);
     }
-    WORD_ATOM(89, 53, "snoc+");
+    WORD_ATOM(94, 53, "snoc+");
     mw_snoc_2B_();
     WORD_EXIT(mw_snoc_2B__2B_);
 }
 static void mw_snoc (void){
-    WORD_ENTER(mw_snoc, "snoc", "src/data/list.mth", 90, 33);
-    WORD_ATOM(90, 33, "snoc+");
+    WORD_ENTER(mw_snoc, "snoc", "src/data/list.mth", 95, 33);
+    WORD_ATOM(95, 33, "snoc+");
     mw_snoc_2B_();
-    WORD_ATOM(90, 39, "List+>List");
+    WORD_ATOM(95, 39, "List+>List");
     mw_List_2B__3E_List();
     WORD_EXIT(mw_snoc);
 }
 static void mw_List_2B__2E_uncons (void){
-    WORD_ENTER(mw_List_2B__2E_uncons, "List+.uncons", "src/data/list.mth", 93, 5);
-    WORD_ATOM(93, 5, "L1+");
+    WORD_ENTER(mw_List_2B__2E_uncons, "List+.uncons", "src/data/list.mth", 98, 5);
+    WORD_ATOM(98, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(93, 12, "L0");
+            co_L1_2B_();
+            WORD_ATOM(98, 12, "L0");
             mw_L0();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(94, 12, "L1");
+            co_L2_2B_();
+            WORD_ATOM(99, 12, "L1");
             mw_L1();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(95, 12, "L2");
+            co_L3_2B_();
+            WORD_ATOM(100, 12, "L2");
             mw_L2();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(96, 14, "drop");
+            co_LCAT_2B_();
+            WORD_ATOM(101, 14, "drop");
             mw_prim_drop();
-            WORD_ATOM(96, 19, "dip");
+            WORD_ATOM(101, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(96, 23, "uncons");
+                WORD_ATOM(101, 23, "uncons");
                 mw_List_2B__2E_uncons();
                 push_value(d4);
             }
-            WORD_ATOM(96, 31, "cat");
+            WORD_ATOM(101, 31, "cat");
             mw_List_2B__2E_cat();
-            WORD_ATOM(96, 35, ">List");
+            WORD_ATOM(101, 35, ">List");
             mw_List_2B__3E_List();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -6529,56 +9790,51 @@ static void mw_List_2B__2E_uncons (void){
 }    WORD_EXIT(mw_List_2B__2E_uncons);
 }
 static void mw_List_2B__2E_unsnoc (void){
-    WORD_ENTER(mw_List_2B__2E_unsnoc, "List+.unsnoc", "src/data/list.mth", 99, 5);
-    WORD_ATOM(99, 5, "L1+");
+    WORD_ENTER(mw_List_2B__2E_unsnoc, "List+.unsnoc", "src/data/list.mth", 104, 5);
+    WORD_ATOM(104, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(99, 12, "dip");
+            co_L1_2B_();
+            WORD_ATOM(104, 12, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(99, 16, "L0");
+                WORD_ATOM(104, 16, "L0");
                 mw_L0();
                 push_value(d4);
             }
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(100, 12, "dip");
+            co_L2_2B_();
+            WORD_ATOM(105, 12, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(100, 16, "L1");
+                WORD_ATOM(105, 16, "L1");
                 mw_L1();
                 push_value(d4);
             }
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(101, 12, "dip");
+            co_L3_2B_();
+            WORD_ATOM(106, 12, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(101, 16, "L2");
+                WORD_ATOM(106, 16, "L2");
                 mw_L2();
                 push_value(d4);
             }
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(102, 14, "drop");
+            co_LCAT_2B_();
+            WORD_ATOM(107, 14, "drop");
             mw_prim_drop();
-            WORD_ATOM(102, 19, "unsnoc");
+            WORD_ATOM(107, 19, "unsnoc");
             mw_List_2B__2E_unsnoc();
-            WORD_ATOM(102, 26, "dip");
+            WORD_ATOM(107, 26, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(102, 30, "cat+");
+                WORD_ATOM(107, 30, "cat+");
                 mw_List_2E_cat_2B_();
-                WORD_ATOM(102, 35, ">List");
+                WORD_ATOM(107, 35, ">List");
                 mw_List_2B__3E_List();
                 push_value(d4);
             }
@@ -6588,10 +9844,10 @@ static void mw_List_2B__2E_unsnoc (void){
 }    WORD_EXIT(mw_List_2B__2E_unsnoc);
 }
 static void mw_List_2E_cat (void){
-    WORD_ENTER(mw_List_2E_cat, "List.cat", "src/data/list.mth", 105, 5);
-    WORD_ATOM(105, 5, ">List+");
+    WORD_ENTER(mw_List_2E_cat, "List.cat", "src/data/list.mth", 110, 5);
+    WORD_ATOM(110, 5, ">List+");
     mw_List_3E_List_2B_();
-    WORD_ATOM(105, 12, "for");
+    WORD_ATOM(110, 12, "for");
     push_u64(0);
     push_fnptr(&mb_List_2E_cat_1);
     mw_prim_pack_cons();
@@ -6599,12 +9855,12 @@ static void mw_List_2E_cat (void){
     WORD_EXIT(mw_List_2E_cat);
 }
 static void mw_List_2B__2E_cat (void){
-    WORD_ENTER(mw_List_2B__2E_cat, "List+.cat", "src/data/list.mth", 108, 5);
-    WORD_ATOM(108, 5, "swap");
+    WORD_ENTER(mw_List_2B__2E_cat, "List+.cat", "src/data/list.mth", 113, 5);
+    WORD_ATOM(113, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(108, 10, ">List+");
+    WORD_ATOM(113, 10, ">List+");
     mw_List_3E_List_2B_();
-    WORD_ATOM(108, 17, "for");
+    WORD_ATOM(113, 17, "for");
     push_u64(0);
     push_fnptr(&mb_List_2B__2E_cat_1);
     mw_prim_pack_cons();
@@ -6612,10 +9868,10 @@ static void mw_List_2B__2E_cat (void){
     WORD_EXIT(mw_List_2B__2E_cat);
 }
 static void mw_List_2E_cat_2B_ (void){
-    WORD_ENTER(mw_List_2E_cat_2B_, "List.cat+", "src/data/list.mth", 111, 5);
-    WORD_ATOM(111, 5, ">List+");
+    WORD_ENTER(mw_List_2E_cat_2B_, "List.cat+", "src/data/list.mth", 116, 5);
+    WORD_ATOM(116, 5, ">List+");
     mw_List_3E_List_2B_();
-    WORD_ATOM(111, 12, "for");
+    WORD_ATOM(116, 12, "for");
     push_u64(0);
     push_fnptr(&mb_List_2E_cat_2B__1);
     mw_prim_pack_cons();
@@ -6623,107 +9879,98 @@ static void mw_List_2E_cat_2B_ (void){
     WORD_EXIT(mw_List_2E_cat_2B_);
 }
 static void mw_List_2B__2E_cat_2B_ (void){
-    WORD_ENTER(mw_List_2B__2E_cat_2B_, "List+.cat+", "src/data/list.mth", 114, 5);
-    WORD_ATOM(114, 5, "swap");
+    WORD_ENTER(mw_List_2B__2E_cat_2B_, "List+.cat+", "src/data/list.mth", 119, 5);
+    WORD_ATOM(119, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(114, 10, "match");
+    WORD_ATOM(119, 10, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(115, 16, "swap");
+            co_L1_2B_();
+            WORD_ATOM(120, 16, "swap");
             mw_prim_swap();
-            WORD_ATOM(115, 21, "cons+");
+            WORD_ATOM(120, 21, "cons+");
             mw_List_2B__2E_cons_2B_();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(117, 13, "rotl");
+            co_L2_2B_();
+            WORD_ATOM(122, 13, "rotl");
             mw_rotl();
-            WORD_ATOM(117, 18, "match");
+            WORD_ATOM(122, 18, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(118, 24, "L3+");
+                    co_L1_2B_();
+                    WORD_ATOM(123, 24, "L3+");
                     mw_L3_2B_();
                     break;
                 case 1LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
-                    mw_prim_pack_uncons(); mw_prim_swap();
-                    WORD_ATOM(119, 24, "L4+");
+                    co_L2_2B_();
+                    WORD_ATOM(124, 24, "L4+");
                     mw_L4_2B_();
                     break;
                 case 2LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
-                    mw_prim_pack_uncons(); mw_prim_swap();
-                    mw_prim_pack_uncons(); mw_prim_swap();
-                    WORD_ATOM(120, 24, "L5+");
+                    co_L3_2B_();
+                    WORD_ATOM(125, 24, "L5+");
                     mw_L5_2B_();
                     break;
                 default:
-                    WORD_ATOM(121, 22, "dip");
+                    WORD_ATOM(126, 22, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(121, 26, "L2+");
+                        WORD_ATOM(126, 26, "L2+");
                         mw_L2_2B_();
                         push_value(d6);
                     }
-                    WORD_ATOM(121, 31, "cat-aux");
+                    WORD_ATOM(126, 31, "cat-aux");
                     mw_List_2B__2E_cat_aux();
                     break;
             
 }            break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(124, 13, "rot4l");
+            co_L3_2B_();
+            WORD_ATOM(129, 13, "rot4l");
             mw_rot4l();
-            WORD_ATOM(124, 19, "match");
+            WORD_ATOM(129, 19, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(125, 24, "L4+");
+                    co_L1_2B_();
+                    WORD_ATOM(130, 24, "L4+");
                     mw_L4_2B_();
                     break;
                 case 1LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
-                    mw_prim_pack_uncons(); mw_prim_swap();
-                    WORD_ATOM(126, 24, "L5+");
+                    co_L2_2B_();
+                    WORD_ATOM(131, 24, "L5+");
                     mw_L5_2B_();
                     break;
                 case 2LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
-                    mw_prim_pack_uncons(); mw_prim_swap();
-                    mw_prim_pack_uncons(); mw_prim_swap();
-                    WORD_ATOM(127, 24, "L6+");
+                    co_L3_2B_();
+                    WORD_ATOM(132, 24, "L6+");
                     mw_L6_2B_();
                     break;
                 default:
-                    WORD_ATOM(128, 22, "dip");
+                    WORD_ATOM(133, 22, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(128, 26, "L3+");
+                        WORD_ATOM(133, 26, "L3+");
                         mw_L3_2B_();
                         push_value(d6);
                     }
-                    WORD_ATOM(128, 31, "cat-aux");
+                    WORD_ATOM(133, 31, "cat-aux");
                     mw_List_2B__2E_cat_aux();
                     break;
             
 }            break;
         default:
-            WORD_ATOM(131, 13, "swap");
+            WORD_ATOM(136, 13, "swap");
             mw_prim_swap();
-            WORD_ATOM(131, 18, "match");
+            WORD_ATOM(136, 18, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(132, 24, "snoc++");
+                    co_L1_2B_();
+                    WORD_ATOM(137, 24, "snoc++");
                     mw_snoc_2B__2B_();
                     break;
                 default:
-                    WORD_ATOM(133, 22, "cat-aux");
+                    WORD_ATOM(138, 22, "cat-aux");
                     mw_List_2B__2E_cat_aux();
                     break;
             
@@ -6732,144 +9979,139 @@ static void mw_List_2B__2E_cat_2B_ (void){
 }    WORD_EXIT(mw_List_2B__2E_cat_2B_);
 }
 static void mw_List_2B__2E_cat_aux (void){
-    WORD_ENTER(mw_List_2B__2E_cat_aux, "List+.cat-aux", "src/data/list.mth", 138, 5);
-    WORD_ATOM(138, 5, "rebalance");
+    WORD_ENTER(mw_List_2B__2E_cat_aux, "List+.cat-aux", "src/data/list.mth", 143, 5);
+    WORD_ATOM(143, 5, "rebalance");
     mw_List_2B__2E_rebalance();
-    WORD_ATOM(138, 15, "dup2");
+    WORD_ATOM(143, 15, "dup2");
     mw_dup2();
-    WORD_ATOM(138, 20, "dip");
+    WORD_ATOM(143, 20, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(138, 24, "len");
+        WORD_ATOM(143, 24, "len");
         mw_List_2B__2E_len();
         push_value(d2);
     }
-    WORD_ATOM(138, 29, "len");
+    WORD_ATOM(143, 29, "len");
     mw_List_2B__2E_len();
-    WORD_ATOM(138, 33, "+");
+    WORD_ATOM(143, 33, "+");
     mw_prim_int_add();
-    WORD_ATOM(138, 35, "LCAT+");
+    WORD_ATOM(143, 35, "LCAT+");
     mw_LCAT_2B_();
     WORD_EXIT(mw_List_2B__2E_cat_aux);
 }
 static void mw_List_2B__2E_rebalance (void){
-    WORD_ENTER(mw_List_2B__2E_rebalance, "List+.rebalance", "src/data/list.mth", 141, 5);
-    WORD_ATOM(141, 5, "dup2");
+    WORD_ENTER(mw_List_2B__2E_rebalance, "List+.rebalance", "src/data/list.mth", 146, 5);
+    WORD_ATOM(146, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(141, 10, "dip");
+    WORD_ATOM(146, 10, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(141, 14, "len");
+        WORD_ATOM(146, 14, "len");
         mw_List_2B__2E_len();
         push_value(d2);
     }
-    WORD_ATOM(141, 19, "len");
+    WORD_ATOM(146, 19, "len");
     mw_List_2B__2E_len();
-    WORD_ATOM(141, 23, "dup2");
+    WORD_ATOM(146, 23, "dup2");
     mw_dup2();
-    WORD_ATOM(141, 28, "");
+    WORD_ATOM(146, 28, "");
     push_i64(6LL);
-    WORD_ATOM(141, 30, "*");
+    WORD_ATOM(146, 30, "*");
     mw_prim_int_mul();
-    WORD_ATOM(141, 32, ">");
+    WORD_ATOM(146, 32, ">");
     mw_Int_3E_();
-    WORD_ATOM(141, 34, "if");
+    WORD_ATOM(146, 34, "if");
     if (pop_u64()) {
-        WORD_ATOM(142, 9, "drop2");
+        WORD_ATOM(147, 9, "drop2");
         mw_drop2();
-        WORD_ATOM(142, 15, "dip");
+        WORD_ATOM(147, 15, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(142, 19, "split-half-left");
+            WORD_ATOM(147, 19, "split-half-left");
             mw_List_2B__2E_split_half_left();
             push_value(d3);
         }
-        WORD_ATOM(142, 36, "cat");
+        WORD_ATOM(147, 36, "cat");
         mw_List_2B__2E_cat();
-        WORD_ATOM(142, 40, "rebalance");
+        WORD_ATOM(147, 40, "rebalance");
         mw_List_2B__2E_rebalance();
     } else {
-        WORD_ATOM(143, 9, "dip");
+        WORD_ATOM(148, 9, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(143, 13, "");
+            WORD_ATOM(148, 13, "");
             push_i64(6LL);
-            WORD_ATOM(143, 15, "*");
+            WORD_ATOM(148, 15, "*");
             mw_prim_int_mul();
             push_value(d3);
         }
-        WORD_ATOM(143, 18, "<");
+        WORD_ATOM(148, 18, "<");
         mw_prim_int_lt();
-        WORD_ATOM(143, 20, "if");
+        WORD_ATOM(148, 20, "if");
         if (pop_u64()) {
-            WORD_ATOM(144, 13, "split-half-right");
+            WORD_ATOM(149, 13, "split-half-right");
             mw_List_2B__2E_split_half_right();
-            WORD_ATOM(144, 30, "dip");
+            WORD_ATOM(149, 30, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(144, 34, "cat+");
+                WORD_ATOM(149, 34, "cat+");
                 mw_List_2E_cat_2B_();
                 push_value(d4);
             }
-            WORD_ATOM(144, 40, "rebalance");
+            WORD_ATOM(149, 40, "rebalance");
             mw_List_2B__2E_rebalance();
         } else {
-            WORD_ATOM(145, 13, "id");
+            WORD_ATOM(150, 13, "id");
             mw_prim_id();
         }
     }
     WORD_EXIT(mw_List_2B__2E_rebalance);
 }
 static void mw_List_2B__2E_split_half_left (void){
-    WORD_ENTER(mw_List_2B__2E_split_half_left, "List+.split-half-left", "src/data/list.mth", 150, 5);
-    WORD_ATOM(150, 5, "L1+");
+    WORD_ENTER(mw_List_2B__2E_split_half_left, "List+.split-half-left", "src/data/list.mth", 155, 5);
+    WORD_ATOM(155, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(150, 12, "L0");
+            co_L1_2B_();
+            WORD_ATOM(155, 12, "L0");
             mw_L0();
-            WORD_ATOM(150, 15, "dip");
+            WORD_ATOM(155, 15, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(150, 19, "L1+");
+                WORD_ATOM(155, 19, "L1+");
                 mw_L1_2B_();
                 push_value(d4);
             }
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(151, 12, "L1");
+            co_L2_2B_();
+            WORD_ATOM(156, 12, "L1");
             mw_L1();
-            WORD_ATOM(151, 15, "dip");
+            WORD_ATOM(156, 15, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(151, 19, "L1+");
+                WORD_ATOM(156, 19, "L1+");
                 mw_L1_2B_();
                 push_value(d4);
             }
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(152, 12, "L1");
+            co_L3_2B_();
+            WORD_ATOM(157, 12, "L1");
             mw_L1();
-            WORD_ATOM(152, 15, "dip");
+            WORD_ATOM(157, 15, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(152, 19, "L2+");
+                WORD_ATOM(157, 19, "L2+");
                 mw_L2_2B_();
                 push_value(d4);
             }
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(153, 14, "drop");
+            co_LCAT_2B_();
+            WORD_ATOM(158, 14, "drop");
             mw_prim_drop();
-            WORD_ATOM(153, 19, "List+>List");
+            WORD_ATOM(158, 19, "List+>List");
             mw_List_2B__3E_List();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -6877,58 +10119,53 @@ static void mw_List_2B__2E_split_half_left (void){
 }    WORD_EXIT(mw_List_2B__2E_split_half_left);
 }
 static void mw_List_2B__2E_split_half_right (void){
-    WORD_ENTER(mw_List_2B__2E_split_half_right, "List+.split-half-right", "src/data/list.mth", 156, 5);
-    WORD_ATOM(156, 5, "L1+");
+    WORD_ENTER(mw_List_2B__2E_split_half_right, "List+.split-half-right", "src/data/list.mth", 161, 5);
+    WORD_ATOM(161, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(156, 12, "L1+");
+            co_L1_2B_();
+            WORD_ATOM(161, 12, "L1+");
             mw_L1_2B_();
-            WORD_ATOM(156, 16, "dip");
+            WORD_ATOM(161, 16, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(156, 20, "L0");
+                WORD_ATOM(161, 20, "L0");
                 mw_L0();
                 push_value(d4);
             }
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(157, 12, "L1+");
+            co_L2_2B_();
+            WORD_ATOM(162, 12, "L1+");
             mw_L1_2B_();
-            WORD_ATOM(157, 16, "dip");
+            WORD_ATOM(162, 16, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(157, 20, "L1");
+                WORD_ATOM(162, 20, "L1");
                 mw_L1();
                 push_value(d4);
             }
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(158, 12, "L2+");
+            co_L3_2B_();
+            WORD_ATOM(163, 12, "L2+");
             mw_L2_2B_();
-            WORD_ATOM(158, 16, "dip");
+            WORD_ATOM(163, 16, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(158, 20, "L1");
+                WORD_ATOM(163, 20, "L1");
                 mw_L1();
                 push_value(d4);
             }
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(159, 14, "drop");
+            co_LCAT_2B_();
+            WORD_ATOM(164, 14, "drop");
             mw_prim_drop();
-            WORD_ATOM(159, 19, "dip");
+            WORD_ATOM(164, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(159, 23, "List+>List");
+                WORD_ATOM(164, 23, "List+>List");
                 mw_List_2B__3E_List();
                 push_value(d4);
             }
@@ -6938,10 +10175,10 @@ static void mw_List_2B__2E_split_half_right (void){
 }    WORD_EXIT(mw_List_2B__2E_split_half_right);
 }
 static void mw_List_2E_first (void){
-    WORD_ENTER(mw_List_2E_first, "List.first", "src/data/list.mth", 168, 38);
-    WORD_ATOM(168, 38, "List>List+");
+    WORD_ENTER(mw_List_2E_first, "List.first", "src/data/list.mth", 173, 38);
+    WORD_ATOM(173, 38, "List>List+");
     mw_List_3E_List_2B_();
-    WORD_ATOM(168, 49, "map");
+    WORD_ATOM(173, 49, "map");
     push_u64(0);
     push_fnptr(&mb_List_2E_first_1);
     mw_prim_pack_cons();
@@ -6949,10 +10186,10 @@ static void mw_List_2E_first (void){
     WORD_EXIT(mw_List_2E_first);
 }
 static void mw_List_2E_last (void){
-    WORD_ENTER(mw_List_2E_last, "List.last", "src/data/list.mth", 169, 37);
-    WORD_ATOM(169, 37, "List>List+");
+    WORD_ENTER(mw_List_2E_last, "List.last", "src/data/list.mth", 174, 37);
+    WORD_ATOM(174, 37, "List>List+");
     mw_List_3E_List_2B_();
-    WORD_ATOM(169, 48, "map");
+    WORD_ATOM(174, 48, "map");
     push_u64(0);
     push_fnptr(&mb_List_2E_last_1);
     mw_prim_pack_cons();
@@ -6960,34 +10197,29 @@ static void mw_List_2E_last (void){
     WORD_EXIT(mw_List_2E_last);
 }
 static void mw_List_2B__2E_first (void){
-    WORD_ENTER(mw_List_2B__2E_first, "List+.first", "src/data/list.mth", 173, 5);
-    WORD_ATOM(173, 5, "L1+");
+    WORD_ENTER(mw_List_2B__2E_first, "List+.first", "src/data/list.mth", 178, 5);
+    WORD_ATOM(178, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(173, 12, "id");
+            co_L1_2B_();
+            WORD_ATOM(178, 12, "id");
             mw_prim_id();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(174, 12, "drop");
+            co_L2_2B_();
+            WORD_ATOM(179, 12, "drop");
             mw_prim_drop();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(175, 12, "drop2");
+            co_L3_2B_();
+            WORD_ATOM(180, 12, "drop2");
             mw_drop2();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(176, 14, "drop2");
+            co_LCAT_2B_();
+            WORD_ATOM(181, 14, "drop2");
             mw_drop2();
-            WORD_ATOM(176, 20, "first");
+            WORD_ATOM(181, 20, "first");
             mw_List_2B__2E_first();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -6995,46 +10227,41 @@ static void mw_List_2B__2E_first (void){
 }    WORD_EXIT(mw_List_2B__2E_first);
 }
 static void mw_List_2B__2E_last (void){
-    WORD_ENTER(mw_List_2B__2E_last, "List+.last", "src/data/list.mth", 179, 5);
-    WORD_ATOM(179, 5, "L1+");
+    WORD_ENTER(mw_List_2B__2E_last, "List+.last", "src/data/list.mth", 184, 5);
+    WORD_ATOM(184, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(179, 12, "id");
+            co_L1_2B_();
+            WORD_ATOM(184, 12, "id");
             mw_prim_id();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(180, 12, "dip");
+            co_L2_2B_();
+            WORD_ATOM(185, 12, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(180, 16, "drop");
+                WORD_ATOM(185, 16, "drop");
                 mw_prim_drop();
                 push_value(d4);
             }
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(181, 12, "dip");
+            co_L3_2B_();
+            WORD_ATOM(186, 12, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(181, 16, "drop2");
+                WORD_ATOM(186, 16, "drop2");
                 mw_drop2();
                 push_value(d4);
             }
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(182, 14, "drop");
+            co_LCAT_2B_();
+            WORD_ATOM(187, 14, "drop");
             mw_prim_drop();
-            WORD_ATOM(182, 19, "nip");
+            WORD_ATOM(187, 19, "nip");
             mw_nip();
-            WORD_ATOM(182, 23, "last");
+            WORD_ATOM(187, 23, "last");
             mw_List_2B__2E_last();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -7042,54 +10269,49 @@ static void mw_List_2B__2E_last (void){
 }    WORD_EXIT(mw_List_2B__2E_last);
 }
 static void mw_List_2E_reverse (void){
-    WORD_ENTER(mw_List_2E_reverse, "List.reverse", "src/data/list.mth", 192, 5);
-    WORD_ATOM(192, 5, "L0");
+    WORD_ENTER(mw_List_2E_reverse, "List.reverse", "src/data/list.mth", 197, 5);
+    WORD_ATOM(197, 5, "L0");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
-            WORD_ATOM(192, 11, "L0");
+            co_L0();
+            WORD_ATOM(197, 11, "L0");
             mw_L0();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(193, 11, "L1");
+            co_L1();
+            WORD_ATOM(198, 11, "L1");
             mw_L1();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(194, 11, "swap");
+            co_L2();
+            WORD_ATOM(199, 11, "swap");
             mw_prim_swap();
-            WORD_ATOM(194, 16, "L2");
+            WORD_ATOM(199, 16, "L2");
             mw_L2();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(195, 11, "rotr");
+            co_L3();
+            WORD_ATOM(200, 11, "rotr");
             mw_rotr();
-            WORD_ATOM(195, 16, "swap");
+            WORD_ATOM(200, 16, "swap");
             mw_prim_swap();
-            WORD_ATOM(195, 21, "L3");
+            WORD_ATOM(200, 21, "L3");
             mw_L3();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(196, 13, "dip");
+            co_LCAT();
+            WORD_ATOM(201, 13, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(196, 17, "reverse");
+                WORD_ATOM(201, 17, "reverse");
                 mw_List_2B__2E_reverse();
-                WORD_ATOM(196, 25, "swap");
+                WORD_ATOM(201, 25, "swap");
                 mw_prim_swap();
-                WORD_ATOM(196, 30, "reverse");
+                WORD_ATOM(201, 30, "reverse");
                 mw_List_2B__2E_reverse();
                 push_value(d4);
             }
-            WORD_ATOM(196, 39, "LCAT");
+            WORD_ATOM(201, 39, "LCAT");
             mw_LCAT();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -7097,49 +10319,44 @@ static void mw_List_2E_reverse (void){
 }    WORD_EXIT(mw_List_2E_reverse);
 }
 static void mw_List_2B__2E_reverse (void){
-    WORD_ENTER(mw_List_2B__2E_reverse, "List+.reverse", "src/data/list.mth", 200, 5);
-    WORD_ATOM(200, 5, "L1+");
+    WORD_ENTER(mw_List_2B__2E_reverse, "List+.reverse", "src/data/list.mth", 205, 5);
+    WORD_ATOM(205, 5, "L1+");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(200, 12, "L1+");
+            co_L1_2B_();
+            WORD_ATOM(205, 12, "L1+");
             mw_L1_2B_();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(201, 12, "swap");
+            co_L2_2B_();
+            WORD_ATOM(206, 12, "swap");
             mw_prim_swap();
-            WORD_ATOM(201, 17, "L2+");
+            WORD_ATOM(206, 17, "L2+");
             mw_L2_2B_();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(202, 12, "rotr");
+            co_L3_2B_();
+            WORD_ATOM(207, 12, "rotr");
             mw_rotr();
-            WORD_ATOM(202, 17, "swap");
+            WORD_ATOM(207, 17, "swap");
             mw_prim_swap();
-            WORD_ATOM(202, 22, "L3+");
+            WORD_ATOM(207, 22, "L3+");
             mw_L3_2B_();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(203, 14, "dip");
+            co_LCAT_2B_();
+            WORD_ATOM(208, 14, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(203, 18, "reverse");
+                WORD_ATOM(208, 18, "reverse");
                 mw_List_2B__2E_reverse();
-                WORD_ATOM(203, 26, "swap");
+                WORD_ATOM(208, 26, "swap");
                 mw_prim_swap();
-                WORD_ATOM(203, 31, "reverse");
+                WORD_ATOM(208, 31, "reverse");
                 mw_List_2B__2E_reverse();
                 push_value(d4);
             }
-            WORD_ATOM(203, 40, "LCAT+");
+            WORD_ATOM(208, 40, "LCAT+");
             mw_LCAT_2B_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -7147,135 +10364,130 @@ static void mw_List_2B__2E_reverse (void){
 }    WORD_EXIT(mw_List_2B__2E_reverse);
 }
 static void mw_List_2E_map (void){
-    WORD_ENTER(mw_List_2E_map, "List.map", "src/data/list.mth", 207, 5);
-    WORD_ATOM(207, 5, "L0");
+    WORD_ENTER(mw_List_2E_map, "List.map", "src/data/list.mth", 212, 5);
+    WORD_ATOM(212, 5, "L0");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(207, 5, "L0");
+        WORD_ATOM(212, 5, "L0");
         switch (get_top_data_tag()) {
             case 0LL:
-                mw_prim_drop();
-                WORD_ATOM(207, 11, "L0");
+                co_L0();
+                WORD_ATOM(212, 11, "L0");
                 mw_L0();
                 break;
             case 1LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                WORD_ATOM(208, 11, "f");
+                co_L1();
+                WORD_ATOM(213, 11, "f");
                 incref(var_f);
                 run_value(var_f);
-                WORD_ATOM(208, 13, "L1");
+                WORD_ATOM(213, 13, "L1");
                 mw_L1();
                 break;
             case 2LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(209, 11, "dip");
+                co_L2();
+                WORD_ATOM(214, 11, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(209, 15, "f");
+                    WORD_ATOM(214, 15, "f");
                     incref(var_f);
                     run_value(var_f);
                     push_value(d5);
                 }
-                WORD_ATOM(209, 18, "swap");
+                WORD_ATOM(214, 18, "swap");
                 mw_prim_swap();
-                WORD_ATOM(209, 23, "dip");
+                WORD_ATOM(214, 23, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(209, 27, "f");
+                    WORD_ATOM(214, 27, "f");
                     incref(var_f);
                     run_value(var_f);
                     push_value(d5);
                 }
-                WORD_ATOM(209, 30, "swap");
+                WORD_ATOM(214, 30, "swap");
                 mw_prim_swap();
-                WORD_ATOM(209, 35, "L2");
+                WORD_ATOM(214, 35, "L2");
                 mw_L2();
                 break;
             case 3LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(210, 11, "dip");
+                co_L3();
+                WORD_ATOM(215, 11, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(210, 15, "dip");
+                    WORD_ATOM(215, 15, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(210, 19, "f");
+                        WORD_ATOM(215, 19, "f");
                         incref(var_f);
                         run_value(var_f);
                         push_value(d6);
                     }
                     push_value(d5);
                 }
-                WORD_ATOM(210, 23, "rotr");
+                WORD_ATOM(215, 23, "rotr");
                 mw_rotr();
-                WORD_ATOM(210, 28, "dip");
+                WORD_ATOM(215, 28, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(210, 32, "dip");
+                    WORD_ATOM(215, 32, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(210, 36, "f");
+                        WORD_ATOM(215, 36, "f");
                         incref(var_f);
                         run_value(var_f);
                         push_value(d6);
                     }
                     push_value(d5);
                 }
-                WORD_ATOM(210, 40, "rotr");
+                WORD_ATOM(215, 40, "rotr");
                 mw_rotr();
-                WORD_ATOM(210, 45, "dip");
+                WORD_ATOM(215, 45, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(210, 49, "dip");
+                    WORD_ATOM(215, 49, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(210, 53, "f");
+                        WORD_ATOM(215, 53, "f");
                         incref(var_f);
                         run_value(var_f);
                         push_value(d6);
                     }
                     push_value(d5);
                 }
-                WORD_ATOM(210, 57, "rotr");
+                WORD_ATOM(215, 57, "rotr");
                 mw_rotr();
-                WORD_ATOM(210, 62, "L3");
+                WORD_ATOM(215, 62, "L3");
                 mw_L3();
                 break;
             case 4LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(211, 13, "dip");
+                co_LCAT();
+                WORD_ATOM(216, 13, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(211, 17, "dip");
+                    WORD_ATOM(216, 17, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(211, 21, "map");
+                        WORD_ATOM(216, 21, "map");
                         incref(var_f);
                         push_value(var_f);
                         mw_List_2B__2E_map();
                         push_value(d6);
                     }
-                    WORD_ATOM(211, 29, "swap");
+                    WORD_ATOM(216, 29, "swap");
                     mw_prim_swap();
-                    WORD_ATOM(211, 34, "dip");
+                    WORD_ATOM(216, 34, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(211, 38, "map");
+                        WORD_ATOM(216, 38, "map");
                         incref(var_f);
                         push_value(var_f);
                         mw_List_2B__2E_map();
                         push_value(d6);
                     }
-                    WORD_ATOM(211, 46, "swap");
+                    WORD_ATOM(216, 46, "swap");
                     mw_prim_swap();
                     push_value(d5);
                 }
-                WORD_ATOM(211, 52, "LCAT");
+                WORD_ATOM(216, 52, "LCAT");
                 mw_LCAT();
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -7285,130 +10497,125 @@ static void mw_List_2E_map (void){
     WORD_EXIT(mw_List_2E_map);
 }
 static void mw_List_2B__2E_map (void){
-    WORD_ENTER(mw_List_2B__2E_map, "List+.map", "src/data/list.mth", 215, 5);
-    WORD_ATOM(215, 5, "L1+");
+    WORD_ENTER(mw_List_2B__2E_map, "List+.map", "src/data/list.mth", 220, 5);
+    WORD_ATOM(220, 5, "L1+");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(215, 5, "L1+");
+        WORD_ATOM(220, 5, "L1+");
         switch (get_top_data_tag()) {
             case 0LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                WORD_ATOM(215, 12, "f");
+                co_L1_2B_();
+                WORD_ATOM(220, 12, "f");
                 incref(var_f);
                 run_value(var_f);
-                WORD_ATOM(215, 14, "L1+");
+                WORD_ATOM(220, 14, "L1+");
                 mw_L1_2B_();
                 break;
             case 1LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(216, 12, "dip");
+                co_L2_2B_();
+                WORD_ATOM(221, 12, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(216, 16, "f");
+                    WORD_ATOM(221, 16, "f");
                     incref(var_f);
                     run_value(var_f);
                     push_value(d5);
                 }
-                WORD_ATOM(216, 19, "swap");
+                WORD_ATOM(221, 19, "swap");
                 mw_prim_swap();
-                WORD_ATOM(216, 24, "dip");
+                WORD_ATOM(221, 24, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(216, 28, "f");
+                    WORD_ATOM(221, 28, "f");
                     incref(var_f);
                     run_value(var_f);
                     push_value(d5);
                 }
-                WORD_ATOM(216, 31, "swap");
+                WORD_ATOM(221, 31, "swap");
                 mw_prim_swap();
-                WORD_ATOM(216, 36, "L2+");
+                WORD_ATOM(221, 36, "L2+");
                 mw_L2_2B_();
                 break;
             case 2LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(217, 12, "dip");
+                co_L3_2B_();
+                WORD_ATOM(222, 12, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(217, 16, "dip");
+                    WORD_ATOM(222, 16, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(217, 20, "f");
+                        WORD_ATOM(222, 20, "f");
                         incref(var_f);
                         run_value(var_f);
                         push_value(d6);
                     }
                     push_value(d5);
                 }
-                WORD_ATOM(217, 24, "rotr");
+                WORD_ATOM(222, 24, "rotr");
                 mw_rotr();
-                WORD_ATOM(217, 29, "dip");
+                WORD_ATOM(222, 29, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(217, 33, "dip");
+                    WORD_ATOM(222, 33, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(217, 37, "f");
+                        WORD_ATOM(222, 37, "f");
                         incref(var_f);
                         run_value(var_f);
                         push_value(d6);
                     }
                     push_value(d5);
                 }
-                WORD_ATOM(217, 41, "rotr");
+                WORD_ATOM(222, 41, "rotr");
                 mw_rotr();
-                WORD_ATOM(217, 46, "dip");
+                WORD_ATOM(222, 46, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(217, 50, "dip");
+                    WORD_ATOM(222, 50, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(217, 54, "f");
+                        WORD_ATOM(222, 54, "f");
                         incref(var_f);
                         run_value(var_f);
                         push_value(d6);
                     }
                     push_value(d5);
                 }
-                WORD_ATOM(217, 58, "rotr");
+                WORD_ATOM(222, 58, "rotr");
                 mw_rotr();
-                WORD_ATOM(217, 63, "L3+");
+                WORD_ATOM(222, 63, "L3+");
                 mw_L3_2B_();
                 break;
             case 3LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(218, 14, "dip");
+                co_LCAT_2B_();
+                WORD_ATOM(223, 14, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(218, 18, "dip");
+                    WORD_ATOM(223, 18, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(218, 22, "map");
+                        WORD_ATOM(223, 22, "map");
                         incref(var_f);
                         push_value(var_f);
                         mw_List_2B__2E_map();
                         push_value(d6);
                     }
-                    WORD_ATOM(218, 30, "swap");
+                    WORD_ATOM(223, 30, "swap");
                     mw_prim_swap();
-                    WORD_ATOM(218, 35, "dip");
+                    WORD_ATOM(223, 35, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(218, 39, "map");
+                        WORD_ATOM(223, 39, "map");
                         incref(var_f);
                         push_value(var_f);
                         mw_List_2B__2E_map();
                         push_value(d6);
                     }
-                    WORD_ATOM(218, 47, "swap");
+                    WORD_ATOM(223, 47, "swap");
                     mw_prim_swap();
                     push_value(d5);
                 }
-                WORD_ATOM(218, 53, "LCAT+");
+                WORD_ATOM(223, 53, "LCAT+");
                 mw_LCAT_2B_();
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -7418,78 +10625,73 @@ static void mw_List_2B__2E_map (void){
     WORD_EXIT(mw_List_2B__2E_map);
 }
 static void mw_List_2E_for (void){
-    WORD_ENTER(mw_List_2E_for, "List.for", "src/data/list.mth", 222, 5);
-    WORD_ATOM(222, 5, "L0");
+    WORD_ENTER(mw_List_2E_for, "List.for", "src/data/list.mth", 227, 5);
+    WORD_ATOM(227, 5, "L0");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(222, 5, "L0");
+        WORD_ATOM(227, 5, "L0");
         switch (get_top_data_tag()) {
             case 0LL:
-                mw_prim_drop();
-                WORD_ATOM(222, 11, "id");
+                co_L0();
+                WORD_ATOM(227, 11, "id");
                 mw_prim_id();
                 break;
             case 1LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                WORD_ATOM(223, 11, "f");
+                co_L1();
+                WORD_ATOM(228, 11, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 2LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(224, 11, "dip");
+                co_L2();
+                WORD_ATOM(229, 11, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(224, 15, "f");
+                    WORD_ATOM(229, 15, "f");
                     incref(var_f);
                     run_value(var_f);
                     push_value(d5);
                 }
-                WORD_ATOM(224, 18, "f");
+                WORD_ATOM(229, 18, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 3LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(225, 11, "dip");
+                co_L3();
+                WORD_ATOM(230, 11, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(225, 15, "dip");
+                    WORD_ATOM(230, 15, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(225, 19, "f");
+                        WORD_ATOM(230, 19, "f");
                         incref(var_f);
                         run_value(var_f);
                         push_value(d6);
                     }
-                    WORD_ATOM(225, 22, "f");
+                    WORD_ATOM(230, 22, "f");
                     incref(var_f);
                     run_value(var_f);
                     push_value(d5);
                 }
-                WORD_ATOM(225, 25, "f");
+                WORD_ATOM(230, 25, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 4LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(226, 13, "drop");
+                co_LCAT();
+                WORD_ATOM(231, 13, "drop");
                 mw_prim_drop();
-                WORD_ATOM(226, 18, "dip");
+                WORD_ATOM(231, 18, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(226, 22, "for");
+                    WORD_ATOM(231, 22, "for");
                     incref(var_f);
                     push_value(var_f);
                     mw_List_2B__2E_for();
                     push_value(d5);
                 }
-                WORD_ATOM(226, 30, "for");
+                WORD_ATOM(231, 30, "for");
                 incref(var_f);
                 push_value(var_f);
                 mw_List_2B__2E_for();
@@ -7501,73 +10703,68 @@ static void mw_List_2E_for (void){
     WORD_EXIT(mw_List_2E_for);
 }
 static void mw_List_2B__2E_for (void){
-    WORD_ENTER(mw_List_2B__2E_for, "List+.for", "src/data/list.mth", 230, 5);
-    WORD_ATOM(230, 5, "L1+");
+    WORD_ENTER(mw_List_2B__2E_for, "List+.for", "src/data/list.mth", 235, 5);
+    WORD_ATOM(235, 5, "L1+");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(230, 5, "L1+");
+        WORD_ATOM(235, 5, "L1+");
         switch (get_top_data_tag()) {
             case 0LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                WORD_ATOM(230, 12, "f");
+                co_L1_2B_();
+                WORD_ATOM(235, 12, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 1LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(231, 12, "dip");
+                co_L2_2B_();
+                WORD_ATOM(236, 12, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(231, 16, "f");
+                    WORD_ATOM(236, 16, "f");
                     incref(var_f);
                     run_value(var_f);
                     push_value(d5);
                 }
-                WORD_ATOM(231, 19, "f");
+                WORD_ATOM(236, 19, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 2LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(232, 12, "dip");
+                co_L3_2B_();
+                WORD_ATOM(237, 12, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(232, 16, "dip");
+                    WORD_ATOM(237, 16, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(232, 20, "f");
+                        WORD_ATOM(237, 20, "f");
                         incref(var_f);
                         run_value(var_f);
                         push_value(d6);
                     }
-                    WORD_ATOM(232, 23, "f");
+                    WORD_ATOM(237, 23, "f");
                     incref(var_f);
                     run_value(var_f);
                     push_value(d5);
                 }
-                WORD_ATOM(232, 26, "f");
+                WORD_ATOM(237, 26, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 3LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(233, 14, "drop");
+                co_LCAT_2B_();
+                WORD_ATOM(238, 14, "drop");
                 mw_prim_drop();
-                WORD_ATOM(233, 19, "dip");
+                WORD_ATOM(238, 19, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(233, 23, "for");
+                    WORD_ATOM(238, 23, "for");
                     incref(var_f);
                     push_value(var_f);
                     mw_List_2B__2E_for();
                     push_value(d5);
                 }
-                WORD_ATOM(233, 31, "for");
+                WORD_ATOM(238, 31, "for");
                 incref(var_f);
                 push_value(var_f);
                 mw_List_2B__2E_for();
@@ -7579,82 +10776,77 @@ static void mw_List_2B__2E_for (void){
     WORD_EXIT(mw_List_2B__2E_for);
 }
 static void mw_List_2E_reverse_for (void){
-    WORD_ENTER(mw_List_2E_reverse_for, "List.reverse-for", "src/data/list.mth", 237, 5);
-    WORD_ATOM(237, 5, "L0");
+    WORD_ENTER(mw_List_2E_reverse_for, "List.reverse-for", "src/data/list.mth", 242, 5);
+    WORD_ATOM(242, 5, "L0");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(237, 5, "L0");
+        WORD_ATOM(242, 5, "L0");
         switch (get_top_data_tag()) {
             case 0LL:
-                mw_prim_drop();
-                WORD_ATOM(237, 11, "id");
+                co_L0();
+                WORD_ATOM(242, 11, "id");
                 mw_prim_id();
                 break;
             case 1LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                WORD_ATOM(238, 11, "f");
+                co_L1();
+                WORD_ATOM(243, 11, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 2LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(239, 11, "swap");
+                co_L2();
+                WORD_ATOM(244, 11, "swap");
                 mw_prim_swap();
-                WORD_ATOM(239, 16, "dip");
+                WORD_ATOM(244, 16, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(239, 20, "f");
+                    WORD_ATOM(244, 20, "f");
                     incref(var_f);
                     run_value(var_f);
                     push_value(d5);
                 }
-                WORD_ATOM(239, 23, "f");
+                WORD_ATOM(244, 23, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 3LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(240, 11, "rotr");
+                co_L3();
+                WORD_ATOM(245, 11, "rotr");
                 mw_rotr();
-                WORD_ATOM(240, 16, "dip2");
+                WORD_ATOM(245, 16, "dip2");
                 incref(var_f);
                 push_value(var_f);
                 mw_dip2();
-                WORD_ATOM(240, 24, "swap");
+                WORD_ATOM(245, 24, "swap");
                 mw_prim_swap();
-                WORD_ATOM(240, 29, "dip");
+                WORD_ATOM(245, 29, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(240, 33, "f");
+                    WORD_ATOM(245, 33, "f");
                     incref(var_f);
                     run_value(var_f);
                     push_value(d5);
                 }
-                WORD_ATOM(240, 36, "f");
+                WORD_ATOM(245, 36, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 4LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(241, 13, "drop");
+                co_LCAT();
+                WORD_ATOM(246, 13, "drop");
                 mw_prim_drop();
-                WORD_ATOM(241, 18, "swap");
+                WORD_ATOM(246, 18, "swap");
                 mw_prim_swap();
-                WORD_ATOM(241, 23, "dip");
+                WORD_ATOM(246, 23, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(241, 27, "reverse-for");
+                    WORD_ATOM(246, 27, "reverse-for");
                     incref(var_f);
                     push_value(var_f);
                     mw_List_2B__2E_reverse_for();
                     push_value(d5);
                 }
-                WORD_ATOM(241, 43, "reverse-for");
+                WORD_ATOM(246, 43, "reverse-for");
                 incref(var_f);
                 push_value(var_f);
                 mw_List_2B__2E_reverse_for();
@@ -7666,77 +10858,72 @@ static void mw_List_2E_reverse_for (void){
     WORD_EXIT(mw_List_2E_reverse_for);
 }
 static void mw_List_2B__2E_reverse_for (void){
-    WORD_ENTER(mw_List_2B__2E_reverse_for, "List+.reverse-for", "src/data/list.mth", 245, 5);
-    WORD_ATOM(245, 5, "L1+");
+    WORD_ENTER(mw_List_2B__2E_reverse_for, "List+.reverse-for", "src/data/list.mth", 250, 5);
+    WORD_ATOM(250, 5, "L1+");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(245, 5, "L1+");
+        WORD_ATOM(250, 5, "L1+");
         switch (get_top_data_tag()) {
             case 0LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                WORD_ATOM(245, 12, "f");
+                co_L1_2B_();
+                WORD_ATOM(250, 12, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 1LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(246, 12, "swap");
+                co_L2_2B_();
+                WORD_ATOM(251, 12, "swap");
                 mw_prim_swap();
-                WORD_ATOM(246, 17, "dip");
+                WORD_ATOM(251, 17, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(246, 21, "f");
+                    WORD_ATOM(251, 21, "f");
                     incref(var_f);
                     run_value(var_f);
                     push_value(d5);
                 }
-                WORD_ATOM(246, 24, "f");
+                WORD_ATOM(251, 24, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 2LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(247, 12, "rotr");
+                co_L3_2B_();
+                WORD_ATOM(252, 12, "rotr");
                 mw_rotr();
-                WORD_ATOM(247, 17, "dip2");
+                WORD_ATOM(252, 17, "dip2");
                 incref(var_f);
                 push_value(var_f);
                 mw_dip2();
-                WORD_ATOM(247, 25, "swap");
+                WORD_ATOM(252, 25, "swap");
                 mw_prim_swap();
-                WORD_ATOM(247, 30, "dip");
+                WORD_ATOM(252, 30, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(247, 34, "f");
+                    WORD_ATOM(252, 34, "f");
                     incref(var_f);
                     run_value(var_f);
                     push_value(d5);
                 }
-                WORD_ATOM(247, 37, "f");
+                WORD_ATOM(252, 37, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 3LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(248, 14, "drop");
+                co_LCAT_2B_();
+                WORD_ATOM(253, 14, "drop");
                 mw_prim_drop();
-                WORD_ATOM(248, 19, "swap");
+                WORD_ATOM(253, 19, "swap");
                 mw_prim_swap();
-                WORD_ATOM(248, 24, "dip");
+                WORD_ATOM(253, 24, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(248, 28, "reverse-for");
+                    WORD_ATOM(253, 28, "reverse-for");
                     incref(var_f);
                     push_value(var_f);
                     mw_List_2B__2E_reverse_for();
                     push_value(d5);
                 }
-                WORD_ATOM(248, 44, "reverse-for");
+                WORD_ATOM(253, 44, "reverse-for");
                 incref(var_f);
                 push_value(var_f);
                 mw_List_2B__2E_reverse_for();
@@ -7748,22 +10935,22 @@ static void mw_List_2B__2E_reverse_for (void){
     WORD_EXIT(mw_List_2B__2E_reverse_for);
 }
 static void mw_List_2E_filter (void){
-    WORD_ENTER(mw_List_2E_filter, "List.filter", "src/data/list.mth", 263, 5);
-    WORD_ATOM(263, 5, "List>List+");
+    WORD_ENTER(mw_List_2E_filter, "List.filter", "src/data/list.mth", 268, 5);
+    WORD_ATOM(268, 5, "List>List+");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(263, 5, "List>List+");
+        WORD_ATOM(268, 5, "List>List+");
         mw_List_3E_List_2B_();
-        WORD_ATOM(263, 16, "match");
+        WORD_ATOM(268, 16, "match");
         switch (get_top_data_tag()) {
             case 0LL:
-                mw_prim_drop();
-                WORD_ATOM(264, 17, "L0");
+                co_NONE();
+                WORD_ATOM(269, 17, "L0");
                 mw_L0();
                 break;
             case 1LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                WORD_ATOM(265, 17, "filter");
+                co_SOME();
+                WORD_ATOM(270, 17, "filter");
                 incref(var_f);
                 push_value(var_f);
                 mw_List_2B__2E_filter();
@@ -7775,28 +10962,26 @@ static void mw_List_2E_filter (void){
     WORD_EXIT(mw_List_2E_filter);
 }
 static void mw_List_2B__2E_filter (void){
-    WORD_ENTER(mw_List_2B__2E_filter, "List+.filter", "src/data/list.mth", 270, 5);
-    WORD_ATOM(270, 5, "LCAT+");
+    WORD_ENTER(mw_List_2B__2E_filter, "List+.filter", "src/data/list.mth", 275, 5);
+    WORD_ATOM(275, 5, "LCAT+");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(270, 5, "LCAT+");
+        WORD_ATOM(275, 5, "LCAT+");
         switch (get_top_data_tag()) {
             case 3LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(270, 14, "drop");
+                co_LCAT_2B_();
+                WORD_ATOM(275, 14, "drop");
                 mw_prim_drop();
-                WORD_ATOM(270, 19, "dip");
+                WORD_ATOM(275, 19, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(270, 23, "filter");
+                    WORD_ATOM(275, 23, "filter");
                     incref(var_f);
                     push_value(var_f);
                     mw_List_2B__2E_filter();
                     push_value(d5);
                 }
-                WORD_ATOM(270, 34, "dip'");
+                WORD_ATOM(275, 34, "dip'");
                 push_u64(0);
                 incref(var_f);
                 push_value(var_f);
@@ -7804,25 +10989,25 @@ static void mw_List_2B__2E_filter (void){
                 push_fnptr(&mb_List_2B__2E_filter_5);
                 mw_prim_pack_cons();
                 mw_dip_27_();
-                WORD_ATOM(270, 50, "cat");
+                WORD_ATOM(275, 50, "cat");
                 mw_List_2E_cat();
                 break;
             default:
-                WORD_ATOM(272, 9, "uncons");
+                WORD_ATOM(277, 9, "uncons");
                 mw_List_2B__2E_uncons();
-                WORD_ATOM(272, 16, "dip");
+                WORD_ATOM(277, 16, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(272, 20, "f");
+                    WORD_ATOM(277, 20, "f");
                     incref(var_f);
                     run_value(var_f);
                     push_value(d5);
                 }
-                WORD_ATOM(272, 23, "swap");
+                WORD_ATOM(277, 23, "swap");
                 mw_prim_swap();
-                WORD_ATOM(272, 28, "if");
+                WORD_ATOM(277, 28, "if");
                 if (pop_u64()) {
-                    WORD_ATOM(273, 13, "dip'");
+                    WORD_ATOM(278, 13, "dip'");
                     push_u64(0);
                     incref(var_f);
                     push_value(var_f);
@@ -7830,12 +11015,12 @@ static void mw_List_2B__2E_filter (void){
                     push_fnptr(&mb_List_2B__2E_filter_10);
                     mw_prim_pack_cons();
                     mw_dip_27_();
-                    WORD_ATOM(273, 29, "cons");
+                    WORD_ATOM(278, 29, "cons");
                     mw_List_2E_cons();
                 } else {
-                    WORD_ATOM(274, 13, "nip");
+                    WORD_ATOM(279, 13, "nip");
                     mw_nip();
-                    WORD_ATOM(274, 17, "filter");
+                    WORD_ATOM(279, 17, "filter");
                     incref(var_f);
                     push_value(var_f);
                     mw_List_2E_filter();
@@ -7847,13 +11032,13 @@ static void mw_List_2B__2E_filter (void){
     WORD_EXIT(mw_List_2B__2E_filter);
 }
 static void mw_List_2E_filter_some (void){
-    WORD_ENTER(mw_List_2E_filter_some, "List.filter-some", "src/data/list.mth", 279, 5);
-    WORD_ATOM(279, 5, "List>List+");
+    WORD_ENTER(mw_List_2E_filter_some, "List.filter-some", "src/data/list.mth", 284, 5);
+    WORD_ATOM(284, 5, "List>List+");
     {
         VAL var_p = pop_value();
-        WORD_ATOM(279, 5, "List>List+");
+        WORD_ATOM(284, 5, "List>List+");
         mw_List_3E_List_2B_();
-        WORD_ATOM(279, 16, "if-some");
+        WORD_ATOM(284, 16, "if-some");
         push_u64(0);
         incref(var_p);
         push_value(var_p);
@@ -7872,28 +11057,26 @@ static void mw_List_2E_filter_some (void){
     WORD_EXIT(mw_List_2E_filter_some);
 }
 static void mw_List_2B__2E_filter_some (void){
-    WORD_ENTER(mw_List_2B__2E_filter_some, "List+.filter-some", "src/data/list.mth", 282, 5);
-    WORD_ATOM(282, 5, "LCAT+");
+    WORD_ENTER(mw_List_2B__2E_filter_some, "List+.filter-some", "src/data/list.mth", 287, 5);
+    WORD_ATOM(287, 5, "LCAT+");
     {
         VAL var_p = pop_value();
-        WORD_ATOM(282, 5, "LCAT+");
+        WORD_ATOM(287, 5, "LCAT+");
         switch (get_top_data_tag()) {
             case 3LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(282, 14, "drop");
+                co_LCAT_2B_();
+                WORD_ATOM(287, 14, "drop");
                 mw_prim_drop();
-                WORD_ATOM(282, 19, "dip");
+                WORD_ATOM(287, 19, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(282, 23, "filter-some");
+                    WORD_ATOM(287, 23, "filter-some");
                     incref(var_p);
                     push_value(var_p);
                     mw_List_2B__2E_filter_some();
                     push_value(d5);
                 }
-                WORD_ATOM(282, 39, "dip'");
+                WORD_ATOM(287, 39, "dip'");
                 push_u64(0);
                 incref(var_p);
                 push_value(var_p);
@@ -7901,26 +11084,26 @@ static void mw_List_2B__2E_filter_some (void){
                 push_fnptr(&mb_List_2B__2E_filter_some_5);
                 mw_prim_pack_cons();
                 mw_dip_27_();
-                WORD_ATOM(282, 60, "cat");
+                WORD_ATOM(287, 60, "cat");
                 mw_List_2E_cat();
                 break;
             default:
-                WORD_ATOM(283, 10, "unsnoc");
+                WORD_ATOM(288, 10, "unsnoc");
                 mw_List_2B__2E_unsnoc();
-                WORD_ATOM(283, 17, "dip");
+                WORD_ATOM(288, 17, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(283, 21, "filter-some");
+                    WORD_ATOM(288, 21, "filter-some");
                     incref(var_p);
                     push_value(var_p);
                     mw_List_2E_filter_some();
                     push_value(d5);
                 }
-                WORD_ATOM(283, 37, "dip'");
+                WORD_ATOM(288, 37, "dip'");
                 incref(var_p);
                 push_value(var_p);
                 mw_dip_27_();
-                WORD_ATOM(283, 45, "if-some");
+                WORD_ATOM(288, 45, "if-some");
                 push_u64(0);
                 incref(var_p);
                 push_value(var_p);
@@ -7941,22 +11124,22 @@ static void mw_List_2B__2E_filter_some (void){
     WORD_EXIT(mw_List_2B__2E_filter_some);
 }
 static void mw_List_2E_find (void){
-    WORD_ENTER(mw_List_2E_find, "List.find", "src/data/list.mth", 287, 5);
-    WORD_ATOM(287, 5, "List>List+");
+    WORD_ENTER(mw_List_2E_find, "List.find", "src/data/list.mth", 292, 5);
+    WORD_ATOM(292, 5, "List>List+");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(287, 5, "List>List+");
+        WORD_ATOM(292, 5, "List>List+");
         mw_List_3E_List_2B_();
-        WORD_ATOM(287, 16, "match");
+        WORD_ATOM(292, 16, "match");
         switch (get_top_data_tag()) {
             case 0LL:
-                mw_prim_drop();
-                WORD_ATOM(288, 17, "NONE");
+                co_NONE();
+                WORD_ATOM(293, 17, "NONE");
                 mw_NONE();
                 break;
             case 1LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                WORD_ATOM(289, 17, "find");
+                co_SOME();
+                WORD_ATOM(294, 17, "find");
                 incref(var_f);
                 push_value(var_f);
                 mw_List_2B__2E_find();
@@ -7968,41 +11151,39 @@ static void mw_List_2E_find (void){
     WORD_EXIT(mw_List_2E_find);
 }
 static void mw_List_2B__2E_find (void){
-    WORD_ENTER(mw_List_2B__2E_find, "List+.find", "src/data/list.mth", 294, 5);
-    WORD_ATOM(294, 5, "LCAT+");
+    WORD_ENTER(mw_List_2B__2E_find, "List+.find", "src/data/list.mth", 299, 5);
+    WORD_ATOM(299, 5, "LCAT+");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(294, 5, "LCAT+");
+        WORD_ATOM(299, 5, "LCAT+");
         switch (get_top_data_tag()) {
             case 3LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                mw_prim_pack_uncons(); mw_prim_swap();
-                WORD_ATOM(295, 9, "drop");
+                co_LCAT_2B_();
+                WORD_ATOM(300, 9, "drop");
                 mw_prim_drop();
-                WORD_ATOM(295, 14, "dip");
+                WORD_ATOM(300, 14, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(295, 18, "find");
+                    WORD_ATOM(300, 18, "find");
                     incref(var_f);
                     push_value(var_f);
                     mw_List_2B__2E_find();
                     push_value(d5);
                 }
-                WORD_ATOM(295, 27, "swap");
+                WORD_ATOM(300, 27, "swap");
                 mw_prim_swap();
-                WORD_ATOM(296, 9, "match");
+                WORD_ATOM(301, 9, "match");
                 switch (get_top_data_tag()) {
                     case 1LL:
-                        mw_prim_pack_uncons(); mw_prim_drop();
-                        WORD_ATOM(297, 21, "nip");
+                        co_SOME();
+                        WORD_ATOM(302, 21, "nip");
                         mw_nip();
-                        WORD_ATOM(297, 25, "SOME");
+                        WORD_ATOM(302, 25, "SOME");
                         mw_SOME();
                         break;
                     case 0LL:
-                        mw_prim_drop();
-                        WORD_ATOM(298, 21, "find");
+                        co_NONE();
+                        WORD_ATOM(303, 21, "find");
                         incref(var_f);
                         push_value(var_f);
                         mw_List_2B__2E_find();
@@ -8011,28 +11192,28 @@ static void mw_List_2B__2E_find (void){
                 
 }                break;
             default:
-                WORD_ATOM(301, 9, "uncons");
+                WORD_ATOM(306, 9, "uncons");
                 mw_List_2B__2E_uncons();
-                WORD_ATOM(301, 16, "dip");
+                WORD_ATOM(306, 16, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(301, 20, "f");
+                    WORD_ATOM(306, 20, "f");
                     incref(var_f);
                     run_value(var_f);
                     push_value(d5);
                 }
-                WORD_ATOM(301, 23, "swap");
+                WORD_ATOM(306, 23, "swap");
                 mw_prim_swap();
-                WORD_ATOM(301, 28, "if");
+                WORD_ATOM(306, 28, "if");
                 if (pop_u64()) {
-                    WORD_ATOM(302, 13, "drop");
+                    WORD_ATOM(307, 13, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(302, 18, "SOME");
+                    WORD_ATOM(307, 18, "SOME");
                     mw_SOME();
                 } else {
-                    WORD_ATOM(303, 13, "nip");
+                    WORD_ATOM(308, 13, "nip");
                     mw_nip();
-                    WORD_ATOM(303, 17, "find");
+                    WORD_ATOM(308, 17, "find");
                     incref(var_f);
                     push_value(var_f);
                     mw_List_2E_find();
@@ -8044,13 +11225,13 @@ static void mw_List_2B__2E_find (void){
     WORD_EXIT(mw_List_2B__2E_find);
 }
 static void mw_List_2E_reverse_find (void){
-    WORD_ENTER(mw_List_2E_reverse_find, "List.reverse-find", "src/data/list.mth", 313, 5);
-    WORD_ATOM(313, 5, "reverse");
+    WORD_ENTER(mw_List_2E_reverse_find, "List.reverse-find", "src/data/list.mth", 318, 5);
+    WORD_ATOM(318, 5, "reverse");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(313, 5, "reverse");
+        WORD_ATOM(318, 5, "reverse");
         mw_List_2E_reverse();
-        WORD_ATOM(313, 13, "find");
+        WORD_ATOM(318, 13, "find");
         incref(var_f);
         push_value(var_f);
         mw_List_2E_find();
@@ -8059,26 +11240,26 @@ static void mw_List_2E_reverse_find (void){
     WORD_EXIT(mw_List_2E_reverse_find);
 }
 static void mw_List_2E_any (void){
-    WORD_ENTER(mw_List_2E_any, "List.any", "src/data/list.mth", 321, 5);
-    WORD_ATOM(321, 5, "find");
+    WORD_ENTER(mw_List_2E_any, "List.any", "src/data/list.mth", 326, 5);
+    WORD_ATOM(326, 5, "find");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(321, 5, "find");
+        WORD_ATOM(326, 5, "find");
         incref(var_f);
         push_value(var_f);
         mw_List_2E_find();
-        WORD_ATOM(321, 13, "some?");
+        WORD_ATOM(326, 13, "some?");
         mw_Maybe_2E_some_3F_();
         decref(var_f);
     }
     WORD_EXIT(mw_List_2E_any);
 }
 static void mw_List_2E_all (void){
-    WORD_ENTER(mw_List_2E_all, "List.all", "src/data/list.mth", 329, 5);
-    WORD_ATOM(329, 5, "find");
+    WORD_ENTER(mw_List_2E_all, "List.all", "src/data/list.mth", 334, 5);
+    WORD_ATOM(334, 5, "find");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(329, 5, "find");
+        WORD_ATOM(334, 5, "find");
         push_u64(0);
         incref(var_f);
         push_value(var_f);
@@ -8086,44 +11267,44 @@ static void mw_List_2E_all (void){
         push_fnptr(&mb_List_2E_all_2);
         mw_prim_pack_cons();
         mw_List_2E_find();
-        WORD_ATOM(329, 17, "none?");
+        WORD_ATOM(334, 17, "none?");
         mw_Maybe_2E_none_3F_();
         decref(var_f);
     }
     WORD_EXIT(mw_List_2E_all);
 }
 static void mw_collect_while (void){
-    WORD_ENTER(mw_collect_while, "collect-while", "src/data/list.mth", 341, 5);
-    WORD_ATOM(341, 5, "L0");
+    WORD_ENTER(mw_collect_while, "collect-while", "src/data/list.mth", 346, 5);
+    WORD_ATOM(346, 5, "L0");
     {
         VAL var_g = pop_value();
         VAL var_f = pop_value();
-        WORD_ATOM(341, 5, "L0");
+        WORD_ATOM(346, 5, "L0");
         mw_L0();
-        WORD_ATOM(341, 8, "while");
+        WORD_ATOM(346, 8, "while");
         while(1) {
-            WORD_ATOM(341, 14, "dip");
+            WORD_ATOM(346, 14, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(341, 18, "f");
+                WORD_ATOM(346, 18, "f");
                 incref(var_f);
                 run_value(var_f);
                 push_value(d4);
             }
-            WORD_ATOM(341, 21, "swap");
+            WORD_ATOM(346, 21, "swap");
             mw_prim_swap();
             if (! pop_u64()) break;
-            WORD_ATOM(341, 27, "dip");
+            WORD_ATOM(346, 27, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(341, 31, "g");
+                WORD_ATOM(346, 31, "g");
                 incref(var_g);
                 run_value(var_g);
                 push_value(d4);
             }
-            WORD_ATOM(341, 34, "swap");
+            WORD_ATOM(346, 34, "swap");
             mw_prim_swap();
-            WORD_ATOM(341, 39, "snoc");
+            WORD_ATOM(346, 39, "snoc");
             mw_snoc();
         }
         decref(var_g);
@@ -8150,12 +11331,12 @@ static void mw_Maybe_3E_Bool (void){
     WORD_ATOM(11, 5, "NONE");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_NONE();
             WORD_ATOM(11, 13, "F");
             mw_F();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_SOME();
             WORD_ATOM(12, 13, "drop");
             mw_prim_drop();
             WORD_ATOM(12, 18, "T");
@@ -8174,7 +11355,7 @@ static void mw_Maybe_2E_if (void){
         WORD_ATOM(19, 5, "SOME");
         switch (get_top_data_tag()) {
             case 1LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
+                co_SOME();
                 WORD_ATOM(19, 13, "drop");
                 mw_prim_drop();
                 WORD_ATOM(19, 18, "f");
@@ -8182,7 +11363,7 @@ static void mw_Maybe_2E_if (void){
                 run_value(var_f);
                 break;
             case 0LL:
-                mw_prim_drop();
+                co_NONE();
                 WORD_ATOM(20, 13, "g");
                 incref(var_g);
                 run_value(var_g);
@@ -8203,13 +11384,13 @@ static void mw_Maybe_2E_if_some (void){
         WORD_ATOM(22, 5, "SOME");
         switch (get_top_data_tag()) {
             case 1LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
+                co_SOME();
                 WORD_ATOM(22, 13, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 0LL:
-                mw_prim_drop();
+                co_NONE();
                 WORD_ATOM(23, 13, "g");
                 incref(var_g);
                 run_value(var_g);
@@ -8229,12 +11410,12 @@ static void mw_Maybe_2E_else (void){
         WORD_ATOM(31, 5, "SOME");
         switch (get_top_data_tag()) {
             case 1LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
+                co_SOME();
                 WORD_ATOM(31, 13, "drop");
                 mw_prim_drop();
                 break;
             case 0LL:
-                mw_prim_drop();
+                co_NONE();
                 WORD_ATOM(32, 13, "f");
                 incref(var_f);
                 run_value(var_f);
@@ -8261,12 +11442,12 @@ static void mw_Maybe_2E_and_some (void){
         WORD_ATOM(41, 5, "NONE");
         switch (get_top_data_tag()) {
             case 0LL:
-                mw_prim_drop();
+                co_NONE();
                 WORD_ATOM(41, 13, "F");
                 mw_F();
                 break;
             case 1LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
+                co_SOME();
                 WORD_ATOM(42, 13, "p");
                 incref(var_p);
                 run_value(var_p);
@@ -8282,7 +11463,7 @@ static void mw_Maybe_2E_unwrap (void){
     WORD_ATOM(45, 5, "NONE");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_NONE();
             WORD_ATOM(45, 13, "");
             {
                 static bool vready = false;
@@ -8298,7 +11479,7 @@ static void mw_Maybe_2E_unwrap (void){
             mw_prim_panic();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_SOME();
             WORD_ATOM(46, 13, "id");
             mw_prim_id();
             break;
@@ -8314,13 +11495,13 @@ static void mw_Maybe_2E_unwrap_or (void){
         WORD_ATOM(49, 5, "NONE");
         switch (get_top_data_tag()) {
             case 0LL:
-                mw_prim_drop();
+                co_NONE();
                 WORD_ATOM(49, 13, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 1LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
+                co_SOME();
                 WORD_ATOM(50, 13, "id");
                 mw_prim_id();
                 break;
@@ -8338,12 +11519,12 @@ static void mw_Maybe_2E_map (void){
         WORD_ATOM(53, 5, "NONE");
         switch (get_top_data_tag()) {
             case 0LL:
-                mw_prim_drop();
+                co_NONE();
                 WORD_ATOM(53, 13, "NONE");
                 mw_NONE();
                 break;
             case 1LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
+                co_SOME();
                 WORD_ATOM(54, 13, "f");
                 incref(var_f);
                 run_value(var_f);
@@ -8364,12 +11545,12 @@ static void mw_Maybe_2E_bind (void){
         WORD_ATOM(57, 5, "NONE");
         switch (get_top_data_tag()) {
             case 0LL:
-                mw_prim_drop();
+                co_NONE();
                 WORD_ATOM(57, 13, "NONE");
                 mw_NONE();
                 break;
             case 1LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
+                co_SOME();
                 WORD_ATOM(58, 13, "f");
                 incref(var_f);
                 run_value(var_f);
@@ -8388,12 +11569,12 @@ static void mw_Maybe_2E_for (void){
         WORD_ATOM(61, 5, "NONE");
         switch (get_top_data_tag()) {
             case 0LL:
-                mw_prim_drop();
+                co_NONE();
                 WORD_ATOM(61, 13, "id");
                 mw_prim_id();
                 break;
             case 1LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
+                co_SOME();
                 WORD_ATOM(62, 13, "f");
                 incref(var_f);
                 run_value(var_f);
@@ -8412,12 +11593,12 @@ static void mw_Maybe_2E_filter (void){
         WORD_ATOM(65, 5, "NONE");
         switch (get_top_data_tag()) {
             case 0LL:
-                mw_prim_drop();
+                co_NONE();
                 WORD_ATOM(65, 13, "NONE");
                 mw_NONE();
                 break;
             case 1LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
+                co_SOME();
                 WORD_ATOM(66, 13, "f");
                 incref(var_f);
                 run_value(var_f);
@@ -8475,12 +11656,12 @@ static void mw_Bool_26__26_ (void){
     WORD_ATOM(41, 32, "T");
     switch (get_top_data_tag()) {
         case 1LL:
-            mw_prim_drop();
+            co_T();
             WORD_ATOM(41, 37, "id");
             mw_prim_id();
             break;
         case 0LL:
-            mw_prim_drop();
+            co_F();
             WORD_ATOM(41, 46, "drop");
             mw_prim_drop();
             WORD_ATOM(41, 51, "F");
@@ -8495,14 +11676,14 @@ static void mw_Bool_7C__7C_ (void){
     WORD_ATOM(42, 32, "T");
     switch (get_top_data_tag()) {
         case 1LL:
-            mw_prim_drop();
+            co_T();
             WORD_ATOM(42, 37, "drop");
             mw_prim_drop();
             WORD_ATOM(42, 42, "T");
             mw_T();
             break;
         case 0LL:
-            mw_prim_drop();
+            co_F();
             WORD_ATOM(42, 50, "id");
             mw_prim_id();
             break;
@@ -8515,12 +11696,12 @@ static void mw_Bool_2E_not (void){
     WORD_ATOM(43, 29, "T");
     switch (get_top_data_tag()) {
         case 1LL:
-            mw_prim_drop();
+            co_T();
             WORD_ATOM(43, 34, "F");
             mw_F();
             break;
         case 0LL:
-            mw_prim_drop();
+            co_F();
             WORD_ATOM(43, 42, "T");
             mw_T();
             break;
@@ -8572,13 +11753,13 @@ static void mw_Bool_2E_then (void){
         WORD_ATOM(51, 5, "T");
         switch (get_top_data_tag()) {
             case 1LL:
-                mw_prim_drop();
+                co_T();
                 WORD_ATOM(51, 10, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 0LL:
-                mw_prim_drop();
+                co_F();
                 WORD_ATOM(52, 10, "id");
                 mw_prim_id();
                 break;
@@ -8596,12 +11777,12 @@ static void mw_Bool_2E_else (void){
         WORD_ATOM(54, 5, "T");
         switch (get_top_data_tag()) {
             case 1LL:
-                mw_prim_drop();
+                co_T();
                 WORD_ATOM(54, 10, "id");
                 mw_prim_id();
                 break;
             case 0LL:
-                mw_prim_drop();
+                co_F();
                 WORD_ATOM(55, 10, "f");
                 incref(var_f);
                 run_value(var_f);
@@ -9050,17 +12231,17 @@ static void mw_Comparison_2E_is_eq (void){
     WORD_ATOM(202, 43, "LT");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_LT();
             WORD_ATOM(202, 49, "F");
             mw_F();
             break;
         case 1LL:
-            mw_prim_drop();
+            co_EQ();
             WORD_ATOM(202, 58, "T");
             mw_T();
             break;
         case 2LL:
-            mw_prim_drop();
+            co_GT();
             WORD_ATOM(202, 67, "F");
             mw_F();
             break;
@@ -9073,17 +12254,17 @@ static void mw_Comparison_2E_is_ne (void){
     WORD_ATOM(207, 43, "LT");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_LT();
             WORD_ATOM(207, 49, "T");
             mw_T();
             break;
         case 1LL:
-            mw_prim_drop();
+            co_EQ();
             WORD_ATOM(207, 58, "F");
             mw_F();
             break;
         case 2LL:
-            mw_prim_drop();
+            co_GT();
             WORD_ATOM(207, 67, "T");
             mw_T();
             break;
@@ -9475,14 +12656,14 @@ static void mw_assert_21_ (void){
     WORD_EXIT(mw_assert_21_);
 }
 static void mw_Byte_3E_Int (void){
-    WORD_ENTER(mw_Byte_3E_Int, "Byte>Int", "src/data/byte.mth", 40, 28);
-    WORD_ATOM(40, 28, "prim-unsafe-cast");
+    WORD_ENTER(mw_Byte_3E_Int, "Byte>Int", "src/data/byte.mth", 41, 28);
+    WORD_ATOM(41, 28, "prim-unsafe-cast");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Byte_3E_Int);
 }
 static void mw_Int_3E_Byte (void){
-    WORD_ENTER(mw_Int_3E_Byte, "Int>Byte", "src/data/byte.mth", 42, 5);
-    WORD_ATOM(42, 5, "assert!");
+    WORD_ENTER(mw_Int_3E_Byte, "Int>Byte", "src/data/byte.mth", 43, 5);
+    WORD_ATOM(43, 5, "assert!");
     push_u64(0);
     push_fnptr(&mb_Int_3E_Byte_1);
     mw_prim_pack_cons();
@@ -9490,128 +12671,110 @@ static void mw_Int_3E_Byte (void){
     push_fnptr(&mb_Int_3E_Byte_2);
     mw_prim_pack_cons();
     mw_assert_21_();
-    WORD_ATOM(43, 5, "prim-unsafe-cast");
+    WORD_ATOM(44, 5, "prim-unsafe-cast");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_Int_3E_Byte);
 }
 static void mw_Byte_3E_U8 (void){
-    WORD_ENTER(mw_Byte_3E_U8, "Byte>U8", "src/data/byte.mth", 44, 26);
-    WORD_ATOM(44, 26, ">Int");
+    WORD_ENTER(mw_Byte_3E_U8, "Byte>U8", "src/data/byte.mth", 45, 26);
+    WORD_ATOM(45, 26, ">Int");
     mw_Byte_3E_Int();
-    WORD_ATOM(44, 31, ">U8");
+    WORD_ATOM(45, 31, ">U8");
     mw_Int_3E_U8();
     WORD_EXIT(mw_Byte_3E_U8);
 }
 static void mw_U8_3E_Byte (void){
-    WORD_ENTER(mw_U8_3E_Byte, "U8>Byte", "src/data/byte.mth", 45, 26);
-    WORD_ATOM(45, 26, ">Int");
+    WORD_ENTER(mw_U8_3E_Byte, "U8>Byte", "src/data/byte.mth", 46, 26);
+    WORD_ATOM(46, 26, ">Int");
     mw_U8_3E_Int();
-    WORD_ATOM(45, 31, ">Byte");
+    WORD_ATOM(46, 31, ">Byte");
     mw_Int_3E_Byte();
     WORD_EXIT(mw_U8_3E_Byte);
 }
 static void mw_Ptr_40_Byte (void){
-    WORD_ENTER(mw_Ptr_40_Byte, "Ptr@Byte", "src/data/byte.mth", 47, 28);
-    WORD_ATOM(47, 28, "@U8");
+    WORD_ENTER(mw_Ptr_40_Byte, "Ptr@Byte", "src/data/byte.mth", 48, 28);
+    WORD_ATOM(48, 28, "@U8");
     mw_prim_u8_get();
-    WORD_ATOM(47, 32, ">Byte");
+    WORD_ATOM(48, 32, ">Byte");
     mw_U8_3E_Byte();
     WORD_EXIT(mw_Ptr_40_Byte);
 }
 static void mw_Byte_3D_ (void){
-    WORD_ENTER(mw_Byte_3D_, "Byte=", "src/data/byte.mth", 51, 32);
-    WORD_ATOM(51, 32, "both");
+    WORD_ENTER(mw_Byte_3D_, "Byte=", "src/data/byte.mth", 52, 32);
+    WORD_ATOM(52, 32, "both");
     push_u64(0);
     push_fnptr(&mb_Byte_3D__1);
     mw_prim_pack_cons();
     mw_both();
-    WORD_ATOM(51, 43, "=");
+    WORD_ATOM(52, 43, "=");
     mw_prim_int_eq();
     WORD_EXIT(mw_Byte_3D_);
 }
 static void mw_Byte_3E_ (void){
-    WORD_ENTER(mw_Byte_3E_, "Byte>", "src/data/byte.mth", 53, 32);
-    WORD_ATOM(53, 32, "both");
+    WORD_ENTER(mw_Byte_3E_, "Byte>", "src/data/byte.mth", 54, 32);
+    WORD_ATOM(54, 32, "both");
     push_u64(0);
     push_fnptr(&mb_Byte_3E__1);
     mw_prim_pack_cons();
     mw_both();
-    WORD_ATOM(53, 43, ">");
+    WORD_ATOM(54, 43, ">");
     mw_Int_3E_();
     WORD_EXIT(mw_Byte_3E_);
 }
 static void mw_Byte_2E_in_range (void){
-    WORD_ENTER(mw_Byte_2E_in_range, "Byte.in-range", "src/data/byte.mth", 57, 44);
-    WORD_ATOM(57, 44, "dip");
+    WORD_ENTER(mw_Byte_2E_in_range, "Byte.in-range", "src/data/byte.mth", 58, 44);
+    WORD_ATOM(58, 44, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(57, 48, "both");
+        WORD_ATOM(58, 48, "both");
         push_u64(0);
         push_fnptr(&mb_Byte_2E_in_range_2);
         mw_prim_pack_cons();
         mw_both();
         push_value(d2);
     }
-    WORD_ATOM(57, 60, ">Int");
+    WORD_ATOM(58, 60, ">Int");
     mw_Byte_3E_Int();
-    WORD_ATOM(57, 65, "in-range");
+    WORD_ATOM(58, 65, "in-range");
     mw_Int_2E_in_range();
     WORD_EXIT(mw_Byte_2E_in_range);
 }
 static void mw_Byte_2E_is_upper (void){
-    WORD_ENTER(mw_Byte_2E_is_upper, "Byte.is-upper", "src/data/byte.mth", 59, 34);
-    WORD_ATOM(59, 34, "B'A'");
+    WORD_ENTER(mw_Byte_2E_is_upper, "Byte.is-upper", "src/data/byte.mth", 60, 34);
+    WORD_ATOM(60, 34, "B'A'");
     mw_B_27_A_27_();
-    WORD_ATOM(59, 39, "B'Z'");
+    WORD_ATOM(60, 39, "B'Z'");
     mw_B_27_Z_27_();
-    WORD_ATOM(59, 44, "in-range");
+    WORD_ATOM(60, 44, "in-range");
     mw_Byte_2E_in_range();
     WORD_EXIT(mw_Byte_2E_is_upper);
 }
 static void mw_Byte_2E_is_lower (void){
-    WORD_ENTER(mw_Byte_2E_is_lower, "Byte.is-lower", "src/data/byte.mth", 60, 34);
-    WORD_ATOM(60, 34, "B'a'");
+    WORD_ENTER(mw_Byte_2E_is_lower, "Byte.is-lower", "src/data/byte.mth", 61, 34);
+    WORD_ATOM(61, 34, "B'a'");
     mw_B_27_a_27_();
-    WORD_ATOM(60, 39, "B'z'");
+    WORD_ATOM(61, 39, "B'z'");
     mw_B_27_z_27_();
-    WORD_ATOM(60, 44, "in-range");
+    WORD_ATOM(61, 44, "in-range");
     mw_Byte_2E_in_range();
     WORD_EXIT(mw_Byte_2E_is_lower);
 }
 static void mw_Byte_2E_is_digit (void){
-    WORD_ENTER(mw_Byte_2E_is_digit, "Byte.is-digit", "src/data/byte.mth", 61, 34);
-    WORD_ATOM(61, 34, "B'0'");
+    WORD_ENTER(mw_Byte_2E_is_digit, "Byte.is-digit", "src/data/byte.mth", 62, 34);
+    WORD_ATOM(62, 34, "B'0'");
     mw_B_27_0_27_();
-    WORD_ATOM(61, 39, "B'9'");
+    WORD_ATOM(62, 39, "B'9'");
     mw_B_27_9_27_();
-    WORD_ATOM(61, 44, "in-range");
+    WORD_ATOM(62, 44, "in-range");
     mw_Byte_2E_in_range();
     WORD_EXIT(mw_Byte_2E_is_digit);
 }
 static void mw_Byte_2E_is_alpha (void){
-    WORD_ENTER(mw_Byte_2E_is_alpha, "Byte.is-alpha", "src/data/byte.mth", 62, 34);
-    WORD_ATOM(62, 34, "dup");
-    mw_prim_dup();
-    WORD_ATOM(62, 38, "is-upper");
-    mw_Byte_2E_is_upper();
-    WORD_ATOM(62, 47, "if");
-    if (pop_u64()) {
-        WORD_ATOM(62, 50, "drop");
-        mw_prim_drop();
-        WORD_ATOM(62, 55, "T");
-        mw_T();
-    } else {
-        WORD_ATOM(62, 58, "is-lower");
-        mw_Byte_2E_is_lower();
-    }
-    WORD_EXIT(mw_Byte_2E_is_alpha);
-}
-static void mw_Byte_2E_is_alnum (void){
-    WORD_ENTER(mw_Byte_2E_is_alnum, "Byte.is-alnum", "src/data/byte.mth", 63, 34);
+    WORD_ENTER(mw_Byte_2E_is_alpha, "Byte.is-alpha", "src/data/byte.mth", 63, 34);
     WORD_ATOM(63, 34, "dup");
     mw_prim_dup();
-    WORD_ATOM(63, 38, "is-digit");
-    mw_Byte_2E_is_digit();
+    WORD_ATOM(63, 38, "is-upper");
+    mw_Byte_2E_is_upper();
     WORD_ATOM(63, 47, "if");
     if (pop_u64()) {
         WORD_ATOM(63, 50, "drop");
@@ -9619,274 +12782,326 @@ static void mw_Byte_2E_is_alnum (void){
         WORD_ATOM(63, 55, "T");
         mw_T();
     } else {
-        WORD_ATOM(63, 58, "is-alpha");
+        WORD_ATOM(63, 58, "is-lower");
+        mw_Byte_2E_is_lower();
+    }
+    WORD_EXIT(mw_Byte_2E_is_alpha);
+}
+static void mw_Byte_2E_is_alnum (void){
+    WORD_ENTER(mw_Byte_2E_is_alnum, "Byte.is-alnum", "src/data/byte.mth", 64, 34);
+    WORD_ATOM(64, 34, "dup");
+    mw_prim_dup();
+    WORD_ATOM(64, 38, "is-digit");
+    mw_Byte_2E_is_digit();
+    WORD_ATOM(64, 47, "if");
+    if (pop_u64()) {
+        WORD_ATOM(64, 50, "drop");
+        mw_prim_drop();
+        WORD_ATOM(64, 55, "T");
+        mw_T();
+    } else {
+        WORD_ATOM(64, 58, "is-alpha");
         mw_Byte_2E_is_alpha();
     }
     WORD_EXIT(mw_Byte_2E_is_alnum);
 }
 static void mw_Byte_2E_is_hexdigit (void){
-    WORD_ENTER(mw_Byte_2E_is_hexdigit, "Byte.is-hexdigit", "src/data/byte.mth", 66, 5);
-    WORD_ATOM(66, 5, "B'0'");
+    WORD_ENTER(mw_Byte_2E_is_hexdigit, "Byte.is-hexdigit", "src/data/byte.mth", 67, 5);
+    WORD_ATOM(67, 5, "B'0'");
     switch (get_top_data_tag()) {
         case 48LL:
-            mw_prim_drop();
-            WORD_ATOM(66, 13, "T");
-            mw_T();
-            break;
-        case 49LL:
-            mw_prim_drop();
-            WORD_ATOM(66, 24, "T");
-            mw_T();
-            break;
-        case 50LL:
-            mw_prim_drop();
-            WORD_ATOM(66, 35, "T");
-            mw_T();
-            break;
-        case 51LL:
-            mw_prim_drop();
-            WORD_ATOM(66, 46, "T");
-            mw_T();
-            break;
-        case 52LL:
-            mw_prim_drop();
+            co_B_27_0_27_();
             WORD_ATOM(67, 13, "T");
             mw_T();
             break;
-        case 53LL:
-            mw_prim_drop();
+        case 49LL:
+            co_B_27_1_27_();
             WORD_ATOM(67, 24, "T");
             mw_T();
             break;
-        case 54LL:
-            mw_prim_drop();
+        case 50LL:
+            co_B_27_2_27_();
             WORD_ATOM(67, 35, "T");
             mw_T();
             break;
-        case 55LL:
-            mw_prim_drop();
+        case 51LL:
+            co_B_27_3_27_();
             WORD_ATOM(67, 46, "T");
             mw_T();
             break;
-        case 56LL:
-            mw_prim_drop();
+        case 52LL:
+            co_B_27_4_27_();
             WORD_ATOM(68, 13, "T");
             mw_T();
             break;
-        case 57LL:
-            mw_prim_drop();
+        case 53LL:
+            co_B_27_5_27_();
             WORD_ATOM(68, 24, "T");
             mw_T();
             break;
-        case 65LL:
-            mw_prim_drop();
+        case 54LL:
+            co_B_27_6_27_();
             WORD_ATOM(68, 35, "T");
             mw_T();
             break;
-        case 66LL:
-            mw_prim_drop();
+        case 55LL:
+            co_B_27_7_27_();
             WORD_ATOM(68, 46, "T");
             mw_T();
             break;
-        case 67LL:
-            mw_prim_drop();
+        case 56LL:
+            co_B_27_8_27_();
             WORD_ATOM(69, 13, "T");
             mw_T();
             break;
-        case 68LL:
-            mw_prim_drop();
+        case 57LL:
+            co_B_27_9_27_();
             WORD_ATOM(69, 24, "T");
             mw_T();
             break;
-        case 69LL:
-            mw_prim_drop();
+        case 65LL:
+            co_B_27_A_27_();
             WORD_ATOM(69, 35, "T");
             mw_T();
             break;
-        case 70LL:
-            mw_prim_drop();
+        case 66LL:
+            co_B_27_B_27_();
             WORD_ATOM(69, 46, "T");
             mw_T();
             break;
+        case 67LL:
+            co_B_27_C_27_();
+            WORD_ATOM(70, 13, "T");
+            mw_T();
+            break;
+        case 68LL:
+            co_B_27_D_27_();
+            WORD_ATOM(70, 24, "T");
+            mw_T();
+            break;
+        case 69LL:
+            co_B_27_E_27_();
+            WORD_ATOM(70, 35, "T");
+            mw_T();
+            break;
+        case 70LL:
+            co_B_27_F_27_();
+            WORD_ATOM(70, 46, "T");
+            mw_T();
+            break;
         default:
-            WORD_ATOM(70, 10, "drop");
+            WORD_ATOM(71, 10, "drop");
             mw_prim_drop();
-            WORD_ATOM(70, 15, "F");
+            WORD_ATOM(71, 15, "F");
             mw_F();
             break;
     
 }    WORD_EXIT(mw_Byte_2E_is_hexdigit);
 }
+static void mw_Byte_2E_to_ascii_str (void){
+    WORD_ENTER(mw_Byte_2E_to_ascii_str, "Byte.to-ascii-str", "src/data/byte.mth", 75, 5);
+    WORD_ATOM(75, 5, "dup");
+    mw_prim_dup();
+    WORD_ATOM(75, 9, "BNUL");
+    mw_BNUL();
+    WORD_ATOM(75, 14, "BDEL");
+    mw_BDEL();
+    WORD_ATOM(75, 19, "in-range");
+    mw_Byte_2E_in_range();
+    WORD_ATOM(75, 28, "if");
+    if (pop_u64()) {
+        WORD_ATOM(76, 9, ">U8");
+        mw_Byte_3E_U8();
+        WORD_ATOM(76, 13, "BYTE_ASCII_BUF");
+        mw_BYTE_5F_ASCII_5F_BUF();
+        WORD_ATOM(76, 28, "!U8");
+        mw_prim_u8_set();
+        WORD_ATOM(77, 9, "BYTE_ASCII_BUF");
+        mw_BYTE_5F_ASCII_5F_BUF();
+        WORD_ATOM(77, 24, "");
+        push_i64(1LL);
+        WORD_ATOM(77, 26, "prim-str-copy");
+        mw_prim_str_copy();
+        WORD_ATOM(78, 9, "SOME");
+        mw_SOME();
+    } else {
+        WORD_ATOM(79, 9, "drop");
+        mw_prim_drop();
+        WORD_ATOM(79, 14, "NONE");
+        mw_NONE();
+    }
+    WORD_EXIT(mw_Byte_2E_to_ascii_str);
+}
 static void mw_Byte_2E_is_string_end (void){
-    WORD_ENTER(mw_Byte_2E_is_string_end, "Byte.is-string-end", "src/data/byte.mth", 73, 5);
-    WORD_ATOM(73, 5, "BQUOTE");
+    WORD_ENTER(mw_Byte_2E_is_string_end, "Byte.is-string-end", "src/data/byte.mth", 83, 5);
+    WORD_ATOM(83, 5, "BQUOTE");
     switch (get_top_data_tag()) {
         case 34LL:
-            mw_prim_drop();
-            WORD_ATOM(73, 15, "T");
+            co_BQUOTE();
+            WORD_ATOM(83, 15, "T");
             mw_T();
             break;
         case 10LL:
-            mw_prim_drop();
-            WORD_ATOM(73, 25, "T");
+            co_BLF();
+            WORD_ATOM(83, 25, "T");
             mw_T();
             break;
         case 0LL:
-            mw_prim_drop();
-            WORD_ATOM(73, 36, "T");
+            co_BNUL();
+            WORD_ATOM(83, 36, "T");
             mw_T();
             break;
         default:
-            WORD_ATOM(73, 44, "drop");
+            WORD_ATOM(83, 44, "drop");
             mw_prim_drop();
-            WORD_ATOM(73, 49, "F");
+            WORD_ATOM(83, 49, "F");
             mw_F();
             break;
     
 }    WORD_EXIT(mw_Byte_2E_is_string_end);
 }
 static void mw_Byte_2E_to_lower (void){
-    WORD_ENTER(mw_Byte_2E_to_lower, "Byte.to-lower", "src/data/byte.mth", 76, 5);
-    WORD_ATOM(76, 5, "dup");
+    WORD_ENTER(mw_Byte_2E_to_lower, "Byte.to-lower", "src/data/byte.mth", 86, 5);
+    WORD_ATOM(86, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(76, 9, "is-upper");
+    WORD_ATOM(86, 9, "is-upper");
     mw_Byte_2E_is_upper();
-    WORD_ATOM(76, 18, "if");
+    WORD_ATOM(86, 18, "if");
     if (pop_u64()) {
-        WORD_ATOM(76, 21, ">Int");
+        WORD_ATOM(86, 21, ">Int");
         mw_Byte_3E_Int();
-        WORD_ATOM(76, 26, "");
+        WORD_ATOM(86, 26, "");
         push_i64(32LL);
-        WORD_ATOM(76, 31, "+");
+        WORD_ATOM(86, 31, "+");
         mw_prim_int_add();
-        WORD_ATOM(76, 33, ">Byte");
+        WORD_ATOM(86, 33, ">Byte");
         mw_Int_3E_Byte();
     } else {
-        WORD_ATOM(76, 40, "id");
+        WORD_ATOM(86, 40, "id");
         mw_prim_id();
     }
     WORD_EXIT(mw_Byte_2E_to_lower);
 }
 static void mw_Byte_2E_to_hexdigits (void){
-    WORD_ENTER(mw_Byte_2E_to_hexdigits, "Byte.to-hexdigits", "src/data/byte.mth", 81, 5);
-    WORD_ATOM(81, 5, ">Int");
+    WORD_ENTER(mw_Byte_2E_to_hexdigits, "Byte.to-hexdigits", "src/data/byte.mth", 91, 5);
+    WORD_ATOM(91, 5, ">Int");
     mw_Byte_3E_Int();
-    WORD_ATOM(82, 5, "dup");
+    WORD_ATOM(92, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(82, 9, "");
+    WORD_ATOM(92, 9, "");
     push_i64(4LL);
-    WORD_ATOM(82, 11, ">>");
+    WORD_ATOM(92, 11, ">>");
     mw_prim_int_shr();
-    WORD_ATOM(82, 14, "one-hexdigit-byte");
+    WORD_ATOM(92, 14, "one-hexdigit-byte");
     mw_one_hexdigit_byte();
-    WORD_ATOM(83, 5, "swap");
+    WORD_ATOM(93, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(83, 10, "");
+    WORD_ATOM(93, 10, "");
     push_i64(15LL);
-    WORD_ATOM(83, 14, "&");
+    WORD_ATOM(93, 14, "&");
     mw_prim_int_and();
-    WORD_ATOM(83, 16, "one-hexdigit-byte");
+    WORD_ATOM(93, 16, "one-hexdigit-byte");
     mw_one_hexdigit_byte();
     WORD_EXIT(mw_Byte_2E_to_hexdigits);
 }
 static void mw_one_hexdigit_byte (void){
-    WORD_ENTER(mw_one_hexdigit_byte, "one-hexdigit-byte", "src/data/byte.mth", 85, 5);
-    WORD_ATOM(85, 5, "dup");
+    WORD_ENTER(mw_one_hexdigit_byte, "one-hexdigit-byte", "src/data/byte.mth", 95, 5);
+    WORD_ATOM(95, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(85, 9, "");
+    WORD_ATOM(95, 9, "");
     push_i64(9LL);
-    WORD_ATOM(85, 11, ">");
+    WORD_ATOM(95, 11, ">");
     mw_Int_3E_();
-    WORD_ATOM(85, 13, "if");
+    WORD_ATOM(95, 13, "if");
     if (pop_u64()) {
-        WORD_ATOM(85, 16, "");
+        WORD_ATOM(95, 16, "");
         push_i64(55LL);
     } else {
-        WORD_ATOM(85, 20, "");
+        WORD_ATOM(95, 20, "");
         push_i64(48LL);
     }
-    WORD_ATOM(85, 24, "+");
+    WORD_ATOM(95, 24, "+");
     mw_prim_int_add();
-    WORD_ATOM(85, 26, ">Byte");
+    WORD_ATOM(95, 26, ">Byte");
     mw_Int_3E_Byte();
     WORD_EXIT(mw_one_hexdigit_byte);
 }
 static void mw_Byte_2E_is_name_byte (void){
-    WORD_ENTER(mw_Byte_2E_is_name_byte, "Byte.is-name-byte", "src/data/byte.mth", 88, 5);
-    WORD_ATOM(88, 5, "BLPAREN");
+    WORD_ENTER(mw_Byte_2E_is_name_byte, "Byte.is-name-byte", "src/data/byte.mth", 98, 5);
+    WORD_ATOM(98, 5, "BLPAREN");
     switch (get_top_data_tag()) {
         case 40LL:
-            mw_prim_drop();
-            WORD_ATOM(88, 16, "F");
+            co_BLPAREN();
+            WORD_ATOM(98, 16, "F");
             mw_F();
             break;
         case 41LL:
-            mw_prim_drop();
-            WORD_ATOM(89, 16, "F");
+            co_BRPAREN();
+            WORD_ATOM(99, 16, "F");
             mw_F();
             break;
         case 91LL:
-            mw_prim_drop();
-            WORD_ATOM(90, 17, "F");
+            co_BLSQUARE();
+            WORD_ATOM(100, 17, "F");
             mw_F();
             break;
         case 93LL:
-            mw_prim_drop();
-            WORD_ATOM(91, 17, "F");
+            co_BRSQUARE();
+            WORD_ATOM(101, 17, "F");
             mw_F();
             break;
         case 123LL:
-            mw_prim_drop();
-            WORD_ATOM(92, 16, "F");
+            co_BLCURLY();
+            WORD_ATOM(102, 16, "F");
             mw_F();
             break;
         case 125LL:
-            mw_prim_drop();
-            WORD_ATOM(93, 16, "F");
+            co_BRCURLY();
+            WORD_ATOM(103, 16, "F");
             mw_F();
             break;
         case 44LL:
-            mw_prim_drop();
-            WORD_ATOM(94, 15, "F");
+            co_BCOMMA();
+            WORD_ATOM(104, 15, "F");
             mw_F();
             break;
         case 34LL:
-            mw_prim_drop();
-            WORD_ATOM(95, 15, "F");
+            co_BQUOTE();
+            WORD_ATOM(105, 15, "F");
             mw_F();
             break;
         case 127LL:
-            mw_prim_drop();
-            WORD_ATOM(96, 13, "F");
+            co_BDEL();
+            WORD_ATOM(106, 13, "F");
             mw_F();
             break;
         default:
-            WORD_ATOM(97, 10, "BSPACE");
+            WORD_ATOM(107, 10, "BSPACE");
             mw_BSPACE();
-            WORD_ATOM(97, 17, ">");
+            WORD_ATOM(107, 17, ">");
             mw_Byte_3E_();
             break;
     
 }    WORD_EXIT(mw_Byte_2E_is_name_byte);
 }
 static void mw_Byte_2E_is_sign (void){
-    WORD_ENTER(mw_Byte_2E_is_sign, "Byte.is-sign", "src/data/byte.mth", 100, 5);
-    WORD_ATOM(100, 5, "B'-'");
+    WORD_ENTER(mw_Byte_2E_is_sign, "Byte.is-sign", "src/data/byte.mth", 110, 5);
+    WORD_ATOM(110, 5, "B'-'");
     switch (get_top_data_tag()) {
         case 45LL:
-            mw_prim_drop();
-            WORD_ATOM(100, 13, "T");
+            co_B_27___27_();
+            WORD_ATOM(110, 13, "T");
             mw_T();
             break;
         case 43LL:
-            mw_prim_drop();
-            WORD_ATOM(101, 13, "T");
+            co_B_27__2B__27_();
+            WORD_ATOM(111, 13, "T");
             mw_T();
             break;
         default:
-            WORD_ATOM(102, 10, "drop");
+            WORD_ATOM(112, 10, "drop");
             mw_prim_drop();
-            WORD_ATOM(102, 15, "F");
+            WORD_ATOM(112, 15, "F");
             mw_F();
             break;
     
@@ -10364,14 +13579,6 @@ static void mw_STDIN (void){
     mw_Int_3E_File();
     WORD_EXIT(mw_STDIN);
 }
-static void mw_STDOUT (void){
-    WORD_ENTER(mw_STDOUT, "STDOUT", "src/platform/posix.mth", 11, 19);
-    WORD_ATOM(11, 19, "");
-    push_i64(1LL);
-    WORD_ATOM(11, 21, ">File");
-    mw_Int_3E_File();
-    WORD_EXIT(mw_STDOUT);
-}
 static void mw_STDERR (void){
     WORD_ENTER(mw_STDERR, "STDERR", "src/platform/posix.mth", 12, 19);
     WORD_ATOM(12, 19, "");
@@ -10642,22 +13849,22 @@ static void mw_O_5F_WRONLY_7C_O_5F_CREAT_7C_O_5F_TRUNC (void){
     WORD_ATOM(67, 16, "match");
     switch (get_top_data_tag()) {
         case 3LL:
-            mw_prim_drop();
+            co_OS_5F_MACOS();
             WORD_ATOM(68, 21, "");
             push_i64(1537LL);
             break;
         case 2LL:
-            mw_prim_drop();
+            co_OS_5F_LINUX();
             WORD_ATOM(69, 21, "");
             push_i64(577LL);
             break;
         case 1LL:
-            mw_prim_drop();
+            co_OS_5F_WINDOWS();
             WORD_ATOM(70, 23, "");
             push_i64(769LL);
             break;
         case 0LL:
-            mw_prim_drop();
+            co_OS_5F_UNKNOWN();
             WORD_ATOM(71, 23, "");
             {
                 static bool vready = false;
@@ -10723,13 +13930,12 @@ static void mw_force_21_ (void){
     WORD_ATOM(25, 11, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_LAZY_5F_READY();
             WORD_ATOM(26, 23, "nip");
             mw_nip();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_LAZY_5F_DELAY();
             WORD_ATOM(28, 13, "rotl");
             mw_rotl();
             WORD_ATOM(28, 18, "LAZY_WAIT");
@@ -10753,7 +13959,7 @@ static void mw_force_21_ (void){
             mw_prim_mut_set();
             break;
         case 2LL:
-            mw_prim_drop();
+            co_LAZY_5F_WAIT();
             WORD_ATOM(31, 13, "");
             {
                 static bool vready = false;
@@ -10784,7 +13990,7 @@ static void mw_force_or_21_ (void){
         WORD_ATOM(34, 11, "match");
         switch (get_top_data_tag()) {
             case 2LL:
-                mw_prim_drop();
+                co_LAZY_5F_WAIT();
                 WORD_ATOM(35, 22, "drop");
                 mw_prim_drop();
                 WORD_ATOM(35, 27, "f");
@@ -11088,379 +14294,249 @@ static void mw_Data_2E_tags (void){
     mw_prim_mut_get();
     WORD_EXIT(mw_Data_2E_tags);
 }
-static void mw_Tag_2E_id (void){
-    WORD_ENTER(mw_Tag_2E_id, "Tag.id", "src/mirth/data/data.mth", 24, 7);
-    WORD_ATOM(24, 7, "Tag");
-    mw_prim_unsafe_cast();
-    WORD_EXIT(mw_Tag_2E_id);
-}
-static void mw_Tag_2E_for (void){
-    WORD_ENTER(mw_Tag_2E_for, "Tag.for", "src/mirth/data/data.mth", 24, 7);
-    WORD_ATOM(24, 7, "Tag");
-    {
-        VAL var_x = pop_value();
-        WORD_ATOM(24, 7, "Tag");
-        push_i64(1LL);
-        WORD_ATOM(24, 7, "Tag");
-        while(1) {
-            WORD_ATOM(24, 7, "Tag");
-            mw_prim_dup();
-            WORD_ATOM(24, 7, "Tag");
-            mw_Tag_2E_NUM();
-            WORD_ATOM(24, 7, "Tag");
-            mw_prim_u64_get();
-            WORD_ATOM(24, 7, "Tag");
-            mw_prim_unsafe_cast();
-            WORD_ATOM(24, 7, "Tag");
-            push_i64(1LL);
-            WORD_ATOM(24, 7, "Tag");
-            mw_prim_int_add();
-            WORD_ATOM(24, 7, "Tag");
-            mw_prim_int_lt();
-            if (! pop_u64()) break;
-            WORD_ATOM(24, 7, "Tag");
-            mw_prim_dup();
-            WORD_ATOM(24, 7, "Tag");
-            {
-                VAL d4 = pop_value();
-                WORD_ATOM(24, 7, "Tag");
-                mw_prim_unsafe_cast();
-                WORD_ATOM(24, 7, "Tag");
-                incref(var_x);
-                run_value(var_x);
-                push_value(d4);
-            }
-            WORD_ATOM(24, 7, "Tag");
-            push_i64(1LL);
-            WORD_ATOM(24, 7, "Tag");
-            mw_prim_int_add();
-        }
-        WORD_ATOM(24, 7, "Tag");
-        mw_prim_drop();
-        decref(var_x);
-    }
-    WORD_EXIT(mw_Tag_2E_for);
-}
-static void mw_Tag_2E_alloc_21_ (void){
-    WORD_ENTER(mw_Tag_2E_alloc_21_, "Tag.alloc!", "src/mirth/data/data.mth", 24, 7);
-    WORD_ATOM(24, 7, "Tag");
-    mw_Tag_2E_NUM();
-    WORD_ATOM(24, 7, "Tag");
-    mw_prim_u64_get();
-    WORD_ATOM(24, 7, "Tag");
-    mw_prim_unsafe_cast();
-    WORD_ATOM(24, 7, "Tag");
-    push_i64(1LL);
-    WORD_ATOM(24, 7, "Tag");
-    mw_prim_int_add();
-    WORD_ATOM(24, 7, "Tag");
-    mw_prim_dup();
-    WORD_ATOM(24, 7, "Tag");
-    mw_prim_unsafe_cast();
-    WORD_ATOM(24, 7, "Tag");
-    mw_Tag_2E_NUM();
-    WORD_ATOM(24, 7, "Tag");
-    mw_prim_u64_set();
-    WORD_ATOM(24, 7, "Tag");
-    mw_prim_unsafe_cast();
-    WORD_EXIT(mw_Tag_2E_alloc_21_);
-}
-static void mw_Tag_2E_data (void){
-    WORD_ENTER(mw_Tag_2E_data, "Tag.data", "src/mirth/data/data.mth", 32, 28);
-    WORD_ATOM(32, 28, "~data");
-    mw_Tag_7E_data();
-    WORD_ATOM(32, 34, "@");
-    mw_prim_mut_get();
-    WORD_EXIT(mw_Tag_2E_data);
-}
-static void mw_Tag_2E_name (void){
-    WORD_ENTER(mw_Tag_2E_name, "Tag.name", "src/mirth/data/data.mth", 33, 28);
-    WORD_ATOM(33, 28, "~name");
-    mw_Tag_7E_name();
-    WORD_ATOM(33, 34, "@");
-    mw_prim_mut_get();
-    WORD_EXIT(mw_Tag_2E_name);
-}
-static void mw_Tag_2E_value (void){
-    WORD_ENTER(mw_Tag_2E_value, "Tag.value", "src/mirth/data/data.mth", 34, 28);
-    WORD_ATOM(34, 28, "~value");
-    mw_Tag_7E_value();
-    WORD_ATOM(34, 35, "@");
-    mw_prim_mut_get();
-    WORD_EXIT(mw_Tag_2E_value);
-}
-static void mw_Tag_2E_num_inputs (void){
-    WORD_ENTER(mw_Tag_2E_num_inputs, "Tag.num-inputs", "src/mirth/data/data.mth", 35, 33);
-    WORD_ATOM(35, 33, "~num-inputs");
-    mw_Tag_7E_num_inputs();
-    WORD_ATOM(35, 45, "@");
-    mw_prim_mut_get();
-    WORD_EXIT(mw_Tag_2E_num_inputs);
-}
-static void mw_Tag_2E_sig_3F_ (void){
-    WORD_ENTER(mw_Tag_2E_sig_3F_, "Tag.sig?", "src/mirth/data/data.mth", 36, 36);
-    WORD_ATOM(36, 36, "~sig?");
-    mw_Tag_7E_sig_3F_();
-    WORD_ATOM(36, 42, "@");
-    mw_prim_mut_get();
-    WORD_EXIT(mw_Tag_2E_sig_3F_);
-}
-static void mw_Tag_2E_ctx_type (void){
-    WORD_ENTER(mw_Tag_2E_ctx_type, "Tag.ctx-type", "src/mirth/data/data.mth", 37, 41);
-    WORD_ATOM(37, 41, "~ctx-type");
-    mw_Tag_7E_ctx_type();
-    WORD_ATOM(37, 51, "force!");
-    mw_force_21_();
-    WORD_ATOM(37, 58, "unpack2");
-    mw_unpack2();
-    WORD_EXIT(mw_Tag_2E_ctx_type);
-}
-static void mw_Tag_2E_type (void){
-    WORD_ENTER(mw_Tag_2E_type, "Tag.type", "src/mirth/data/data.mth", 39, 33);
-    WORD_ATOM(39, 33, "ctx-type");
-    mw_Tag_2E_ctx_type();
-    WORD_ATOM(39, 42, "nip");
-    mw_nip();
-    WORD_EXIT(mw_Tag_2E_type);
-}
 static void mw_TYPE_5F_BOOL (void){
-    WORD_ENTER(mw_TYPE_5F_BOOL, "TYPE_BOOL", "src/mirth/data/data.mth", 44, 22);
-    WORD_ATOM(44, 22, "DATA_BOOL");
+    WORD_ENTER(mw_TYPE_5F_BOOL, "TYPE_BOOL", "src/mirth/data/data.mth", 27, 22);
+    WORD_ATOM(27, 22, "DATA_BOOL");
     mw_DATA_5F_BOOL();
-    WORD_ATOM(44, 32, "@");
+    WORD_ATOM(27, 32, "@");
     mw_prim_mut_get();
-    WORD_ATOM(44, 34, "TData");
+    WORD_ATOM(27, 34, "TData");
     mw_TData();
     WORD_EXIT(mw_TYPE_5F_BOOL);
 }
 static void mw_TYPE_5F_U64 (void){
-    WORD_ENTER(mw_TYPE_5F_U64, "TYPE_U64", "src/mirth/data/data.mth", 54, 21);
-    WORD_ATOM(54, 21, "DATA_U64");
+    WORD_ENTER(mw_TYPE_5F_U64, "TYPE_U64", "src/mirth/data/data.mth", 37, 21);
+    WORD_ATOM(37, 21, "DATA_U64");
     mw_DATA_5F_U64();
-    WORD_ATOM(54, 30, "@");
+    WORD_ATOM(37, 30, "@");
     mw_prim_mut_get();
-    WORD_ATOM(54, 32, "TData");
+    WORD_ATOM(37, 32, "TData");
     mw_TData();
     WORD_EXIT(mw_TYPE_5F_U64);
 }
 static void mw_TYPE_5F_U32 (void){
-    WORD_ENTER(mw_TYPE_5F_U32, "TYPE_U32", "src/mirth/data/data.mth", 55, 21);
-    WORD_ATOM(55, 21, "DATA_U32");
+    WORD_ENTER(mw_TYPE_5F_U32, "TYPE_U32", "src/mirth/data/data.mth", 38, 21);
+    WORD_ATOM(38, 21, "DATA_U32");
     mw_DATA_5F_U32();
-    WORD_ATOM(55, 30, "@");
+    WORD_ATOM(38, 30, "@");
     mw_prim_mut_get();
-    WORD_ATOM(55, 32, "TData");
+    WORD_ATOM(38, 32, "TData");
     mw_TData();
     WORD_EXIT(mw_TYPE_5F_U32);
 }
 static void mw_TYPE_5F_U16 (void){
-    WORD_ENTER(mw_TYPE_5F_U16, "TYPE_U16", "src/mirth/data/data.mth", 56, 21);
-    WORD_ATOM(56, 21, "DATA_U16");
+    WORD_ENTER(mw_TYPE_5F_U16, "TYPE_U16", "src/mirth/data/data.mth", 39, 21);
+    WORD_ATOM(39, 21, "DATA_U16");
     mw_DATA_5F_U16();
-    WORD_ATOM(56, 30, "@");
+    WORD_ATOM(39, 30, "@");
     mw_prim_mut_get();
-    WORD_ATOM(56, 32, "TData");
+    WORD_ATOM(39, 32, "TData");
     mw_TData();
     WORD_EXIT(mw_TYPE_5F_U16);
 }
 static void mw_TYPE_5F_U8 (void){
-    WORD_ENTER(mw_TYPE_5F_U8, "TYPE_U8", "src/mirth/data/data.mth", 57, 20);
-    WORD_ATOM(57, 20, "DATA_U8");
+    WORD_ENTER(mw_TYPE_5F_U8, "TYPE_U8", "src/mirth/data/data.mth", 40, 20);
+    WORD_ATOM(40, 20, "DATA_U8");
     mw_DATA_5F_U8();
-    WORD_ATOM(57, 28, "@");
+    WORD_ATOM(40, 28, "@");
     mw_prim_mut_get();
-    WORD_ATOM(57, 30, "TData");
+    WORD_ATOM(40, 30, "TData");
     mw_TData();
     WORD_EXIT(mw_TYPE_5F_U8);
 }
 static void mw_TYPE_5F_I64 (void){
-    WORD_ENTER(mw_TYPE_5F_I64, "TYPE_I64", "src/mirth/data/data.mth", 58, 21);
-    WORD_ATOM(58, 21, "DATA_I64");
+    WORD_ENTER(mw_TYPE_5F_I64, "TYPE_I64", "src/mirth/data/data.mth", 41, 21);
+    WORD_ATOM(41, 21, "DATA_I64");
     mw_DATA_5F_I64();
-    WORD_ATOM(58, 30, "@");
+    WORD_ATOM(41, 30, "@");
     mw_prim_mut_get();
-    WORD_ATOM(58, 32, "TData");
+    WORD_ATOM(41, 32, "TData");
     mw_TData();
     WORD_EXIT(mw_TYPE_5F_I64);
 }
 static void mw_TYPE_5F_I32 (void){
-    WORD_ENTER(mw_TYPE_5F_I32, "TYPE_I32", "src/mirth/data/data.mth", 59, 21);
-    WORD_ATOM(59, 21, "DATA_I32");
+    WORD_ENTER(mw_TYPE_5F_I32, "TYPE_I32", "src/mirth/data/data.mth", 42, 21);
+    WORD_ATOM(42, 21, "DATA_I32");
     mw_DATA_5F_I32();
-    WORD_ATOM(59, 30, "@");
+    WORD_ATOM(42, 30, "@");
     mw_prim_mut_get();
-    WORD_ATOM(59, 32, "TData");
+    WORD_ATOM(42, 32, "TData");
     mw_TData();
     WORD_EXIT(mw_TYPE_5F_I32);
 }
 static void mw_TYPE_5F_I16 (void){
-    WORD_ENTER(mw_TYPE_5F_I16, "TYPE_I16", "src/mirth/data/data.mth", 60, 21);
-    WORD_ATOM(60, 21, "DATA_I16");
+    WORD_ENTER(mw_TYPE_5F_I16, "TYPE_I16", "src/mirth/data/data.mth", 43, 21);
+    WORD_ATOM(43, 21, "DATA_I16");
     mw_DATA_5F_I16();
-    WORD_ATOM(60, 30, "@");
+    WORD_ATOM(43, 30, "@");
     mw_prim_mut_get();
-    WORD_ATOM(60, 32, "TData");
+    WORD_ATOM(43, 32, "TData");
     mw_TData();
     WORD_EXIT(mw_TYPE_5F_I16);
 }
 static void mw_TYPE_5F_I8 (void){
-    WORD_ENTER(mw_TYPE_5F_I8, "TYPE_I8", "src/mirth/data/data.mth", 61, 20);
-    WORD_ATOM(61, 20, "DATA_I8");
+    WORD_ENTER(mw_TYPE_5F_I8, "TYPE_I8", "src/mirth/data/data.mth", 44, 20);
+    WORD_ATOM(44, 20, "DATA_I8");
     mw_DATA_5F_I8();
-    WORD_ATOM(61, 28, "@");
+    WORD_ATOM(44, 28, "@");
     mw_prim_mut_get();
-    WORD_ATOM(61, 30, "TData");
+    WORD_ATOM(44, 30, "TData");
     mw_TData();
     WORD_EXIT(mw_TYPE_5F_I8);
 }
 static void mw_make_data_21_ (void){
-    WORD_ENTER(mw_make_data_21_, "make-data!", "src/mirth/data/data.mth", 64, 5);
-    WORD_ATOM(64, 5, "dip");
+    WORD_ENTER(mw_make_data_21_, "make-data!", "src/mirth/data/data.mth", 47, 5);
+    WORD_ATOM(47, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(64, 9, "dip");
+        WORD_ATOM(47, 9, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(64, 13, "Data.alloc!");
+            WORD_ATOM(47, 13, "Data.alloc!");
             mw_Data_2E_alloc_21_();
-            WORD_ATOM(64, 25, "dup");
+            WORD_ATOM(47, 25, "dup");
             mw_prim_dup();
             push_value(d3);
         }
-        WORD_ATOM(64, 30, "!");
+        WORD_ATOM(47, 30, "!");
         mw_prim_mut_set();
         push_value(d2);
     }
-    WORD_ATOM(65, 5, "map");
+    WORD_ATOM(48, 5, "map");
     push_u64(0);
     push_fnptr(&mb_make_data_21__3);
     mw_prim_pack_cons();
     mw_List_2E_map();
-    WORD_ATOM(67, 5, "dip");
+    WORD_ATOM(50, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(68, 9, "dip");
+        WORD_ATOM(51, 9, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(68, 13, ">Name");
+            WORD_ATOM(51, 13, ">Name");
             mw_Str_3E_Name();
             push_value(d3);
         }
-        WORD_ATOM(69, 9, "dup2");
+        WORD_ATOM(52, 9, "dup2");
         mw_dup2();
-        WORD_ATOM(69, 14, "~name");
+        WORD_ATOM(52, 14, "~name");
         mw_Data_7E_name();
-        WORD_ATOM(69, 20, "!");
+        WORD_ATOM(52, 20, "!");
         mw_prim_mut_set();
-        WORD_ATOM(70, 9, "tuck");
+        WORD_ATOM(53, 9, "tuck");
         mw_tuck();
-        WORD_ATOM(70, 14, "TData");
+        WORD_ATOM(53, 14, "TData");
         mw_TData();
-        WORD_ATOM(70, 20, "DEF_TYPE");
+        WORD_ATOM(53, 20, "DEF_TYPE");
         mw_DEF_5F_TYPE();
-        WORD_ATOM(70, 29, "swap");
+        WORD_ATOM(53, 29, "swap");
         mw_prim_swap();
-        WORD_ATOM(70, 34, "~Def");
+        WORD_ATOM(53, 34, "~Def");
         mw_Name_7E_Def();
-        WORD_ATOM(70, 39, "!");
+        WORD_ATOM(53, 39, "!");
         mw_prim_mut_set();
         push_value(d2);
     }
-    WORD_ATOM(73, 5, "dup");
+    WORD_ATOM(56, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(73, 9, "for");
+    WORD_ATOM(56, 9, "for");
     push_u64(0);
     push_fnptr(&mb_make_data_21__7);
     mw_prim_pack_cons();
     mw_List_2E_for();
-    WORD_ATOM(74, 5, "over");
+    WORD_ATOM(57, 5, "over");
     mw_over();
-    WORD_ATOM(74, 10, "~tags");
+    WORD_ATOM(57, 10, "~tags");
     mw_Data_7E_tags();
-    WORD_ATOM(74, 16, "!");
+    WORD_ATOM(57, 16, "!");
     mw_prim_mut_set();
-    WORD_ATOM(76, 5, "");
+    WORD_ATOM(59, 5, "");
     push_i64(0LL);
-    WORD_ATOM(76, 7, "over");
+    WORD_ATOM(59, 7, "over");
     mw_over();
-    WORD_ATOM(76, 12, "~arity");
+    WORD_ATOM(59, 12, "~arity");
     mw_Data_7E_arity();
-    WORD_ATOM(76, 19, "!");
+    WORD_ATOM(59, 19, "!");
     mw_prim_mut_set();
-    WORD_ATOM(77, 5, "NONE");
+    WORD_ATOM(60, 5, "NONE");
     mw_NONE();
-    WORD_ATOM(77, 10, "over");
+    WORD_ATOM(60, 10, "over");
     mw_over();
-    WORD_ATOM(77, 15, "~head?");
+    WORD_ATOM(60, 15, "~head?");
     mw_Data_7E_head_3F_();
-    WORD_ATOM(77, 22, "!");
+    WORD_ATOM(60, 22, "!");
     mw_prim_mut_set();
-    WORD_ATOM(78, 5, "drop");
+    WORD_ATOM(61, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_make_data_21_);
 }
 static void mw_make_tag_21_ (void){
-    WORD_ENTER(mw_make_tag_21_, "make-tag!", "src/mirth/data/data.mth", 82, 5);
-    WORD_ATOM(82, 5, "@");
+    WORD_ENTER(mw_make_tag_21_, "make-tag!", "src/mirth/data/data.mth", 65, 5);
+    WORD_ATOM(65, 5, "@");
     mw_prim_mut_get();
-    WORD_ATOM(83, 5, "dip");
+    WORD_ATOM(66, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(83, 9, "sip");
+        WORD_ATOM(66, 9, "sip");
         push_u64(0);
         push_fnptr(&mb_make_tag_21__2);
         mw_prim_pack_cons();
         mw_sip();
-        WORD_ATOM(83, 18, "TT");
+        WORD_ATOM(66, 18, "TT");
         mw_TT();
         push_value(d2);
     }
-    WORD_ATOM(84, 5, "sip");
+    WORD_ATOM(67, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_make_tag_21__3);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(84, 56, "sip");
+    WORD_ATOM(67, 56, "sip");
     push_u64(0);
     push_fnptr(&mb_make_tag_21__4);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(85, 5, "sip");
+    WORD_ATOM(68, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_make_tag_21__5);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(86, 5, "sip");
+    WORD_ATOM(69, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_make_tag_21__6);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(87, 5, "dip");
+    WORD_ATOM(70, 5, "sip");
+    push_u64(0);
+    push_fnptr(&mb_make_tag_21__7);
+    mw_prim_pack_cons();
+    mw_sip();
+    WORD_ATOM(71, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(87, 9, ">Name");
+        WORD_ATOM(71, 9, ">Name");
         mw_Str_3E_Name();
         push_value(d2);
     }
-    WORD_ATOM(87, 16, "dup2");
+    WORD_ATOM(71, 16, "dup2");
     mw_dup2();
-    WORD_ATOM(87, 21, "~name");
+    WORD_ATOM(71, 21, "~name");
     mw_Tag_7E_name();
-    WORD_ATOM(87, 27, "!");
+    WORD_ATOM(71, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(88, 5, "DEF_TAG");
+    WORD_ATOM(72, 5, "DEF_TAG");
     mw_DEF_5F_TAG();
-    WORD_ATOM(88, 13, "swap");
+    WORD_ATOM(72, 13, "swap");
     mw_prim_swap();
-    WORD_ATOM(88, 18, "~Def");
+    WORD_ATOM(72, 18, "~Def");
     mw_Name_7E_Def();
-    WORD_ATOM(88, 23, "!");
+    WORD_ATOM(72, 23, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_make_tag_21_);
 }
 static void mw_init_data_21_ (void){
-    WORD_ENTER(mw_init_data_21_, "init-data!", "src/mirth/data/data.mth", 91, 5);
-    WORD_ATOM(91, 5, "");
+    WORD_ENTER(mw_init_data_21_, "init-data!", "src/mirth/data/data.mth", 75, 5);
+    WORD_ATOM(75, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -11471,17 +14547,17 @@ static void mw_init_data_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(91, 12, "DATA_BOOL");
+    WORD_ATOM(75, 12, "DATA_BOOL");
     mw_DATA_5F_BOOL();
-    WORD_ATOM(91, 22, "TAG_F");
+    WORD_ATOM(75, 22, "TAG_F");
     mw_TAG_5F_F();
-    WORD_ATOM(91, 28, "TAG_T");
+    WORD_ATOM(75, 28, "TAG_T");
     mw_TAG_5F_T();
-    WORD_ATOM(91, 34, "L2");
+    WORD_ATOM(75, 34, "L2");
     mw_L2();
-    WORD_ATOM(91, 37, "make-data!");
+    WORD_ATOM(75, 37, "make-data!");
     mw_make_data_21_();
-    WORD_ATOM(92, 5, "");
+    WORD_ATOM(76, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -11492,15 +14568,15 @@ static void mw_init_data_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(92, 9, "");
+    WORD_ATOM(76, 9, "");
     push_i64(0LL);
-    WORD_ATOM(92, 11, "L0");
+    WORD_ATOM(76, 11, "L0");
     mw_L0();
-    WORD_ATOM(92, 14, "TAG_F");
+    WORD_ATOM(76, 14, "TAG_F");
     mw_TAG_5F_F();
-    WORD_ATOM(92, 20, "make-tag!");
+    WORD_ATOM(76, 20, "make-tag!");
     mw_make_tag_21_();
-    WORD_ATOM(93, 5, "");
+    WORD_ATOM(77, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -11511,15 +14587,15 @@ static void mw_init_data_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(93, 9, "");
+    WORD_ATOM(77, 9, "");
     push_i64(1LL);
-    WORD_ATOM(93, 11, "L0");
+    WORD_ATOM(77, 11, "L0");
     mw_L0();
-    WORD_ATOM(93, 14, "TAG_T");
+    WORD_ATOM(77, 14, "TAG_T");
     mw_TAG_5F_T();
-    WORD_ATOM(93, 20, "make-tag!");
+    WORD_ATOM(77, 20, "make-tag!");
     mw_make_tag_21_();
-    WORD_ATOM(95, 5, "");
+    WORD_ATOM(79, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -11530,15 +14606,15 @@ static void mw_init_data_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(95, 11, "DATA_U64");
+    WORD_ATOM(79, 11, "DATA_U64");
     mw_DATA_5F_U64();
-    WORD_ATOM(95, 20, "TAG_U64");
+    WORD_ATOM(79, 20, "TAG_U64");
     mw_TAG_5F_U64();
-    WORD_ATOM(95, 28, "L1");
+    WORD_ATOM(79, 28, "L1");
     mw_L1();
-    WORD_ATOM(95, 31, "make-data!");
+    WORD_ATOM(79, 31, "make-data!");
     mw_make_data_21_();
-    WORD_ATOM(95, 42, "");
+    WORD_ATOM(79, 42, "");
     {
         static bool vready = false;
         static VAL v;
@@ -11549,17 +14625,17 @@ static void mw_init_data_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(95, 59, "");
+    WORD_ATOM(79, 59, "");
     push_i64(0LL);
-    WORD_ATOM(95, 61, "TYPE_INT");
+    WORD_ATOM(79, 61, "TYPE_INT");
     mw_TYPE_5F_INT();
-    WORD_ATOM(95, 70, "L1");
+    WORD_ATOM(79, 70, "L1");
     mw_L1();
-    WORD_ATOM(95, 73, "TAG_U64");
+    WORD_ATOM(79, 73, "TAG_U64");
     mw_TAG_5F_U64();
-    WORD_ATOM(95, 81, "make-tag!");
+    WORD_ATOM(79, 81, "make-tag!");
     mw_make_tag_21_();
-    WORD_ATOM(96, 5, "");
+    WORD_ATOM(80, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -11570,15 +14646,15 @@ static void mw_init_data_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(96, 11, "DATA_U32");
+    WORD_ATOM(80, 11, "DATA_U32");
     mw_DATA_5F_U32();
-    WORD_ATOM(96, 20, "TAG_U32");
+    WORD_ATOM(80, 20, "TAG_U32");
     mw_TAG_5F_U32();
-    WORD_ATOM(96, 28, "L1");
+    WORD_ATOM(80, 28, "L1");
     mw_L1();
-    WORD_ATOM(96, 31, "make-data!");
+    WORD_ATOM(80, 31, "make-data!");
     mw_make_data_21_();
-    WORD_ATOM(96, 42, "");
+    WORD_ATOM(80, 42, "");
     {
         static bool vready = false;
         static VAL v;
@@ -11589,17 +14665,17 @@ static void mw_init_data_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(96, 59, "");
+    WORD_ATOM(80, 59, "");
     push_i64(0LL);
-    WORD_ATOM(96, 61, "TYPE_INT");
+    WORD_ATOM(80, 61, "TYPE_INT");
     mw_TYPE_5F_INT();
-    WORD_ATOM(96, 70, "L1");
+    WORD_ATOM(80, 70, "L1");
     mw_L1();
-    WORD_ATOM(96, 73, "TAG_U32");
+    WORD_ATOM(80, 73, "TAG_U32");
     mw_TAG_5F_U32();
-    WORD_ATOM(96, 81, "make-tag!");
+    WORD_ATOM(80, 81, "make-tag!");
     mw_make_tag_21_();
-    WORD_ATOM(97, 5, "");
+    WORD_ATOM(81, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -11610,15 +14686,15 @@ static void mw_init_data_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(97, 11, "DATA_U16");
+    WORD_ATOM(81, 11, "DATA_U16");
     mw_DATA_5F_U16();
-    WORD_ATOM(97, 20, "TAG_U16");
+    WORD_ATOM(81, 20, "TAG_U16");
     mw_TAG_5F_U16();
-    WORD_ATOM(97, 28, "L1");
+    WORD_ATOM(81, 28, "L1");
     mw_L1();
-    WORD_ATOM(97, 31, "make-data!");
+    WORD_ATOM(81, 31, "make-data!");
     mw_make_data_21_();
-    WORD_ATOM(97, 42, "");
+    WORD_ATOM(81, 42, "");
     {
         static bool vready = false;
         static VAL v;
@@ -11629,17 +14705,17 @@ static void mw_init_data_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(97, 59, "");
+    WORD_ATOM(81, 59, "");
     push_i64(0LL);
-    WORD_ATOM(97, 61, "TYPE_INT");
+    WORD_ATOM(81, 61, "TYPE_INT");
     mw_TYPE_5F_INT();
-    WORD_ATOM(97, 70, "L1");
+    WORD_ATOM(81, 70, "L1");
     mw_L1();
-    WORD_ATOM(97, 73, "TAG_U16");
+    WORD_ATOM(81, 73, "TAG_U16");
     mw_TAG_5F_U16();
-    WORD_ATOM(97, 81, "make-tag!");
+    WORD_ATOM(81, 81, "make-tag!");
     mw_make_tag_21_();
-    WORD_ATOM(98, 5, "");
+    WORD_ATOM(82, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -11650,15 +14726,15 @@ static void mw_init_data_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(98, 11, "DATA_U8");
+    WORD_ATOM(82, 11, "DATA_U8");
     mw_DATA_5F_U8();
-    WORD_ATOM(98, 20, "TAG_U8");
+    WORD_ATOM(82, 20, "TAG_U8");
     mw_TAG_5F_U8();
-    WORD_ATOM(98, 28, "L1");
+    WORD_ATOM(82, 28, "L1");
     mw_L1();
-    WORD_ATOM(98, 31, "make-data!");
+    WORD_ATOM(82, 31, "make-data!");
     mw_make_data_21_();
-    WORD_ATOM(98, 42, "");
+    WORD_ATOM(82, 42, "");
     {
         static bool vready = false;
         static VAL v;
@@ -11669,17 +14745,17 @@ static void mw_init_data_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(98, 59, "");
+    WORD_ATOM(82, 59, "");
     push_i64(0LL);
-    WORD_ATOM(98, 61, "TYPE_INT");
+    WORD_ATOM(82, 61, "TYPE_INT");
     mw_TYPE_5F_INT();
-    WORD_ATOM(98, 70, "L1");
+    WORD_ATOM(82, 70, "L1");
     mw_L1();
-    WORD_ATOM(98, 73, "TAG_U8");
+    WORD_ATOM(82, 73, "TAG_U8");
     mw_TAG_5F_U8();
-    WORD_ATOM(98, 81, "make-tag!");
+    WORD_ATOM(82, 81, "make-tag!");
     mw_make_tag_21_();
-    WORD_ATOM(99, 5, "");
+    WORD_ATOM(83, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -11690,15 +14766,15 @@ static void mw_init_data_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(99, 11, "DATA_I64");
+    WORD_ATOM(83, 11, "DATA_I64");
     mw_DATA_5F_I64();
-    WORD_ATOM(99, 20, "TAG_I64");
+    WORD_ATOM(83, 20, "TAG_I64");
     mw_TAG_5F_I64();
-    WORD_ATOM(99, 28, "L1");
+    WORD_ATOM(83, 28, "L1");
     mw_L1();
-    WORD_ATOM(99, 31, "make-data!");
+    WORD_ATOM(83, 31, "make-data!");
     mw_make_data_21_();
-    WORD_ATOM(99, 42, "");
+    WORD_ATOM(83, 42, "");
     {
         static bool vready = false;
         static VAL v;
@@ -11709,17 +14785,17 @@ static void mw_init_data_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(99, 59, "");
+    WORD_ATOM(83, 59, "");
     push_i64(0LL);
-    WORD_ATOM(99, 61, "TYPE_INT");
+    WORD_ATOM(83, 61, "TYPE_INT");
     mw_TYPE_5F_INT();
-    WORD_ATOM(99, 70, "L1");
+    WORD_ATOM(83, 70, "L1");
     mw_L1();
-    WORD_ATOM(99, 73, "TAG_I64");
+    WORD_ATOM(83, 73, "TAG_I64");
     mw_TAG_5F_I64();
-    WORD_ATOM(99, 81, "make-tag!");
+    WORD_ATOM(83, 81, "make-tag!");
     mw_make_tag_21_();
-    WORD_ATOM(100, 5, "");
+    WORD_ATOM(84, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -11730,15 +14806,15 @@ static void mw_init_data_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(100, 11, "DATA_I32");
+    WORD_ATOM(84, 11, "DATA_I32");
     mw_DATA_5F_I32();
-    WORD_ATOM(100, 20, "TAG_I32");
+    WORD_ATOM(84, 20, "TAG_I32");
     mw_TAG_5F_I32();
-    WORD_ATOM(100, 28, "L1");
+    WORD_ATOM(84, 28, "L1");
     mw_L1();
-    WORD_ATOM(100, 31, "make-data!");
+    WORD_ATOM(84, 31, "make-data!");
     mw_make_data_21_();
-    WORD_ATOM(100, 42, "");
+    WORD_ATOM(84, 42, "");
     {
         static bool vready = false;
         static VAL v;
@@ -11749,17 +14825,17 @@ static void mw_init_data_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(100, 59, "");
+    WORD_ATOM(84, 59, "");
     push_i64(0LL);
-    WORD_ATOM(100, 61, "TYPE_INT");
+    WORD_ATOM(84, 61, "TYPE_INT");
     mw_TYPE_5F_INT();
-    WORD_ATOM(100, 70, "L1");
+    WORD_ATOM(84, 70, "L1");
     mw_L1();
-    WORD_ATOM(100, 73, "TAG_I32");
+    WORD_ATOM(84, 73, "TAG_I32");
     mw_TAG_5F_I32();
-    WORD_ATOM(100, 81, "make-tag!");
+    WORD_ATOM(84, 81, "make-tag!");
     mw_make_tag_21_();
-    WORD_ATOM(101, 5, "");
+    WORD_ATOM(85, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -11770,15 +14846,15 @@ static void mw_init_data_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(101, 11, "DATA_I16");
+    WORD_ATOM(85, 11, "DATA_I16");
     mw_DATA_5F_I16();
-    WORD_ATOM(101, 20, "TAG_I16");
+    WORD_ATOM(85, 20, "TAG_I16");
     mw_TAG_5F_I16();
-    WORD_ATOM(101, 28, "L1");
+    WORD_ATOM(85, 28, "L1");
     mw_L1();
-    WORD_ATOM(101, 31, "make-data!");
+    WORD_ATOM(85, 31, "make-data!");
     mw_make_data_21_();
-    WORD_ATOM(101, 42, "");
+    WORD_ATOM(85, 42, "");
     {
         static bool vready = false;
         static VAL v;
@@ -11789,17 +14865,17 @@ static void mw_init_data_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(101, 59, "");
+    WORD_ATOM(85, 59, "");
     push_i64(0LL);
-    WORD_ATOM(101, 61, "TYPE_INT");
+    WORD_ATOM(85, 61, "TYPE_INT");
     mw_TYPE_5F_INT();
-    WORD_ATOM(101, 70, "L1");
+    WORD_ATOM(85, 70, "L1");
     mw_L1();
-    WORD_ATOM(101, 73, "TAG_I16");
+    WORD_ATOM(85, 73, "TAG_I16");
     mw_TAG_5F_I16();
-    WORD_ATOM(101, 81, "make-tag!");
+    WORD_ATOM(85, 81, "make-tag!");
     mw_make_tag_21_();
-    WORD_ATOM(102, 5, "");
+    WORD_ATOM(86, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -11810,15 +14886,15 @@ static void mw_init_data_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(102, 11, "DATA_I8");
+    WORD_ATOM(86, 11, "DATA_I8");
     mw_DATA_5F_I8();
-    WORD_ATOM(102, 20, "TAG_I8");
+    WORD_ATOM(86, 20, "TAG_I8");
     mw_TAG_5F_I8();
-    WORD_ATOM(102, 28, "L1");
+    WORD_ATOM(86, 28, "L1");
     mw_L1();
-    WORD_ATOM(102, 31, "make-data!");
+    WORD_ATOM(86, 31, "make-data!");
     mw_make_data_21_();
-    WORD_ATOM(102, 42, "");
+    WORD_ATOM(86, 42, "");
     {
         static bool vready = false;
         static VAL v;
@@ -11829,130 +14905,321 @@ static void mw_init_data_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(102, 59, "");
+    WORD_ATOM(86, 59, "");
     push_i64(0LL);
-    WORD_ATOM(102, 61, "TYPE_INT");
+    WORD_ATOM(86, 61, "TYPE_INT");
     mw_TYPE_5F_INT();
-    WORD_ATOM(102, 70, "L1");
+    WORD_ATOM(86, 70, "L1");
     mw_L1();
-    WORD_ATOM(102, 73, "TAG_I8");
+    WORD_ATOM(86, 73, "TAG_I8");
     mw_TAG_5F_I8();
-    WORD_ATOM(102, 81, "make-tag!");
+    WORD_ATOM(86, 81, "make-tag!");
     mw_make_tag_21_();
     WORD_EXIT(mw_init_data_21_);
 }
 static void mw_Data_3D_ (void){
-    WORD_ENTER(mw_Data_3D_, "Data=", "src/mirth/data/data.mth", 108, 31);
-    WORD_ATOM(108, 31, "both");
+    WORD_ENTER(mw_Data_3D_, "Data=", "src/mirth/data/data.mth", 92, 31);
+    WORD_ATOM(92, 31, "both");
     push_u64(0);
     push_fnptr(&mb_Data_3D__1);
     mw_prim_pack_cons();
     mw_both();
-    WORD_ATOM(108, 41, "=");
+    WORD_ATOM(92, 41, "=");
     mw_prim_int_eq();
     WORD_EXIT(mw_Data_3D_);
 }
 static void mw_Data_2E_num_tags (void){
-    WORD_ENTER(mw_Data_2E_num_tags, "Data.num-tags", "src/mirth/data/data.mth", 109, 33);
-    WORD_ATOM(109, 33, "tags");
+    WORD_ENTER(mw_Data_2E_num_tags, "Data.num-tags", "src/mirth/data/data.mth", 93, 33);
+    WORD_ATOM(93, 33, "tags");
     mw_Data_2E_tags();
-    WORD_ATOM(109, 38, "len");
+    WORD_ATOM(93, 38, "len");
     mw_List_2E_len();
     WORD_EXIT(mw_Data_2E_num_tags);
 }
 static void mw_Data_2E_add_tag_21_ (void){
-    WORD_ENTER(mw_Data_2E_add_tag_21_, "Data.add-tag!", "src/mirth/data/data.mth", 113, 5);
-    WORD_ATOM(113, 5, "dup2");
+    WORD_ENTER(mw_Data_2E_add_tag_21_, "Data.add-tag!", "src/mirth/data/data.mth", 97, 5);
+    WORD_ATOM(97, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(113, 10, "num-tags");
+    WORD_ATOM(97, 10, "num-tags");
     mw_Data_2E_num_tags();
-    WORD_ATOM(113, 19, "swap");
+    WORD_ATOM(97, 19, "swap");
     mw_prim_swap();
-    WORD_ATOM(113, 24, "~value");
+    WORD_ATOM(97, 24, "~value");
     mw_Tag_7E_value();
-    WORD_ATOM(113, 31, "!");
+    WORD_ATOM(97, 31, "!");
     mw_prim_mut_set();
-    WORD_ATOM(114, 5, "dup");
+    WORD_ATOM(98, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(114, 9, "tags");
+    WORD_ATOM(98, 9, "tags");
     mw_Data_2E_tags();
-    WORD_ATOM(114, 14, "rotr");
+    WORD_ATOM(98, 14, "rotr");
     mw_rotr();
-    WORD_ATOM(114, 19, "dip");
+    WORD_ATOM(98, 19, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(114, 23, "snoc");
+        WORD_ATOM(98, 23, "snoc");
         mw_snoc();
         push_value(d2);
     }
-    WORD_ATOM(114, 29, "~tags");
+    WORD_ATOM(98, 29, "~tags");
     mw_Data_7E_tags();
-    WORD_ATOM(114, 35, "!");
+    WORD_ATOM(98, 35, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_Data_2E_add_tag_21_);
 }
 static void mw_Data_2E_is_transparent_3F_ (void){
-    WORD_ENTER(mw_Data_2E_is_transparent_3F_, "Data.is-transparent?", "src/mirth/data/data.mth", 120, 5);
-    WORD_ATOM(120, 5, "tags");
-    mw_Data_2E_tags();
-    WORD_ATOM(120, 10, "match");
-    switch (get_top_data_tag()) {
-        case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(121, 15, "num-inputs");
-            mw_Tag_2E_num_inputs();
-            WORD_ATOM(121, 26, "");
-            push_i64(1LL);
-            WORD_ATOM(121, 28, "=");
-            mw_prim_int_eq();
-            break;
-        default:
-            WORD_ATOM(122, 14, "drop");
-            mw_prim_drop();
-            WORD_ATOM(122, 19, "F");
-            mw_F();
-            break;
-    
-}    WORD_EXIT(mw_Data_2E_is_transparent_3F_);
+    WORD_ENTER(mw_Data_2E_is_transparent_3F_, "Data.is-transparent?", "src/mirth/data/data.mth", 104, 5);
+    WORD_ATOM(104, 5, "dup");
+    mw_prim_dup();
+    WORD_ATOM(104, 9, "is-resource?");
+    mw_Data_2E_is_resource_3F_();
+    WORD_ATOM(104, 22, "if");
+    if (pop_u64()) {
+        WORD_ATOM(105, 9, "drop");
+        mw_prim_drop();
+        WORD_ATOM(105, 14, "F");
+        mw_F();
+    } else {
+        WORD_ATOM(106, 9, "tags");
+        mw_Data_2E_tags();
+        WORD_ATOM(106, 14, "match");
+        switch (get_top_data_tag()) {
+            case 1LL:
+                co_L1();
+                WORD_ATOM(107, 19, "dup");
+                mw_prim_dup();
+                WORD_ATOM(107, 23, "num-type-inputs");
+                mw_Tag_2E_num_type_inputs();
+                WORD_ATOM(107, 39, "");
+                push_i64(1LL);
+                WORD_ATOM(107, 41, "=");
+                mw_prim_int_eq();
+                WORD_ATOM(107, 43, "swap");
+                mw_prim_swap();
+                WORD_ATOM(107, 48, "num-resource-inputs");
+                mw_Tag_2E_num_resource_inputs();
+                WORD_ATOM(107, 68, "");
+                push_i64(0LL);
+                WORD_ATOM(107, 70, "=");
+                mw_prim_int_eq();
+                WORD_ATOM(107, 72, "&&");
+                mw_Bool_26__26_();
+                break;
+            default:
+                WORD_ATOM(108, 18, "drop");
+                mw_prim_drop();
+                WORD_ATOM(108, 23, "F");
+                mw_F();
+                break;
+        
+}    }
+    WORD_EXIT(mw_Data_2E_is_transparent_3F_);
 }
 static void mw_Data_2E_is_resource_3F_ (void){
-    WORD_ENTER(mw_Data_2E_is_resource_3F_, "Data.is-resource?", "src/mirth/data/data.mth", 126, 5);
-    WORD_ATOM(126, 5, "name");
+    WORD_ENTER(mw_Data_2E_is_resource_3F_, "Data.is-resource?", "src/mirth/data/data.mth", 113, 5);
+    WORD_ATOM(113, 5, "name");
     mw_Data_2E_name();
-    WORD_ATOM(126, 10, "could-be-resource-con");
+    WORD_ATOM(113, 10, "could-be-resource-con");
     mw_Name_2E_could_be_resource_con();
     WORD_EXIT(mw_Data_2E_is_resource_3F_);
 }
-static void mw_Tag_2E_num_inputs_from_sig (void){
-    WORD_ENTER(mw_Tag_2E_num_inputs_from_sig, "Tag.num-inputs-from-sig", "src/mirth/data/data.mth", 133, 5);
-    WORD_ATOM(133, 5, "sig?");
+static void mw_Tag_2E_id (void){
+    WORD_ENTER(mw_Tag_2E_id, "Tag.id", "src/mirth/data/data.mth", 119, 7);
+    WORD_ATOM(119, 7, "Tag");
+    mw_prim_unsafe_cast();
+    WORD_EXIT(mw_Tag_2E_id);
+}
+static void mw_Tag_2E_for (void){
+    WORD_ENTER(mw_Tag_2E_for, "Tag.for", "src/mirth/data/data.mth", 119, 7);
+    WORD_ATOM(119, 7, "Tag");
+    {
+        VAL var_x = pop_value();
+        WORD_ATOM(119, 7, "Tag");
+        push_i64(1LL);
+        WORD_ATOM(119, 7, "Tag");
+        while(1) {
+            WORD_ATOM(119, 7, "Tag");
+            mw_prim_dup();
+            WORD_ATOM(119, 7, "Tag");
+            mw_Tag_2E_NUM();
+            WORD_ATOM(119, 7, "Tag");
+            mw_prim_u64_get();
+            WORD_ATOM(119, 7, "Tag");
+            mw_prim_unsafe_cast();
+            WORD_ATOM(119, 7, "Tag");
+            push_i64(1LL);
+            WORD_ATOM(119, 7, "Tag");
+            mw_prim_int_add();
+            WORD_ATOM(119, 7, "Tag");
+            mw_prim_int_lt();
+            if (! pop_u64()) break;
+            WORD_ATOM(119, 7, "Tag");
+            mw_prim_dup();
+            WORD_ATOM(119, 7, "Tag");
+            {
+                VAL d4 = pop_value();
+                WORD_ATOM(119, 7, "Tag");
+                mw_prim_unsafe_cast();
+                WORD_ATOM(119, 7, "Tag");
+                incref(var_x);
+                run_value(var_x);
+                push_value(d4);
+            }
+            WORD_ATOM(119, 7, "Tag");
+            push_i64(1LL);
+            WORD_ATOM(119, 7, "Tag");
+            mw_prim_int_add();
+        }
+        WORD_ATOM(119, 7, "Tag");
+        mw_prim_drop();
+        decref(var_x);
+    }
+    WORD_EXIT(mw_Tag_2E_for);
+}
+static void mw_Tag_2E_alloc_21_ (void){
+    WORD_ENTER(mw_Tag_2E_alloc_21_, "Tag.alloc!", "src/mirth/data/data.mth", 119, 7);
+    WORD_ATOM(119, 7, "Tag");
+    mw_Tag_2E_NUM();
+    WORD_ATOM(119, 7, "Tag");
+    mw_prim_u64_get();
+    WORD_ATOM(119, 7, "Tag");
+    mw_prim_unsafe_cast();
+    WORD_ATOM(119, 7, "Tag");
+    push_i64(1LL);
+    WORD_ATOM(119, 7, "Tag");
+    mw_prim_int_add();
+    WORD_ATOM(119, 7, "Tag");
+    mw_prim_dup();
+    WORD_ATOM(119, 7, "Tag");
+    mw_prim_unsafe_cast();
+    WORD_ATOM(119, 7, "Tag");
+    mw_Tag_2E_NUM();
+    WORD_ATOM(119, 7, "Tag");
+    mw_prim_u64_set();
+    WORD_ATOM(119, 7, "Tag");
+    mw_prim_unsafe_cast();
+    WORD_EXIT(mw_Tag_2E_alloc_21_);
+}
+static void mw_Tag_2E_data (void){
+    WORD_ENTER(mw_Tag_2E_data, "Tag.data", "src/mirth/data/data.mth", 128, 28);
+    WORD_ATOM(128, 28, "~data");
+    mw_Tag_7E_data();
+    WORD_ATOM(128, 34, "@");
+    mw_prim_mut_get();
+    WORD_EXIT(mw_Tag_2E_data);
+}
+static void mw_Tag_2E_name (void){
+    WORD_ENTER(mw_Tag_2E_name, "Tag.name", "src/mirth/data/data.mth", 129, 28);
+    WORD_ATOM(129, 28, "~name");
+    mw_Tag_7E_name();
+    WORD_ATOM(129, 34, "@");
+    mw_prim_mut_get();
+    WORD_EXIT(mw_Tag_2E_name);
+}
+static void mw_Tag_2E_value (void){
+    WORD_ENTER(mw_Tag_2E_value, "Tag.value", "src/mirth/data/data.mth", 130, 28);
+    WORD_ATOM(130, 28, "~value");
+    mw_Tag_7E_value();
+    WORD_ATOM(130, 35, "@");
+    mw_prim_mut_get();
+    WORD_EXIT(mw_Tag_2E_value);
+}
+static void mw_Tag_2E_num_type_inputs (void){
+    WORD_ENTER(mw_Tag_2E_num_type_inputs, "Tag.num-type-inputs", "src/mirth/data/data.mth", 131, 38);
+    WORD_ATOM(131, 38, "~num-type-inputs");
+    mw_Tag_7E_num_type_inputs();
+    WORD_ATOM(131, 55, "@");
+    mw_prim_mut_get();
+    WORD_EXIT(mw_Tag_2E_num_type_inputs);
+}
+static void mw_Tag_2E_num_resource_inputs (void){
+    WORD_ENTER(mw_Tag_2E_num_resource_inputs, "Tag.num-resource-inputs", "src/mirth/data/data.mth", 132, 42);
+    WORD_ATOM(132, 42, "~num-resource-inputs");
+    mw_Tag_7E_num_resource_inputs();
+    WORD_ATOM(132, 63, "@");
+    mw_prim_mut_get();
+    WORD_EXIT(mw_Tag_2E_num_resource_inputs);
+}
+static void mw_Tag_2E_sig_3F_ (void){
+    WORD_ENTER(mw_Tag_2E_sig_3F_, "Tag.sig?", "src/mirth/data/data.mth", 133, 36);
+    WORD_ATOM(133, 36, "~sig?");
+    mw_Tag_7E_sig_3F_();
+    WORD_ATOM(133, 42, "@");
+    mw_prim_mut_get();
+    WORD_EXIT(mw_Tag_2E_sig_3F_);
+}
+static void mw_Tag_2E_ctx_type (void){
+    WORD_ENTER(mw_Tag_2E_ctx_type, "Tag.ctx-type", "src/mirth/data/data.mth", 134, 41);
+    WORD_ATOM(134, 41, "~ctx-type");
+    mw_Tag_7E_ctx_type();
+    WORD_ATOM(134, 51, "force!");
+    mw_force_21_();
+    WORD_ATOM(134, 58, "unpack2");
+    mw_unpack2();
+    WORD_EXIT(mw_Tag_2E_ctx_type);
+}
+static void mw_Tag_2E_type (void){
+    WORD_ENTER(mw_Tag_2E_type, "Tag.type", "src/mirth/data/data.mth", 136, 33);
+    WORD_ATOM(136, 33, "ctx-type");
+    mw_Tag_2E_ctx_type();
+    WORD_ATOM(136, 42, "nip");
+    mw_nip();
+    WORD_EXIT(mw_Tag_2E_type);
+}
+static void mw_Tag_2E_num_type_inputs_from_sig (void){
+    WORD_ENTER(mw_Tag_2E_num_type_inputs_from_sig, "Tag.num-type-inputs-from-sig", "src/mirth/data/data.mth", 139, 5);
+    WORD_ATOM(139, 5, "dup");
+    mw_prim_dup();
+    WORD_ATOM(139, 9, "sig?");
     mw_Tag_2E_sig_3F_();
-    WORD_ATOM(133, 10, "if-some");
+    WORD_ATOM(139, 14, "if-some");
     push_u64(0);
-    push_fnptr(&mb_Tag_2E_num_inputs_from_sig_1);
+    push_fnptr(&mb_Tag_2E_num_type_inputs_from_sig_1);
     mw_prim_pack_cons();
     push_u64(0);
-    push_fnptr(&mb_Tag_2E_num_inputs_from_sig_2);
+    push_fnptr(&mb_Tag_2E_num_type_inputs_from_sig_2);
     mw_prim_pack_cons();
     mw_Maybe_2E_if_some();
-    WORD_EXIT(mw_Tag_2E_num_inputs_from_sig);
+    WORD_EXIT(mw_Tag_2E_num_type_inputs_from_sig);
+}
+static void mw_Tag_2E_num_resource_inputs_from_sig (void){
+    WORD_ENTER(mw_Tag_2E_num_resource_inputs_from_sig, "Tag.num-resource-inputs-from-sig", "src/mirth/data/data.mth", 146, 5);
+    WORD_ATOM(146, 5, "sig?");
+    mw_Tag_2E_sig_3F_();
+    WORD_ATOM(146, 10, "if-some");
+    push_u64(0);
+    push_fnptr(&mb_Tag_2E_num_resource_inputs_from_sig_1);
+    mw_prim_pack_cons();
+    push_u64(0);
+    push_fnptr(&mb_Tag_2E_num_resource_inputs_from_sig_5);
+    mw_prim_pack_cons();
+    mw_Maybe_2E_if_some();
+    WORD_EXIT(mw_Tag_2E_num_resource_inputs_from_sig);
 }
 static void mw_Tag_2E_is_transparent_3F_ (void){
-    WORD_ENTER(mw_Tag_2E_is_transparent_3F_, "Tag.is-transparent?", "src/mirth/data/data.mth", 136, 5);
-    WORD_ATOM(136, 5, ".data");
+    WORD_ENTER(mw_Tag_2E_is_transparent_3F_, "Tag.is-transparent?", "src/mirth/data/data.mth", 154, 5);
+    WORD_ATOM(154, 5, ".data");
     mw_Tag_2E_data();
-    WORD_ATOM(136, 11, "is-transparent?");
+    WORD_ATOM(154, 11, "is-transparent?");
     mw_Data_2E_is_transparent_3F_();
     WORD_EXIT(mw_Tag_2E_is_transparent_3F_);
 }
+static void mw_Tag_2E_outputs_resource_3F_ (void){
+    WORD_ENTER(mw_Tag_2E_outputs_resource_3F_, "Tag.outputs-resource?", "src/mirth/data/data.mth", 157, 5);
+    WORD_ATOM(157, 5, ".data");
+    mw_Tag_2E_data();
+    WORD_ATOM(157, 11, "is-resource?");
+    mw_Data_2E_is_resource_3F_();
+    WORD_EXIT(mw_Tag_2E_outputs_resource_3F_);
+}
 static void mw_Tag_3D_ (void){
-    WORD_ENTER(mw_Tag_3D_, "Tag=", "src/mirth/data/data.mth", 138, 28);
-    WORD_ATOM(138, 28, "both");
+    WORD_ENTER(mw_Tag_3D_, "Tag=", "src/mirth/data/data.mth", 159, 28);
+    WORD_ATOM(159, 28, "both");
     push_u64(0);
     push_fnptr(&mb_Tag_3D__1);
     mw_prim_pack_cons();
     mw_both();
-    WORD_ATOM(138, 38, "=");
+    WORD_ATOM(159, 38, "=");
     mw_prim_int_eq();
     WORD_EXIT(mw_Tag_3D_);
 }
@@ -12158,20 +15425,20 @@ static void mw_Match_2E_is_transparent_3F_ (void){
     WORD_ATOM(71, 11, "match");
     switch (get_top_data_tag()) {
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_L1();
             WORD_ATOM(72, 15, "pattern");
             mw_Case_2E_pattern();
             WORD_ATOM(72, 23, "match");
             switch (get_top_data_tag()) {
                 case 1LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_PATTERN_5F_TAG();
                     WORD_ATOM(73, 28, ".data");
                     mw_Tag_2E_data();
                     WORD_ATOM(73, 34, "is-transparent?");
                     mw_Data_2E_is_transparent_3F_();
                     break;
                 case 0LL:
-                    mw_prim_drop();
+                    co_PATTERN_5F_UNDERSCORE();
                     WORD_ATOM(74, 35, "T");
                     mw_T();
                     break;
@@ -12262,7 +15529,7 @@ static void mw_Pattern_2E_underscore_3F_ (void){
     WORD_ATOM(106, 43, "PATTERN_UNDERSCORE");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_PATTERN_5F_UNDERSCORE();
             WORD_ATOM(106, 65, "T");
             mw_T();
             break;
@@ -12280,7 +15547,7 @@ static void mw_Pattern_2E_tag_3F_ (void){
     WORD_ATOM(107, 42, "PATTERN_TAG");
     switch (get_top_data_tag()) {
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_PATTERN_5F_TAG();
             WORD_ATOM(107, 57, "SOME");
             mw_SOME();
             break;
@@ -12312,14 +15579,14 @@ static void mw_Pattern_2E_covers_3F_ (void){
     WORD_ATOM(116, 5, "PATTERN_UNDERSCORE");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_PATTERN_5F_UNDERSCORE();
             WORD_ATOM(116, 27, "drop");
             mw_prim_drop();
             WORD_ATOM(116, 32, "T");
             mw_T();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_PATTERN_5F_TAG();
             WORD_ATOM(117, 20, "swap");
             mw_prim_swap();
             WORD_ATOM(117, 25, "tag=");
@@ -13178,15 +16445,14 @@ static void mw_Stack_2E_uncons (void){
     WORD_ATOM(14, 5, "STACK_NIL");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_STACK_5F_NIL();
             WORD_ATOM(14, 18, "NONE");
             mw_NONE();
             WORD_ATOM(14, 23, "STACK_NIL");
             mw_STACK_5F_NIL();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STACK_5F_CONS();
             WORD_ATOM(15, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -13509,14 +16775,14 @@ static void mw_run_lexer_21_ (void){
     WORD_ATOM(41, 22, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_NONE();
             WORD_ATOM(42, 17, "TOKEN_NONE");
             mw_TOKEN_5F_NONE();
             WORD_ATOM(42, 28, "lexer-emit!");
             mw_lexer_emit_21_();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_SOME();
             WORD_ATOM(43, 17, "");
             {
                 static bool vready = false;
@@ -13622,41 +16888,41 @@ static void mw_lexer_next_21_ (void){
     WORD_ATOM(67, 33, "match");
     switch (get_top_data_tag()) {
         case 10LL:
-            mw_prim_drop();
+            co_BLF();
             WORD_ATOM(68, 12, "lexer-newline!");
             mw_lexer_newline_21_();
             WORD_ATOM(68, 27, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 32LL:
-            mw_prim_drop();
+            co_BSPACE();
             WORD_ATOM(69, 15, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 9LL:
-            mw_prim_drop();
+            co_BHT();
             WORD_ATOM(70, 12, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 11LL:
-            mw_prim_drop();
+            co_BVT();
             WORD_ATOM(71, 12, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 13LL:
-            mw_prim_drop();
+            co_BCR();
             WORD_ATOM(72, 12, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 35LL:
-            mw_prim_drop();
+            co_BHASH();
             WORD_ATOM(73, 14, "lexer-skip-comment!");
             mw_lexer_skip_comment_21_();
             WORD_ATOM(73, 34, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 44LL:
-            mw_prim_drop();
+            co_BCOMMA();
             WORD_ATOM(74, 15, "TOKEN_COMMA");
             mw_TOKEN_5F_COMMA();
             WORD_ATOM(74, 27, "lexer-emit!");
@@ -13665,49 +16931,49 @@ static void mw_lexer_next_21_ (void){
             mw_lexer_move_21_();
             break;
         case 40LL:
-            mw_prim_drop();
+            co_BLPAREN();
             WORD_ATOM(75, 16, "lexer-emit-lparen!");
             mw_lexer_emit_lparen_21_();
             WORD_ATOM(75, 35, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 41LL:
-            mw_prim_drop();
+            co_BRPAREN();
             WORD_ATOM(76, 16, "lexer-emit-rparen!");
             mw_lexer_emit_rparen_21_();
             WORD_ATOM(76, 35, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 91LL:
-            mw_prim_drop();
+            co_BLSQUARE();
             WORD_ATOM(77, 17, "lexer-emit-lsquare!");
             mw_lexer_emit_lsquare_21_();
             WORD_ATOM(77, 37, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 93LL:
-            mw_prim_drop();
+            co_BRSQUARE();
             WORD_ATOM(78, 17, "lexer-emit-rsquare!");
             mw_lexer_emit_rsquare_21_();
             WORD_ATOM(78, 37, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 123LL:
-            mw_prim_drop();
+            co_BLCURLY();
             WORD_ATOM(79, 16, "lexer-emit-lcurly!");
             mw_lexer_emit_lcurly_21_();
             WORD_ATOM(79, 35, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 125LL:
-            mw_prim_drop();
+            co_BRCURLY();
             WORD_ATOM(80, 16, "lexer-emit-rcurly!");
             mw_lexer_emit_rcurly_21_();
             WORD_ATOM(80, 35, "lexer-move!");
             mw_lexer_move_21_();
             break;
         case 34LL:
-            mw_prim_drop();
+            co_BQUOTE();
             WORD_ATOM(81, 15, "lexer-emit-string!");
             mw_lexer_emit_string_21_();
             WORD_ATOM(81, 34, "lexer-move!");
@@ -13779,7 +17045,7 @@ static void mw_lexer_emit_rparen_21_ (void){
     WORD_ATOM(95, 22, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_NONE();
             WORD_ATOM(96, 17, "");
             {
                 static bool vready = false;
@@ -13795,7 +17061,7 @@ static void mw_lexer_emit_rparen_21_ (void){
             mw_lexer_emit_fatal_error_21_();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_SOME();
             WORD_ATOM(97, 17, "dup");
             mw_prim_dup();
             WORD_ATOM(97, 21, "lparen-open?");
@@ -13857,7 +17123,7 @@ static void mw_lexer_emit_rsquare_21_ (void){
     WORD_ATOM(108, 22, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_NONE();
             WORD_ATOM(109, 17, "");
             {
                 static bool vready = false;
@@ -13873,7 +17139,7 @@ static void mw_lexer_emit_rsquare_21_ (void){
             mw_lexer_emit_fatal_error_21_();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_SOME();
             WORD_ATOM(110, 17, "dup");
             mw_prim_dup();
             WORD_ATOM(110, 21, "lsquare-open?");
@@ -13935,7 +17201,7 @@ static void mw_lexer_emit_rcurly_21_ (void){
     WORD_ATOM(121, 22, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_NONE();
             WORD_ATOM(122, 17, "");
             {
                 static bool vready = false;
@@ -13951,7 +17217,7 @@ static void mw_lexer_emit_rcurly_21_ (void){
             mw_lexer_emit_fatal_error_21_();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_SOME();
             WORD_ATOM(123, 17, "dup");
             mw_prim_dup();
             WORD_ATOM(123, 21, "lcurly-open?");
@@ -14313,7 +17579,7 @@ static void mw_str_buf_int_sign (void){
     WORD_ATOM(228, 21, "match");
     switch (get_top_data_tag()) {
         case 45LL:
-            mw_prim_drop();
+            co_B_27___27_();
             WORD_ATOM(229, 17, "");
             push_i64(-1LL);
             WORD_ATOM(229, 20, "");
@@ -14322,7 +17588,7 @@ static void mw_str_buf_int_sign (void){
             push_i64(1LL);
             break;
         case 43LL:
-            mw_prim_drop();
+            co_B_27__2B__27_();
             WORD_ATOM(230, 17, "");
             push_i64(1LL);
             WORD_ATOM(230, 20, "");
@@ -14472,7 +17738,7 @@ static void mw_lexer_push_string_byte_21_ (void){
     WORD_ATOM(276, 5, "B'\\'");
     switch (get_top_data_tag()) {
         case 92LL:
-            mw_prim_drop();
+            co_B_27__5C__27_();
             WORD_ATOM(276, 13, "lexer-move!");
             mw_lexer_move_21_();
             WORD_ATOM(276, 25, "lexer-peek");
@@ -14492,40 +17758,40 @@ static void mw_lexer_push_string_escape_byte_21_ (void){
     WORD_ATOM(280, 5, "BLF");
     switch (get_top_data_tag()) {
         case 10LL:
-            mw_prim_drop();
+            co_BLF();
             WORD_ATOM(280, 12, "id");
             mw_prim_id();
             break;
         case 110LL:
-            mw_prim_drop();
+            co_B_27_n_27_();
             WORD_ATOM(281, 13, "BLF");
             mw_BLF();
             WORD_ATOM(281, 17, "str-buf-push-byte!");
             mw_str_buf_push_byte_21_();
             break;
         case 114LL:
-            mw_prim_drop();
+            co_B_27_r_27_();
             WORD_ATOM(282, 13, "BCR");
             mw_BCR();
             WORD_ATOM(282, 17, "str-buf-push-byte!");
             mw_str_buf_push_byte_21_();
             break;
         case 116LL:
-            mw_prim_drop();
+            co_B_27_t_27_();
             WORD_ATOM(283, 13, "BHT");
             mw_BHT();
             WORD_ATOM(283, 17, "str-buf-push-byte!");
             mw_str_buf_push_byte_21_();
             break;
         case 92LL:
-            mw_prim_drop();
+            co_B_27__5C__27_();
             WORD_ATOM(284, 13, "B'\\'");
             mw_B_27__5C__27_();
             WORD_ATOM(284, 18, "str-buf-push-byte!");
             mw_str_buf_push_byte_21_();
             break;
         case 34LL:
-            mw_prim_drop();
+            co_BQUOTE();
             WORD_ATOM(285, 15, "BQUOTE");
             mw_BQUOTE();
             WORD_ATOM(285, 22, "str-buf-push-byte!");
@@ -14682,36 +17948,30 @@ static void mw_lexer_emit_fatal_error_21_ (void){
     mw_emit_fatal_error_at_21_();
     WORD_EXIT(mw_lexer_emit_fatal_error_21_);
 }
-static void mw_CODEGEN_5F_BUF_5F_SIZE (void){
-    WORD_ENTER(mw_CODEGEN_5F_BUF_5F_SIZE, "CODEGEN_BUF_SIZE", "src/mirth/codegen.mth", 35, 29);
-    WORD_ATOM(35, 29, "");
-    push_i64(8192LL);
-    WORD_EXIT(mw_CODEGEN_5F_BUF_5F_SIZE);
-}
 static void mw_reset_needs_21_ (void){
-    WORD_ENTER(mw_reset_needs_21_, "reset-needs!", "src/mirth/codegen.mth", 47, 5);
-    WORD_ATOM(47, 5, "Block.for");
+    WORD_ENTER(mw_reset_needs_21_, "reset-needs!", "src/mirth/codegen.mth", 43, 5);
+    WORD_ATOM(43, 5, "Block.for");
     push_u64(0);
     push_fnptr(&mb_reset_needs_21__1);
     mw_prim_pack_cons();
     mw_Block_2E_for();
-    WORD_ATOM(48, 5, "Word.for");
+    WORD_ATOM(44, 5, "Word.for");
     push_u64(0);
     push_fnptr(&mb_reset_needs_21__2);
     mw_prim_pack_cons();
     mw_Word_2E_for();
-    WORD_ATOM(49, 5, "needs-stack");
+    WORD_ATOM(45, 5, "needs-stack");
     mw_needs_stack();
-    WORD_ATOM(49, 17, "reset!");
+    WORD_ATOM(45, 17, "reset!");
     mw_Stack_2E_reset_21_();
     WORD_EXIT(mw_reset_needs_21_);
 }
 static void mw_for_needed_words (void){
-    WORD_ENTER(mw_for_needed_words, "for-needed-words", "src/mirth/codegen.mth", 51, 5);
-    WORD_ATOM(51, 5, "Word.for");
+    WORD_ENTER(mw_for_needed_words, "for-needed-words", "src/mirth/codegen.mth", 47, 5);
+    WORD_ATOM(47, 5, "Word.for");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(51, 5, "Word.for");
+        WORD_ATOM(47, 5, "Word.for");
         push_u64(0);
         incref(var_f);
         push_value(var_f);
@@ -14724,11 +17984,11 @@ static void mw_for_needed_words (void){
     WORD_EXIT(mw_for_needed_words);
 }
 static void mw_for_needed_blocks (void){
-    WORD_ENTER(mw_for_needed_blocks, "for-needed-blocks", "src/mirth/codegen.mth", 53, 5);
-    WORD_ATOM(53, 5, "Block.for");
+    WORD_ENTER(mw_for_needed_blocks, "for-needed-blocks", "src/mirth/codegen.mth", 49, 5);
+    WORD_ATOM(49, 5, "Block.for");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(53, 5, "Block.for");
+        WORD_ATOM(49, 5, "Block.for");
         push_u64(0);
         incref(var_f);
         push_value(var_f);
@@ -14741,76 +18001,76 @@ static void mw_for_needed_blocks (void){
     WORD_EXIT(mw_for_needed_blocks);
 }
 static void mw_need_block (void){
-    WORD_ENTER(mw_need_block, "need-block", "src/mirth/codegen.mth", 56, 5);
-    WORD_ATOM(56, 5, "dup");
+    WORD_ENTER(mw_need_block, "need-block", "src/mirth/codegen.mth", 52, 5);
+    WORD_ATOM(52, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(56, 9, "block-needed");
+    WORD_ATOM(52, 9, "block-needed");
     mw_block_needed();
-    WORD_ATOM(56, 22, "@");
+    WORD_ATOM(52, 22, "@");
     mw_prim_mut_get();
-    WORD_ATOM(56, 24, "if");
+    WORD_ATOM(52, 24, "if");
     if (pop_u64()) {
-        WORD_ATOM(57, 9, "drop");
+        WORD_ATOM(53, 9, "drop");
         mw_prim_drop();
     } else {
-        WORD_ATOM(58, 9, "T");
+        WORD_ATOM(54, 9, "T");
         mw_T();
-        WORD_ATOM(58, 11, "over");
+        WORD_ATOM(54, 11, "over");
         mw_over();
-        WORD_ATOM(58, 16, "block-needed");
+        WORD_ATOM(54, 16, "block-needed");
         mw_block_needed();
-        WORD_ATOM(58, 29, "!");
+        WORD_ATOM(54, 29, "!");
         mw_prim_mut_set();
-        WORD_ATOM(59, 9, "NEED_BLOCK");
+        WORD_ATOM(55, 9, "NEED_BLOCK");
         mw_NEED_5F_BLOCK();
-        WORD_ATOM(59, 20, "needs-stack");
+        WORD_ATOM(55, 20, "needs-stack");
         mw_needs_stack();
-        WORD_ATOM(59, 32, "push!");
+        WORD_ATOM(55, 32, "push!");
         mw_Stack_2E_push_21_();
     }
     WORD_EXIT(mw_need_block);
 }
 static void mw_need_word (void){
-    WORD_ENTER(mw_need_word, "need-word", "src/mirth/codegen.mth", 62, 5);
-    WORD_ATOM(62, 5, "dup");
+    WORD_ENTER(mw_need_word, "need-word", "src/mirth/codegen.mth", 58, 5);
+    WORD_ATOM(58, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(62, 9, "word-needed");
+    WORD_ATOM(58, 9, "word-needed");
     mw_word_needed();
-    WORD_ATOM(62, 21, "@");
+    WORD_ATOM(58, 21, "@");
     mw_prim_mut_get();
-    WORD_ATOM(62, 23, "if");
+    WORD_ATOM(58, 23, "if");
     if (pop_u64()) {
-        WORD_ATOM(63, 9, "drop");
+        WORD_ATOM(59, 9, "drop");
         mw_prim_drop();
     } else {
-        WORD_ATOM(64, 9, "T");
+        WORD_ATOM(60, 9, "T");
         mw_T();
-        WORD_ATOM(64, 11, "over");
+        WORD_ATOM(60, 11, "over");
         mw_over();
-        WORD_ATOM(64, 16, "word-needed");
+        WORD_ATOM(60, 16, "word-needed");
         mw_word_needed();
-        WORD_ATOM(64, 28, "!");
+        WORD_ATOM(60, 28, "!");
         mw_prim_mut_set();
-        WORD_ATOM(65, 9, "NEED_WORD");
+        WORD_ATOM(61, 9, "NEED_WORD");
         mw_NEED_5F_WORD();
-        WORD_ATOM(65, 19, "needs-stack");
+        WORD_ATOM(61, 19, "needs-stack");
         mw_needs_stack();
-        WORD_ATOM(65, 31, "push!");
+        WORD_ATOM(61, 31, "push!");
         mw_Stack_2E_push_21_();
     }
     WORD_EXIT(mw_need_word);
 }
 static void mw_determine_arrow_needs_21_ (void){
-    WORD_ENTER(mw_determine_arrow_needs_21_, "determine-arrow-needs!", "src/mirth/codegen.mth", 69, 5);
-    WORD_ATOM(69, 5, "need-arrow-run");
+    WORD_ENTER(mw_determine_arrow_needs_21_, "determine-arrow-needs!", "src/mirth/codegen.mth", 65, 5);
+    WORD_ATOM(65, 5, "need-arrow-run");
     mw_need_arrow_run();
-    WORD_ATOM(69, 20, "determine-transitive-needs!");
+    WORD_ATOM(65, 20, "determine-transitive-needs!");
     mw_determine_transitive_needs_21_();
     WORD_EXIT(mw_determine_arrow_needs_21_);
 }
 static void mw_determine_transitive_needs_21_ (void){
-    WORD_ENTER(mw_determine_transitive_needs_21_, "determine-transitive-needs!", "src/mirth/codegen.mth", 71, 5);
-    WORD_ATOM(71, 5, "while-some");
+    WORD_ENTER(mw_determine_transitive_needs_21_, "determine-transitive-needs!", "src/mirth/codegen.mth", 67, 5);
+    WORD_ATOM(67, 5, "while-some");
     push_u64(0);
     push_fnptr(&mb_determine_transitive_needs_21__1);
     mw_prim_pack_cons();
@@ -14821,10 +18081,10 @@ static void mw_determine_transitive_needs_21_ (void){
     WORD_EXIT(mw_determine_transitive_needs_21_);
 }
 static void mw_need_arrow_run (void){
-    WORD_ENTER(mw_need_arrow_run, "need-arrow-run", "src/mirth/codegen.mth", 76, 31);
-    WORD_ATOM(76, 31, "atoms");
+    WORD_ENTER(mw_need_arrow_run, "need-arrow-run", "src/mirth/codegen.mth", 72, 31);
+    WORD_ATOM(72, 31, "atoms");
     mw_Arrow_2E_atoms();
-    WORD_ATOM(76, 37, "for");
+    WORD_ATOM(72, 37, "for");
     push_u64(0);
     push_fnptr(&mb_need_arrow_run_1);
     mw_prim_pack_cons();
@@ -14832,107 +18092,107 @@ static void mw_need_arrow_run (void){
     WORD_EXIT(mw_need_arrow_run);
 }
 static void mw_need_atom_run (void){
-    WORD_ENTER(mw_need_atom_run, "need-atom-run", "src/mirth/codegen.mth", 78, 5);
-    WORD_ATOM(78, 5, "sip");
+    WORD_ENTER(mw_need_atom_run, "need-atom-run", "src/mirth/codegen.mth", 74, 5);
+    WORD_ATOM(74, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_need_atom_run_1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(78, 15, "op");
+    WORD_ATOM(74, 15, "op");
     mw_Atom_2E_op();
-    WORD_ATOM(78, 18, "match");
+    WORD_ATOM(74, 18, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
-            WORD_ATOM(79, 20, "drop");
+            co_OP_5F_NONE();
+            WORD_ATOM(75, 20, "drop");
             mw_prim_drop();
             break;
         case 8LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(80, 19, "drop2");
+            co_OP_5F_INT();
+            WORD_ATOM(76, 19, "drop2");
             mw_drop2();
             break;
         case 9LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(81, 19, "drop2");
+            co_OP_5F_STR();
+            WORD_ATOM(77, 19, "drop2");
             mw_drop2();
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(82, 24, "drop2");
+            co_OP_5F_CONSTANT();
+            WORD_ATOM(78, 24, "drop2");
             mw_drop2();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(83, 20, "need-word");
+            co_OP_5F_WORD();
+            WORD_ATOM(79, 20, "need-word");
             mw_need_word();
-            WORD_ATOM(83, 30, "need-args-push");
+            WORD_ATOM(79, 30, "need-args-push");
             mw_need_args_push();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(84, 24, "drop");
+            co_OP_5F_EXTERNAL();
+            WORD_ATOM(80, 24, "drop");
             mw_prim_drop();
-            WORD_ATOM(84, 29, "need-args-push");
+            WORD_ATOM(80, 29, "need-args-push");
             mw_need_args_push();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(85, 22, "drop");
+            co_OP_5F_BUFFER();
+            WORD_ATOM(81, 22, "drop");
             mw_prim_drop();
-            WORD_ATOM(85, 27, "need-args-push");
+            WORD_ATOM(81, 27, "need-args-push");
             mw_need_args_push();
             break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(86, 24, "drop");
+            co_OP_5F_VARIABLE();
+            WORD_ATOM(82, 24, "drop");
             mw_prim_drop();
-            WORD_ATOM(86, 29, "need-args-push");
+            WORD_ATOM(82, 29, "need-args-push");
             mw_need_args_push();
             break;
         case 7LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(87, 21, "drop");
+            co_OP_5F_FIELD();
+            WORD_ATOM(83, 21, "drop");
             mw_prim_drop();
-            WORD_ATOM(87, 26, "need-args-push");
+            WORD_ATOM(83, 26, "need-args-push");
             mw_need_args_push();
             break;
         case 10LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(88, 19, "drop");
+            co_OP_5F_TAG();
+            WORD_ATOM(84, 19, "drop");
             mw_prim_drop();
-            WORD_ATOM(88, 24, "need-args-push");
+            WORD_ATOM(84, 24, "need-args-push");
             mw_need_args_push();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(89, 20, "need-prim");
+            co_OP_5F_PRIM();
+            WORD_ATOM(85, 20, "need-prim");
             mw_need_prim();
             break;
         case 11LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(90, 21, "nip");
+            co_OP_5F_MATCH();
+            WORD_ATOM(86, 21, "nip");
             mw_nip();
-            WORD_ATOM(90, 25, "need-match");
+            WORD_ATOM(86, 25, "need-match");
             mw_need_match();
             break;
         case 12LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(91, 22, "nip");
+            co_OP_5F_LAMBDA();
+            WORD_ATOM(87, 22, "nip");
             mw_nip();
-            WORD_ATOM(91, 26, "need-lambda");
+            WORD_ATOM(87, 26, "need-lambda");
             mw_need_lambda();
             break;
         case 13LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(92, 19, "drop2");
+            co_OP_5F_VAR();
+            WORD_ATOM(88, 19, "drop2");
             mw_drop2();
             break;
         case 14LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(93, 21, "nip");
+            co_OP_5F_BLOCK();
+            WORD_ATOM(89, 21, "nip");
             mw_nip();
-            WORD_ATOM(93, 25, "need-block-push");
+            WORD_ATOM(89, 25, "need-block-push");
             mw_need_block_push();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -14940,8 +18200,8 @@ static void mw_need_atom_run (void){
 }    WORD_EXIT(mw_need_atom_run);
 }
 static void mw_need_args_push (void){
-    WORD_ENTER(mw_need_args_push, "need-args-push", "src/mirth/codegen.mth", 95, 35);
-    WORD_ATOM(95, 35, "for");
+    WORD_ENTER(mw_need_args_push, "need-args-push", "src/mirth/codegen.mth", 91, 35);
+    WORD_ATOM(91, 35, "for");
     push_u64(0);
     push_fnptr(&mb_need_args_push_1);
     mw_prim_pack_cons();
@@ -14949,113 +18209,111 @@ static void mw_need_args_push (void){
     WORD_EXIT(mw_need_args_push);
 }
 static void mw_need_arg_push (void){
-    WORD_ENTER(mw_need_arg_push, "need-arg-push", "src/mirth/codegen.mth", 96, 28);
-    WORD_ATOM(96, 28, "ARG_BLOCK");
-    WORD_ATOM(96, 41, "need-block-push");
+    WORD_ENTER(mw_need_arg_push, "need-arg-push", "src/mirth/codegen.mth", 92, 28);
+    WORD_ATOM(92, 28, "ARG_BLOCK");
+    WORD_ATOM(92, 41, "need-block-push");
     mw_need_block_push();
     WORD_EXIT(mw_need_arg_push);
 }
 static void mw_need_arg_run (void){
-    WORD_ENTER(mw_need_arg_run, "need-arg-run", "src/mirth/codegen.mth", 97, 27);
-    WORD_ATOM(97, 27, "ARG_BLOCK");
-    WORD_ATOM(97, 40, "need-block-run");
+    WORD_ENTER(mw_need_arg_run, "need-arg-run", "src/mirth/codegen.mth", 93, 27);
+    WORD_ATOM(93, 27, "ARG_BLOCK");
+    WORD_ATOM(93, 40, "need-block-run");
     mw_need_block_run();
     WORD_EXIT(mw_need_arg_run);
 }
 static void mw_need_prim (void){
-    WORD_ENTER(mw_need_prim, "need-prim", "src/mirth/codegen.mth", 100, 5);
-    WORD_ATOM(100, 5, "PRIM_CORE_DIP");
+    WORD_ENTER(mw_need_prim, "need-prim", "src/mirth/codegen.mth", 96, 5);
+    WORD_ATOM(96, 5, "PRIM_CORE_DIP");
     switch (get_top_data_tag()) {
         case 4LL:
-            mw_prim_drop();
-            WORD_ATOM(101, 9, "match");
+            co_PRIM_5F_CORE_5F_DIP();
+            WORD_ATOM(97, 9, "match");
             switch (get_top_data_tag()) {
                 case 1LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(102, 19, "need-arg-run");
+                    co_L1();
+                    WORD_ATOM(98, 19, "need-arg-run");
                     mw_need_arg_run();
                     break;
                 default:
-                    WORD_ATOM(103, 18, "need-args-push");
+                    WORD_ATOM(99, 18, "need-args-push");
                     mw_need_args_push();
                     break;
             
 }            break;
         case 13LL:
-            mw_prim_drop();
-            WORD_ATOM(106, 9, "match");
+            co_PRIM_5F_CORE_5F_RDIP();
+            WORD_ATOM(102, 9, "match");
             switch (get_top_data_tag()) {
                 case 1LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(107, 19, "need-arg-run");
+                    co_L1();
+                    WORD_ATOM(103, 19, "need-arg-run");
                     mw_need_arg_run();
                     break;
                 default:
-                    WORD_ATOM(108, 18, "need-args-push");
+                    WORD_ATOM(104, 18, "need-args-push");
                     mw_need_args_push();
                     break;
             
 }            break;
         case 5LL:
-            mw_prim_drop();
-            WORD_ATOM(111, 9, "match");
+            co_PRIM_5F_CORE_5F_IF();
+            WORD_ATOM(107, 9, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
-                    mw_prim_pack_uncons(); mw_prim_swap();
-                    WORD_ATOM(112, 19, "dip");
+                    co_L2();
+                    WORD_ATOM(108, 19, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(112, 23, "need-arg-run");
+                        WORD_ATOM(108, 23, "need-arg-run");
                         mw_need_arg_run();
                         push_value(d6);
                     }
-                    WORD_ATOM(112, 37, "need-arg-run");
+                    WORD_ATOM(108, 37, "need-arg-run");
                     mw_need_arg_run();
                     break;
                 default:
-                    WORD_ATOM(113, 18, "need-args-push");
+                    WORD_ATOM(109, 18, "need-args-push");
                     mw_need_args_push();
                     break;
             
 }            break;
         case 6LL:
-            mw_prim_drop();
-            WORD_ATOM(116, 9, "match");
+            co_PRIM_5F_CORE_5F_WHILE();
+            WORD_ATOM(112, 9, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
-                    mw_prim_pack_uncons(); mw_prim_swap();
-                    WORD_ATOM(117, 19, "dip");
+                    co_L2();
+                    WORD_ATOM(113, 19, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(117, 23, "need-arg-run");
+                        WORD_ATOM(113, 23, "need-arg-run");
                         mw_need_arg_run();
                         push_value(d6);
                     }
-                    WORD_ATOM(117, 37, "need-arg-run");
+                    WORD_ATOM(113, 37, "need-arg-run");
                     mw_need_arg_run();
                     break;
                 default:
-                    WORD_ATOM(118, 18, "need-args-push");
+                    WORD_ATOM(114, 18, "need-args-push");
                     mw_need_args_push();
                     break;
             
 }            break;
         default:
-            WORD_ATOM(120, 10, "drop");
+            WORD_ATOM(116, 10, "drop");
             mw_prim_drop();
-            WORD_ATOM(120, 15, "need-args-push");
+            WORD_ATOM(116, 15, "need-args-push");
             mw_need_args_push();
             break;
     
 }    WORD_EXIT(mw_need_prim);
 }
 static void mw_need_match (void){
-    WORD_ENTER(mw_need_match, "need-match", "src/mirth/codegen.mth", 122, 27);
-    WORD_ATOM(122, 27, "cases");
+    WORD_ENTER(mw_need_match, "need-match", "src/mirth/codegen.mth", 118, 27);
+    WORD_ATOM(118, 27, "cases");
     mw_Match_2E_cases();
-    WORD_ATOM(122, 33, "for");
+    WORD_ATOM(118, 33, "for");
     push_u64(0);
     push_fnptr(&mb_need_match_1);
     mw_prim_pack_cons();
@@ -15063,29 +18321,29 @@ static void mw_need_match (void){
     WORD_EXIT(mw_need_match);
 }
 static void mw_need_lambda (void){
-    WORD_ENTER(mw_need_lambda, "need-lambda", "src/mirth/codegen.mth", 123, 29);
-    WORD_ATOM(123, 29, "body");
+    WORD_ENTER(mw_need_lambda, "need-lambda", "src/mirth/codegen.mth", 119, 29);
+    WORD_ATOM(119, 29, "body");
     mw_Lambda_2E_body();
-    WORD_ATOM(123, 34, "need-arrow-run");
+    WORD_ATOM(119, 34, "need-arrow-run");
     mw_need_arrow_run();
     WORD_EXIT(mw_need_lambda);
 }
 static void mw_need_block_push (void){
-    WORD_ENTER(mw_need_block_push, "need-block-push", "src/mirth/codegen.mth", 126, 5);
-    WORD_ATOM(126, 5, "dup");
+    WORD_ENTER(mw_need_block_push, "need-block-push", "src/mirth/codegen.mth", 122, 5);
+    WORD_ATOM(122, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(126, 9, "block-to-run-var");
+    WORD_ATOM(122, 9, "block-to-run-var");
     mw_block_to_run_var();
-    WORD_ATOM(126, 26, "match");
+    WORD_ATOM(122, 26, "match");
     switch (get_top_data_tag()) {
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(127, 17, "drop2");
+            co_SOME();
+            WORD_ATOM(123, 17, "drop2");
             mw_drop2();
             break;
         case 0LL:
-            mw_prim_drop();
-            WORD_ATOM(128, 17, "need-block");
+            co_NONE();
+            WORD_ATOM(124, 17, "need-block");
             mw_need_block();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -15093,350 +18351,220 @@ static void mw_need_block_push (void){
 }    WORD_EXIT(mw_need_block_push);
 }
 static void mw_need_block_run (void){
-    WORD_ENTER(mw_need_block_run, "need-block-run", "src/mirth/codegen.mth", 130, 31);
-    WORD_ATOM(130, 31, "arrow");
+    WORD_ENTER(mw_need_block_run, "need-block-run", "src/mirth/codegen.mth", 126, 31);
+    WORD_ATOM(126, 31, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(130, 37, "need-arrow-run");
+    WORD_ATOM(126, 37, "need-arrow-run");
     mw_need_arrow_run();
     WORD_EXIT(mw_need_block_run);
 }
-static void mw_codegen_full_3F_ (void){
-    WORD_ENTER(mw_codegen_full_3F_, "codegen-full?", "src/mirth/codegen.mth", 133, 5);
-    WORD_ATOM(133, 5, "codegen-length");
-    mw_codegen_length();
-    WORD_ATOM(133, 20, "@");
-    mw_prim_mut_get();
-    WORD_ATOM(133, 22, "");
-    push_i64(4LL);
-    WORD_ATOM(133, 24, "+");
-    mw_prim_int_add();
-    WORD_ATOM(133, 26, "CODEGEN_BUF_SIZE");
-    mw_CODEGEN_5F_BUF_5F_SIZE();
-    WORD_ATOM(133, 43, ">=");
-    mw_Int_3E__3D_();
-    WORD_EXIT(mw_codegen_full_3F_);
-}
-static void mw_codegen_flush_21_ (void){
-    WORD_ENTER(mw_codegen_flush_21_, "codegen-flush!", "src/mirth/codegen.mth", 136, 5);
-    WORD_ATOM(136, 5, "codegen-length");
-    mw_codegen_length();
-    WORD_ATOM(136, 20, "@");
-    mw_prim_mut_get();
-    WORD_ATOM(136, 22, "0>");
-    mw_0_3E_();
-    WORD_ATOM(136, 25, "if");
-    if (pop_u64()) {
-        WORD_ATOM(137, 9, "codegen-file");
-        mw_codegen_file();
-        WORD_ATOM(137, 22, "@");
-        mw_prim_mut_get();
-        WORD_ATOM(137, 24, "File>Int");
-        mw_File_3E_Int();
-        WORD_ATOM(137, 33, "CODEGEN_BUF");
-        mw_CODEGEN_5F_BUF();
-        WORD_ATOM(137, 45, "codegen-length");
-        mw_codegen_length();
-        WORD_ATOM(137, 60, "@");
-        mw_prim_mut_get();
-        WORD_ATOM(138, 9, "posix-write!");
-        mw_prim_posix_write();
-        WORD_ATOM(139, 9, "expect!");
-        push_u64(0);
-        push_fnptr(&mb_codegen_flush_21__2);
-        mw_prim_pack_cons();
-        push_u64(0);
-        push_fnptr(&mb_codegen_flush_21__3);
-        mw_prim_pack_cons();
-        mw_expect_21_();
-        WORD_ATOM(140, 9, "expect!");
-        push_u64(0);
-        push_fnptr(&mb_codegen_flush_21__4);
-        mw_prim_pack_cons();
-        push_u64(0);
-        push_fnptr(&mb_codegen_flush_21__5);
-        mw_prim_pack_cons();
-        mw_expect_21_();
-        WORD_ATOM(141, 9, "drop");
-        mw_prim_drop();
-        WORD_ATOM(142, 9, "");
-        push_i64(0LL);
-        WORD_ATOM(142, 11, "codegen-length");
-        mw_codegen_length();
-        WORD_ATOM(142, 26, "!");
-        mw_prim_mut_set();
-    } else {
-        WORD_ATOM(143, 9, "id");
-        mw_prim_id();
-    }
-    WORD_EXIT(mw_codegen_flush_21_);
-}
-static void mw__2E_b (void){
-    WORD_ENTER(mw__2E_b, ".b", "src/mirth/codegen.mth", 147, 5);
-    WORD_ATOM(147, 5, ">U8");
-    mw_Byte_3E_U8();
-    WORD_ATOM(148, 5, "codegen-full?");
-    mw_codegen_full_3F_();
-    WORD_ATOM(148, 19, "if");
-    if (pop_u64()) {
-        WORD_ATOM(148, 22, "codegen-flush!");
-        mw_codegen_flush_21_();
-    } else {
-        WORD_ATOM(148, 38, "id");
-        mw_prim_id();
-    }
-    WORD_ATOM(149, 5, "codegen-length");
-    mw_codegen_length();
-    WORD_ATOM(149, 20, "modify");
+static void mw_Str_2B_C99_2E_ (void){
+    WORD_ENTER(mw_Str_2B_C99_2E_, "Str+C99.", "src/mirth/codegen.mth", 139, 5);
+    WORD_ATOM(139, 5, "c99-buffer-var");
+    mw_c99_buffer_var();
+    WORD_ATOM(139, 20, "modify");
     push_u64(0);
-    push_fnptr(&mb__2E_b_3);
+    push_fnptr(&mb_Str_2B_C99_2E__1);
     mw_prim_pack_cons();
     mw_modify();
-    WORD_ATOM(150, 5, "CODEGEN_BUF");
-    mw_CODEGEN_5F_BUF();
-    WORD_ATOM(150, 17, "!!U8");
-    mw_Ptr_21__21_U8();
-    WORD_EXIT(mw__2E_b);
-}
-static void mw__2E_ (void){
-    WORD_ENTER(mw__2E_, ".", "src/mirth/codegen.mth", 153, 5);
-    WORD_ATOM(153, 5, "dup");
-    mw_prim_dup();
-    WORD_ATOM(153, 9, "prim-str-base");
-    mw_prim_str_base();
-    WORD_ATOM(153, 23, "over");
-    mw_over();
-    WORD_ATOM(153, 28, "num-bytes");
-    mw_prim_str_num_bytes();
-    WORD_ATOM(154, 5, "dup");
-    mw_prim_dup();
-    WORD_ATOM(154, 9, "codegen-length");
-    mw_codegen_length();
-    WORD_ATOM(154, 24, "@");
+    WORD_ATOM(140, 5, "swap");
+    mw_prim_swap();
+    WORD_ATOM(140, 10, "cat");
+    mw_prim_str_cat();
+    WORD_ATOM(141, 5, "c99-buffer-var");
+    mw_c99_buffer_var();
+    WORD_ATOM(141, 20, "!");
+    mw_prim_mut_set();
+    WORD_ATOM(142, 5, "c99-buffer-var");
+    mw_c99_buffer_var();
+    WORD_ATOM(142, 20, "@");
     mw_prim_mut_get();
-    WORD_ATOM(154, 26, "+");
-    mw_prim_int_add();
-    WORD_ATOM(154, 28, "CODEGEN_BUF_SIZE");
-    mw_CODEGEN_5F_BUF_5F_SIZE();
-    WORD_ATOM(154, 45, ">");
+    WORD_ATOM(142, 22, "num-bytes");
+    mw_prim_str_num_bytes();
+    WORD_ATOM(142, 32, "");
+    push_i64(512LL);
+    WORD_ATOM(142, 36, ">");
     mw_Int_3E_();
-    WORD_ATOM(154, 47, "if");
-    if (pop_u64()) {
-        WORD_ATOM(155, 9, "codegen-flush!");
-        mw_codegen_flush_21_();
-        WORD_ATOM(156, 9, "while");
-        while(1) {
-            WORD_ATOM(156, 15, "dup");
-            mw_prim_dup();
-            WORD_ATOM(156, 19, "CODEGEN_BUF_SIZE");
-            mw_CODEGEN_5F_BUF_5F_SIZE();
-            WORD_ATOM(156, 36, ">");
-            mw_Int_3E_();
-            if (! pop_u64()) break;
-            WORD_ATOM(157, 13, "over");
-            mw_over();
-            WORD_ATOM(157, 18, "CODEGEN_BUF_SIZE");
-            mw_CODEGEN_5F_BUF_5F_SIZE();
-            WORD_ATOM(157, 35, "CODEGEN_BUF");
-            mw_CODEGEN_5F_BUF();
-            WORD_ATOM(157, 47, "prim-ptr-copy");
-            mw_prim_ptr_copy();
-            WORD_ATOM(158, 13, "CODEGEN_BUF_SIZE");
-            mw_CODEGEN_5F_BUF_5F_SIZE();
-            WORD_ATOM(158, 30, "codegen-length");
-            mw_codegen_length();
-            WORD_ATOM(158, 45, "!");
-            mw_prim_mut_set();
-            WORD_ATOM(159, 13, "codegen-flush!");
-            mw_codegen_flush_21_();
-            WORD_ATOM(160, 13, "dip");
-            {
-                VAL d4 = pop_value();
-                WORD_ATOM(160, 17, "CODEGEN_BUF_SIZE");
-                mw_CODEGEN_5F_BUF_5F_SIZE();
-                WORD_ATOM(160, 34, "swap");
-                mw_prim_swap();
-                WORD_ATOM(160, 39, ".offset-unsafe");
-                mw_prim_ptr_add();
-                push_value(d4);
-            }
-            WORD_ATOM(161, 13, "CODEGEN_BUF_SIZE");
-            mw_CODEGEN_5F_BUF_5F_SIZE();
-            WORD_ATOM(161, 30, "-");
-            mw_prim_int_sub();
-        }
-        WORD_ATOM(163, 9, "dup");
-        mw_prim_dup();
-        WORD_ATOM(163, 13, "codegen-length");
-        mw_codegen_length();
-        WORD_ATOM(163, 28, "!");
-        mw_prim_mut_set();
-        WORD_ATOM(163, 30, "CODEGEN_BUF");
-        mw_CODEGEN_5F_BUF();
-        WORD_ATOM(163, 42, "prim-ptr-copy");
-        mw_prim_ptr_copy();
-    } else {
-        WORD_ATOM(165, 9, "sip");
-        push_u64(0);
-        push_fnptr(&mb__2E__6);
-        mw_prim_pack_cons();
-        mw_sip();
-        WORD_ATOM(166, 9, "codegen-length");
-        mw_codegen_length();
-        WORD_ATOM(166, 24, "modify");
-        push_u64(0);
-        push_fnptr(&mb__2E__7);
-        mw_prim_pack_cons();
-        mw_modify();
-    }
-    WORD_ATOM(167, 7, "drop");
-    mw_prim_drop();
-    WORD_EXIT(mw__2E_);
+    WORD_ATOM(142, 38, "then");
+    push_u64(0);
+    push_fnptr(&mb_Str_2B_C99_2E__2);
+    mw_prim_pack_cons();
+    mw_Bool_2E_then();
+    WORD_EXIT(mw_Str_2B_C99_2E_);
+}
+static void mw_Int_2B_C99_2E_n (void){
+    WORD_ENTER(mw_Int_2B_C99_2E_n, "Int+C99.n", "src/mirth/codegen.mth", 143, 34);
+    WORD_ATOM(143, 34, "int-to-str");
+    mw_prim_int_to_str();
+    WORD_ATOM(143, 45, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_EXIT(mw_Int_2B_C99_2E_n);
+}
+static void mw_Byte_2B_C99_2E_b (void){
+    WORD_ENTER(mw_Byte_2B_C99_2E_b, "Byte+C99.b", "src/mirth/codegen.mth", 144, 36);
+    WORD_ATOM(144, 36, "to-ascii-str");
+    mw_Byte_2E_to_ascii_str();
+    WORD_ATOM(144, 49, "unwrap");
+    mw_Maybe_2E_unwrap();
+    WORD_ATOM(144, 56, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_EXIT(mw_Byte_2B_C99_2E_b);
+}
+static void mw__2B_C99_2E_depth_40_ (void){
+    WORD_ENTER(mw__2B_C99_2E_depth_40_, "+C99.depth@", "src/mirth/codegen.mth", 145, 36);
+    WORD_ATOM(145, 36, "c99-depth-var");
+    mw_c99_depth_var();
+    WORD_ATOM(145, 50, "@");
+    mw_prim_mut_get();
+    WORD_EXIT(mw__2B_C99_2E_depth_40_);
+}
+static void mw__2B_C99_2E_depth_21_ (void){
+    WORD_ENTER(mw__2B_C99_2E_depth_21_, "+C99.depth!", "src/mirth/codegen.mth", 146, 36);
+    WORD_ATOM(146, 36, "c99-depth-var");
+    mw_c99_depth_var();
+    WORD_ATOM(146, 50, "!");
+    mw_prim_mut_set();
+    WORD_EXIT(mw__2B_C99_2E_depth_21_);
 }
 static void mw_codegen_start_21_ (void){
-    WORD_ENTER(mw_codegen_start_21_, "codegen-start!", "src/mirth/codegen.mth", 170, 5);
-    WORD_ATOM(170, 5, "codegen-file");
-    mw_codegen_file();
-    WORD_ATOM(170, 18, "!");
+    WORD_ENTER(mw_codegen_start_21_, "codegen-start!", "src/mirth/codegen.mth", 149, 5);
+    WORD_ATOM(149, 5, "c99-file-var");
+    mw_c99_file_var();
+    WORD_ATOM(149, 18, "!");
     mw_prim_mut_set();
-    WORD_ATOM(170, 20, "");
+    WORD_ATOM(150, 5, "");
     push_i64(0LL);
-    WORD_ATOM(170, 22, "codegen-length");
-    mw_codegen_length();
-    WORD_ATOM(170, 37, "!");
+    WORD_ATOM(150, 7, "c99-depth-var");
+    mw_c99_depth_var();
+    WORD_ATOM(150, 21, "!");
+    mw_prim_mut_set();
+    WORD_ATOM(151, 5, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("", 0);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(151, 8, "c99-buffer-var");
+    mw_c99_buffer_var();
+    WORD_ATOM(151, 23, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_codegen_start_21_);
 }
-static void mw_codegen_end_21_ (void){
-    WORD_ENTER(mw_codegen_end_21_, "codegen-end!", "src/mirth/codegen.mth", 173, 5);
-    WORD_ATOM(173, 5, "codegen-flush!");
-    mw_codegen_flush_21_();
-    WORD_ATOM(174, 5, "codegen-file");
-    mw_codegen_file();
-    WORD_ATOM(174, 18, "@");
+static void mw_codegen_flush_21_ (void){
+    WORD_ENTER(mw_codegen_flush_21_, "codegen-flush!", "src/mirth/codegen.mth", 154, 5);
+    WORD_ATOM(154, 5, "c99-file-var");
+    mw_c99_file_var();
+    WORD_ATOM(154, 18, "@");
     mw_prim_mut_get();
-    WORD_ATOM(174, 20, "close-file!");
+    WORD_ATOM(155, 5, "c99-buffer-var");
+    mw_c99_buffer_var();
+    WORD_ATOM(155, 20, "modify");
+    push_u64(0);
+    push_fnptr(&mb_codegen_flush_21__1);
+    mw_prim_pack_cons();
+    mw_modify();
+    WORD_ATOM(156, 5, "write!");
+    mw_Str_2E_write_21_();
+    WORD_EXIT(mw_codegen_flush_21_);
+}
+static void mw_codegen_end_21_ (void){
+    WORD_ENTER(mw_codegen_end_21_, "codegen-end!", "src/mirth/codegen.mth", 159, 5);
+    WORD_ATOM(159, 5, "codegen-flush!");
+    mw_codegen_flush_21_();
+    WORD_ATOM(160, 5, "c99-file-var");
+    mw_c99_file_var();
+    WORD_ATOM(160, 18, "@");
+    mw_prim_mut_get();
+    WORD_ATOM(160, 20, "close-file!");
     mw_close_file_21_();
-    WORD_ATOM(175, 5, "STDOUT");
-    mw_STDOUT();
-    WORD_ATOM(175, 12, "codegen-file");
-    mw_codegen_file();
-    WORD_ATOM(175, 25, "!");
-    mw_prim_mut_set();
-    WORD_ATOM(176, 5, "");
-    push_i64(0LL);
-    WORD_ATOM(176, 7, "codegen-length");
-    mw_codegen_length();
-    WORD_ATOM(176, 22, "!");
-    mw_prim_mut_set();
     WORD_EXIT(mw_codegen_end_21_);
 }
+static void mw_with_c99 (void){
+    WORD_ENTER(mw_with_c99, "with-c99", "src/mirth/codegen.mth", 162, 46);
+    WORD_ATOM(162, 46, "prim-unsafe-cast");
+    mw_prim_unsafe_cast();
+    WORD_ATOM(162, 63, "run");
+    mw_prim_run();
+    WORD_EXIT(mw_with_c99);
+}
 static void mw_run_output_c99_21_ (void){
-    WORD_ENTER(mw_run_output_c99_21_, "run-output-c99!", "src/mirth/codegen.mth", 179, 5);
-    WORD_ATOM(179, 5, "num-errors");
+    WORD_ENTER(mw_run_output_c99_21_, "run-output-c99!", "src/mirth/codegen.mth", 165, 5);
+    WORD_ATOM(165, 5, "num-errors");
     mw_num_errors();
-    WORD_ATOM(179, 16, "@");
+    WORD_ATOM(165, 16, "@");
     mw_prim_mut_get();
-    WORD_ATOM(179, 18, "0>");
+    WORD_ATOM(165, 18, "0>");
     mw_0_3E_();
-    WORD_ATOM(179, 21, "if");
+    WORD_ATOM(165, 21, "if");
     if (pop_u64()) {
-        WORD_ATOM(180, 9, "drop2");
+        WORD_ATOM(166, 9, "drop2");
         mw_drop2();
     } else {
-        WORD_ATOM(182, 9, "reset-needs!");
+        WORD_ATOM(168, 9, "reset-needs!");
         mw_reset_needs_21_();
-        WORD_ATOM(183, 9, "over");
+        WORD_ATOM(169, 9, "over");
         mw_over();
-        WORD_ATOM(183, 14, "determine-arrow-needs!");
+        WORD_ATOM(169, 14, "determine-arrow-needs!");
         mw_determine_arrow_needs_21_();
-        WORD_ATOM(185, 9, "");
-        push_i64(0LL);
-        WORD_ATOM(185, 11, "c99-depth");
-        mw_c99_depth();
-        WORD_ATOM(185, 21, "!");
-        mw_prim_mut_set();
-        WORD_ATOM(186, 9, "to-output-path");
-        mw_Path_2E_to_output_path();
-        WORD_ATOM(186, 24, ">Str");
-        mw_Path_3E_Str();
-        WORD_ATOM(187, 9, "create-file!");
-        mw_create_file_21_();
-        WORD_ATOM(187, 22, "codegen-start!");
-        mw_codegen_start_21_();
-        WORD_ATOM(188, 9, "c99-header!");
-        mw_c99_header_21_();
-        WORD_ATOM(189, 9, "c99-tags!");
-        mw_c99_tags_21_();
-        WORD_ATOM(190, 9, "c99-buffers!");
-        mw_c99_buffers_21_();
-        WORD_ATOM(191, 9, "c99-variables!");
-        mw_c99_variables_21_();
-        WORD_ATOM(192, 9, "c99-externals!");
-        mw_c99_externals_21_();
-        WORD_ATOM(193, 9, "c99-word-sigs!");
-        mw_c99_word_sigs_21_();
-        WORD_ATOM(194, 9, "c99-block-sigs!");
-        mw_c99_block_sigs_21_();
-        WORD_ATOM(195, 9, "c99-field-sigs!");
-        mw_c99_field_sigs_21_();
-        WORD_ATOM(196, 9, "c99-main!");
-        mw_c99_main_21_();
-        WORD_ATOM(197, 9, "c99-field-defs!");
-        mw_c99_field_defs_21_();
-        WORD_ATOM(198, 9, "c99-word-defs!");
-        mw_c99_word_defs_21_();
-        WORD_ATOM(199, 9, "c99-block-defs!");
-        mw_c99_block_defs_21_();
-        WORD_ATOM(200, 9, "codegen-end!");
-        mw_codegen_end_21_();
+        WORD_ATOM(171, 9, "with-c99");
+        push_u64(0);
+        push_fnptr(&mb_run_output_c99_21__3);
+        mw_prim_pack_cons();
+        mw_with_c99();
     }
     WORD_EXIT(mw_run_output_c99_21_);
 }
-static void mw__2E_lf (void){
-    WORD_ENTER(mw__2E_lf, ".lf", "src/mirth/codegen.mth", 205, 14);
-    WORD_ATOM(205, 14, "BLF");
-    mw_BLF();
-    WORD_ATOM(205, 18, ".b");
-    mw__2E_b();
-    WORD_EXIT(mw__2E_lf);
+static void mw__2B_C99_2E_lf (void){
+    WORD_ENTER(mw__2B_C99_2E_lf, "+C99.lf", "src/mirth/codegen.mth", 190, 28);
+    WORD_ATOM(190, 28, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("\n", 1);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(190, 33, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_EXIT(mw__2B_C99_2E_lf);
 }
-static void mw__3B_ (void){
-    WORD_ENTER(mw__3B_, ";", "src/mirth/codegen.mth", 206, 16);
-    WORD_ATOM(206, 16, ".");
-    mw__2E_();
-    WORD_ATOM(206, 18, ".lf");
-    mw__2E_lf();
-    WORD_EXIT(mw__3B_);
+static void mw_Str_2B_C99_3B_ (void){
+    WORD_ENTER(mw_Str_2B_C99_3B_, "Str+C99;", "src/mirth/codegen.mth", 191, 33);
+    WORD_ATOM(191, 33, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(191, 35, ".lf");
+    mw__2B_C99_2E_lf();
+    WORD_EXIT(mw_Str_2B_C99_3B_);
 }
-static void mw__3B__3B_ (void){
-    WORD_ENTER(mw__3B__3B_, ";;", "src/mirth/codegen.mth", 207, 17);
-    WORD_ATOM(207, 17, ".");
-    mw__2E_();
-    WORD_ATOM(207, 19, ".lf");
-    mw__2E_lf();
-    WORD_ATOM(207, 23, ".lf");
-    mw__2E_lf();
-    WORD_EXIT(mw__3B__3B_);
+static void mw_Str_2B_C99_3B__3B_ (void){
+    WORD_ENTER(mw_Str_2B_C99_3B__3B_, "Str+C99;;", "src/mirth/codegen.mth", 192, 34);
+    WORD_ATOM(192, 34, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(192, 36, ".lf");
+    mw__2B_C99_2E_lf();
+    WORD_ATOM(192, 40, ".lf");
+    mw__2B_C99_2E_lf();
+    WORD_EXIT(mw_Str_2B_C99_3B__3B_);
 }
-static void mw__2E_n (void){
-    WORD_ENTER(mw__2E_n, ".n", "src/mirth/codegen.mth", 208, 17);
-    WORD_ATOM(208, 17, "int-to-str");
-    mw_prim_int_to_str();
-    WORD_ATOM(208, 28, ".");
-    mw__2E_();
-    WORD_EXIT(mw__2E_n);
-}
-static void mw__2E_name (void){
-    WORD_ENTER(mw__2E_name, ".name", "src/mirth/codegen.mth", 209, 21);
-    WORD_ATOM(209, 21, "mangled");
+static void mw_Name_2B_C99_2E_name (void){
+    WORD_ENTER(mw_Name_2B_C99_2E_name, "Name+C99.name", "src/mirth/codegen.mth", 193, 39);
+    WORD_ATOM(193, 39, "mangled");
     mw_Name_2E_mangled();
-    WORD_ATOM(209, 29, ".");
-    mw__2E_();
-    WORD_EXIT(mw__2E_name);
+    WORD_ATOM(193, 47, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_EXIT(mw_Name_2B_C99_2E_name);
 }
-static void mw__2E_w (void){
-    WORD_ENTER(mw__2E_w, ".w", "src/mirth/codegen.mth", 211, 18);
-    WORD_ATOM(211, 18, "");
+static void mw_Name_2B_C99_2E_w (void){
+    WORD_ENTER(mw_Name_2B_C99_2E_w, "Name+C99.w", "src/mirth/codegen.mth", 194, 36);
+    WORD_ATOM(194, 36, "");
     {
         static bool vready = false;
         static VAL v;
@@ -15447,11 +18575,11 @@ static void mw__2E_w (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(211, 36, ".");
-    mw__2E_();
-    WORD_ATOM(211, 38, ".name");
-    mw__2E_name();
-    WORD_ATOM(211, 44, "");
+    WORD_ATOM(194, 54, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(194, 56, ".name");
+    mw_Name_2B_C99_2E_name();
+    WORD_ATOM(194, 62, "");
     {
         static bool vready = false;
         static VAL v;
@@ -15462,13 +18590,13 @@ static void mw__2E_w (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(211, 54, ".");
-    mw__2E_();
-    WORD_EXIT(mw__2E_w);
+    WORD_ATOM(194, 72, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_EXIT(mw_Name_2B_C99_2E_w);
 }
 static void mw_c99_header_21_ (void){
-    WORD_ENTER(mw_c99_header_21_, "c99-header!", "src/mirth/codegen.mth", 216, 22);
-    WORD_ATOM(216, 22, "c99-header-str");
+    WORD_ENTER(mw_c99_header_21_, "c99-header!", "src/mirth/codegen.mth", 199, 32);
+    WORD_ATOM(199, 32, "c99-header-str");
     {
         static bool vready = false;
         static VAL v;
@@ -15732,6 +18860,12 @@ static uint8_t b[] = {                47,42,32,77,73,82,84,72,32,72,69,65,68,69,
                 32,32,32,32,32,32,32,32,42,99,100,114,32,61,32,118,97,108,59,10,
                 32,32,32,32,125,10,
                 125,10,
+                115,116,97,116,105,99,32,118,111,105,100,32,118,97,108,117,101,95,117,110,99,111,110,115,95,99,40,86,65,76,32,118,97,108,44,32,86,65,76,42,32,99,97,114,44,32,86,65,76,42,32,99,100,114,41,32,123,10,
+                32,32,32,32,118,97,108,117,101,95,117,110,99,111,110,115,40,118,97,108,44,32,99,97,114,44,32,99,100,114,41,59,10,
+                32,32,32,32,105,110,99,114,101,102,40,42,99,97,114,41,59,10,
+                32,32,32,32,105,110,99,114,101,102,40,42,99,100,114,41,59,10,
+                32,32,32,32,100,101,99,114,101,102,40,118,97,108,41,59,10,
+                125,10,
                 10,
                 115,116,97,116,105,99,32,118,111,105,100,42,32,118,97,108,117,101,95,112,116,114,32,40,86,65,76,32,118,41,32,123,10,
                 32,32,32,32,65,83,83,69,82,84,40,73,83,95,80,84,82,40,118,41,41,59,10,
@@ -15847,35 +18981,6 @@ static uint8_t b[] = {                47,42,32,77,73,82,84,72,32,72,69,65,68,69,
                 10,
                 115,116,97,116,105,99,32,85,83,73,90,69,32,103,101,116,95,116,111,112,95,114,101,115,111,117,114,99,101,95,100,97,116,97,95,116,97,103,40,118,111,105,100,41,32,123,10,
                 32,32,32,32,114,101,116,117,114,110,32,103,101,116,95,100,97,116,97,95,116,97,103,40,116,111,112,95,114,101,115,111,117,114,99,101,40,41,41,59,10,
-                125,10,
-                10,
-                115,116,97,116,105,99,32,105,110,116,32,118,97,108,117,101,95,99,109,112,95,40,86,65,76,32,118,49,44,32,86,65,76,32,118,50,41,32,123,10,
-                32,32,32,32,119,104,105,108,101,32,40,73,83,95,67,79,78,83,40,118,49,41,32,124,124,32,73,83,95,67,79,78,83,40,118,50,41,41,32,123,10,
-                32,32,32,32,32,32,32,32,86,65,76,32,118,49,99,97,114,44,32,118,49,99,100,114,59,32,118,97,108,117,101,95,117,110,99,111,110,115,40,118,49,44,32,38,118,49,99,97,114,44,32,38,118,49,99,100,114,41,59,10,
-                32,32,32,32,32,32,32,32,86,65,76,32,118,50,99,97,114,44,32,118,50,99,100,114,59,32,118,97,108,117,101,95,117,110,99,111,110,115,40,118,50,44,32,38,118,50,99,97,114,44,32,38,118,50,99,100,114,41,59,10,
-                32,32,32,32,32,32,32,32,105,110,116,32,114,32,61,32,118,97,108,117,101,95,99,109,112,95,40,118,49,99,100,114,44,32,118,50,99,100,114,41,59,10,
-                32,32,32,32,32,32,32,32,105,102,32,40,114,41,32,114,101,116,117,114,110,32,114,59,10,
-                32,32,32,32,32,32,32,32,118,49,32,61,32,118,49,99,97,114,59,10,
-                32,32,32,32,32,32,32,32,118,50,32,61,32,118,50,99,97,114,59,10,
-                32,32,32,32,125,10,
-                32,32,32,32,105,102,32,40,73,83,95,73,78,84,40,118,49,41,32,38,38,32,73,83,95,73,78,84,40,118,50,41,41,32,123,10,
-                32,32,32,32,32,32,32,32,105,102,32,40,86,73,78,84,40,118,49,41,32,60,32,86,73,78,84,40,118,50,41,41,32,114,101,116,117,114,110,32,45,49,59,10,
-                32,32,32,32,32,32,32,32,105,102,32,40,86,73,78,84,40,118,49,41,32,62,32,86,73,78,84,40,118,50,41,41,32,114,101,116,117,114,110,32,49,59,10,
-                32,32,32,32,32,32,32,32,114,101,116,117,114,110,32,48,59,10,
-                32,32,32,32,125,32,101,108,115,101,32,105,102,32,40,73,83,95,83,84,82,40,118,49,41,32,38,38,32,73,83,95,83,84,82,40,118,50,41,41,32,123,10,
-                32,32,32,32,32,32,32,32,65,83,83,69,82,84,50,40,86,83,84,82,40,118,49,41,32,38,38,32,86,83,84,82,40,118,50,41,44,32,118,49,44,32,118,50,41,59,10,
-                32,32,32,32,32,32,32,32,85,83,73,90,69,32,110,49,32,61,32,86,83,84,82,40,118,49,41,45,62,115,105,122,101,59,10,
-                32,32,32,32,32,32,32,32,85,83,73,90,69,32,110,50,32,61,32,86,83,84,82,40,118,50,41,45,62,115,105,122,101,59,10,
-                32,32,32,32,32,32,32,32,85,83,73,90,69,32,110,32,61,32,40,110,49,32,60,32,110,50,32,63,32,110,49,32,58,32,110,50,41,59,10,
-                32,32,32,32,32,32,32,32,65,83,83,69,82,84,40,110,32,60,32,83,73,90,69,95,77,65,88,41,59,10,
-                32,32,32,32,32,32,32,32,105,110,116,32,114,32,61,32,109,101,109,99,109,112,40,86,83,84,82,40,118,49,41,45,62,100,97,116,97,44,32,86,83,84,82,40,118,50,41,45,62,100,97,116,97,44,32,40,115,105,122,101,95,116,41,110,41,59,10,
-                32,32,32,32,32,32,32,32,105,102,32,40,114,41,32,114,101,116,117,114,110,32,114,59,10,
-                32,32,32,32,32,32,32,32,105,102,32,40,110,49,32,60,32,110,50,41,32,114,101,116,117,114,110,32,45,49,59,10,
-                32,32,32,32,32,32,32,32,105,102,32,40,110,49,32,62,32,110,50,41,32,114,101,116,117,114,110,32,49,59,10,
-                32,32,32,32,32,32,32,32,114,101,116,117,114,110,32,48,59,10,
-                32,32,32,32,125,10,
-                32,32,32,32,65,83,83,69,82,84,50,40,48,44,32,118,49,44,32,118,50,41,59,10,
-                32,32,32,32,114,101,116,117,114,110,32,48,59,10,
                 125,10,
                 10,
                 115,116,97,116,105,99,32,105,110,116,32,115,116,114,95,99,109,112,95,40,83,84,82,42,32,115,49,44,32,83,84,82,42,32,115,50,41,32,123,10,
@@ -16599,7 +19704,7 @@ static uint8_t b[] = {                47,42,32,77,73,82,84,72,32,72,69,65,68,69,
                 32,32,32,32,32,32,32,32,100,101,99,114,101,102,40,118,50,41,59,10,
                 32,32,32,32,125,32,101,108,115,101,32,123,10,
                 32,32,32,32,32,32,32,32,85,83,73,90,69,32,109,50,32,61,32,110,49,32,43,32,110,50,32,43,32,52,59,10,
-                32,32,32,32,32,32,32,32,105,102,32,40,109,50,32,60,32,109,42,50,41,32,109,50,32,61,32,109,42,50,59,10,
+                32,32,32,32,32,32,32,32,105,102,32,40,40,115,49,45,62,114,101,102,115,32,61,61,32,49,41,32,38,38,32,40,109,50,32,60,32,109,42,50,41,41,32,109,50,32,61,32,109,42,50,59,10,
                 32,32,32,32,32,32,32,32,83,84,82,42,32,115,116,114,32,61,32,115,116,114,95,97,108,108,111,99,40,109,50,41,59,10,
                 32,32,32,32,32,32,32,32,115,116,114,45,62,115,105,122,101,32,61,32,110,49,43,110,50,59,10,
                 32,32,32,32,32,32,32,32,65,83,83,69,82,84,40,110,49,32,60,61,32,83,73,90,69,95,77,65,88,41,59,10,
@@ -16692,38 +19797,38 @@ static uint8_t b[] = {                47,42,32,77,73,82,84,72,32,72,69,65,68,69,
                 47,42,32,71,69,78,69,82,65,84,69,68,32,67,57,57,32,42,47,10,
                 
             };
-            v = mkstr((char*)b, 32178);
+            v = mkstr((char*)b, 31441);
             vready = true;
         }
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(216, 37, ".");
-    mw__2E_();
-    WORD_ATOM(216, 39, ".lf");
-    mw__2E_lf();
+    WORD_ATOM(199, 47, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(199, 49, ".lf");
+    mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_header_21_);
 }
 static void mw_c99_buffers_21_ (void){
-    WORD_ENTER(mw_c99_buffers_21_, "c99-buffers!", "src/mirth/codegen.mth", 218, 23);
-    WORD_ATOM(218, 23, "Buffer.for");
+    WORD_ENTER(mw_c99_buffers_21_, "c99-buffers!", "src/mirth/codegen.mth", 201, 33);
+    WORD_ATOM(201, 33, "Buffer.for");
     push_u64(0);
     push_fnptr(&mb_c99_buffers_21__1);
     mw_prim_pack_cons();
     mw_Buffer_2E_for();
-    WORD_ATOM(218, 47, ".lf");
-    mw__2E_lf();
+    WORD_ATOM(201, 57, ".lf");
+    mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_buffers_21_);
 }
 static void mw_c99_buffer_21_ (void){
-    WORD_ENTER(mw_c99_buffer_21_, "c99-buffer!", "src/mirth/codegen.mth", 220, 5);
-    WORD_ATOM(220, 5, "dup");
+    WORD_ENTER(mw_c99_buffer_21_, "c99-buffer!", "src/mirth/codegen.mth", 203, 5);
+    WORD_ATOM(203, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(220, 9, "name");
+    WORD_ATOM(203, 9, "name");
     mw_Buffer_2E_name();
-    WORD_ATOM(220, 14, ".w");
-    mw__2E_w();
-    WORD_ATOM(220, 17, "");
+    WORD_ATOM(203, 14, ".w");
+    mw_Name_2B_C99_2E_w();
+    WORD_ATOM(203, 17, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16734,9 +19839,9 @@ static void mw_c99_buffer_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(220, 22, ";");
-    mw__3B_();
-    WORD_ATOM(221, 5, "");
+    WORD_ATOM(203, 22, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(204, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16747,15 +19852,15 @@ static void mw_c99_buffer_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(221, 29, ".");
-    mw__2E_();
-    WORD_ATOM(221, 31, "dup");
+    WORD_ATOM(204, 29, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(204, 31, "dup");
     mw_prim_dup();
-    WORD_ATOM(221, 35, "size");
+    WORD_ATOM(204, 35, "size");
     mw_Buffer_2E_size();
-    WORD_ATOM(221, 40, ".n");
-    mw__2E_n();
-    WORD_ATOM(221, 43, "");
+    WORD_ATOM(204, 40, ".n");
+    mw_Int_2B_C99_2E_n();
+    WORD_ATOM(204, 43, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16766,9 +19871,9 @@ static void mw_c99_buffer_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(221, 54, ";");
-    mw__3B_();
-    WORD_ATOM(222, 5, "");
+    WORD_ATOM(204, 54, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(205, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16779,9 +19884,9 @@ static void mw_c99_buffer_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(222, 25, ";");
-    mw__3B_();
-    WORD_ATOM(223, 5, "");
+    WORD_ATOM(205, 25, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(206, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16792,26 +19897,26 @@ static void mw_c99_buffer_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(223, 9, ";");
-    mw__3B_();
-    WORD_ATOM(224, 5, "drop");
+    WORD_ATOM(206, 9, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(207, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_buffer_21_);
 }
 static void mw_c99_variables_21_ (void){
-    WORD_ENTER(mw_c99_variables_21_, "c99-variables!", "src/mirth/codegen.mth", 226, 25);
-    WORD_ATOM(226, 25, "Variable.for");
+    WORD_ENTER(mw_c99_variables_21_, "c99-variables!", "src/mirth/codegen.mth", 209, 35);
+    WORD_ATOM(209, 35, "Variable.for");
     push_u64(0);
     push_fnptr(&mb_c99_variables_21__1);
     mw_prim_pack_cons();
     mw_Variable_2E_for();
-    WORD_ATOM(226, 53, ".lf");
-    mw__2E_lf();
+    WORD_ATOM(209, 63, ".lf");
+    mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_variables_21_);
 }
 static void mw_c99_variable_21_ (void){
-    WORD_ENTER(mw_c99_variable_21_, "c99-variable!", "src/mirth/codegen.mth", 228, 5);
-    WORD_ATOM(228, 5, "");
+    WORD_ENTER(mw_c99_variable_21_, "c99-variable!", "src/mirth/codegen.mth", 211, 5);
+    WORD_ATOM(211, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16822,13 +19927,13 @@ static void mw_c99_variable_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(228, 16, ".");
-    mw__2E_();
-    WORD_ATOM(228, 18, "name");
+    WORD_ATOM(211, 16, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(211, 18, "name");
     mw_Variable_2E_name();
-    WORD_ATOM(228, 23, ".name");
-    mw__2E_name();
-    WORD_ATOM(228, 29, "");
+    WORD_ATOM(211, 23, ".name");
+    mw_Name_2B_C99_2E_name();
+    WORD_ATOM(211, 29, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16839,9 +19944,9 @@ static void mw_c99_variable_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(228, 36, ";");
-    mw__3B_();
-    WORD_ATOM(229, 5, "");
+    WORD_ATOM(211, 36, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(212, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16852,9 +19957,9 @@ static void mw_c99_variable_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(229, 31, ";");
-    mw__3B_();
-    WORD_ATOM(230, 5, "");
+    WORD_ATOM(212, 31, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(213, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16865,9 +19970,9 @@ static void mw_c99_variable_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(230, 25, ";");
-    mw__3B_();
-    WORD_ATOM(231, 5, "");
+    WORD_ATOM(213, 25, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(214, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16878,30 +19983,30 @@ static void mw_c99_variable_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(231, 9, ";");
-    mw__3B_();
+    WORD_ATOM(214, 9, ";");
+    mw_Str_2B_C99_3B_();
     WORD_EXIT(mw_c99_variable_21_);
 }
 static void mw_c99_tags_21_ (void){
-    WORD_ENTER(mw_c99_tags_21_, "c99-tags!", "src/mirth/codegen.mth", 233, 20);
-    WORD_ATOM(233, 20, "Tag.for");
+    WORD_ENTER(mw_c99_tags_21_, "c99-tags!", "src/mirth/codegen.mth", 216, 30);
+    WORD_ATOM(216, 30, "Tag.for");
     push_u64(0);
     push_fnptr(&mb_c99_tags_21__1);
     mw_prim_pack_cons();
     mw_Tag_2E_for();
-    WORD_ATOM(233, 38, ".lf");
-    mw__2E_lf();
+    WORD_ATOM(216, 48, ".lf");
+    mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_tags_21_);
 }
 static void mw_c99_tag_21_ (void){
-    WORD_ENTER(mw_c99_tag_21_, "c99-tag!", "src/mirth/codegen.mth", 235, 5);
-    WORD_ATOM(235, 5, "dup");
+    WORD_ENTER(mw_c99_tag_21_, "c99-tag!", "src/mirth/codegen.mth", 218, 5);
+    WORD_ATOM(218, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(235, 9, "name");
+    WORD_ATOM(218, 9, "name");
     mw_Tag_2E_name();
-    WORD_ATOM(235, 14, ".w");
-    mw__2E_w();
-    WORD_ATOM(235, 17, "");
+    WORD_ATOM(218, 14, ".w");
+    mw_Name_2B_C99_2E_w();
+    WORD_ATOM(218, 17, "");
     {
         static bool vready = false;
         static VAL v;
@@ -16912,124 +20017,114 @@ static void mw_c99_tag_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(235, 22, ";");
-    mw__3B_();
-    WORD_ATOM(236, 5, "dup");
+    WORD_ATOM(218, 22, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(219, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(236, 9, "is-transparent?");
+    WORD_ATOM(219, 9, "is-transparent?");
     mw_Tag_2E_is_transparent_3F_();
-    WORD_ATOM(236, 25, "if");
+    WORD_ATOM(219, 25, "if");
     if (pop_u64()) {
-        WORD_ATOM(237, 9, "drop");
-        mw_prim_drop();
+        WORD_ATOM(220, 9, "id");
+        mw_prim_id();
     } else {
-        WORD_ATOM(238, 9, "dup");
+        WORD_ATOM(221, 9, "");
+        {
+            static bool vready = false;
+            static VAL v;
+            if (! vready) {
+                v = mkstr("    VAL tag = MKU64(", 20);
+                vready = true;
+            }
+            push_value(v);
+            incref(v);
+        }
+        WORD_ATOM(221, 32, ".");
+        mw_Str_2B_C99_2E_();
+        WORD_ATOM(221, 34, "dup");
         mw_prim_dup();
-        WORD_ATOM(238, 13, "num-inputs");
-        mw_Tag_2E_num_inputs();
-        WORD_ATOM(238, 24, "0=");
-        mw_0_3D_();
-        WORD_ATOM(238, 27, "if");
+        WORD_ATOM(221, 38, "value");
+        mw_Tag_2E_value();
+        WORD_ATOM(221, 44, ".n");
+        mw_Int_2B_C99_2E_n();
+        WORD_ATOM(221, 47, "");
+        {
+            static bool vready = false;
+            static VAL v;
+            if (! vready) {
+                v = mkstr("LL);", 4);
+                vready = true;
+            }
+            push_value(v);
+            incref(v);
+        }
+        WORD_ATOM(221, 54, ";");
+        mw_Str_2B_C99_3B_();
+        WORD_ATOM(222, 9, "");
+        {
+            static bool vready = false;
+            static VAL v;
+            if (! vready) {
+                v = mkstr("    VAL car = (", 15);
+                vready = true;
+            }
+            push_value(v);
+            incref(v);
+        }
+        WORD_ATOM(222, 27, ".");
+        mw_Str_2B_C99_2E_();
+        WORD_ATOM(223, 9, "dup");
+        mw_prim_dup();
+        WORD_ATOM(223, 13, "num-type-inputs");
+        mw_Tag_2E_num_type_inputs();
+        WORD_ATOM(223, 29, "repeat");
+        push_u64(0);
+        push_fnptr(&mb_c99_tag_21__3);
+        mw_prim_pack_cons();
+        mw_repeat();
+        WORD_ATOM(227, 9, "dup");
+        mw_prim_dup();
+        WORD_ATOM(227, 13, "num-resource-inputs");
+        mw_Tag_2E_num_resource_inputs();
+        WORD_ATOM(227, 33, "repeat");
+        push_u64(0);
+        push_fnptr(&mb_c99_tag_21__4);
+        mw_prim_pack_cons();
+        mw_repeat();
+        WORD_ATOM(231, 9, "");
+        {
+            static bool vready = false;
+            static VAL v;
+            if (! vready) {
+                v = mkstr("tag);", 5);
+                vready = true;
+            }
+            push_value(v);
+            incref(v);
+        }
+        WORD_ATOM(231, 17, ";");
+        mw_Str_2B_C99_3B_();
+        WORD_ATOM(232, 9, "dup");
+        mw_prim_dup();
+        WORD_ATOM(232, 13, "outputs-resource?");
+        mw_Tag_2E_outputs_resource_3F_();
+        WORD_ATOM(232, 31, "if");
         if (pop_u64()) {
-            WORD_ATOM(239, 13, "");
+            WORD_ATOM(233, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
                 if (! vready) {
-                    v = mkstr("    push_u64(", 13);
+                    v = mkstr("    push_resource(car);", 23);
                     vready = true;
                 }
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(239, 29, ".");
-            mw__2E_();
-            WORD_ATOM(239, 31, "value");
-            mw_Tag_2E_value();
-            WORD_ATOM(239, 37, ".n");
-            mw__2E_n();
-            WORD_ATOM(239, 40, "");
-            {
-                static bool vready = false;
-                static VAL v;
-                if (! vready) {
-                    v = mkstr("LL);", 4);
-                    vready = true;
-                }
-                push_value(v);
-                incref(v);
-            }
-            WORD_ATOM(239, 47, ";");
-            mw__3B_();
+            WORD_ATOM(233, 39, ";");
+            mw_Str_2B_C99_3B_();
         } else {
-            WORD_ATOM(241, 13, "");
-            {
-                static bool vready = false;
-                static VAL v;
-                if (! vready) {
-                    v = mkstr("    VAL car = pop_value();", 26);
-                    vready = true;
-                }
-                push_value(v);
-                incref(v);
-            }
-            WORD_ATOM(241, 42, ";");
-            mw__3B_();
-            WORD_ATOM(242, 13, "dup");
-            mw_prim_dup();
-            WORD_ATOM(242, 17, "num-inputs");
-            mw_Tag_2E_num_inputs();
-            WORD_ATOM(242, 28, "1-");
-            mw_prim_int_pred();
-            WORD_ATOM(242, 31, "repeat");
-            push_u64(0);
-            push_fnptr(&mb_c99_tag_21__5);
-            mw_prim_pack_cons();
-            mw_repeat();
-            WORD_ATOM(243, 13, "");
-            {
-                static bool vready = false;
-                static VAL v;
-                if (! vready) {
-                    v = mkstr("    VAL tag = MKU64(", 20);
-                    vready = true;
-                }
-                push_value(v);
-                incref(v);
-            }
-            WORD_ATOM(243, 36, ".");
-            mw__2E_();
-            WORD_ATOM(243, 38, "value");
-            mw_Tag_2E_value();
-            WORD_ATOM(243, 44, ".n");
-            mw__2E_n();
-            WORD_ATOM(243, 47, "");
-            {
-                static bool vready = false;
-                static VAL v;
-                if (! vready) {
-                    v = mkstr("LL);", 4);
-                    vready = true;
-                }
-                push_value(v);
-                incref(v);
-            }
-            WORD_ATOM(243, 54, ";");
-            mw__3B_();
-            WORD_ATOM(244, 13, "");
-            {
-                static bool vready = false;
-                static VAL v;
-                if (! vready) {
-                    v = mkstr("    car = mkcons(car, tag);", 27);
-                    vready = true;
-                }
-                push_value(v);
-                incref(v);
-            }
-            WORD_ATOM(244, 43, ";");
-            mw__3B_();
-            WORD_ATOM(245, 13, "");
+            WORD_ATOM(234, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -17040,11 +20135,11 @@ static void mw_c99_tag_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(245, 36, ";");
-            mw__3B_();
+            WORD_ATOM(234, 36, ";");
+            mw_Str_2B_C99_3B_();
         }
     }
-    WORD_ATOM(248, 5, "");
+    WORD_ATOM(237, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -17055,38 +20150,186 @@ static void mw_c99_tag_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(248, 9, ";");
-    mw__3B_();
+    WORD_ATOM(237, 9, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(239, 5, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("void co_", 8);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(239, 16, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(239, 18, "dup");
+    mw_prim_dup();
+    WORD_ATOM(239, 22, "name");
+    mw_Tag_2E_name();
+    WORD_ATOM(239, 27, ".name");
+    mw_Name_2B_C99_2E_name();
+    WORD_ATOM(239, 33, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("() {", 4);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(239, 40, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(240, 5, "dup");
+    mw_prim_dup();
+    WORD_ATOM(240, 9, "is-transparent?");
+    mw_Tag_2E_is_transparent_3F_();
+    WORD_ATOM(240, 25, "if");
+    if (pop_u64()) {
+        WORD_ATOM(241, 9, "id");
+        mw_prim_id();
+    } else {
+        WORD_ATOM(242, 9, "dup");
+        mw_prim_dup();
+        WORD_ATOM(242, 13, "outputs-resource?");
+        mw_Tag_2E_outputs_resource_3F_();
+        WORD_ATOM(242, 31, "if");
+        if (pop_u64()) {
+            WORD_ATOM(243, 13, "");
+            {
+                static bool vready = false;
+                static VAL v;
+                if (! vready) {
+                    v = mkstr("    VAL car = pop_resource();", 29);
+                    vready = true;
+                }
+                push_value(v);
+                incref(v);
+            }
+            WORD_ATOM(243, 45, ";");
+            mw_Str_2B_C99_3B_();
+        } else {
+            WORD_ATOM(244, 13, "");
+            {
+                static bool vready = false;
+                static VAL v;
+                if (! vready) {
+                    v = mkstr("    VAL car = pop_value();", 26);
+                    vready = true;
+                }
+                push_value(v);
+                incref(v);
+            }
+            WORD_ATOM(244, 42, ";");
+            mw_Str_2B_C99_3B_();
+        }
+        WORD_ATOM(246, 9, "");
+        {
+            static bool vready = false;
+            static VAL v;
+            if (! vready) {
+                v = mkstr("    VAL cdr;", 12);
+                vready = true;
+            }
+            push_value(v);
+            incref(v);
+        }
+        WORD_ATOM(246, 24, ";");
+        mw_Str_2B_C99_3B_();
+        WORD_ATOM(247, 9, "");
+        {
+            static bool vready = false;
+            static VAL v;
+            if (! vready) {
+                v = mkstr("    decref(", 11);
+                vready = true;
+            }
+            push_value(v);
+            incref(v);
+        }
+        WORD_ATOM(248, 9, "over");
+        mw_over();
+        WORD_ATOM(248, 14, "num-resource-inputs");
+        mw_Tag_2E_num_resource_inputs();
+        WORD_ATOM(248, 34, "repeat");
+        push_u64(0);
+        push_fnptr(&mb_c99_tag_21__11);
+        mw_prim_pack_cons();
+        mw_repeat();
+        WORD_ATOM(253, 9, "over");
+        mw_over();
+        WORD_ATOM(253, 14, "num-type-inputs");
+        mw_Tag_2E_num_type_inputs();
+        WORD_ATOM(253, 30, "repeat");
+        push_u64(0);
+        push_fnptr(&mb_c99_tag_21__12);
+        mw_prim_pack_cons();
+        mw_repeat();
+        WORD_ATOM(258, 9, ".");
+        mw_Str_2B_C99_2E_();
+        WORD_ATOM(258, 11, "");
+        {
+            static bool vready = false;
+            static VAL v;
+            if (! vready) {
+                v = mkstr("car);", 5);
+                vready = true;
+            }
+            push_value(v);
+            incref(v);
+        }
+        WORD_ATOM(258, 19, ";");
+        mw_Str_2B_C99_3B_();
+    }
+    WORD_ATOM(260, 5, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("}", 1);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(260, 9, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(262, 5, "drop");
+    mw_prim_drop();
     WORD_EXIT(mw_c99_tag_21_);
 }
 static void mw_c99_externals_21_ (void){
-    WORD_ENTER(mw_c99_externals_21_, "c99-externals!", "src/mirth/codegen.mth", 251, 5);
-    WORD_ATOM(251, 5, "External.for");
+    WORD_ENTER(mw_c99_externals_21_, "c99-externals!", "src/mirth/codegen.mth", 265, 5);
+    WORD_ATOM(265, 5, "External.for");
     push_u64(0);
     push_fnptr(&mb_c99_externals_21__1);
     mw_prim_pack_cons();
     mw_External_2E_for();
-    WORD_ATOM(251, 33, ".lf");
-    mw__2E_lf();
+    WORD_ATOM(265, 33, ".lf");
+    mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_externals_21_);
 }
 static void mw_c99_external_21_ (void){
-    WORD_ENTER(mw_c99_external_21_, "c99-external!", "src/mirth/codegen.mth", 254, 5);
-    WORD_ATOM(254, 5, "dup");
+    WORD_ENTER(mw_c99_external_21_, "c99-external!", "src/mirth/codegen.mth", 268, 5);
+    WORD_ATOM(268, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(254, 9, "sig");
+    WORD_ATOM(268, 9, "sig");
     mw_External_2E_sig();
-    WORD_ATOM(254, 13, "sig-arity");
+    WORD_ATOM(268, 13, "sig-arity");
     mw_Token_2E_sig_arity();
-    WORD_ATOM(255, 5, "dup");
+    WORD_ATOM(269, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(255, 9, "");
+    WORD_ATOM(269, 9, "");
     push_i64(2LL);
-    WORD_ATOM(255, 11, ">=");
+    WORD_ATOM(269, 11, ">=");
     mw_Int_3E__3D_();
-    WORD_ATOM(255, 14, "if");
+    WORD_ATOM(269, 14, "if");
     if (pop_u64()) {
-        WORD_ATOM(256, 9, "");
+        WORD_ATOM(270, 9, "");
         {
             static bool vready = false;
             static VAL v;
@@ -17097,18 +20340,18 @@ static void mw_c99_external_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(256, 62, "panic!");
+        WORD_ATOM(270, 62, "panic!");
         mw_prim_panic();
     } else {
-        WORD_ATOM(258, 9, "dup");
+        WORD_ATOM(272, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(258, 13, "");
+        WORD_ATOM(272, 13, "");
         push_i64(1LL);
-        WORD_ATOM(258, 15, ">=");
+        WORD_ATOM(272, 15, ">=");
         mw_Int_3E__3D_();
-        WORD_ATOM(258, 18, "if");
+        WORD_ATOM(272, 18, "if");
         if (pop_u64()) {
-            WORD_ATOM(259, 13, "");
+            WORD_ATOM(273, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -17119,10 +20362,10 @@ static void mw_c99_external_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(259, 24, ".");
-            mw__2E_();
+            WORD_ATOM(273, 24, ".");
+            mw_Str_2B_C99_2E_();
         } else {
-            WORD_ATOM(260, 13, "");
+            WORD_ATOM(274, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -17133,16 +20376,16 @@ static void mw_c99_external_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(260, 21, ".");
-            mw__2E_();
+            WORD_ATOM(274, 21, ".");
+            mw_Str_2B_C99_2E_();
         }
     }
-    WORD_ATOM(264, 5, "dip2");
+    WORD_ATOM(278, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_c99_external_21__5);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(266, 5, "");
+    WORD_ATOM(280, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -17153,17 +20396,17 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(266, 10, ".");
-    mw__2E_();
-    WORD_ATOM(267, 5, "over");
+    WORD_ATOM(280, 10, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(281, 5, "over");
     mw_over();
-    WORD_ATOM(267, 10, "dup");
+    WORD_ATOM(281, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(267, 14, "0>");
+    WORD_ATOM(281, 14, "0>");
     mw_0_3E_();
-    WORD_ATOM(267, 17, "if");
+    WORD_ATOM(281, 17, "if");
     if (pop_u64()) {
-        WORD_ATOM(267, 20, "");
+        WORD_ATOM(281, 20, "");
         {
             static bool vready = false;
             static VAL v;
@@ -17174,19 +20417,19 @@ static void mw_c99_external_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(267, 30, ".");
-        mw__2E_();
-        WORD_ATOM(267, 32, "1-");
+        WORD_ATOM(281, 30, ".");
+        mw_Str_2B_C99_2E_();
+        WORD_ATOM(281, 32, "1-");
         mw_prim_int_pred();
-        WORD_ATOM(267, 35, "repeat");
+        WORD_ATOM(281, 35, "repeat");
         push_u64(0);
         push_fnptr(&mb_c99_external_21__7);
         mw_prim_pack_cons();
         mw_repeat();
     } else {
-        WORD_ATOM(267, 58, "drop");
+        WORD_ATOM(281, 58, "drop");
         mw_prim_drop();
-        WORD_ATOM(267, 63, "");
+        WORD_ATOM(281, 63, "");
         {
             static bool vready = false;
             static VAL v;
@@ -17197,10 +20440,10 @@ static void mw_c99_external_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(267, 70, ".");
-        mw__2E_();
+        WORD_ATOM(281, 70, ".");
+        mw_Str_2B_C99_2E_();
     }
-    WORD_ATOM(268, 5, "");
+    WORD_ATOM(282, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -17211,9 +20454,9 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(268, 10, ";");
-    mw__3B_();
-    WORD_ATOM(270, 5, "");
+    WORD_ATOM(282, 10, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(284, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -17224,14 +20467,14 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(270, 23, ".");
-    mw__2E_();
-    WORD_ATOM(270, 25, "dip2");
+    WORD_ATOM(284, 23, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(284, 25, "dip2");
     push_u64(0);
     push_fnptr(&mb_c99_external_21__9);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(270, 46, "");
+    WORD_ATOM(284, 46, "");
     {
         static bool vready = false;
         static VAL v;
@@ -17242,22 +20485,22 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(270, 58, ";");
-    mw__3B_();
-    WORD_ATOM(271, 5, "over");
+    WORD_ATOM(284, 58, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(285, 5, "over");
     mw_over();
-    WORD_ATOM(271, 10, "countdown");
+    WORD_ATOM(285, 10, "countdown");
     push_u64(0);
     push_fnptr(&mb_c99_external_21__10);
     mw_prim_pack_cons();
     mw_countdown();
-    WORD_ATOM(272, 5, "dup");
+    WORD_ATOM(286, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(272, 9, "0>");
+    WORD_ATOM(286, 9, "0>");
     mw_0_3E_();
-    WORD_ATOM(272, 12, "if");
+    WORD_ATOM(286, 12, "if");
     if (pop_u64()) {
-        WORD_ATOM(272, 15, "");
+        WORD_ATOM(286, 15, "");
         {
             static bool vready = false;
             static VAL v;
@@ -17269,7 +20512,7 @@ static void mw_c99_external_21_ (void){
             incref(v);
         }
     } else {
-        WORD_ATOM(272, 32, "");
+        WORD_ATOM(286, 32, "");
         {
             static bool vready = false;
             static VAL v;
@@ -17281,14 +20524,14 @@ static void mw_c99_external_21_ (void){
             incref(v);
         }
     }
-    WORD_ATOM(272, 40, ".");
-    mw__2E_();
-    WORD_ATOM(273, 5, "dip2");
+    WORD_ATOM(286, 40, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(287, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_c99_external_21__13);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(274, 5, "");
+    WORD_ATOM(288, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -17299,29 +20542,29 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(274, 9, ".");
-    mw__2E_();
-    WORD_ATOM(275, 5, "dip");
+    WORD_ATOM(288, 9, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(289, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(275, 9, "dup");
+        WORD_ATOM(289, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(275, 13, "0>");
+        WORD_ATOM(289, 13, "0>");
         mw_0_3E_();
-        WORD_ATOM(275, 16, "if");
+        WORD_ATOM(289, 16, "if");
         if (pop_u64()) {
-            WORD_ATOM(276, 9, "dup");
+            WORD_ATOM(290, 9, "dup");
             mw_prim_dup();
-            WORD_ATOM(276, 13, "1-");
+            WORD_ATOM(290, 13, "1-");
             mw_prim_int_pred();
-            WORD_ATOM(276, 16, "dup");
+            WORD_ATOM(290, 16, "dup");
             mw_prim_dup();
-            WORD_ATOM(276, 20, "count");
+            WORD_ATOM(290, 20, "count");
             push_u64(0);
             push_fnptr(&mb_c99_external_21__16);
             mw_prim_pack_cons();
             mw_count();
-            WORD_ATOM(276, 43, "");
+            WORD_ATOM(290, 43, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -17332,17 +20575,17 @@ static void mw_c99_external_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(276, 47, ".");
-            mw__2E_();
-            WORD_ATOM(276, 49, ".n");
-            mw__2E_n();
+            WORD_ATOM(290, 47, ".");
+            mw_Str_2B_C99_2E_();
+            WORD_ATOM(290, 49, ".n");
+            mw_Int_2B_C99_2E_n();
         } else {
-            WORD_ATOM(277, 9, "id");
+            WORD_ATOM(291, 9, "id");
             mw_prim_id();
         }
         push_value(d2);
     }
-    WORD_ATOM(279, 5, "");
+    WORD_ATOM(293, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -17353,15 +20596,15 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(279, 9, ".");
-    mw__2E_();
-    WORD_ATOM(280, 5, "dup");
+    WORD_ATOM(293, 9, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(294, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(280, 9, "0>");
+    WORD_ATOM(294, 9, "0>");
     mw_0_3E_();
-    WORD_ATOM(280, 12, "if");
+    WORD_ATOM(294, 12, "if");
     if (pop_u64()) {
-        WORD_ATOM(280, 15, "");
+        WORD_ATOM(294, 15, "");
         {
             static bool vready = false;
             static VAL v;
@@ -17373,7 +20616,7 @@ static void mw_c99_external_21_ (void){
             incref(v);
         }
     } else {
-        WORD_ATOM(280, 21, "");
+        WORD_ATOM(294, 21, "");
         {
             static bool vready = false;
             static VAL v;
@@ -17385,9 +20628,9 @@ static void mw_c99_external_21_ (void){
             incref(v);
         }
     }
-    WORD_ATOM(280, 26, ";");
-    mw__3B_();
-    WORD_ATOM(281, 5, "");
+    WORD_ATOM(294, 26, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(295, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -17398,51 +20641,41 @@ static void mw_c99_external_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(281, 9, ";");
-    mw__3B_();
-    WORD_ATOM(282, 5, "drop3");
+    WORD_ATOM(295, 9, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(296, 5, "drop3");
     mw_drop3();
     WORD_EXIT(mw_c99_external_21_);
 }
 static void mw_c99_nest (void){
-    WORD_ENTER(mw_c99_nest, "c99-nest", "src/mirth/codegen.mth", 285, 5);
-    WORD_ATOM(285, 5, "c99-depth");
+    WORD_ENTER(mw_c99_nest, "c99-nest", "src/mirth/codegen.mth", 299, 5);
+    WORD_ATOM(299, 5, "depth@");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(285, 5, "c99-depth");
-        mw_c99_depth();
-        WORD_ATOM(285, 15, "modify");
-        push_u64(0);
-        incref(var_f);
-        push_value(var_f);
-        mw_prim_pack_cons();
-        push_fnptr(&mb_c99_nest_2);
-        mw_prim_pack_cons();
-        mw_modify();
-        WORD_ATOM(286, 5, "f");
+        WORD_ATOM(299, 5, "depth@");
+        mw__2B_C99_2E_depth_40_();
+        WORD_ATOM(299, 12, "1+");
+        mw_prim_int_succ();
+        WORD_ATOM(299, 15, "depth!");
+        mw__2B_C99_2E_depth_21_();
+        WORD_ATOM(300, 5, "f");
         incref(var_f);
         run_value(var_f);
-        WORD_ATOM(287, 5, "c99-depth");
-        mw_c99_depth();
-        WORD_ATOM(287, 15, "modify");
-        push_u64(0);
-        incref(var_f);
-        push_value(var_f);
-        mw_prim_pack_cons();
-        push_fnptr(&mb_c99_nest_3);
-        mw_prim_pack_cons();
-        mw_modify();
+        WORD_ATOM(301, 5, "depth@");
+        mw__2B_C99_2E_depth_40_();
+        WORD_ATOM(301, 12, "1-");
+        mw_prim_int_pred();
+        WORD_ATOM(301, 15, "depth!");
+        mw__2B_C99_2E_depth_21_();
         decref(var_f);
     }
     WORD_EXIT(mw_c99_nest);
 }
 static void mw_c99_indent (void){
-    WORD_ENTER(mw_c99_indent, "c99-indent", "src/mirth/codegen.mth", 289, 21);
-    WORD_ATOM(289, 21, "c99-depth");
-    mw_c99_depth();
-    WORD_ATOM(289, 31, "@");
-    mw_prim_mut_get();
-    WORD_ATOM(289, 33, "repeat");
+    WORD_ENTER(mw_c99_indent, "c99-indent", "src/mirth/codegen.mth", 303, 31);
+    WORD_ATOM(303, 31, "depth@");
+    mw__2B_C99_2E_depth_40_();
+    WORD_ATOM(303, 38, "repeat");
     push_u64(0);
     push_fnptr(&mb_c99_indent_1);
     mw_prim_pack_cons();
@@ -17450,31 +20683,31 @@ static void mw_c99_indent (void){
     WORD_EXIT(mw_c99_indent);
 }
 static void mw_c99_line (void){
-    WORD_ENTER(mw_c99_line, "c99-line", "src/mirth/codegen.mth", 290, 39);
-    WORD_ATOM(290, 39, "c99-indent");
+    WORD_ENTER(mw_c99_line, "c99-line", "src/mirth/codegen.mth", 304, 59);
+    WORD_ATOM(304, 59, "c99-indent");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(290, 39, "c99-indent");
+        WORD_ATOM(304, 59, "c99-indent");
         mw_c99_indent();
-        WORD_ATOM(290, 50, "f");
+        WORD_ATOM(304, 70, "f");
         incref(var_f);
         run_value(var_f);
-        WORD_ATOM(290, 52, ".lf");
-        mw__2E_lf();
+        WORD_ATOM(304, 72, ".lf");
+        mw__2B_C99_2E_lf();
         decref(var_f);
     }
     WORD_EXIT(mw_c99_line);
 }
 static void mw_c99_call_21_ (void){
-    WORD_ENTER(mw_c99_call_21_, "c99-call!", "src/mirth/codegen.mth", 293, 5);
-    WORD_ATOM(293, 5, "dip");
+    WORD_ENTER(mw_c99_call_21_, "c99-call!", "src/mirth/codegen.mth", 307, 5);
+    WORD_ATOM(307, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(293, 9, "c99-args-push!");
+        WORD_ATOM(307, 9, "c99-args-push!");
         mw_c99_args_push_21_();
         push_value(d2);
     }
-    WORD_ATOM(294, 5, "c99-line");
+    WORD_ATOM(308, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_call_21__2);
     mw_prim_pack_cons();
@@ -17482,10 +20715,10 @@ static void mw_c99_call_21_ (void){
     WORD_EXIT(mw_c99_call_21_);
 }
 static void mw_c99_arrow_21_ (void){
-    WORD_ENTER(mw_c99_arrow_21_, "c99-arrow!", "src/mirth/codegen.mth", 296, 27);
-    WORD_ATOM(296, 27, "atoms");
+    WORD_ENTER(mw_c99_arrow_21_, "c99-arrow!", "src/mirth/codegen.mth", 310, 37);
+    WORD_ATOM(310, 37, "atoms");
     mw_Arrow_2E_atoms();
-    WORD_ATOM(296, 33, "for");
+    WORD_ATOM(310, 43, "for");
     push_u64(0);
     push_fnptr(&mb_c99_arrow_21__1);
     mw_prim_pack_cons();
@@ -17493,126 +20726,126 @@ static void mw_c99_arrow_21_ (void){
     WORD_EXIT(mw_c99_arrow_21_);
 }
 static void mw_c99_atom_21_ (void){
-    WORD_ENTER(mw_c99_atom_21_, "c99-atom!", "src/mirth/codegen.mth", 298, 5);
-    WORD_ATOM(298, 5, "c99-line");
+    WORD_ENTER(mw_c99_atom_21_, "c99-atom!", "src/mirth/codegen.mth", 312, 5);
+    WORD_ATOM(312, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_atom_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(303, 5, "sip");
+    WORD_ATOM(317, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_c99_atom_21__4);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(303, 15, "op");
+    WORD_ATOM(317, 15, "op");
     mw_Atom_2E_op();
-    WORD_ATOM(304, 5, "c99-args-op!");
+    WORD_ATOM(318, 5, "c99-args-op!");
     mw_c99_args_op_21_();
     WORD_EXIT(mw_c99_atom_21_);
 }
 static void mw_c99_args_op_21_ (void){
-    WORD_ENTER(mw_c99_args_op_21_, "c99-args-op!", "src/mirth/codegen.mth", 307, 5);
-    WORD_ATOM(307, 5, "OP_NONE");
+    WORD_ENTER(mw_c99_args_op_21_, "c99-args-op!", "src/mirth/codegen.mth", 321, 5);
+    WORD_ATOM(321, 5, "OP_NONE");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
-            WORD_ATOM(307, 20, "drop");
+            co_OP_5F_NONE();
+            WORD_ATOM(321, 20, "drop");
             mw_prim_drop();
             break;
         case 8LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(308, 20, "nip");
+            co_OP_5F_INT();
+            WORD_ATOM(322, 20, "nip");
             mw_nip();
-            WORD_ATOM(308, 24, "c99-int!");
+            WORD_ATOM(322, 24, "c99-int!");
             mw_c99_int_21_();
             break;
         case 9LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(309, 20, "nip");
+            co_OP_5F_STR();
+            WORD_ATOM(323, 20, "nip");
             mw_nip();
-            WORD_ATOM(309, 24, "c99-str!");
+            WORD_ATOM(323, 24, "c99-str!");
             mw_c99_str_21_();
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(310, 20, "nip");
+            co_OP_5F_CONSTANT();
+            WORD_ATOM(324, 20, "nip");
             mw_nip();
-            WORD_ATOM(310, 24, "c99-constant!");
+            WORD_ATOM(324, 24, "c99-constant!");
             mw_c99_constant_21_();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(311, 20, "name");
+            co_OP_5F_WORD();
+            WORD_ATOM(325, 20, "name");
             mw_Word_2E_name();
-            WORD_ATOM(311, 25, "c99-call!");
+            WORD_ATOM(325, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(312, 20, "name");
+            co_OP_5F_EXTERNAL();
+            WORD_ATOM(326, 20, "name");
             mw_External_2E_name();
-            WORD_ATOM(312, 25, "c99-call!");
+            WORD_ATOM(326, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(313, 20, "name");
+            co_OP_5F_BUFFER();
+            WORD_ATOM(327, 20, "name");
             mw_Buffer_2E_name();
-            WORD_ATOM(313, 25, "c99-call!");
+            WORD_ATOM(327, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(314, 20, "name");
+            co_OP_5F_VARIABLE();
+            WORD_ATOM(328, 20, "name");
             mw_Variable_2E_name();
-            WORD_ATOM(314, 25, "c99-call!");
+            WORD_ATOM(328, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 7LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(315, 20, "name");
+            co_OP_5F_FIELD();
+            WORD_ATOM(329, 20, "name");
             mw_Field_2E_name();
-            WORD_ATOM(315, 25, "c99-call!");
+            WORD_ATOM(329, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 10LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(316, 20, "name");
+            co_OP_5F_TAG();
+            WORD_ATOM(330, 20, "name");
             mw_Tag_2E_name();
-            WORD_ATOM(316, 25, "c99-call!");
+            WORD_ATOM(330, 25, "c99-call!");
             mw_c99_call_21_();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(317, 20, "c99-prim!");
+            co_OP_5F_PRIM();
+            WORD_ATOM(331, 20, "c99-prim!");
             mw_c99_prim_21_();
             break;
         case 11LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(318, 20, "nip");
+            co_OP_5F_MATCH();
+            WORD_ATOM(332, 20, "nip");
             mw_nip();
-            WORD_ATOM(318, 24, "c99-match!");
+            WORD_ATOM(332, 24, "c99-match!");
             mw_c99_match_21_();
             break;
         case 12LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(319, 20, "nip");
+            co_OP_5F_LAMBDA();
+            WORD_ATOM(333, 20, "nip");
             mw_nip();
-            WORD_ATOM(319, 24, "c99-lambda!");
+            WORD_ATOM(333, 24, "c99-lambda!");
             mw_c99_lambda_21_();
             break;
         case 13LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(320, 20, "nip");
+            co_OP_5F_VAR();
+            WORD_ATOM(334, 20, "nip");
             mw_nip();
-            WORD_ATOM(320, 24, "c99-var!");
+            WORD_ATOM(334, 24, "c99-var!");
             mw_c99_var_21_();
             break;
         case 14LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(321, 20, "nip");
+            co_OP_5F_BLOCK();
+            WORD_ATOM(335, 20, "nip");
             mw_nip();
-            WORD_ATOM(321, 24, "c99-block-push!");
+            WORD_ATOM(335, 24, "c99-block-push!");
             mw_c99_block_push_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -17620,8 +20853,8 @@ static void mw_c99_args_op_21_ (void){
 }    WORD_EXIT(mw_c99_args_op_21_);
 }
 static void mw_c99_int_21_ (void){
-    WORD_ENTER(mw_c99_int_21_, "c99-int!", "src/mirth/codegen.mth", 324, 5);
-    WORD_ATOM(324, 5, "c99-line");
+    WORD_ENTER(mw_c99_int_21_, "c99-int!", "src/mirth/codegen.mth", 338, 5);
+    WORD_ATOM(338, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_int_21__1);
     mw_prim_pack_cons();
@@ -17629,29 +20862,29 @@ static void mw_c99_int_21_ (void){
     WORD_EXIT(mw_c99_int_21_);
 }
 static void mw_c99_str_21_ (void){
-    WORD_ENTER(mw_c99_str_21_, "c99-str!", "src/mirth/codegen.mth", 327, 5);
-    WORD_ATOM(327, 5, "c99-line");
+    WORD_ENTER(mw_c99_str_21_, "c99-str!", "src/mirth/codegen.mth", 341, 5);
+    WORD_ATOM(341, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(328, 5, "c99-nest");
+    WORD_ATOM(342, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(351, 5, "c99-line");
+    WORD_ATOM(365, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__20);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(352, 5, "drop");
+    WORD_ATOM(366, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_str_21_);
 }
 static void mw__2E_str (void){
-    WORD_ENTER(mw__2E_str, ".str", "src/mirth/codegen.mth", 354, 19);
-    WORD_ATOM(354, 19, "");
+    WORD_ENTER(mw__2E_str, ".str", "src/mirth/codegen.mth", 368, 29);
+    WORD_ATOM(368, 29, "");
     {
         static bool vready = false;
         static VAL v;
@@ -17662,14 +20895,14 @@ static void mw__2E_str (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(354, 24, ".");
-    mw__2E_();
-    WORD_ATOM(354, 26, "str-bytes-for");
+    WORD_ATOM(368, 34, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(368, 36, "str-bytes-for");
     push_u64(0);
     push_fnptr(&mb__2E_str_1);
     mw_prim_pack_cons();
     mw_str_bytes_for();
-    WORD_ATOM(354, 58, "");
+    WORD_ATOM(368, 68, "");
     {
         static bool vready = false;
         static VAL v;
@@ -17680,17 +20913,17 @@ static void mw__2E_str (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(354, 63, ".");
-    mw__2E_();
+    WORD_ATOM(368, 73, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mw__2E_str);
 }
 static void mw_c99_string_byte_21_ (void){
-    WORD_ENTER(mw_c99_string_byte_21_, "c99-string-byte!", "src/mirth/codegen.mth", 357, 5);
-    WORD_ATOM(357, 5, "B'\\'");
+    WORD_ENTER(mw_c99_string_byte_21_, "c99-string-byte!", "src/mirth/codegen.mth", 371, 5);
+    WORD_ATOM(371, 5, "B'\\'");
     switch (get_top_data_tag()) {
         case 92LL:
-            mw_prim_drop();
-            WORD_ATOM(357, 13, "");
+            co_B_27__5C__27_();
+            WORD_ATOM(371, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -17701,12 +20934,12 @@ static void mw_c99_string_byte_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(357, 20, ".");
-            mw__2E_();
+            WORD_ATOM(371, 20, ".");
+            mw_Str_2B_C99_2E_();
             break;
         case 34LL:
-            mw_prim_drop();
-            WORD_ATOM(358, 15, "");
+            co_BQUOTE();
+            WORD_ATOM(372, 15, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -17717,12 +20950,12 @@ static void mw_c99_string_byte_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(358, 22, ".");
-            mw__2E_();
+            WORD_ATOM(372, 22, ".");
+            mw_Str_2B_C99_2E_();
             break;
         case 9LL:
-            mw_prim_drop();
-            WORD_ATOM(359, 12, "");
+            co_BHT();
+            WORD_ATOM(373, 12, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -17733,12 +20966,12 @@ static void mw_c99_string_byte_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(359, 18, ".");
-            mw__2E_();
+            WORD_ATOM(373, 18, ".");
+            mw_Str_2B_C99_2E_();
             break;
         case 10LL:
-            mw_prim_drop();
-            WORD_ATOM(360, 12, "");
+            co_BLF();
+            WORD_ATOM(374, 12, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -17749,12 +20982,12 @@ static void mw_c99_string_byte_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(360, 18, ".");
-            mw__2E_();
+            WORD_ATOM(374, 18, ".");
+            mw_Str_2B_C99_2E_();
             break;
         case 13LL:
-            mw_prim_drop();
-            WORD_ATOM(361, 12, "");
+            co_BCR();
+            WORD_ATOM(375, 12, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -17765,24 +20998,24 @@ static void mw_c99_string_byte_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(361, 18, ".");
-            mw__2E_();
+            WORD_ATOM(375, 18, ".");
+            mw_Str_2B_C99_2E_();
             break;
         default:
-            WORD_ATOM(363, 9, "dup");
+            WORD_ATOM(377, 9, "dup");
             mw_prim_dup();
-            WORD_ATOM(363, 13, "BSPACE");
+            WORD_ATOM(377, 13, "BSPACE");
             mw_BSPACE();
-            WORD_ATOM(363, 20, "B'~'");
+            WORD_ATOM(377, 20, "B'~'");
             mw_B_27__7E__27_();
-            WORD_ATOM(363, 25, "in-range");
+            WORD_ATOM(377, 25, "in-range");
             mw_Byte_2E_in_range();
-            WORD_ATOM(363, 34, "if");
+            WORD_ATOM(377, 34, "if");
             if (pop_u64()) {
-                WORD_ATOM(364, 13, ".b");
-                mw__2E_b();
+                WORD_ATOM(378, 13, ".b");
+                mw_Byte_2B_C99_2E_b();
             } else {
-                WORD_ATOM(365, 13, "");
+                WORD_ATOM(379, 13, "");
                 {
                     static bool vready = false;
                     static VAL v;
@@ -17793,49 +21026,49 @@ static void mw_c99_string_byte_21_ (void){
                     push_value(v);
                     incref(v);
                 }
-                WORD_ATOM(365, 19, ".");
-                mw__2E_();
-                WORD_ATOM(365, 21, "to-hexdigits");
+                WORD_ATOM(379, 19, ".");
+                mw_Str_2B_C99_2E_();
+                WORD_ATOM(379, 21, "to-hexdigits");
                 mw_Byte_2E_to_hexdigits();
-                WORD_ATOM(365, 34, "dip");
+                WORD_ATOM(379, 34, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(365, 38, ".b");
-                    mw__2E_b();
+                    WORD_ATOM(379, 38, ".b");
+                    mw_Byte_2B_C99_2E_b();
                     push_value(d5);
                 }
-                WORD_ATOM(365, 42, ".b");
-                mw__2E_b();
+                WORD_ATOM(379, 42, ".b");
+                mw_Byte_2B_C99_2E_b();
             }
             break;
     
 }    WORD_EXIT(mw_c99_string_byte_21_);
 }
 static void mw_c99_constant_21_ (void){
-    WORD_ENTER(mw_c99_constant_21_, "c99-constant!", "src/mirth/codegen.mth", 370, 5);
-    WORD_ATOM(370, 5, "value");
+    WORD_ENTER(mw_c99_constant_21_, "c99-constant!", "src/mirth/codegen.mth", 384, 5);
+    WORD_ATOM(384, 5, "value");
     mw_Constant_2E_value();
-    WORD_ATOM(370, 11, "c99-value!");
+    WORD_ATOM(384, 11, "c99-value!");
     mw_c99_value_21_();
     WORD_EXIT(mw_c99_constant_21_);
 }
 static void mw_c99_value_21_ (void){
-    WORD_ENTER(mw_c99_value_21_, "c99-value!", "src/mirth/codegen.mth", 373, 5);
-    WORD_ATOM(373, 5, "VALUE_INT");
+    WORD_ENTER(mw_c99_value_21_, "c99-value!", "src/mirth/codegen.mth", 387, 5);
+    WORD_ATOM(387, 5, "VALUE_INT");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(373, 18, "c99-int!");
+            co_VALUE_5F_INT();
+            WORD_ATOM(387, 18, "c99-int!");
             mw_c99_int_21_();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(374, 18, "c99-str!");
+            co_VALUE_5F_STR();
+            WORD_ATOM(388, 18, "c99-str!");
             mw_c99_str_21_();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(375, 20, "c99-block-push!");
+            co_VALUE_5F_BLOCK();
+            WORD_ATOM(389, 20, "c99-block-push!");
             mw_c99_block_push_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -17843,159 +21076,157 @@ static void mw_c99_value_21_ (void){
 }    WORD_EXIT(mw_c99_value_21_);
 }
 static void mw_c99_prim_21_ (void){
-    WORD_ENTER(mw_c99_prim_21_, "c99-prim!", "src/mirth/codegen.mth", 378, 5);
-    WORD_ATOM(378, 5, "PRIM_CORE_DIP");
+    WORD_ENTER(mw_c99_prim_21_, "c99-prim!", "src/mirth/codegen.mth", 392, 5);
+    WORD_ATOM(392, 5, "PRIM_CORE_DIP");
     switch (get_top_data_tag()) {
         case 4LL:
-            mw_prim_drop();
-            WORD_ATOM(379, 9, "match");
+            co_PRIM_5F_CORE_5F_DIP();
+            WORD_ATOM(393, 9, "match");
             switch (get_top_data_tag()) {
                 case 1LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(381, 17, "c99-line");
+                    co_L1();
+                    WORD_ATOM(395, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__3);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(382, 17, "c99-nest");
+                    WORD_ATOM(396, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__4);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(387, 17, "c99-line");
+                    WORD_ATOM(401, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__7);
                     mw_prim_pack_cons();
                     mw_c99_line();
                     break;
                 default:
-                    WORD_ATOM(389, 17, "PRIM_CORE_DIP");
+                    WORD_ATOM(403, 17, "PRIM_CORE_DIP");
                     mw_PRIM_5F_CORE_5F_DIP();
-                    WORD_ATOM(389, 31, "c99-prim-default!");
+                    WORD_ATOM(403, 31, "c99-prim-default!");
                     mw_c99_prim_default_21_();
                     break;
             
 }            break;
         case 13LL:
-            mw_prim_drop();
-            WORD_ATOM(393, 9, "match");
+            co_PRIM_5F_CORE_5F_RDIP();
+            WORD_ATOM(407, 9, "match");
             switch (get_top_data_tag()) {
                 case 1LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(395, 17, "c99-line");
+                    co_L1();
+                    WORD_ATOM(409, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__11);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(396, 17, "c99-nest");
+                    WORD_ATOM(410, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__12);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(401, 17, "c99-line");
+                    WORD_ATOM(415, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__15);
                     mw_prim_pack_cons();
                     mw_c99_line();
                     break;
                 default:
-                    WORD_ATOM(403, 17, "PRIM_CORE_RDIP");
+                    WORD_ATOM(417, 17, "PRIM_CORE_RDIP");
                     mw_PRIM_5F_CORE_5F_RDIP();
-                    WORD_ATOM(403, 32, "c99-prim-default!");
+                    WORD_ATOM(417, 32, "c99-prim-default!");
                     mw_c99_prim_default_21_();
                     break;
             
 }            break;
         case 5LL:
-            mw_prim_drop();
-            WORD_ATOM(407, 9, "match");
+            co_PRIM_5F_CORE_5F_IF();
+            WORD_ATOM(421, 9, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
-                    mw_prim_pack_uncons(); mw_prim_swap();
-                    WORD_ATOM(409, 17, "c99-line");
+                    co_L2();
+                    WORD_ATOM(423, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__19);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(410, 17, "c99-nest");
+                    WORD_ATOM(424, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__20);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(411, 17, "c99-line");
+                    WORD_ATOM(425, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__21);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(412, 17, "c99-nest");
+                    WORD_ATOM(426, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__22);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(413, 17, "c99-line");
+                    WORD_ATOM(427, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__23);
                     mw_prim_pack_cons();
                     mw_c99_line();
                     break;
                 default:
-                    WORD_ATOM(415, 17, "PRIM_CORE_IF");
+                    WORD_ATOM(429, 17, "PRIM_CORE_IF");
                     mw_PRIM_5F_CORE_5F_IF();
-                    WORD_ATOM(415, 30, "c99-prim-default!");
+                    WORD_ATOM(429, 30, "c99-prim-default!");
                     mw_c99_prim_default_21_();
                     break;
             
 }            break;
         case 6LL:
-            mw_prim_drop();
-            WORD_ATOM(419, 9, "match");
+            co_PRIM_5F_CORE_5F_WHILE();
+            WORD_ATOM(433, 9, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
-                    mw_prim_pack_uncons(); mw_prim_swap();
-                    WORD_ATOM(421, 17, "c99-line");
+                    co_L2();
+                    WORD_ATOM(435, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__27);
                     mw_prim_pack_cons();
                     mw_c99_line();
-                    WORD_ATOM(422, 17, "c99-nest");
+                    WORD_ATOM(436, 17, "c99-nest");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__28);
                     mw_prim_pack_cons();
                     mw_c99_nest();
-                    WORD_ATOM(427, 17, "c99-line");
+                    WORD_ATOM(441, 17, "c99-line");
                     push_u64(0);
                     push_fnptr(&mb_c99_prim_21__30);
                     mw_prim_pack_cons();
                     mw_c99_line();
                     break;
                 default:
-                    WORD_ATOM(430, 17, "PRIM_CORE_WHILE");
+                    WORD_ATOM(444, 17, "PRIM_CORE_WHILE");
                     mw_PRIM_5F_CORE_5F_WHILE();
-                    WORD_ATOM(430, 33, "c99-prim-default!");
+                    WORD_ATOM(444, 33, "c99-prim-default!");
                     mw_c99_prim_default_21_();
                     break;
             
 }            break;
         default:
-            WORD_ATOM(433, 10, "c99-prim-default!");
+            WORD_ATOM(447, 10, "c99-prim-default!");
             mw_c99_prim_default_21_();
             break;
     
 }    WORD_EXIT(mw_c99_prim_21_);
 }
 static void mw_c99_prim_default_21_ (void){
-    WORD_ENTER(mw_c99_prim_default_21_, "c99-prim-default!", "src/mirth/codegen.mth", 436, 5);
-    WORD_ATOM(436, 5, "name");
+    WORD_ENTER(mw_c99_prim_default_21_, "c99-prim-default!", "src/mirth/codegen.mth", 450, 5);
+    WORD_ATOM(450, 5, "name");
     mw_Prim_2E_name();
-    WORD_ATOM(436, 10, "c99-call!");
+    WORD_ATOM(450, 10, "c99-call!");
     mw_c99_call_21_();
     WORD_EXIT(mw_c99_prim_default_21_);
 }
 static void mw_c99_args_push_21_ (void){
-    WORD_ENTER(mw_c99_args_push_21_, "c99-args-push!", "src/mirth/codegen.mth", 439, 5);
-    WORD_ATOM(439, 5, "for");
+    WORD_ENTER(mw_c99_args_push_21_, "c99-args-push!", "src/mirth/codegen.mth", 453, 5);
+    WORD_ATOM(453, 5, "for");
     push_u64(0);
     push_fnptr(&mb_c99_args_push_21__1);
     mw_prim_pack_cons();
@@ -18003,30 +21234,30 @@ static void mw_c99_args_push_21_ (void){
     WORD_EXIT(mw_c99_args_push_21_);
 }
 static void mw_c99_arg_push_21_ (void){
-    WORD_ENTER(mw_c99_arg_push_21_, "c99-arg-push!", "src/mirth/codegen.mth", 442, 5);
-    WORD_ATOM(442, 5, "ARG_BLOCK");
-    WORD_ATOM(442, 18, "c99-block-push!");
+    WORD_ENTER(mw_c99_arg_push_21_, "c99-arg-push!", "src/mirth/codegen.mth", 456, 5);
+    WORD_ATOM(456, 5, "ARG_BLOCK");
+    WORD_ATOM(456, 18, "c99-block-push!");
     mw_c99_block_push_21_();
     WORD_EXIT(mw_c99_arg_push_21_);
 }
 static void mw_c99_arg_run_21_ (void){
-    WORD_ENTER(mw_c99_arg_run_21_, "c99-arg-run!", "src/mirth/codegen.mth", 445, 5);
-    WORD_ATOM(445, 5, "ARG_BLOCK");
-    WORD_ATOM(445, 18, "c99-block-run!");
+    WORD_ENTER(mw_c99_arg_run_21_, "c99-arg-run!", "src/mirth/codegen.mth", 459, 5);
+    WORD_ATOM(459, 5, "ARG_BLOCK");
+    WORD_ATOM(459, 18, "c99-block-run!");
     mw_c99_block_run_21_();
     WORD_EXIT(mw_c99_arg_run_21_);
 }
 static void mw_c99_block_run_21_ (void){
-    WORD_ENTER(mw_c99_block_run_21_, "c99-block-run!", "src/mirth/codegen.mth", 448, 5);
-    WORD_ATOM(448, 5, "arrow");
+    WORD_ENTER(mw_c99_block_run_21_, "c99-block-run!", "src/mirth/codegen.mth", 462, 5);
+    WORD_ATOM(462, 5, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(448, 11, "c99-arrow!");
+    WORD_ATOM(462, 11, "c99-arrow!");
     mw_c99_arrow_21_();
     WORD_EXIT(mw_c99_block_run_21_);
 }
-static void mw__2E_var (void){
-    WORD_ENTER(mw__2E_var, ".var", "src/mirth/codegen.mth", 450, 19);
-    WORD_ATOM(450, 19, "");
+static void mw_Var_2B_C99_2E_var (void){
+    WORD_ENTER(mw_Var_2B_C99_2E_var, "Var+C99.var", "src/mirth/codegen.mth", 464, 36);
+    WORD_ATOM(464, 36, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18037,32 +21268,32 @@ static void mw__2E_var (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(450, 26, ".");
-    mw__2E_();
-    WORD_ATOM(450, 28, "name");
+    WORD_ATOM(464, 43, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(464, 45, "name");
     mw_Var_2E_name();
-    WORD_ATOM(450, 33, ".name");
-    mw__2E_name();
-    WORD_EXIT(mw__2E_var);
+    WORD_ATOM(464, 50, ".name");
+    mw_Name_2B_C99_2E_name();
+    WORD_EXIT(mw_Var_2B_C99_2E_var);
 }
-static void mw__2E_param (void){
-    WORD_ENTER(mw__2E_param, ".param", "src/mirth/codegen.mth", 451, 23);
-    WORD_ATOM(451, 23, ">Var");
+static void mw_Param_2B_C99_2E_param (void){
+    WORD_ENTER(mw_Param_2B_C99_2E_param, "Param+C99.param", "src/mirth/codegen.mth", 465, 42);
+    WORD_ATOM(465, 42, ">Var");
     mw_Param_3E_Var();
-    WORD_ATOM(451, 28, ".var");
-    mw__2E_var();
-    WORD_EXIT(mw__2E_param);
+    WORD_ATOM(465, 47, ".var");
+    mw_Var_2B_C99_2E_var();
+    WORD_EXIT(mw_Param_2B_C99_2E_param);
 }
 static void mw_c99_pack_ctx_21_ (void){
-    WORD_ENTER(mw_c99_pack_ctx_21_, "c99-pack-ctx!", "src/mirth/codegen.mth", 454, 5);
-    WORD_ATOM(454, 5, "c99-line");
+    WORD_ENTER(mw_c99_pack_ctx_21_, "c99-pack-ctx!", "src/mirth/codegen.mth", 468, 5);
+    WORD_ATOM(468, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_pack_ctx_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(455, 5, "physical-vars");
+    WORD_ATOM(469, 5, "physical-vars");
     mw_Ctx_2E_physical_vars();
-    WORD_ATOM(455, 19, "for");
+    WORD_ATOM(469, 19, "for");
     push_u64(0);
     push_fnptr(&mb_c99_pack_ctx_21__2);
     mw_prim_pack_cons();
@@ -18070,15 +21301,15 @@ static void mw_c99_pack_ctx_21_ (void){
     WORD_EXIT(mw_c99_pack_ctx_21_);
 }
 static void mw_c99_unpack_ctx_21_ (void){
-    WORD_ENTER(mw_c99_unpack_ctx_21_, "c99-unpack-ctx!", "src/mirth/codegen.mth", 461, 5);
-    WORD_ATOM(461, 5, "physical-vars");
+    WORD_ENTER(mw_c99_unpack_ctx_21_, "c99-unpack-ctx!", "src/mirth/codegen.mth", 475, 5);
+    WORD_ATOM(475, 5, "physical-vars");
     mw_Ctx_2E_physical_vars();
-    WORD_ATOM(461, 19, "reverse-for");
+    WORD_ATOM(475, 19, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_c99_unpack_ctx_21__1);
     mw_prim_pack_cons();
     mw_List_2E_reverse_for();
-    WORD_ATOM(465, 5, "c99-line");
+    WORD_ATOM(479, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_unpack_ctx_21__4);
     mw_prim_pack_cons();
@@ -18086,10 +21317,10 @@ static void mw_c99_unpack_ctx_21_ (void){
     WORD_EXIT(mw_c99_unpack_ctx_21_);
 }
 static void mw_c99_decref_ctx_21_ (void){
-    WORD_ENTER(mw_c99_decref_ctx_21_, "c99-decref-ctx!", "src/mirth/codegen.mth", 468, 5);
-    WORD_ATOM(468, 5, "physical-vars");
+    WORD_ENTER(mw_c99_decref_ctx_21_, "c99-decref-ctx!", "src/mirth/codegen.mth", 482, 5);
+    WORD_ATOM(482, 5, "physical-vars");
     mw_Ctx_2E_physical_vars();
-    WORD_ATOM(468, 19, "reverse-for");
+    WORD_ATOM(482, 19, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_c99_decref_ctx_21__1);
     mw_prim_pack_cons();
@@ -18097,34 +21328,34 @@ static void mw_c99_decref_ctx_21_ (void){
     WORD_EXIT(mw_c99_decref_ctx_21_);
 }
 static void mw_c99_block_push_21_ (void){
-    WORD_ENTER(mw_c99_block_push_21_, "c99-block-push!", "src/mirth/codegen.mth", 473, 5);
-    WORD_ATOM(473, 5, "dup");
+    WORD_ENTER(mw_c99_block_push_21_, "c99-block-push!", "src/mirth/codegen.mth", 487, 5);
+    WORD_ATOM(487, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(473, 9, "block-to-run-var");
+    WORD_ATOM(487, 9, "block-to-run-var");
     mw_block_to_run_var();
-    WORD_ATOM(473, 26, "match");
+    WORD_ATOM(487, 26, "match");
     switch (get_top_data_tag()) {
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(474, 17, "nip");
+            co_SOME();
+            WORD_ATOM(488, 17, "nip");
             mw_nip();
-            WORD_ATOM(474, 21, "c99-var-push!");
+            WORD_ATOM(488, 21, "c99-var-push!");
             mw_c99_var_push_21_();
             break;
         case 0LL:
-            mw_prim_drop();
-            WORD_ATOM(476, 13, "dup");
+            co_NONE();
+            WORD_ATOM(490, 13, "dup");
             mw_prim_dup();
-            WORD_ATOM(476, 17, "ctx");
+            WORD_ATOM(490, 17, "ctx");
             mw_Block_2E_ctx();
-            WORD_ATOM(476, 21, "c99-pack-ctx!");
+            WORD_ATOM(490, 21, "c99-pack-ctx!");
             mw_c99_pack_ctx_21_();
-            WORD_ATOM(477, 13, "c99-line");
+            WORD_ATOM(491, 13, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_block_push_21__3);
             mw_prim_pack_cons();
             mw_c99_line();
-            WORD_ATOM(478, 13, "c99-line");
+            WORD_ATOM(492, 13, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_block_push_21__4);
             mw_prim_pack_cons();
@@ -18135,66 +21366,66 @@ static void mw_c99_block_push_21_ (void){
 }    WORD_EXIT(mw_c99_block_push_21_);
 }
 static void mw_c99_var_21_ (void){
-    WORD_ENTER(mw_c99_var_21_, "c99-var!", "src/mirth/codegen.mth", 482, 5);
-    WORD_ATOM(482, 5, "dup");
+    WORD_ENTER(mw_c99_var_21_, "c99-var!", "src/mirth/codegen.mth", 496, 5);
+    WORD_ATOM(496, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(482, 9, "auto-run?");
+    WORD_ATOM(496, 9, "auto-run?");
     mw_Var_2E_auto_run_3F_();
-    WORD_ATOM(482, 19, "if");
+    WORD_ATOM(496, 19, "if");
     if (pop_u64()) {
-        WORD_ATOM(482, 22, "c99-var-run!");
+        WORD_ATOM(496, 22, "c99-var-run!");
         mw_c99_var_run_21_();
     } else {
-        WORD_ATOM(482, 36, "c99-var-push!");
+        WORD_ATOM(496, 36, "c99-var-push!");
         mw_c99_var_push_21_();
     }
     WORD_EXIT(mw_c99_var_21_);
 }
 static void mw_c99_var_run_21_ (void){
-    WORD_ENTER(mw_c99_var_run_21_, "c99-var-run!", "src/mirth/codegen.mth", 485, 5);
-    WORD_ATOM(485, 5, "c99-line");
+    WORD_ENTER(mw_c99_var_run_21_, "c99-var-run!", "src/mirth/codegen.mth", 499, 5);
+    WORD_ATOM(499, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_var_run_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(486, 5, "c99-line");
+    WORD_ATOM(500, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_var_run_21__2);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(487, 5, "drop");
+    WORD_ATOM(501, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_var_run_21_);
 }
 static void mw_c99_var_push_21_ (void){
-    WORD_ENTER(mw_c99_var_push_21_, "c99-var-push!", "src/mirth/codegen.mth", 490, 5);
-    WORD_ATOM(490, 5, "c99-line");
+    WORD_ENTER(mw_c99_var_push_21_, "c99-var-push!", "src/mirth/codegen.mth", 504, 5);
+    WORD_ATOM(504, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_var_push_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(491, 5, "c99-line");
+    WORD_ATOM(505, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_var_push_21__2);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(492, 5, "drop");
+    WORD_ATOM(506, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_var_push_21_);
 }
 static void mw_c99_lambda_21_ (void){
-    WORD_ENTER(mw_c99_lambda_21_, "c99-lambda!", "src/mirth/codegen.mth", 495, 5);
-    WORD_ATOM(495, 5, "c99-line");
+    WORD_ENTER(mw_c99_lambda_21_, "c99-lambda!", "src/mirth/codegen.mth", 509, 5);
+    WORD_ATOM(509, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(496, 5, "c99-nest");
+    WORD_ATOM(510, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(505, 5, "c99-line");
+    WORD_ATOM(519, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__7);
     mw_prim_pack_cons();
@@ -18202,73 +21433,73 @@ static void mw_c99_lambda_21_ (void){
     WORD_EXIT(mw_c99_lambda_21_);
 }
 static void mw_c99_match_21_ (void){
-    WORD_ENTER(mw_c99_match_21_, "c99-match!", "src/mirth/codegen.mth", 508, 5);
-    WORD_ATOM(508, 5, "dup");
+    WORD_ENTER(mw_c99_match_21_, "c99-match!", "src/mirth/codegen.mth", 522, 5);
+    WORD_ATOM(522, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(508, 9, "is-transparent?");
+    WORD_ATOM(522, 9, "is-transparent?");
     mw_Match_2E_is_transparent_3F_();
-    WORD_ATOM(508, 25, "if");
+    WORD_ATOM(522, 25, "if");
     if (pop_u64()) {
-        WORD_ATOM(509, 9, "cases");
+        WORD_ATOM(523, 9, "cases");
         mw_Match_2E_cases();
-        WORD_ATOM(509, 15, "first");
+        WORD_ATOM(523, 15, "first");
         mw_List_2E_first();
-        WORD_ATOM(509, 21, "unwrap");
+        WORD_ATOM(523, 21, "unwrap");
         mw_Maybe_2E_unwrap();
-        WORD_ATOM(509, 28, "body");
+        WORD_ATOM(523, 28, "body");
         mw_Case_2E_body();
-        WORD_ATOM(509, 33, "c99-arrow!");
+        WORD_ATOM(523, 33, "c99-arrow!");
         mw_c99_arrow_21_();
     } else {
-        WORD_ATOM(511, 9, "dup");
+        WORD_ATOM(525, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(511, 13, "scrutinee-data?");
+        WORD_ATOM(525, 13, "scrutinee-data?");
         mw_Match_2E_scrutinee_data_3F_();
-        WORD_ATOM(512, 9, "unwrap-or");
+        WORD_ATOM(526, 9, "unwrap-or");
         push_u64(0);
         push_fnptr(&mb_c99_match_21__3);
         mw_prim_pack_cons();
         mw_Maybe_2E_unwrap_or();
-        WORD_ATOM(513, 9, "is-resource?");
+        WORD_ATOM(527, 9, "is-resource?");
         mw_Data_2E_is_resource_3F_();
-        WORD_ATOM(513, 22, "if");
+        WORD_ATOM(527, 22, "if");
         if (pop_u64()) {
-            WORD_ATOM(514, 13, "c99-line");
+            WORD_ATOM(528, 13, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_match_21__5);
             mw_prim_pack_cons();
             mw_c99_line();
         } else {
-            WORD_ATOM(515, 13, "c99-line");
+            WORD_ATOM(529, 13, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_match_21__7);
             mw_prim_pack_cons();
             mw_c99_line();
         }
-        WORD_ATOM(517, 9, "c99-nest");
+        WORD_ATOM(531, 9, "c99-nest");
         push_u64(0);
         push_fnptr(&mb_c99_match_21__8);
         mw_prim_pack_cons();
         mw_c99_nest();
-        WORD_ATOM(523, 9, "c99-line");
+        WORD_ATOM(537, 9, "c99-line");
         push_u64(0);
         push_fnptr(&mb_c99_match_21__12);
         mw_prim_pack_cons();
         mw_c99_line();
-        WORD_ATOM(523, 22, ".");
-        mw__2E_();
+        WORD_ATOM(537, 22, ".");
+        mw_Str_2B_C99_2E_();
     }
     WORD_EXIT(mw_c99_match_21_);
 }
 static void mw_c99_case_21_ (void){
-    WORD_ENTER(mw_c99_case_21_, "c99-case!", "src/mirth/codegen.mth", 527, 5);
-    WORD_ATOM(527, 5, "dup");
+    WORD_ENTER(mw_c99_case_21_, "c99-case!", "src/mirth/codegen.mth", 541, 5);
+    WORD_ATOM(541, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(527, 9, "pattern");
+    WORD_ATOM(541, 9, "pattern");
     mw_Case_2E_pattern();
-    WORD_ATOM(527, 17, "c99-pattern!");
+    WORD_ATOM(541, 17, "c99-pattern!");
     mw_c99_pattern_21_();
-    WORD_ATOM(528, 5, "c99-nest");
+    WORD_ATOM(542, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_case_21__1);
     mw_prim_pack_cons();
@@ -18276,25 +21507,25 @@ static void mw_c99_case_21_ (void){
     WORD_EXIT(mw_c99_case_21_);
 }
 static void mw_c99_pattern_21_ (void){
-    WORD_ENTER(mw_c99_pattern_21_, "c99-pattern!", "src/mirth/codegen.mth", 534, 5);
-    WORD_ATOM(534, 5, "PATTERN_UNDERSCORE");
+    WORD_ENTER(mw_c99_pattern_21_, "c99-pattern!", "src/mirth/codegen.mth", 548, 5);
+    WORD_ATOM(548, 5, "PATTERN_UNDERSCORE");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
-            WORD_ATOM(535, 9, "c99-line");
+            co_PATTERN_5F_UNDERSCORE();
+            WORD_ATOM(549, 9, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_pattern_21__2);
             mw_prim_pack_cons();
             mw_c99_line();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(538, 9, "c99-line");
+            co_PATTERN_5F_TAG();
+            WORD_ATOM(552, 9, "c99-line");
             push_u64(0);
             push_fnptr(&mb_c99_pattern_21__4);
             mw_prim_pack_cons();
             mw_c99_line();
-            WORD_ATOM(539, 9, "c99-nest");
+            WORD_ATOM(553, 9, "c99-nest");
             push_u64(0);
             push_fnptr(&mb_c99_pattern_21__5);
             mw_prim_pack_cons();
@@ -18305,19 +21536,19 @@ static void mw_c99_pattern_21_ (void){
 }    WORD_EXIT(mw_c99_pattern_21_);
 }
 static void mw_c99_word_sigs_21_ (void){
-    WORD_ENTER(mw_c99_word_sigs_21_, "c99-word-sigs!", "src/mirth/codegen.mth", 548, 25);
-    WORD_ATOM(548, 25, "for-needed-words");
+    WORD_ENTER(mw_c99_word_sigs_21_, "c99-word-sigs!", "src/mirth/codegen.mth", 558, 35);
+    WORD_ATOM(558, 35, "for-needed-words");
     push_u64(0);
     push_fnptr(&mb_c99_word_sigs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_words();
-    WORD_ATOM(548, 57, ".lf");
-    mw__2E_lf();
+    WORD_ATOM(558, 67, ".lf");
+    mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_word_sigs_21_);
 }
 static void mw_c99_word_sig_21_ (void){
-    WORD_ENTER(mw_c99_word_sig_21_, "c99-word-sig!", "src/mirth/codegen.mth", 550, 5);
-    WORD_ATOM(550, 5, "c99-line");
+    WORD_ENTER(mw_c99_word_sig_21_, "c99-word-sig!", "src/mirth/codegen.mth", 560, 5);
+    WORD_ATOM(560, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_sig_21__1);
     mw_prim_pack_cons();
@@ -18325,19 +21556,19 @@ static void mw_c99_word_sig_21_ (void){
     WORD_EXIT(mw_c99_word_sig_21_);
 }
 static void mw_c99_block_sigs_21_ (void){
-    WORD_ENTER(mw_c99_block_sigs_21_, "c99-block-sigs!", "src/mirth/codegen.mth", 552, 26);
-    WORD_ATOM(552, 26, "for-needed-blocks");
+    WORD_ENTER(mw_c99_block_sigs_21_, "c99-block-sigs!", "src/mirth/codegen.mth", 562, 36);
+    WORD_ATOM(562, 36, "for-needed-blocks");
     push_u64(0);
     push_fnptr(&mb_c99_block_sigs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_blocks();
-    WORD_ATOM(552, 60, ".lf");
-    mw__2E_lf();
+    WORD_ATOM(562, 70, ".lf");
+    mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_block_sigs_21_);
 }
 static void mw_c99_block_sig_21_ (void){
-    WORD_ENTER(mw_c99_block_sig_21_, "c99-block-sig!", "src/mirth/codegen.mth", 554, 5);
-    WORD_ATOM(554, 5, "c99-line");
+    WORD_ENTER(mw_c99_block_sig_21_, "c99-block-sig!", "src/mirth/codegen.mth", 564, 5);
+    WORD_ATOM(564, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_sig_21__1);
     mw_prim_pack_cons();
@@ -18345,19 +21576,19 @@ static void mw_c99_block_sig_21_ (void){
     WORD_EXIT(mw_c99_block_sig_21_);
 }
 static void mw_c99_field_sigs_21_ (void){
-    WORD_ENTER(mw_c99_field_sigs_21_, "c99-field-sigs!", "src/mirth/codegen.mth", 556, 26);
-    WORD_ATOM(556, 26, "Field.for");
+    WORD_ENTER(mw_c99_field_sigs_21_, "c99-field-sigs!", "src/mirth/codegen.mth", 566, 36);
+    WORD_ATOM(566, 36, "Field.for");
     push_u64(0);
     push_fnptr(&mb_c99_field_sigs_21__1);
     mw_prim_pack_cons();
     mw_Field_2E_for();
-    WORD_ATOM(556, 52, ".lf");
-    mw__2E_lf();
+    WORD_ATOM(566, 62, ".lf");
+    mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_field_sigs_21_);
 }
 static void mw_c99_field_sig_21_ (void){
-    WORD_ENTER(mw_c99_field_sig_21_, "c99-field-sig!", "src/mirth/codegen.mth", 558, 5);
-    WORD_ATOM(558, 5, "c99-line");
+    WORD_ENTER(mw_c99_field_sig_21_, "c99-field-sig!", "src/mirth/codegen.mth", 568, 5);
+    WORD_ATOM(568, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_field_sig_21__1);
     mw_prim_pack_cons();
@@ -18365,19 +21596,19 @@ static void mw_c99_field_sig_21_ (void){
     WORD_EXIT(mw_c99_field_sig_21_);
 }
 static void mw_c99_block_enter_21_ (void){
-    WORD_ENTER(mw_c99_block_enter_21_, "c99-block-enter!", "src/mirth/codegen.mth", 561, 5);
-    WORD_ATOM(561, 5, "c99-line");
+    WORD_ENTER(mw_c99_block_enter_21_, "c99-block-enter!", "src/mirth/codegen.mth", 571, 5);
+    WORD_ATOM(571, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_enter_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(570, 5, "drop");
+    WORD_ATOM(580, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_block_enter_21_);
 }
 static void mw_c99_block_exit_21_ (void){
-    WORD_ENTER(mw_c99_block_exit_21_, "c99-block-exit!", "src/mirth/codegen.mth", 573, 5);
-    WORD_ATOM(573, 5, "c99-line");
+    WORD_ENTER(mw_c99_block_exit_21_, "c99-block-exit!", "src/mirth/codegen.mth", 583, 5);
+    WORD_ATOM(583, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_exit_21__1);
     mw_prim_pack_cons();
@@ -18385,40 +21616,40 @@ static void mw_c99_block_exit_21_ (void){
     WORD_EXIT(mw_c99_block_exit_21_);
 }
 static void mw_c99_block_defs_21_ (void){
-    WORD_ENTER(mw_c99_block_defs_21_, "c99-block-defs!", "src/mirth/codegen.mth", 575, 26);
-    WORD_ATOM(575, 26, "for-needed-blocks");
+    WORD_ENTER(mw_c99_block_defs_21_, "c99-block-defs!", "src/mirth/codegen.mth", 585, 36);
+    WORD_ATOM(585, 36, "for-needed-blocks");
     push_u64(0);
     push_fnptr(&mb_c99_block_defs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_blocks();
-    WORD_ATOM(575, 60, ".lf");
-    mw__2E_lf();
+    WORD_ATOM(585, 70, ".lf");
+    mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_block_defs_21_);
 }
 static void mw_c99_block_def_21_ (void){
-    WORD_ENTER(mw_c99_block_def_21_, "c99-block-def!", "src/mirth/codegen.mth", 577, 5);
-    WORD_ATOM(577, 5, "c99-line");
+    WORD_ENTER(mw_c99_block_def_21_, "c99-block-def!", "src/mirth/codegen.mth", 587, 5);
+    WORD_ATOM(587, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_def_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(578, 5, "c99-nest");
+    WORD_ATOM(588, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_block_def_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(586, 5, "c99-line");
+    WORD_ATOM(596, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_block_def_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(586, 21, ".lf");
-    mw__2E_lf();
+    WORD_ATOM(596, 21, ".lf");
+    mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_block_def_21_);
 }
-static void mw__2E_block (void){
-    WORD_ENTER(mw__2E_block, ".block", "src/mirth/codegen.mth", 589, 5);
-    WORD_ATOM(589, 5, "");
+static void mw_Block_2B_C99_2E_block (void){
+    WORD_ENTER(mw_Block_2B_C99_2E_block, "Block+C99.block", "src/mirth/codegen.mth", 599, 5);
+    WORD_ATOM(599, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18429,34 +21660,34 @@ static void mw__2E_block (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(589, 11, ".");
-    mw__2E_();
-    WORD_ATOM(590, 5, "dup");
+    WORD_ATOM(599, 11, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(600, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(590, 9, "arrow");
+    WORD_ATOM(600, 9, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(590, 15, "dup");
+    WORD_ATOM(600, 15, "dup");
     mw_prim_dup();
-    WORD_ATOM(590, 19, "home");
+    WORD_ATOM(600, 19, "home");
     mw_Arrow_2E_home();
-    WORD_ATOM(590, 24, "match");
+    WORD_ATOM(600, 24, "match");
     switch (get_top_data_tag()) {
         case 0LL:
+            co_NONE();
+            WORD_ATOM(601, 17, "drop");
             mw_prim_drop();
-            WORD_ATOM(591, 17, "drop");
-            mw_prim_drop();
-            WORD_ATOM(591, 22, "Block.id");
+            WORD_ATOM(601, 22, "Block.id");
             mw_Block_2E_id();
-            WORD_ATOM(591, 31, ".n");
-            mw__2E_n();
+            WORD_ATOM(601, 31, ".n");
+            mw_Int_2B_C99_2E_n();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(593, 13, "name");
+            co_SOME();
+            WORD_ATOM(603, 13, "name");
             mw_Word_2E_name();
-            WORD_ATOM(593, 18, ".name");
-            mw__2E_name();
-            WORD_ATOM(593, 24, "");
+            WORD_ATOM(603, 18, ".name");
+            mw_Name_2B_C99_2E_name();
+            WORD_ATOM(603, 24, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -18467,87 +21698,87 @@ static void mw__2E_block (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(593, 28, ".");
-            mw__2E_();
-            WORD_ATOM(594, 13, "homeidx");
+            WORD_ATOM(603, 28, ".");
+            mw_Str_2B_C99_2E_();
+            WORD_ATOM(604, 13, "homeidx");
             mw_Arrow_2E_homeidx();
-            WORD_ATOM(594, 21, ".n");
-            mw__2E_n();
-            WORD_ATOM(594, 24, "drop");
+            WORD_ATOM(604, 21, ".n");
+            mw_Int_2B_C99_2E_n();
+            WORD_ATOM(604, 24, "drop");
             mw_prim_drop();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
     
-}    WORD_EXIT(mw__2E_block);
+}    WORD_EXIT(mw_Block_2B_C99_2E_block);
 }
 static void mw_c99_word_enter_21_ (void){
-    WORD_ENTER(mw_c99_word_enter_21_, "c99-word-enter!", "src/mirth/codegen.mth", 598, 5);
-    WORD_ATOM(598, 5, "c99-line");
+    WORD_ENTER(mw_c99_word_enter_21_, "c99-word-enter!", "src/mirth/codegen.mth", 608, 5);
+    WORD_ATOM(608, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_enter_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(604, 5, "drop");
+    WORD_ATOM(614, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_word_enter_21_);
 }
 static void mw_c99_word_exit_21_ (void){
-    WORD_ENTER(mw_c99_word_exit_21_, "c99-word-exit!", "src/mirth/codegen.mth", 607, 5);
-    WORD_ATOM(607, 5, "c99-line");
+    WORD_ENTER(mw_c99_word_exit_21_, "c99-word-exit!", "src/mirth/codegen.mth", 617, 5);
+    WORD_ATOM(617, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_exit_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(609, 5, "drop");
+    WORD_ATOM(619, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_word_exit_21_);
 }
 static void mw_c99_word_defs_21_ (void){
-    WORD_ENTER(mw_c99_word_defs_21_, "c99-word-defs!", "src/mirth/codegen.mth", 611, 25);
-    WORD_ATOM(611, 25, "for-needed-words");
+    WORD_ENTER(mw_c99_word_defs_21_, "c99-word-defs!", "src/mirth/codegen.mth", 621, 35);
+    WORD_ATOM(621, 35, "for-needed-words");
     push_u64(0);
     push_fnptr(&mb_c99_word_defs_21__1);
     mw_prim_pack_cons();
     mw_for_needed_words();
-    WORD_ATOM(611, 57, ".lf");
-    mw__2E_lf();
+    WORD_ATOM(621, 67, ".lf");
+    mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_word_defs_21_);
 }
 static void mw_c99_word_def_21_ (void){
-    WORD_ENTER(mw_c99_word_def_21_, "c99-word-def!", "src/mirth/codegen.mth", 613, 5);
-    WORD_ATOM(613, 5, "c99-line");
+    WORD_ENTER(mw_c99_word_def_21_, "c99-word-def!", "src/mirth/codegen.mth", 623, 5);
+    WORD_ATOM(623, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_def_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(614, 5, "c99-nest");
+    WORD_ATOM(624, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_word_def_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(619, 5, "c99-line");
+    WORD_ATOM(629, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_word_def_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(620, 5, "drop");
+    WORD_ATOM(630, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_word_def_21_);
 }
 static void mw_c99_field_defs_21_ (void){
-    WORD_ENTER(mw_c99_field_defs_21_, "c99-field-defs!", "src/mirth/codegen.mth", 622, 26);
-    WORD_ATOM(622, 26, "Field.for");
+    WORD_ENTER(mw_c99_field_defs_21_, "c99-field-defs!", "src/mirth/codegen.mth", 632, 36);
+    WORD_ATOM(632, 36, "Field.for");
     push_u64(0);
     push_fnptr(&mb_c99_field_defs_21__1);
     mw_prim_pack_cons();
     mw_Field_2E_for();
-    WORD_ATOM(622, 52, ".lf");
-    mw__2E_lf();
+    WORD_ATOM(632, 62, ".lf");
+    mw__2B_C99_2E_lf();
     WORD_EXIT(mw_c99_field_defs_21_);
 }
 static void mw_c99_field_def_21_ (void){
-    WORD_ENTER(mw_c99_field_def_21_, "c99-field-def!", "src/mirth/codegen.mth", 624, 5);
-    WORD_ATOM(624, 5, "");
+    WORD_ENTER(mw_c99_field_def_21_, "c99-field-def!", "src/mirth/codegen.mth", 634, 5);
+    WORD_ATOM(634, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18558,15 +21789,15 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(624, 29, ".");
-    mw__2E_();
-    WORD_ATOM(624, 31, "dup");
+    WORD_ATOM(634, 29, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(634, 31, "dup");
     mw_prim_dup();
-    WORD_ATOM(624, 35, "name");
+    WORD_ATOM(634, 35, "name");
     mw_Field_2E_name();
-    WORD_ATOM(624, 40, ".name");
-    mw__2E_name();
-    WORD_ATOM(624, 46, "");
+    WORD_ATOM(634, 40, ".name");
+    mw_Name_2B_C99_2E_name();
+    WORD_ATOM(634, 46, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18577,9 +21808,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(624, 62, ";");
-    mw__3B_();
-    WORD_ATOM(625, 5, "");
+    WORD_ATOM(634, 62, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(635, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18590,9 +21821,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(625, 37, ";");
-    mw__3B_();
-    WORD_ATOM(626, 5, "");
+    WORD_ATOM(635, 37, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(636, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18603,13 +21834,13 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(626, 23, ".");
-    mw__2E_();
-    WORD_ATOM(626, 25, "TABLE_MAX_SIZE");
+    WORD_ATOM(636, 23, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(636, 25, "TABLE_MAX_SIZE");
     mw_TABLE_5F_MAX_5F_SIZE();
-    WORD_ATOM(626, 40, ".n");
-    mw__2E_n();
-    WORD_ATOM(626, 43, "");
+    WORD_ATOM(636, 40, ".n");
+    mw_Int_2B_C99_2E_n();
+    WORD_ATOM(636, 43, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18620,9 +21851,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(626, 47, ";");
-    mw__3B_();
-    WORD_ATOM(627, 5, "");
+    WORD_ATOM(636, 47, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(637, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18633,9 +21864,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(627, 50, ";");
-    mw__3B_();
-    WORD_ATOM(628, 5, "");
+    WORD_ATOM(637, 50, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(638, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18646,9 +21877,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(628, 70, ";");
-    mw__3B_();
-    WORD_ATOM(629, 5, "");
+    WORD_ATOM(638, 70, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(639, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18659,9 +21890,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(629, 23, ";");
-    mw__3B_();
-    WORD_ATOM(630, 5, "");
+    WORD_ATOM(639, 23, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(640, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18672,15 +21903,15 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(630, 9, ";;");
-    mw__3B__3B_();
-    WORD_ATOM(633, 5, "dup");
+    WORD_ATOM(640, 9, ";;");
+    mw_Str_2B_C99_3B__3B_();
+    WORD_ATOM(643, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(633, 9, "name");
+    WORD_ATOM(643, 9, "name");
     mw_Field_2E_name();
-    WORD_ATOM(633, 14, ".w");
-    mw__2E_w();
-    WORD_ATOM(633, 17, "");
+    WORD_ATOM(643, 14, ".w");
+    mw_Name_2B_C99_2E_w();
+    WORD_ATOM(643, 17, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18691,9 +21922,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(633, 21, ";");
-    mw__3B_();
-    WORD_ATOM(634, 5, "");
+    WORD_ATOM(643, 21, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(644, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18704,9 +21935,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(634, 45, ";");
-    mw__3B_();
-    WORD_ATOM(635, 5, "");
+    WORD_ATOM(644, 45, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(645, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18717,15 +21948,15 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(635, 30, ".");
-    mw__2E_();
-    WORD_ATOM(635, 32, "dup");
+    WORD_ATOM(645, 30, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(645, 32, "dup");
     mw_prim_dup();
-    WORD_ATOM(635, 36, "name");
+    WORD_ATOM(645, 36, "name");
     mw_Field_2E_name();
-    WORD_ATOM(635, 41, ".name");
-    mw__2E_name();
-    WORD_ATOM(635, 47, "");
+    WORD_ATOM(645, 41, ".name");
+    mw_Name_2B_C99_2E_name();
+    WORD_ATOM(645, 47, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18736,9 +21967,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(635, 58, ";");
-    mw__3B_();
-    WORD_ATOM(636, 5, "");
+    WORD_ATOM(645, 58, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(646, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18749,9 +21980,9 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(636, 24, ";");
-    mw__3B_();
-    WORD_ATOM(637, 5, "");
+    WORD_ATOM(646, 24, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(647, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18762,25 +21993,25 @@ static void mw_c99_field_def_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(637, 9, ";;");
-    mw__3B__3B_();
-    WORD_ATOM(639, 5, "drop");
+    WORD_ATOM(647, 9, ";;");
+    mw_Str_2B_C99_3B__3B_();
+    WORD_ATOM(649, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_c99_field_def_21_);
 }
 static void mw_c99_main_21_ (void){
-    WORD_ENTER(mw_c99_main_21_, "c99-main!", "src/mirth/codegen.mth", 642, 5);
-    WORD_ATOM(642, 5, "c99-line");
+    WORD_ENTER(mw_c99_main_21_, "c99-main!", "src/mirth/codegen.mth", 652, 5);
+    WORD_ATOM(652, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__1);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(643, 5, "c99-nest");
+    WORD_ATOM(653, 5, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__2);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(656, 5, "c99-line");
+    WORD_ATOM(666, 5, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__8);
     mw_prim_pack_cons();
@@ -18815,8 +22046,7 @@ static void mw_type_elab_holes_allowed (void){
     WORD_ATOM(42, 48, "TYPE_ELAB");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_TYPE_5F_ELAB();
             WORD_ATOM(42, 61, "drop");
             mw_prim_drop();
             break;
@@ -18829,8 +22059,7 @@ static void mw_type_elab_ctx (void){
     WORD_ATOM(43, 37, "TYPE_ELAB");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_TYPE_5F_ELAB();
             WORD_ATOM(43, 50, "nip");
             mw_nip();
             break;
@@ -18853,8 +22082,7 @@ static void mw_type_elab_ctx_replace (void){
     WORD_ATOM(46, 10, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_TYPE_5F_ELAB();
             WORD_ATOM(46, 29, "drop");
             mw_prim_drop();
             WORD_ATOM(46, 34, "swap");
@@ -19044,12 +22272,12 @@ static void mw_elab_type_arg_21_ (void){
     WORD_ATOM(83, 10, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_LEFT();
             WORD_ATOM(84, 17, "swap");
             mw_prim_swap();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_RIGHT();
             WORD_ATOM(85, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(85, 23, "");
@@ -19260,7 +22488,7 @@ static void mw_elab_implicit_var_21_ (void){
     WORD_ATOM(131, 10, "match");
     switch (get_top_data_tag()) {
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_SOME();
             WORD_ATOM(133, 13, "rotr");
             mw_rotr();
             WORD_ATOM(133, 18, "dip2");
@@ -19274,7 +22502,7 @@ static void mw_elab_implicit_var_21_ (void){
             mw_nip();
             break;
         case 0LL:
-            mw_prim_drop();
+            co_NONE();
             WORD_ATOM(136, 13, "dip");
             {
                 VAL d4 = pop_value();
@@ -19352,7 +22580,7 @@ static void mw_elab_type_con_21_ (void){
         WORD_ATOM(149, 31, "match");
         switch (get_top_data_tag()) {
             case 3LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
+                co_DEF_5F_TYPE();
                 WORD_ATOM(151, 17, "over");
                 mw_over();
                 WORD_ATOM(151, 22, "num-args");
@@ -19390,7 +22618,7 @@ static void mw_elab_type_con_21_ (void){
                 }
                 break;
             case 0LL:
-                mw_prim_drop();
+                co_DEF_5F_NONE();
                 WORD_ATOM(160, 17, "dup");
                 mw_prim_dup();
                 WORD_ATOM(160, 21, "");
@@ -19939,7 +23167,7 @@ static void mw_atom_accepts_args_3F_ (void){
     WORD_ATOM(280, 12, "match");
     switch (get_top_data_tag()) {
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_OP_5F_WORD();
             WORD_ATOM(281, 20, "dip");
             {
                 VAL d4 = pop_value();
@@ -19959,11 +23187,11 @@ static void mw_atom_accepts_args_3F_ (void){
             mw_prim_int_lt();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_OP_5F_PRIM();
             WORD_ATOM(283, 13, "match");
             switch (get_top_data_tag()) {
                 case 4LL:
-                    mw_prim_drop();
+                    co_PRIM_5F_CORE_5F_DIP();
                     WORD_ATOM(284, 34, "dup");
                     mw_prim_dup();
                     WORD_ATOM(284, 38, "args");
@@ -19976,7 +23204,7 @@ static void mw_atom_accepts_args_3F_ (void){
                     mw_prim_int_lt();
                     break;
                 case 13LL:
-                    mw_prim_drop();
+                    co_PRIM_5F_CORE_5F_RDIP();
                     WORD_ATOM(285, 35, "dup");
                     mw_prim_dup();
                     WORD_ATOM(285, 39, "args");
@@ -19989,7 +23217,7 @@ static void mw_atom_accepts_args_3F_ (void){
                     mw_prim_int_lt();
                     break;
                 case 5LL:
-                    mw_prim_drop();
+                    co_PRIM_5F_CORE_5F_IF();
                     WORD_ATOM(286, 33, "dup");
                     mw_prim_dup();
                     WORD_ATOM(286, 37, "args");
@@ -20002,7 +23230,7 @@ static void mw_atom_accepts_args_3F_ (void){
                     mw_prim_int_lt();
                     break;
                 case 6LL:
-                    mw_prim_drop();
+                    co_PRIM_5F_CORE_5F_WHILE();
                     WORD_ATOM(287, 36, "dup");
                     mw_prim_dup();
                     WORD_ATOM(287, 40, "args");
@@ -20040,18 +23268,18 @@ static void mw_atoms_has_last_block_3F_ (void){
     WORD_ATOM(294, 14, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_NONE();
             WORD_ATOM(295, 17, "F");
             mw_F();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_SOME();
             WORD_ATOM(297, 13, "op");
             mw_Atom_2E_op();
             WORD_ATOM(297, 16, "match");
             switch (get_top_data_tag()) {
                 case 14LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_OP_5F_BLOCK();
                     WORD_ATOM(298, 29, "drop");
                     mw_prim_drop();
                     WORD_ATOM(298, 34, "T");
@@ -20076,12 +23304,12 @@ static void mw_atoms_turn_last_block_to_arg (void){
     WORD_ATOM(304, 12, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_NONE();
             WORD_ATOM(305, 17, "L0");
             mw_L0();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_SOME();
             WORD_ATOM(307, 13, "unsnoc");
             mw_List_2B__2E_unsnoc();
             WORD_ATOM(307, 20, "dup");
@@ -20091,7 +23319,7 @@ static void mw_atoms_turn_last_block_to_arg (void){
             WORD_ATOM(307, 27, "match");
             switch (get_top_data_tag()) {
                 case 14LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_OP_5F_BLOCK();
                     WORD_ATOM(310, 21, "dip");
                     {
                         VAL d6 = pop_value();
@@ -20143,7 +23371,7 @@ static void mw_arrow_to_run_var (void){
     WORD_ATOM(322, 11, "match");
     switch (get_top_data_tag()) {
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_L1();
             WORD_ATOM(323, 15, "atom-to-run-var");
             mw_atom_to_run_var();
             break;
@@ -20163,7 +23391,7 @@ static void mw_atom_to_run_var (void){
     WORD_ATOM(328, 8, "match");
     switch (get_top_data_tag()) {
         case 13LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_OP_5F_VAR();
             WORD_ATOM(329, 19, "dup");
             mw_prim_dup();
             WORD_ATOM(329, 23, "auto-run?");
@@ -20269,7 +23497,7 @@ static void mw_ab_expand_opsig_21_ (void){
     WORD_ATOM(346, 5, "OPSIG_ID");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_OPSIG_5F_ID();
             WORD_ATOM(346, 17, "ab-type");
             mw_ab_type();
             WORD_ATOM(346, 25, "@");
@@ -20278,7 +23506,7 @@ static void mw_ab_expand_opsig_21_ (void){
             mw_prim_dup();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_OPSIG_5F_PUSH();
             WORD_ATOM(347, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -20294,7 +23522,7 @@ static void mw_ab_expand_opsig_21_ (void){
             mw_STCons();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_OPSIG_5F_APPLY();
             WORD_ATOM(349, 9, "dip");
             {
                 VAL d4 = pop_value();
@@ -20669,12 +23897,12 @@ static void mw_elab_op_fresh_sig_21_ (void){
     WORD_ATOM(416, 20, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_OP_5F_NONE();
             WORD_ATOM(417, 20, "OPSIG_ID");
             mw_OPSIG_5F_ID();
             break;
         case 8LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_OP_5F_INT();
             WORD_ATOM(418, 19, "VALUE_INT");
             mw_VALUE_5F_INT();
             WORD_ATOM(418, 29, "TValue");
@@ -20683,7 +23911,7 @@ static void mw_elab_op_fresh_sig_21_ (void){
             mw_OPSIG_5F_PUSH();
             break;
         case 9LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_OP_5F_STR();
             WORD_ATOM(419, 19, "VALUE_STR");
             mw_VALUE_5F_STR();
             WORD_ATOM(419, 29, "TValue");
@@ -20692,7 +23920,7 @@ static void mw_elab_op_fresh_sig_21_ (void){
             mw_OPSIG_5F_PUSH();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_OP_5F_BUFFER();
             WORD_ATOM(420, 22, "drop");
             mw_prim_drop();
             WORD_ATOM(420, 27, "TYPE_PTR");
@@ -20701,7 +23929,7 @@ static void mw_elab_op_fresh_sig_21_ (void){
             mw_OPSIG_5F_PUSH();
             break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_OP_5F_VARIABLE();
             WORD_ATOM(421, 24, "type");
             mw_Variable_2E_type();
             WORD_ATOM(421, 29, "TMut");
@@ -20710,7 +23938,7 @@ static void mw_elab_op_fresh_sig_21_ (void){
             mw_OPSIG_5F_PUSH();
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_OP_5F_CONSTANT();
             WORD_ATOM(422, 24, "value");
             mw_Constant_2E_value();
             WORD_ATOM(422, 30, "TValue");
@@ -20719,7 +23947,7 @@ static void mw_elab_op_fresh_sig_21_ (void){
             mw_OPSIG_5F_PUSH();
             break;
         case 10LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_OP_5F_TAG();
             WORD_ATOM(423, 19, "type");
             mw_Tag_2E_type();
             WORD_ATOM(423, 24, "freshen-sig");
@@ -20728,7 +23956,7 @@ static void mw_elab_op_fresh_sig_21_ (void){
             mw_OPSIG_5F_APPLY();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_OP_5F_WORD();
             WORD_ATOM(424, 20, "type");
             mw_Word_2E_type();
             WORD_ATOM(424, 25, "freshen-sig");
@@ -20737,7 +23965,7 @@ static void mw_elab_op_fresh_sig_21_ (void){
             mw_OPSIG_5F_APPLY();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_OP_5F_PRIM();
             WORD_ATOM(425, 20, "type");
             mw_Prim_2E_type();
             WORD_ATOM(425, 25, "freshen-sig");
@@ -20746,7 +23974,7 @@ static void mw_elab_op_fresh_sig_21_ (void){
             mw_OPSIG_5F_APPLY();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_OP_5F_EXTERNAL();
             WORD_ATOM(426, 24, "type");
             mw_External_2E_type();
             WORD_ATOM(426, 29, "freshen-sig");
@@ -20755,7 +23983,7 @@ static void mw_elab_op_fresh_sig_21_ (void){
             mw_OPSIG_5F_APPLY();
             break;
         case 7LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_OP_5F_FIELD();
             WORD_ATOM(427, 21, "type");
             mw_Field_2E_type();
             WORD_ATOM(427, 26, "freshen-sig");
@@ -20764,22 +23992,22 @@ static void mw_elab_op_fresh_sig_21_ (void){
             mw_OPSIG_5F_APPLY();
             break;
         case 14LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_OP_5F_BLOCK();
             WORD_ATOM(428, 21, "elab-block-sig!");
             mw_elab_block_sig_21_();
             break;
         case 13LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_OP_5F_VAR();
             WORD_ATOM(429, 19, "elab-var-sig!");
             mw_elab_var_sig_21_();
             break;
         case 11LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_OP_5F_MATCH();
             WORD_ATOM(430, 21, "elab-match-sig!");
             mw_elab_match_sig_21_();
             break;
         case 12LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_OP_5F_LAMBDA();
             WORD_ATOM(431, 22, "elab-lambda-sig!");
             mw_elab_lambda_sig_21_();
             break;
@@ -20862,7 +24090,7 @@ static void mw_elab_word_ctx_type_weak_21_ (void){
     WORD_ATOM(450, 13, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_NONE();
             WORD_ATOM(451, 17, "~ctx-type");
             mw_Word_7E_ctx_type();
             WORD_ATOM(451, 27, "@");
@@ -20870,7 +24098,7 @@ static void mw_elab_word_ctx_type_weak_21_ (void){
             WORD_ATOM(451, 29, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_LAZY_5F_READY();
                     WORD_ATOM(452, 27, "unpack2");
                     mw_unpack2();
                     break;
@@ -20893,7 +24121,7 @@ static void mw_elab_word_ctx_type_weak_21_ (void){
             
 }            break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_SOME();
             WORD_ATOM(455, 17, "drop");
             mw_prim_drop();
             WORD_ATOM(455, 22, "ctx-type");
@@ -20994,29 +24222,29 @@ static void mw_elab_atom_21_ (void){
     WORD_ATOM(482, 22, "match");
     switch (get_top_data_tag()) {
         case 13LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_NAME();
             WORD_ATOM(483, 23, "elab-atom-name!");
             mw_elab_atom_name_21_();
             break;
         case 11LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_INT();
             WORD_ATOM(484, 22, "ab-int!");
             mw_ab_int_21_();
             break;
         case 12LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_STR();
             WORD_ATOM(485, 22, "ab-str!");
             mw_ab_str_21_();
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_LSQUARE();
             WORD_ATOM(486, 26, "drop");
             mw_prim_drop();
             WORD_ATOM(486, 31, "elab-atom-block!");
             mw_elab_atom_block_21_();
             break;
         case 9LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_LCURLY();
             WORD_ATOM(487, 25, "drop");
             mw_prim_drop();
             WORD_ATOM(487, 30, "elab-atom-assert!");
@@ -21110,7 +24338,7 @@ static void mw_elab_atom_name_21_ (void){
     WORD_ATOM(504, 25, "match");
     switch (get_top_data_tag()) {
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_SOME();
             WORD_ATOM(505, 17, "nip");
             mw_nip();
             WORD_ATOM(505, 21, "elab-args!");
@@ -21119,7 +24347,7 @@ static void mw_elab_atom_name_21_ (void){
             mw_ab_var_21_();
             break;
         case 0LL:
-            mw_prim_drop();
+            co_NONE();
             WORD_ATOM(507, 13, "elab-relativize-name!");
             mw_elab_relativize_name_21_();
             WORD_ATOM(508, 13, "elab-check-name-visible!");
@@ -21278,7 +24506,7 @@ static void mw_elab_atom_name_global_21_ (void){
     WORD_ATOM(548, 14, "match");
     switch (get_top_data_tag()) {
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_ALIAS();
             WORD_ATOM(549, 22, "nip");
             mw_nip();
             WORD_ATOM(549, 26, "target");
@@ -21287,7 +24515,7 @@ static void mw_elab_atom_name_global_21_ (void){
             mw_elab_atom_name_global_21_();
             break;
         case 7LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_BUFFER();
             WORD_ATOM(550, 23, "nip");
             mw_nip();
             WORD_ATOM(550, 27, "elab-no-args!");
@@ -21296,7 +24524,7 @@ static void mw_elab_atom_name_global_21_ (void){
             mw_ab_buffer_21_();
             break;
         case 8LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_VARIABLE();
             WORD_ATOM(551, 25, "nip");
             mw_nip();
             WORD_ATOM(551, 29, "elab-no-args!");
@@ -21305,7 +24533,7 @@ static void mw_elab_atom_name_global_21_ (void){
             mw_ab_variable_21_();
             break;
         case 9LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_CONSTANT();
             WORD_ATOM(552, 25, "nip");
             mw_nip();
             WORD_ATOM(552, 29, "elab-no-args!");
@@ -21314,7 +24542,7 @@ static void mw_elab_atom_name_global_21_ (void){
             mw_ab_constant_21_();
             break;
         case 10LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_EXTERNAL();
             WORD_ATOM(553, 25, "nip");
             mw_nip();
             WORD_ATOM(553, 29, "elab-no-args!");
@@ -21323,7 +24551,7 @@ static void mw_elab_atom_name_global_21_ (void){
             mw_ab_external_21_();
             break;
         case 11LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_FIELD();
             WORD_ATOM(554, 22, "nip");
             mw_nip();
             WORD_ATOM(554, 26, "elab-no-args!");
@@ -21332,7 +24560,7 @@ static void mw_elab_atom_name_global_21_ (void){
             mw_ab_field_21_();
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_WORD();
             WORD_ATOM(555, 21, "nip");
             mw_nip();
             WORD_ATOM(555, 25, "elab-args!");
@@ -21341,7 +24569,7 @@ static void mw_elab_atom_name_global_21_ (void){
             mw_ab_word_21_();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_TAG();
             WORD_ATOM(556, 20, "nip");
             mw_nip();
             WORD_ATOM(556, 24, "elab-args!");
@@ -21350,7 +24578,7 @@ static void mw_elab_atom_name_global_21_ (void){
             mw_ab_tag_21_();
             break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_PRIM();
             WORD_ATOM(557, 21, "nip");
             mw_nip();
             WORD_ATOM(557, 25, "elab-prim!");
@@ -21400,12 +24628,12 @@ static void mw_elab_prim_21_ (void){
     WORD_ATOM(566, 5, "match");
     switch (get_top_data_tag()) {
         case 10LL:
-            mw_prim_drop();
+            co_PRIM_5F_CORE_5F_MATCH();
             WORD_ATOM(567, 28, "elab-atom-match!");
             mw_elab_atom_match_21_();
             break;
         case 11LL:
-            mw_prim_drop();
+            co_PRIM_5F_CORE_5F_LAMBDA();
             WORD_ATOM(568, 29, "elab-atom-lambda!");
             mw_elab_atom_lambda_21_();
             break;
@@ -21589,7 +24817,7 @@ static void mw_elab_expand_tensor_21_ (void){
     WORD_ATOM(610, 17, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_STACK_5F_TYPE_5F_ERROR();
             WORD_ATOM(611, 29, "dip");
             {
                 VAL d4 = pop_value();
@@ -21601,13 +24829,12 @@ static void mw_elab_expand_tensor_21_ (void){
             }
             break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STCons();
             WORD_ATOM(612, 19, "rotl");
             mw_rotl();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_STMeta();
             WORD_ATOM(614, 13, "dip");
             {
                 VAL d4 = pop_value();
@@ -22224,7 +25451,7 @@ static void mw_elab_module_import_21_ (void){
     WORD_ATOM(798, 22, "match");
     switch (get_top_data_tag()) {
         case 13LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_NAME();
             WORD_ATOM(800, 13, "dup");
             mw_prim_dup();
             WORD_ATOM(800, 17, ">Def");
@@ -22232,7 +25459,7 @@ static void mw_elab_module_import_21_ (void){
             WORD_ATOM(800, 22, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_DEF_5F_MODULE();
                     WORD_ATOM(802, 21, "dip");
                     {
                         VAL d6 = pop_value();
@@ -22248,7 +25475,7 @@ static void mw_elab_module_import_21_ (void){
                     mw_Module_2E_add_import_21_();
                     break;
                 case 0LL:
-                    mw_prim_drop();
+                    co_DEF_5F_NONE();
                     WORD_ATOM(806, 21, "to-module-path");
                     mw_Name_2E_to_module_path();
                     WORD_ATOM(806, 36, "run-lexer!");
@@ -22515,19 +25742,32 @@ static void mw_elab_data_tag_21_ (void){
     push_fnptr(&mb_elab_data_tag_21__15);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(871, 30, "~num-inputs");
-    mw_Tag_7E_num_inputs();
-    WORD_ATOM(871, 42, "!");
-    mw_prim_mut_set();
+    WORD_ATOM(871, 35, "sip");
+    push_u64(0);
+    push_fnptr(&mb_elab_data_tag_21__16);
+    mw_prim_pack_cons();
+    mw_sip();
+    WORD_ATOM(872, 5, "sip");
+    push_u64(0);
+    push_fnptr(&mb_elab_data_tag_21__17);
+    mw_prim_pack_cons();
+    mw_sip();
+    WORD_ATOM(872, 39, "sip");
+    push_u64(0);
+    push_fnptr(&mb_elab_data_tag_21__18);
+    mw_prim_pack_cons();
+    mw_sip();
+    WORD_ATOM(873, 5, "drop");
+    mw_prim_drop();
     WORD_EXIT(mw_elab_data_tag_21_);
 }
 static void mw_expect_token_arrow (void){
-    WORD_ENTER(mw_expect_token_arrow, "expect-token-arrow", "src/mirth/elab.mth", 874, 5);
-    WORD_ATOM(874, 5, "dup");
+    WORD_ENTER(mw_expect_token_arrow, "expect-token-arrow", "src/mirth/elab.mth", 876, 5);
+    WORD_ATOM(876, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(874, 9, "pat-arrow?");
+    WORD_ATOM(876, 9, "pat-arrow?");
     mw_Token_2E_pat_arrow_3F_();
-    WORD_ATOM(874, 20, "else");
+    WORD_ATOM(876, 20, "else");
     push_u64(0);
     push_fnptr(&mb_expect_token_arrow_1);
     mw_prim_pack_cons();
@@ -22535,27 +25775,27 @@ static void mw_expect_token_arrow (void){
     WORD_EXIT(mw_expect_token_arrow);
 }
 static void mw_token_def_args (void){
-    WORD_ENTER(mw_token_def_args, "token-def-args", "src/mirth/elab.mth", 881, 5);
-    WORD_ATOM(881, 5, "dup");
+    WORD_ENTER(mw_token_def_args, "token-def-args", "src/mirth/elab.mth", 883, 5);
+    WORD_ATOM(883, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(881, 9, "args");
+    WORD_ATOM(883, 9, "args");
     mw_Token_2E_args();
-    WORD_ATOM(881, 14, "dup");
+    WORD_ATOM(883, 14, "dup");
     mw_prim_dup();
-    WORD_ATOM(881, 18, "len");
+    WORD_ATOM(883, 18, "len");
     mw_List_2E_len();
-    WORD_ATOM(881, 22, "");
+    WORD_ATOM(883, 22, "");
     push_i64(2LL);
-    WORD_ATOM(881, 24, ">=");
+    WORD_ATOM(883, 24, ">=");
     mw_Int_3E__3D_();
-    WORD_ATOM(881, 27, "if");
+    WORD_ATOM(883, 27, "if");
     if (pop_u64()) {
-        WORD_ATOM(881, 30, "nip");
+        WORD_ATOM(883, 30, "nip");
         mw_nip();
     } else {
-        WORD_ATOM(882, 9, "drop");
+        WORD_ATOM(884, 9, "drop");
         mw_prim_drop();
-        WORD_ATOM(882, 14, "");
+        WORD_ATOM(884, 14, "");
         {
             static bool vready = false;
             static VAL v;
@@ -22566,24 +25806,24 @@ static void mw_token_def_args (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(882, 51, "emit-fatal-error!");
+        WORD_ATOM(884, 51, "emit-fatal-error!");
         mw_emit_fatal_error_21_();
     }
-    WORD_ATOM(883, 5, ">List+");
-    mw_List_3E_List_2B_();
-    WORD_ATOM(883, 12, "unwrap");
-    mw_Maybe_2E_unwrap();
-    WORD_ATOM(883, 19, "uncons");
-    mw_List_2B__2E_uncons();
-    WORD_ATOM(884, 5, ">List+");
-    mw_List_3E_List_2B_();
-    WORD_ATOM(884, 12, "unwrap");
-    mw_Maybe_2E_unwrap();
-    WORD_ATOM(884, 19, "uncons");
-    mw_List_2B__2E_uncons();
     WORD_ATOM(885, 5, ">List+");
     mw_List_3E_List_2B_();
-    WORD_ATOM(885, 12, "if-some");
+    WORD_ATOM(885, 12, "unwrap");
+    mw_Maybe_2E_unwrap();
+    WORD_ATOM(885, 19, "uncons");
+    mw_List_2B__2E_uncons();
+    WORD_ATOM(886, 5, ">List+");
+    mw_List_3E_List_2B_();
+    WORD_ATOM(886, 12, "unwrap");
+    mw_Maybe_2E_unwrap();
+    WORD_ATOM(886, 19, "uncons");
+    mw_List_2B__2E_uncons();
+    WORD_ATOM(887, 5, ">List+");
+    mw_List_3E_List_2B_();
+    WORD_ATOM(887, 12, "if-some");
     push_u64(0);
     push_fnptr(&mb_token_def_args_3);
     mw_prim_pack_cons();
@@ -22594,126 +25834,126 @@ static void mw_token_def_args (void){
     WORD_EXIT(mw_token_def_args);
 }
 static void mw_elab_alias_21_ (void){
-    WORD_ENTER(mw_elab_alias_21_, "elab-alias!", "src/mirth/elab.mth", 895, 5);
-    WORD_ATOM(895, 5, "sip");
+    WORD_ENTER(mw_elab_alias_21_, "elab-alias!", "src/mirth/elab.mth", 897, 5);
+    WORD_ATOM(897, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_alias_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(895, 15, "args-2");
+    WORD_ATOM(897, 15, "args-2");
     mw_Token_2E_args_2();
-    WORD_ATOM(895, 22, "swap");
+    WORD_ATOM(897, 22, "swap");
     mw_prim_swap();
-    WORD_ATOM(896, 5, "dup");
-    mw_prim_dup();
-    WORD_ATOM(896, 9, "name?");
-    mw_Token_2E_name_3F_();
-    WORD_ATOM(896, 15, "unwrap-or");
-    push_u64(0);
-    push_fnptr(&mb_elab_alias_21__2);
-    mw_prim_pack_cons();
-    mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(896, 65, "dip");
-    {
-        VAL d2 = pop_value();
-        WORD_ATOM(896, 69, "dup");
-        mw_prim_dup();
-        WORD_ATOM(896, 73, "args-0");
-        mw_Token_2E_args_0();
-        push_value(d2);
-    }
-    WORD_ATOM(897, 5, "name-undefined?");
-    mw_name_undefined_3F_();
-    WORD_ATOM(897, 21, "else");
-    push_u64(0);
-    push_fnptr(&mb_elab_alias_21__4);
-    mw_prim_pack_cons();
-    mw_Bool_2E_else();
-    WORD_ATOM(897, 73, "rotl");
-    mw_rotl();
     WORD_ATOM(898, 5, "dup");
     mw_prim_dup();
     WORD_ATOM(898, 9, "name?");
     mw_Token_2E_name_3F_();
     WORD_ATOM(898, 15, "unwrap-or");
     push_u64(0);
-    push_fnptr(&mb_elab_alias_21__5);
+    push_fnptr(&mb_elab_alias_21__2);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
     WORD_ATOM(898, 65, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(898, 69, "args-0");
+        WORD_ATOM(898, 69, "dup");
+        mw_prim_dup();
+        WORD_ATOM(898, 73, "args-0");
         mw_Token_2E_args_0();
         push_value(d2);
     }
-    WORD_ATOM(899, 5, "Alias.new!");
+    WORD_ATOM(899, 5, "name-undefined?");
+    mw_name_undefined_3F_();
+    WORD_ATOM(899, 21, "else");
+    push_u64(0);
+    push_fnptr(&mb_elab_alias_21__4);
+    mw_prim_pack_cons();
+    mw_Bool_2E_else();
+    WORD_ATOM(899, 73, "rotl");
+    mw_rotl();
+    WORD_ATOM(900, 5, "dup");
+    mw_prim_dup();
+    WORD_ATOM(900, 9, "name?");
+    mw_Token_2E_name_3F_();
+    WORD_ATOM(900, 15, "unwrap-or");
+    push_u64(0);
+    push_fnptr(&mb_elab_alias_21__5);
+    mw_prim_pack_cons();
+    mw_Maybe_2E_unwrap_or();
+    WORD_ATOM(900, 65, "dip");
+    {
+        VAL d2 = pop_value();
+        WORD_ATOM(900, 69, "args-0");
+        mw_Token_2E_args_0();
+        push_value(d2);
+    }
+    WORD_ATOM(901, 5, "Alias.new!");
     mw_Alias_2E_new_21_();
-    WORD_ATOM(899, 16, "drop");
+    WORD_ATOM(901, 16, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_alias_21_);
 }
 static void mw_elab_def_missing_21_ (void){
-    WORD_ENTER(mw_elab_def_missing_21_, "elab-def-missing!", "src/mirth/elab.mth", 904, 5);
-    WORD_ATOM(904, 5, "dup");
+    WORD_ENTER(mw_elab_def_missing_21_, "elab-def-missing!", "src/mirth/elab.mth", 906, 5);
+    WORD_ATOM(906, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(904, 9, "succ");
+    WORD_ATOM(906, 9, "succ");
     mw_Token_2E_succ();
-    WORD_ATOM(904, 14, "succ");
+    WORD_ATOM(906, 14, "succ");
     mw_Token_2E_succ();
-    WORD_ATOM(904, 19, "dup");
+    WORD_ATOM(906, 19, "dup");
     mw_prim_dup();
-    WORD_ATOM(904, 23, "name?");
+    WORD_ATOM(906, 23, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(904, 29, "unwrap-or");
+    WORD_ATOM(906, 29, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_def_missing_21__1);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(904, 74, "nip");
+    WORD_ATOM(906, 74, "nip");
     mw_nip();
-    WORD_ATOM(904, 78, "name-defined?");
+    WORD_ATOM(906, 78, "name-defined?");
     mw_name_defined_3F_();
-    WORD_ATOM(904, 92, "nip");
+    WORD_ATOM(906, 92, "nip");
     mw_nip();
-    WORD_ATOM(904, 96, "if");
+    WORD_ATOM(906, 96, "if");
     if (pop_u64()) {
-        WORD_ATOM(905, 9, "next");
+        WORD_ATOM(907, 9, "next");
         mw_Token_2E_next();
     } else {
-        WORD_ATOM(906, 9, "elab-def!");
+        WORD_ATOM(908, 9, "elab-def!");
         mw_elab_def_21_();
     }
     WORD_EXIT(mw_elab_def_missing_21_);
 }
 static void mw_elab_def_21_ (void){
-    WORD_ENTER(mw_elab_def_21_, "elab-def!", "src/mirth/elab.mth", 911, 5);
-    WORD_ATOM(911, 5, "sip");
+    WORD_ENTER(mw_elab_def_21_, "elab-def!", "src/mirth/elab.mth", 913, 5);
+    WORD_ATOM(913, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_def_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(911, 15, "token-def-args");
+    WORD_ATOM(913, 15, "token-def-args");
     mw_token_def_args();
-    WORD_ATOM(912, 5, "uncons");
+    WORD_ATOM(914, 5, "uncons");
     mw_List_2B__2E_uncons();
-    WORD_ATOM(912, 12, "is-empty");
+    WORD_ATOM(914, 12, "is-empty");
     mw_List_2E_is_empty();
-    WORD_ATOM(912, 21, "if");
+    WORD_ATOM(914, 21, "if");
     if (pop_u64()) {
-        WORD_ATOM(912, 24, "id");
+        WORD_ATOM(914, 24, "id");
         mw_prim_id();
     } else {
-        WORD_ATOM(913, 9, "dup");
+        WORD_ATOM(915, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(913, 13, "run-has-arrow?");
+        WORD_ATOM(915, 13, "run-has-arrow?");
         mw_Token_2E_run_has_arrow_3F_();
-        WORD_ATOM(913, 28, "if");
+        WORD_ATOM(915, 28, "if");
         if (pop_u64()) {
-            WORD_ATOM(913, 31, "id");
+            WORD_ATOM(915, 31, "id");
             mw_prim_id();
         } else {
-            WORD_ATOM(914, 13, "");
+            WORD_ATOM(916, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -22724,31 +25964,31 @@ static void mw_elab_def_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(914, 35, "emit-fatal-error!");
+            WORD_ATOM(916, 35, "emit-fatal-error!");
             mw_emit_fatal_error_21_();
         }
     }
-    WORD_ATOM(915, 5, "rotl");
+    WORD_ATOM(917, 5, "rotl");
     mw_rotl();
-    WORD_ATOM(915, 10, "dup");
+    WORD_ATOM(917, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(915, 14, "name?");
+    WORD_ATOM(917, 14, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(915, 20, "unwrap-or");
+    WORD_ATOM(917, 20, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_def_21__6);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(916, 5, "name-undefined?");
+    WORD_ATOM(918, 5, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(916, 21, "if");
+    WORD_ATOM(918, 21, "if");
     if (pop_u64()) {
-        WORD_ATOM(916, 24, "id");
+        WORD_ATOM(918, 24, "id");
         mw_prim_id();
     } else {
-        WORD_ATOM(916, 28, "drop");
+        WORD_ATOM(918, 28, "drop");
         mw_prim_drop();
-        WORD_ATOM(916, 33, "");
+        WORD_ATOM(918, 33, "");
         {
             static bool vready = false;
             static VAL v;
@@ -22759,453 +25999,453 @@ static void mw_elab_def_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(916, 56, "emit-fatal-error!");
+        WORD_ATOM(918, 56, "emit-fatal-error!");
         mw_emit_fatal_error_21_();
     }
-    WORD_ATOM(918, 5, "Word.new!");
+    WORD_ATOM(920, 5, "Word.new!");
     mw_Word_2E_new_21_();
-    WORD_ATOM(919, 5, "tuck");
+    WORD_ATOM(921, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(919, 10, "~sig");
+    WORD_ATOM(921, 10, "~sig");
     mw_Word_7E_sig();
-    WORD_ATOM(919, 15, "!");
+    WORD_ATOM(921, 15, "!");
     mw_prim_mut_set();
-    WORD_ATOM(921, 5, "dup");
+    WORD_ATOM(923, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(921, 9, "delay");
+    WORD_ATOM(923, 9, "delay");
     push_u64(0);
     push_fnptr(&mb_elab_def_21__9);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(926, 7, "over");
+    WORD_ATOM(928, 7, "over");
     mw_over();
-    WORD_ATOM(926, 12, "~ctx-type");
+    WORD_ATOM(928, 12, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(926, 22, "!");
+    WORD_ATOM(928, 22, "!");
     mw_prim_mut_set();
-    WORD_ATOM(927, 5, "dup");
+    WORD_ATOM(929, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(927, 9, "delay");
+    WORD_ATOM(929, 9, "delay");
     push_u64(0);
     push_fnptr(&mb_elab_def_21__12);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(927, 33, "over");
+    WORD_ATOM(929, 33, "over");
     mw_over();
-    WORD_ATOM(927, 38, "~params");
+    WORD_ATOM(929, 38, "~params");
     mw_Word_7E_params();
-    WORD_ATOM(927, 46, "!");
+    WORD_ATOM(929, 46, "!");
     mw_prim_mut_set();
-    WORD_ATOM(928, 5, "dup");
+    WORD_ATOM(930, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(928, 9, "delay");
+    WORD_ATOM(930, 9, "delay");
     push_u64(0);
     push_fnptr(&mb_elab_def_21__13);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(935, 7, "swap");
+    WORD_ATOM(937, 7, "swap");
     mw_prim_swap();
-    WORD_ATOM(935, 12, "~arrow");
+    WORD_ATOM(937, 12, "~arrow");
     mw_Word_7E_arrow();
-    WORD_ATOM(935, 19, "!");
+    WORD_ATOM(937, 19, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_elab_def_21_);
 }
 static void mw_elab_def_params_21_ (void){
-    WORD_ENTER(mw_elab_def_params_21_, "elab-def-params!", "src/mirth/elab.mth", 939, 5);
-    WORD_ATOM(939, 5, "L0");
+    WORD_ENTER(mw_elab_def_params_21_, "elab-def-params!", "src/mirth/elab.mth", 941, 5);
+    WORD_ATOM(941, 5, "L0");
     mw_L0();
-    WORD_ATOM(939, 8, "over");
+    WORD_ATOM(941, 8, "over");
     mw_over();
-    WORD_ATOM(939, 13, "elab-word-ctx-type-weak!");
+    WORD_ATOM(941, 13, "elab-word-ctx-type-weak!");
     mw_elab_word_ctx_type_weak_21_();
-    WORD_ATOM(939, 38, "nip");
+    WORD_ATOM(941, 38, "nip");
     mw_nip();
-    WORD_ATOM(940, 5, "rotl");
+    WORD_ATOM(942, 5, "rotl");
     mw_rotl();
-    WORD_ATOM(940, 10, "head");
+    WORD_ATOM(942, 10, "head");
     mw_Word_2E_head();
-    WORD_ATOM(940, 15, "dip");
+    WORD_ATOM(942, 15, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(940, 19, "unpack");
+        WORD_ATOM(942, 19, "unpack");
         mw_ArrowType_2E_unpack();
         push_value(d2);
     }
-    WORD_ATOM(940, 27, "nip");
+    WORD_ATOM(942, 27, "nip");
     mw_nip();
-    WORD_ATOM(941, 5, "args");
+    WORD_ATOM(943, 5, "args");
     mw_Token_2E_args();
-    WORD_ATOM(941, 10, "reverse-for");
+    WORD_ATOM(943, 10, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_elab_def_params_21__2);
     mw_prim_pack_cons();
     mw_List_2E_reverse_for();
-    WORD_ATOM(949, 7, "drop");
+    WORD_ATOM(951, 7, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_def_params_21_);
 }
 static void mw_elab_def_body_21_ (void){
-    WORD_ENTER(mw_elab_def_body_21_, "elab-def-body!", "src/mirth/elab.mth", 954, 5);
-    WORD_ATOM(954, 5, "ab-token");
+    WORD_ENTER(mw_elab_def_body_21_, "elab-def-body!", "src/mirth/elab.mth", 956, 5);
+    WORD_ATOM(956, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(954, 14, "@");
+    WORD_ATOM(956, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(954, 16, "run-has-arrow?");
+    WORD_ATOM(956, 16, "run-has-arrow?");
     mw_Token_2E_run_has_arrow_3F_();
-    WORD_ATOM(954, 31, "if");
+    WORD_ATOM(956, 31, "if");
     if (pop_u64()) {
-        WORD_ATOM(955, 9, "dup");
+        WORD_ATOM(957, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(955, 13, "ab-token");
+        WORD_ATOM(957, 13, "ab-token");
         mw_ab_token();
-        WORD_ATOM(955, 22, "@");
+        WORD_ATOM(957, 22, "@");
         mw_prim_mut_get();
-        WORD_ATOM(955, 24, "elab-match-at!");
+        WORD_ATOM(957, 24, "elab-match-at!");
         mw_elab_match_at_21_();
     } else {
-        WORD_ATOM(956, 9, "elab-atoms!");
+        WORD_ATOM(958, 9, "elab-atoms!");
         mw_elab_atoms_21_();
     }
     WORD_EXIT(mw_elab_def_body_21_);
 }
 static void mw_elab_def_external_21_ (void){
-    WORD_ENTER(mw_elab_def_external_21_, "elab-def-external!", "src/mirth/elab.mth", 961, 5);
-    WORD_ATOM(961, 5, "sip");
+    WORD_ENTER(mw_elab_def_external_21_, "elab-def-external!", "src/mirth/elab.mth", 963, 5);
+    WORD_ATOM(963, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_def_external_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(961, 15, "args-2");
+    WORD_ATOM(963, 15, "args-2");
     mw_Token_2E_args_2();
-    WORD_ATOM(962, 5, "swap");
+    WORD_ATOM(964, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(962, 10, "dup");
+    WORD_ATOM(964, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(962, 14, "name?");
+    WORD_ATOM(964, 14, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(962, 20, "unwrap-or");
+    WORD_ATOM(964, 20, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_def_external_21__2);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(963, 5, "name-undefined?");
+    WORD_ATOM(965, 5, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(963, 21, "else");
+    WORD_ATOM(965, 21, "else");
     push_u64(0);
     push_fnptr(&mb_elab_def_external_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(964, 5, "nip");
+    WORD_ATOM(966, 5, "nip");
     mw_nip();
-    WORD_ATOM(965, 5, "External.alloc!");
+    WORD_ATOM(967, 5, "External.alloc!");
     mw_External_2E_alloc_21_();
-    WORD_ATOM(966, 5, "dup2");
+    WORD_ATOM(968, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(966, 10, "DEF_EXTERNAL");
+    WORD_ATOM(968, 10, "DEF_EXTERNAL");
     mw_DEF_5F_EXTERNAL();
-    WORD_ATOM(966, 23, "swap");
+    WORD_ATOM(968, 23, "swap");
     mw_prim_swap();
-    WORD_ATOM(966, 28, "~Def");
+    WORD_ATOM(968, 28, "~Def");
     mw_Name_7E_Def();
-    WORD_ATOM(966, 33, "!");
+    WORD_ATOM(968, 33, "!");
     mw_prim_mut_set();
-    WORD_ATOM(967, 5, "tuck");
+    WORD_ATOM(969, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(967, 10, "~name");
+    WORD_ATOM(969, 10, "~name");
     mw_External_7E_name();
-    WORD_ATOM(967, 16, "!");
+    WORD_ATOM(969, 16, "!");
     mw_prim_mut_set();
-    WORD_ATOM(968, 5, "tuck");
+    WORD_ATOM(970, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(968, 10, "~sig");
+    WORD_ATOM(970, 10, "~sig");
     mw_External_7E_sig();
-    WORD_ATOM(968, 15, "!");
+    WORD_ATOM(970, 15, "!");
     mw_prim_mut_set();
-    WORD_ATOM(969, 5, "dup");
+    WORD_ATOM(971, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(969, 9, "delay");
+    WORD_ATOM(971, 9, "delay");
     push_u64(0);
     push_fnptr(&mb_elab_def_external_21__4);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(972, 7, "swap");
+    WORD_ATOM(974, 7, "swap");
     mw_prim_swap();
-    WORD_ATOM(972, 12, "~ctx-type");
+    WORD_ATOM(974, 12, "~ctx-type");
     mw_External_7E_ctx_type();
-    WORD_ATOM(972, 22, "!");
+    WORD_ATOM(974, 22, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_elab_def_external_21_);
 }
 static void mw_elab_def_type_21_ (void){
-    WORD_ENTER(mw_elab_def_type_21_, "elab-def-type!", "src/mirth/elab.mth", 976, 5);
-    WORD_ATOM(976, 5, "sip");
+    WORD_ENTER(mw_elab_def_type_21_, "elab-def-type!", "src/mirth/elab.mth", 978, 5);
+    WORD_ATOM(978, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_def_type_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(976, 15, "args-2");
+    WORD_ATOM(978, 15, "args-2");
     mw_Token_2E_args_2();
-    WORD_ATOM(977, 5, "swap");
+    WORD_ATOM(979, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(977, 10, "dup");
+    WORD_ATOM(979, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(977, 14, "sig-type-con?");
+    WORD_ATOM(979, 14, "sig-type-con?");
     mw_Token_2E_sig_type_con_3F_();
-    WORD_ATOM(977, 28, "else");
+    WORD_ATOM(979, 28, "else");
     push_u64(0);
     push_fnptr(&mb_elab_def_type_21__2);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(978, 5, "dup");
+    WORD_ATOM(980, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(978, 9, "name?");
+    WORD_ATOM(980, 9, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(978, 15, "unwrap");
+    WORD_ATOM(980, 15, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(978, 22, "name-undefined?");
+    WORD_ATOM(980, 22, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(978, 38, "else");
+    WORD_ATOM(980, 38, "else");
     push_u64(0);
     push_fnptr(&mb_elab_def_type_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(979, 5, "nip");
+    WORD_ATOM(981, 5, "nip");
     mw_nip();
-    WORD_ATOM(979, 9, "swap");
+    WORD_ATOM(981, 9, "swap");
     mw_prim_swap();
-    WORD_ATOM(979, 14, "elab-simple-type-arg!");
+    WORD_ATOM(981, 14, "elab-simple-type-arg!");
     mw_elab_simple_type_arg_21_();
-    WORD_ATOM(979, 36, "DEF_TYPE");
+    WORD_ATOM(981, 36, "DEF_TYPE");
     mw_DEF_5F_TYPE();
-    WORD_ATOM(979, 45, "swap");
+    WORD_ATOM(981, 45, "swap");
     mw_prim_swap();
-    WORD_ATOM(979, 50, "~Def");
+    WORD_ATOM(981, 50, "~Def");
     mw_Name_7E_Def();
-    WORD_ATOM(979, 55, "!");
+    WORD_ATOM(981, 55, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_elab_def_type_21_);
 }
 static void mw_elab_buffer_21_ (void){
-    WORD_ENTER(mw_elab_buffer_21_, "elab-buffer!", "src/mirth/elab.mth", 983, 5);
-    WORD_ATOM(983, 5, "sip");
+    WORD_ENTER(mw_elab_buffer_21_, "elab-buffer!", "src/mirth/elab.mth", 985, 5);
+    WORD_ATOM(985, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_buffer_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(983, 15, "args-2");
+    WORD_ATOM(985, 15, "args-2");
     mw_Token_2E_args_2();
-    WORD_ATOM(984, 5, "swap");
+    WORD_ATOM(986, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(984, 10, "dup");
+    WORD_ATOM(986, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(984, 14, "name?");
+    WORD_ATOM(986, 14, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(984, 20, "unwrap-or");
+    WORD_ATOM(986, 20, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_buffer_21__2);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(985, 5, "name-undefined?");
+    WORD_ATOM(987, 5, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(985, 21, "else");
+    WORD_ATOM(987, 21, "else");
     push_u64(0);
     push_fnptr(&mb_elab_buffer_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(986, 5, "rotl");
+    WORD_ATOM(988, 5, "rotl");
     mw_rotl();
-    WORD_ATOM(986, 10, "dup");
+    WORD_ATOM(988, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(986, 14, "int?");
+    WORD_ATOM(988, 14, "int?");
     mw_Token_2E_int_3F_();
-    WORD_ATOM(986, 19, "unwrap-or");
+    WORD_ATOM(988, 19, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_buffer_21__4);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(986, 71, "nip");
+    WORD_ATOM(988, 71, "nip");
     mw_nip();
-    WORD_ATOM(987, 5, "Buffer.new!");
+    WORD_ATOM(989, 5, "Buffer.new!");
     mw_Buffer_2E_new_21_();
-    WORD_ATOM(987, 17, "drop");
+    WORD_ATOM(989, 17, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_buffer_21_);
 }
 static void mw_elab_variable_21_ (void){
-    WORD_ENTER(mw_elab_variable_21_, "elab-variable!", "src/mirth/elab.mth", 991, 5);
-    WORD_ATOM(991, 5, "sip");
+    WORD_ENTER(mw_elab_variable_21_, "elab-variable!", "src/mirth/elab.mth", 993, 5);
+    WORD_ATOM(993, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_variable_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(991, 15, "args-2");
+    WORD_ATOM(993, 15, "args-2");
     mw_Token_2E_args_2();
-    WORD_ATOM(992, 5, "swap");
+    WORD_ATOM(994, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(992, 10, "dup");
+    WORD_ATOM(994, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(992, 14, "name?");
+    WORD_ATOM(994, 14, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(992, 20, "unwrap-or");
+    WORD_ATOM(994, 20, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_variable_21__2);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(993, 5, "name-undefined?");
+    WORD_ATOM(995, 5, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(993, 21, "else");
+    WORD_ATOM(995, 21, "else");
     push_u64(0);
     push_fnptr(&mb_elab_variable_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(994, 5, "rotl");
+    WORD_ATOM(996, 5, "rotl");
     mw_rotl();
-    WORD_ATOM(994, 10, "delay");
+    WORD_ATOM(996, 10, "delay");
     push_u64(0);
     push_fnptr(&mb_elab_variable_21__4);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(995, 5, "Variable.new!");
+    WORD_ATOM(997, 5, "Variable.new!");
     mw_Variable_2E_new_21_();
-    WORD_ATOM(995, 19, "drop");
+    WORD_ATOM(997, 19, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_variable_21_);
 }
 static void mw_elab_table_21_ (void){
-    WORD_ENTER(mw_elab_table_21_, "elab-table!", "src/mirth/elab.mth", 999, 5);
-    WORD_ATOM(999, 5, "sip");
+    WORD_ENTER(mw_elab_table_21_, "elab-table!", "src/mirth/elab.mth", 1001, 5);
+    WORD_ATOM(1001, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_table_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(999, 15, "args-1");
+    WORD_ATOM(1001, 15, "args-1");
     mw_Token_2E_args_1();
-    WORD_ATOM(1000, 5, "dup");
+    WORD_ATOM(1002, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1000, 9, "sig-type-con?");
+    WORD_ATOM(1002, 9, "sig-type-con?");
     mw_Token_2E_sig_type_con_3F_();
-    WORD_ATOM(1000, 23, "else");
+    WORD_ATOM(1002, 23, "else");
     push_u64(0);
     push_fnptr(&mb_elab_table_21__2);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(1001, 5, "dup");
+    WORD_ATOM(1003, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1001, 9, "name?");
+    WORD_ATOM(1003, 9, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(1001, 15, "unwrap");
+    WORD_ATOM(1003, 15, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(1001, 22, "name-undefined?");
+    WORD_ATOM(1003, 22, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(1001, 38, "else");
+    WORD_ATOM(1003, 38, "else");
     push_u64(0);
     push_fnptr(&mb_elab_table_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(1002, 5, "table-new!");
+    WORD_ATOM(1004, 5, "table-new!");
     mw_table_new_21_();
-    WORD_ATOM(1002, 16, "drop");
+    WORD_ATOM(1004, 16, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_table_21_);
 }
 static void mw_elab_target_c99_21_ (void){
-    WORD_ENTER(mw_elab_target_c99_21_, "elab-target-c99!", "src/mirth/elab.mth", 1006, 5);
-    WORD_ATOM(1006, 5, "typecheck-everything!");
+    WORD_ENTER(mw_elab_target_c99_21_, "elab-target-c99!", "src/mirth/elab.mth", 1008, 5);
+    WORD_ATOM(1008, 5, "typecheck-everything!");
     mw_typecheck_everything_21_();
-    WORD_ATOM(1007, 5, "sip");
+    WORD_ATOM(1009, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_target_c99_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(1007, 15, "args-2");
+    WORD_ATOM(1009, 15, "args-2");
     mw_Token_2E_args_2();
-    WORD_ATOM(1008, 5, "dip");
+    WORD_ATOM(1010, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(1008, 9, "dup");
+        WORD_ATOM(1010, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(1008, 13, "str?");
+        WORD_ATOM(1010, 13, "str?");
         mw_Token_2E_str_3F_();
-        WORD_ATOM(1008, 18, "unwrap-or");
+        WORD_ATOM(1010, 18, "unwrap-or");
         push_u64(0);
         push_fnptr(&mb_elab_target_c99_21__3);
         mw_prim_pack_cons();
         mw_Maybe_2E_unwrap_or();
-        WORD_ATOM(1008, 70, "nip");
+        WORD_ATOM(1010, 70, "nip");
         mw_nip();
-        WORD_ATOM(1008, 74, ">Path");
+        WORD_ATOM(1010, 74, ">Path");
         mw_Str_3E_Path();
         push_value(d2);
     }
-    WORD_ATOM(1009, 5, "dip");
+    WORD_ATOM(1011, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(1009, 9, "CTX0");
+        WORD_ATOM(1011, 9, "CTX0");
         mw_CTX0();
-        WORD_ATOM(1009, 14, "T0");
+        WORD_ATOM(1011, 14, "T0");
         mw_T0();
-        WORD_ATOM(1009, 17, "RESOURCE_+PLATFORM");
+        WORD_ATOM(1011, 17, "RESOURCE_+PLATFORM");
         mw_RESOURCE_5F__2B_PLATFORM();
-        WORD_ATOM(1009, 36, "T+");
+        WORD_ATOM(1011, 36, "T+");
         mw_T_2B_();
-        WORD_ATOM(1009, 39, "T0");
+        WORD_ATOM(1011, 39, "T0");
         mw_T0();
-        WORD_ATOM(1009, 42, "RESOURCE_+PLATFORM");
+        WORD_ATOM(1011, 42, "RESOURCE_+PLATFORM");
         mw_RESOURCE_5F__2B_PLATFORM();
-        WORD_ATOM(1009, 61, "T+");
+        WORD_ATOM(1011, 61, "T+");
         mw_T_2B_();
-        WORD_ATOM(1009, 64, "T->");
+        WORD_ATOM(1011, 64, "T->");
         mw_T__3E_();
         push_value(d2);
     }
-    WORD_ATOM(1010, 5, "elab-arrow!");
+    WORD_ATOM(1012, 5, "elab-arrow!");
     mw_elab_arrow_21_();
-    WORD_ATOM(1011, 5, "swap");
+    WORD_ATOM(1013, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(1011, 10, "run-output-c99!");
+    WORD_ATOM(1013, 10, "run-output-c99!");
     mw_run_output_c99_21_();
     WORD_EXIT(mw_elab_target_c99_21_);
 }
 static void mw_elab_embed_str_21_ (void){
-    WORD_ENTER(mw_elab_embed_str_21_, "elab-embed-str!", "src/mirth/elab.mth", 1016, 5);
-    WORD_ATOM(1016, 5, "sip");
+    WORD_ENTER(mw_elab_embed_str_21_, "elab-embed-str!", "src/mirth/elab.mth", 1018, 5);
+    WORD_ATOM(1018, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_embed_str_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(1016, 15, "args-2");
+    WORD_ATOM(1018, 15, "args-2");
     mw_Token_2E_args_2();
-    WORD_ATOM(1016, 22, "swap");
+    WORD_ATOM(1018, 22, "swap");
     mw_prim_swap();
-    WORD_ATOM(1017, 5, "dup");
+    WORD_ATOM(1019, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1017, 9, "name?");
+    WORD_ATOM(1019, 9, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(1017, 15, "unwrap-or");
+    WORD_ATOM(1019, 15, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_embed_str_21__2);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(1018, 5, "name-undefined?");
+    WORD_ATOM(1020, 5, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(1018, 21, "else");
+    WORD_ATOM(1020, 21, "else");
     push_u64(0);
     push_fnptr(&mb_elab_embed_str_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(1019, 5, "rotl");
+    WORD_ATOM(1021, 5, "rotl");
     mw_rotl();
-    WORD_ATOM(1019, 10, "dup");
+    WORD_ATOM(1021, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(1019, 14, "str?");
+    WORD_ATOM(1021, 14, "str?");
     mw_Token_2E_str_3F_();
-    WORD_ATOM(1019, 19, "unwrap-or");
+    WORD_ATOM(1021, 19, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_embed_str_21__4);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(1020, 5, "with-open-file!");
+    WORD_ATOM(1022, 5, "with-open-file!");
     push_u64(0);
     push_fnptr(&mb_elab_embed_str_21__5);
     mw_prim_pack_cons();
@@ -23213,22 +26453,22 @@ static void mw_elab_embed_str_21_ (void){
     push_fnptr(&mb_elab_embed_str_21__6);
     mw_prim_pack_cons();
     mw_with_open_file_21_();
-    WORD_ATOM(1021, 5, "VALUE_STR");
+    WORD_ATOM(1023, 5, "VALUE_STR");
     mw_VALUE_5F_STR();
-    WORD_ATOM(1021, 15, "Constant.new!");
+    WORD_ATOM(1023, 15, "Constant.new!");
     mw_Constant_2E_new_21_();
-    WORD_ATOM(1021, 29, "drop");
+    WORD_ATOM(1023, 29, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_embed_str_21_);
 }
 static void mw_typecheck_everything_21_ (void){
-    WORD_ENTER(mw_typecheck_everything_21_, "typecheck-everything!", "src/mirth/elab.mth", 1025, 5);
-    WORD_ATOM(1025, 5, "Name.for");
+    WORD_ENTER(mw_typecheck_everything_21_, "typecheck-everything!", "src/mirth/elab.mth", 1027, 5);
+    WORD_ATOM(1027, 5, "Name.for");
     push_u64(0);
     push_fnptr(&mb_typecheck_everything_21__1);
     mw_prim_pack_cons();
     mw_Name_2E_for();
-    WORD_ATOM(1026, 5, "Block.for");
+    WORD_ATOM(1028, 5, "Block.for");
     push_u64(0);
     push_fnptr(&mb_typecheck_everything_21__2);
     mw_prim_pack_cons();
@@ -23236,75 +26476,75 @@ static void mw_typecheck_everything_21_ (void){
     WORD_EXIT(mw_typecheck_everything_21_);
 }
 static void mw_TABLE_5F_MAX_5F_SIZE (void){
-    WORD_ENTER(mw_TABLE_5F_MAX_5F_SIZE, "TABLE_MAX_SIZE", "src/mirth/elab.mth", 1032, 26);
-    WORD_ATOM(1032, 26, "");
+    WORD_ENTER(mw_TABLE_5F_MAX_5F_SIZE, "TABLE_MAX_SIZE", "src/mirth/elab.mth", 1034, 26);
+    WORD_ATOM(1034, 26, "");
     push_i64(65536LL);
     WORD_EXIT(mw_TABLE_5F_MAX_5F_SIZE);
 }
 static void mw_table_word_new_21_ (void){
-    WORD_ENTER(mw_table_word_new_21_, "table-word-new!", "src/mirth/elab.mth", 1035, 5);
-    WORD_ATOM(1035, 5, "dip");
+    WORD_ENTER(mw_table_word_new_21_, "table-word-new!", "src/mirth/elab.mth", 1037, 5);
+    WORD_ATOM(1037, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(1035, 9, "dup");
+        WORD_ATOM(1037, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(1035, 13, "head");
+        WORD_ATOM(1037, 13, "head");
         mw_Table_2E_head();
-        WORD_ATOM(1035, 18, "dup");
+        WORD_ATOM(1037, 18, "dup");
         mw_prim_dup();
-        WORD_ATOM(1035, 22, "rotl");
+        WORD_ATOM(1037, 22, "rotl");
         mw_rotl();
-        WORD_ATOM(1035, 27, "name");
+        WORD_ATOM(1037, 27, "name");
         mw_Table_2E_name();
         push_value(d2);
     }
-    WORD_ATOM(1035, 33, "Name.cat");
+    WORD_ATOM(1037, 33, "Name.cat");
     mw_Name_2E_cat();
-    WORD_ATOM(1035, 42, "Word.new!");
+    WORD_ATOM(1037, 42, "Word.new!");
     mw_Word_2E_new_21_();
     WORD_EXIT(mw_table_word_new_21_);
 }
 static void mw_table_new_21_ (void){
-    WORD_ENTER(mw_table_new_21_, "table-new!", "src/mirth/elab.mth", 1038, 5);
-    WORD_ATOM(1038, 5, "Table.alloc!");
+    WORD_ENTER(mw_table_new_21_, "table-new!", "src/mirth/elab.mth", 1040, 5);
+    WORD_ATOM(1040, 5, "Table.alloc!");
     mw_Table_2E_alloc_21_();
-    WORD_ATOM(1039, 5, "tuck");
+    WORD_ATOM(1041, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(1039, 10, "~name");
+    WORD_ATOM(1041, 10, "~name");
     mw_Table_7E_name();
-    WORD_ATOM(1039, 16, "!");
+    WORD_ATOM(1041, 16, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1040, 5, "tuck");
+    WORD_ATOM(1042, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(1040, 10, "~head");
+    WORD_ATOM(1042, 10, "~head");
     mw_Table_7E_head();
-    WORD_ATOM(1040, 16, "!");
+    WORD_ATOM(1042, 16, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1041, 5, "TABLE_MAX_SIZE");
+    WORD_ATOM(1043, 5, "TABLE_MAX_SIZE");
     mw_TABLE_5F_MAX_5F_SIZE();
-    WORD_ATOM(1041, 20, "over");
+    WORD_ATOM(1043, 20, "over");
     mw_over();
-    WORD_ATOM(1041, 25, "~max-count");
+    WORD_ATOM(1043, 25, "~max-count");
     mw_Table_7E_max_count();
-    WORD_ATOM(1041, 36, "!");
+    WORD_ATOM(1043, 36, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1042, 5, "dup");
+    WORD_ATOM(1044, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1042, 9, "TTable");
+    WORD_ATOM(1044, 9, "TTable");
     mw_TTable();
-    WORD_ATOM(1042, 16, "DEF_TYPE");
+    WORD_ATOM(1044, 16, "DEF_TYPE");
     mw_DEF_5F_TYPE();
-    WORD_ATOM(1042, 25, "over");
+    WORD_ATOM(1044, 25, "over");
     mw_over();
-    WORD_ATOM(1042, 30, "name");
+    WORD_ATOM(1044, 30, "name");
     mw_Table_2E_name();
-    WORD_ATOM(1042, 35, "~Def");
+    WORD_ATOM(1044, 35, "~Def");
     mw_Name_7E_Def();
-    WORD_ATOM(1042, 40, "!");
+    WORD_ATOM(1044, 40, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1046, 5, "dup");
+    WORD_ATOM(1048, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1046, 9, "");
+    WORD_ATOM(1048, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23315,38 +26555,38 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1046, 16, "table-word-new!");
+    WORD_ATOM(1048, 16, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1048, 5, "L0");
+    WORD_ATOM(1050, 5, "L0");
     mw_L0();
-    WORD_ATOM(1048, 8, "CTX");
+    WORD_ATOM(1050, 8, "CTX");
     mw_CTX();
-    WORD_ATOM(1049, 5, "T0");
+    WORD_ATOM(1051, 5, "T0");
     mw_T0();
-    WORD_ATOM(1049, 8, "TYPE_INT");
+    WORD_ATOM(1051, 8, "TYPE_INT");
     mw_TYPE_5F_INT();
-    WORD_ATOM(1049, 17, "T1");
+    WORD_ATOM(1051, 17, "T1");
     mw_T1();
-    WORD_ATOM(1049, 20, "T->");
+    WORD_ATOM(1051, 20, "T->");
     mw_T__3E_();
-    WORD_ATOM(1050, 5, "ready2");
+    WORD_ATOM(1052, 5, "ready2");
     mw_ready2();
-    WORD_ATOM(1050, 12, "over");
+    WORD_ATOM(1052, 12, "over");
     mw_over();
-    WORD_ATOM(1050, 17, "~ctx-type");
+    WORD_ATOM(1052, 17, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(1050, 27, "!");
+    WORD_ATOM(1052, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1052, 5, "ab-build-word!");
+    WORD_ATOM(1054, 5, "ab-build-word!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__1);
     mw_prim_pack_cons();
     mw_ab_build_word_21_();
-    WORD_ATOM(1055, 7, "drop");
+    WORD_ATOM(1057, 7, "drop");
     mw_prim_drop();
-    WORD_ATOM(1058, 5, "dup");
+    WORD_ATOM(1060, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1058, 9, "");
+    WORD_ATOM(1060, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23357,46 +26597,46 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1058, 16, "table-word-new!");
+    WORD_ATOM(1060, 16, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1060, 5, "L0");
+    WORD_ATOM(1062, 5, "L0");
     mw_L0();
-    WORD_ATOM(1060, 8, "CTX");
+    WORD_ATOM(1062, 8, "CTX");
     mw_CTX();
-    WORD_ATOM(1061, 5, "T0");
+    WORD_ATOM(1063, 5, "T0");
     mw_T0();
-    WORD_ATOM(1061, 8, "over3");
+    WORD_ATOM(1063, 8, "over3");
     mw_over3();
-    WORD_ATOM(1061, 14, "TTable");
+    WORD_ATOM(1063, 14, "TTable");
     mw_TTable();
-    WORD_ATOM(1061, 21, "T1");
+    WORD_ATOM(1063, 21, "T1");
     mw_T1();
-    WORD_ATOM(1061, 24, "T->");
+    WORD_ATOM(1063, 24, "T->");
     mw_T__3E_();
-    WORD_ATOM(1062, 5, "ready2");
+    WORD_ATOM(1064, 5, "ready2");
     mw_ready2();
-    WORD_ATOM(1062, 12, "over");
+    WORD_ATOM(1064, 12, "over");
     mw_over();
-    WORD_ATOM(1062, 17, "~ctx-type");
+    WORD_ATOM(1064, 17, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(1062, 27, "!");
+    WORD_ATOM(1064, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1064, 5, "ab-build-word!");
+    WORD_ATOM(1066, 5, "ab-build-word!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__2);
     mw_prim_pack_cons();
     mw_ab_build_word_21_();
-    WORD_ATOM(1068, 7, "drop");
+    WORD_ATOM(1070, 7, "drop");
     mw_prim_drop();
-    WORD_ATOM(1071, 5, "dup");
+    WORD_ATOM(1073, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1071, 9, "head");
+    WORD_ATOM(1073, 9, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1072, 5, "over");
+    WORD_ATOM(1074, 5, "over");
     mw_over();
-    WORD_ATOM(1072, 10, "name");
+    WORD_ATOM(1074, 10, "name");
     mw_Table_2E_name();
-    WORD_ATOM(1072, 15, "");
+    WORD_ATOM(1074, 15, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23407,21 +26647,21 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1072, 22, "Name.cat");
+    WORD_ATOM(1074, 22, "Name.cat");
     mw_Name_2E_cat();
-    WORD_ATOM(1073, 5, "");
+    WORD_ATOM(1075, 5, "");
     push_i64(8LL);
-    WORD_ATOM(1073, 7, "Buffer.new!");
+    WORD_ATOM(1075, 7, "Buffer.new!");
     mw_Buffer_2E_new_21_();
-    WORD_ATOM(1074, 5, "over");
+    WORD_ATOM(1076, 5, "over");
     mw_over();
-    WORD_ATOM(1074, 10, "~num-buffer");
+    WORD_ATOM(1076, 10, "~num-buffer");
     mw_Table_7E_num_buffer();
-    WORD_ATOM(1074, 22, "!");
+    WORD_ATOM(1076, 22, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1077, 5, "dup");
+    WORD_ATOM(1079, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1077, 9, "");
+    WORD_ATOM(1079, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23432,42 +26672,42 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1077, 15, "table-word-new!");
+    WORD_ATOM(1079, 15, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1079, 5, "L0");
+    WORD_ATOM(1081, 5, "L0");
     mw_L0();
-    WORD_ATOM(1079, 8, "CTX");
+    WORD_ATOM(1081, 8, "CTX");
     mw_CTX();
-    WORD_ATOM(1080, 5, "over2");
+    WORD_ATOM(1082, 5, "over2");
     mw_over2();
-    WORD_ATOM(1080, 11, "TTable");
+    WORD_ATOM(1082, 11, "TTable");
     mw_TTable();
-    WORD_ATOM(1080, 18, "T1");
+    WORD_ATOM(1082, 18, "T1");
     mw_T1();
-    WORD_ATOM(1080, 21, "TYPE_INT");
+    WORD_ATOM(1082, 21, "TYPE_INT");
     mw_TYPE_5F_INT();
-    WORD_ATOM(1080, 30, "T1");
+    WORD_ATOM(1082, 30, "T1");
     mw_T1();
-    WORD_ATOM(1080, 33, "T->");
+    WORD_ATOM(1082, 33, "T->");
     mw_T__3E_();
-    WORD_ATOM(1081, 5, "ready2");
+    WORD_ATOM(1083, 5, "ready2");
     mw_ready2();
-    WORD_ATOM(1081, 12, "over");
+    WORD_ATOM(1083, 12, "over");
     mw_over();
-    WORD_ATOM(1081, 17, "~ctx-type");
+    WORD_ATOM(1083, 17, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(1081, 27, "!");
+    WORD_ATOM(1083, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1083, 5, "ab-build-word!");
+    WORD_ATOM(1085, 5, "ab-build-word!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__3);
     mw_prim_pack_cons();
     mw_ab_build_word_21_();
-    WORD_ATOM(1086, 7, "drop");
+    WORD_ATOM(1088, 7, "drop");
     mw_prim_drop();
-    WORD_ATOM(1089, 5, "dup");
+    WORD_ATOM(1091, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1089, 9, "");
+    WORD_ATOM(1091, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23478,44 +26718,44 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1089, 20, "table-word-new!");
+    WORD_ATOM(1091, 20, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1091, 5, "L0");
+    WORD_ATOM(1093, 5, "L0");
     mw_L0();
-    WORD_ATOM(1091, 8, "CTX");
+    WORD_ATOM(1093, 8, "CTX");
     mw_CTX();
-    WORD_ATOM(1092, 5, "over2");
+    WORD_ATOM(1094, 5, "over2");
     mw_over2();
-    WORD_ATOM(1092, 11, "TTable");
+    WORD_ATOM(1094, 11, "TTable");
     mw_TTable();
-    WORD_ATOM(1092, 18, "T1");
+    WORD_ATOM(1094, 18, "T1");
     mw_T1();
-    WORD_ATOM(1092, 21, "TYPE_INT");
+    WORD_ATOM(1094, 21, "TYPE_INT");
     mw_TYPE_5F_INT();
-    WORD_ATOM(1092, 30, "T1");
+    WORD_ATOM(1094, 30, "T1");
     mw_T1();
-    WORD_ATOM(1092, 33, "swap");
+    WORD_ATOM(1094, 33, "swap");
     mw_prim_swap();
-    WORD_ATOM(1092, 38, "T->");
+    WORD_ATOM(1094, 38, "T->");
     mw_T__3E_();
-    WORD_ATOM(1093, 5, "ready2");
+    WORD_ATOM(1095, 5, "ready2");
     mw_ready2();
-    WORD_ATOM(1093, 12, "over");
+    WORD_ATOM(1095, 12, "over");
     mw_over();
-    WORD_ATOM(1093, 17, "~ctx-type");
+    WORD_ATOM(1095, 17, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(1093, 27, "!");
+    WORD_ATOM(1095, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1095, 5, "ab-build-word!");
+    WORD_ATOM(1097, 5, "ab-build-word!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__4);
     mw_prim_pack_cons();
     mw_ab_build_word_21_();
-    WORD_ATOM(1098, 7, "drop");
+    WORD_ATOM(1100, 7, "drop");
     mw_prim_drop();
-    WORD_ATOM(1101, 5, "dup");
+    WORD_ATOM(1103, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1101, 9, "");
+    WORD_ATOM(1103, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23526,40 +26766,40 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1101, 17, "table-word-new!");
+    WORD_ATOM(1103, 17, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1103, 5, "L0");
+    WORD_ATOM(1105, 5, "L0");
     mw_L0();
-    WORD_ATOM(1103, 8, "CTX");
+    WORD_ATOM(1105, 8, "CTX");
     mw_CTX();
-    WORD_ATOM(1104, 5, "over2");
+    WORD_ATOM(1106, 5, "over2");
     mw_over2();
-    WORD_ATOM(1104, 11, "TTable");
+    WORD_ATOM(1106, 11, "TTable");
     mw_TTable();
-    WORD_ATOM(1104, 18, "T1");
+    WORD_ATOM(1106, 18, "T1");
     mw_T1();
-    WORD_ATOM(1104, 21, "dup");
+    WORD_ATOM(1106, 21, "dup");
     mw_prim_dup();
-    WORD_ATOM(1104, 25, "T->");
+    WORD_ATOM(1106, 25, "T->");
     mw_T__3E_();
-    WORD_ATOM(1105, 5, "ready2");
+    WORD_ATOM(1107, 5, "ready2");
     mw_ready2();
-    WORD_ATOM(1105, 12, "over");
+    WORD_ATOM(1107, 12, "over");
     mw_over();
-    WORD_ATOM(1105, 17, "~ctx-type");
+    WORD_ATOM(1107, 17, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(1105, 27, "!");
+    WORD_ATOM(1107, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1107, 5, "ab-build-word!");
+    WORD_ATOM(1109, 5, "ab-build-word!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__5);
     mw_prim_pack_cons();
     mw_ab_build_word_21_();
-    WORD_ATOM(1119, 7, "drop");
+    WORD_ATOM(1121, 7, "drop");
     mw_prim_drop();
-    WORD_ATOM(1122, 5, "dup");
+    WORD_ATOM(1124, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1122, 9, "");
+    WORD_ATOM(1124, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23570,40 +26810,40 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1122, 17, "table-word-new!");
+    WORD_ATOM(1124, 17, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1124, 5, "L0");
+    WORD_ATOM(1126, 5, "L0");
     mw_L0();
-    WORD_ATOM(1124, 8, "CTX");
+    WORD_ATOM(1126, 8, "CTX");
     mw_CTX();
-    WORD_ATOM(1125, 5, "over2");
+    WORD_ATOM(1127, 5, "over2");
     mw_over2();
-    WORD_ATOM(1125, 11, "TTable");
+    WORD_ATOM(1127, 11, "TTable");
     mw_TTable();
-    WORD_ATOM(1125, 18, "T1");
+    WORD_ATOM(1127, 18, "T1");
     mw_T1();
-    WORD_ATOM(1125, 21, "dup");
+    WORD_ATOM(1127, 21, "dup");
     mw_prim_dup();
-    WORD_ATOM(1125, 25, "T->");
+    WORD_ATOM(1127, 25, "T->");
     mw_T__3E_();
-    WORD_ATOM(1126, 5, "ready2");
+    WORD_ATOM(1128, 5, "ready2");
     mw_ready2();
-    WORD_ATOM(1126, 12, "over");
+    WORD_ATOM(1128, 12, "over");
     mw_over();
-    WORD_ATOM(1126, 17, "~ctx-type");
+    WORD_ATOM(1128, 17, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(1126, 27, "!");
+    WORD_ATOM(1128, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1128, 5, "ab-build-word!");
+    WORD_ATOM(1130, 5, "ab-build-word!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__6);
     mw_prim_pack_cons();
     mw_ab_build_word_21_();
-    WORD_ATOM(1140, 7, "drop");
+    WORD_ATOM(1142, 7, "drop");
     mw_prim_drop();
-    WORD_ATOM(1144, 5, "dup");
+    WORD_ATOM(1146, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1144, 9, "");
+    WORD_ATOM(1146, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23614,11 +26854,11 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1144, 16, "table-word-new!");
+    WORD_ATOM(1146, 16, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1145, 5, "TYPE_STACK");
+    WORD_ATOM(1147, 5, "TYPE_STACK");
     mw_TYPE_5F_STACK();
-    WORD_ATOM(1145, 16, "");
+    WORD_ATOM(1147, 16, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23629,38 +26869,38 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1145, 21, ">Name");
+    WORD_ATOM(1147, 21, ">Name");
     mw_Str_3E_Name();
-    WORD_ATOM(1145, 27, "Var.new!");
+    WORD_ATOM(1147, 27, "Var.new!");
     mw_Var_2E_new_21_();
-    WORD_ATOM(1145, 36, "dup");
+    WORD_ATOM(1147, 36, "dup");
     mw_prim_dup();
-    WORD_ATOM(1145, 40, "STVar");
+    WORD_ATOM(1147, 40, "STVar");
     mw_STVar();
-    WORD_ATOM(1146, 5, "\\");
+    WORD_ATOM(1148, 5, "\\");
     {
         VAL var_a = pop_value();
         VAL var_va = pop_value();
         VAL var_w = pop_value();
         VAL var_t = pop_value();
-        WORD_ATOM(1146, 19, "a");
+        WORD_ATOM(1148, 19, "a");
         incref(var_a);
         push_value(var_a);
-        WORD_ATOM(1146, 21, "t");
+        WORD_ATOM(1148, 21, "t");
         incref(var_t);
         push_value(var_t);
-        WORD_ATOM(1146, 23, "TTable");
+        WORD_ATOM(1148, 23, "TTable");
         mw_TTable();
-        WORD_ATOM(1146, 30, "T*");
+        WORD_ATOM(1148, 30, "T*");
         mw_T_2A_();
-        WORD_ATOM(1146, 33, "a");
+        WORD_ATOM(1148, 33, "a");
         incref(var_a);
         push_value(var_a);
-        WORD_ATOM(1146, 35, "T->");
+        WORD_ATOM(1148, 35, "T->");
         mw_T__3E_();
-        WORD_ATOM(1146, 39, ">Type");
+        WORD_ATOM(1148, 39, ">Type");
         mw_ArrowType_3E_Type();
-        WORD_ATOM(1146, 45, "");
+        WORD_ATOM(1148, 45, "");
         {
             static bool vready = false;
             static VAL v;
@@ -23671,58 +26911,58 @@ static void mw_table_new_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(1146, 49, ">Name");
+        WORD_ATOM(1148, 49, ">Name");
         mw_Str_3E_Name();
-        WORD_ATOM(1146, 55, "Var.new-auto-run!");
+        WORD_ATOM(1148, 55, "Var.new-auto-run!");
         mw_Var_2E_new_auto_run_21_();
-        WORD_ATOM(1147, 5, "\\");
+        WORD_ATOM(1149, 5, "\\");
         {
             VAL var_x = pop_value();
-            WORD_ATOM(1148, 9, "va");
+            WORD_ATOM(1150, 9, "va");
             incref(var_va);
             push_value(var_va);
-            WORD_ATOM(1148, 12, "CTX1");
+            WORD_ATOM(1150, 12, "CTX1");
             mw_CTX1();
-            WORD_ATOM(1149, 9, "a");
+            WORD_ATOM(1151, 9, "a");
             incref(var_a);
             push_value(var_a);
-            WORD_ATOM(1149, 11, "a");
+            WORD_ATOM(1151, 11, "a");
             incref(var_a);
             push_value(var_a);
-            WORD_ATOM(1149, 13, "t");
+            WORD_ATOM(1151, 13, "t");
             incref(var_t);
             push_value(var_t);
-            WORD_ATOM(1149, 15, "TTable");
+            WORD_ATOM(1151, 15, "TTable");
             mw_TTable();
-            WORD_ATOM(1149, 22, "T*");
+            WORD_ATOM(1151, 22, "T*");
             mw_T_2A_();
-            WORD_ATOM(1149, 25, "a");
+            WORD_ATOM(1151, 25, "a");
             incref(var_a);
             push_value(var_a);
-            WORD_ATOM(1149, 27, "T->");
+            WORD_ATOM(1151, 27, "T->");
             mw_T__3E_();
-            WORD_ATOM(1149, 31, ">Type");
+            WORD_ATOM(1151, 31, ">Type");
             mw_ArrowType_3E_Type();
-            WORD_ATOM(1149, 37, "T*");
+            WORD_ATOM(1151, 37, "T*");
             mw_T_2A_();
-            WORD_ATOM(1149, 40, "a");
+            WORD_ATOM(1151, 40, "a");
             incref(var_a);
             push_value(var_a);
-            WORD_ATOM(1149, 42, "T->");
+            WORD_ATOM(1151, 42, "T->");
             mw_T__3E_();
-            WORD_ATOM(1150, 9, "ready2");
+            WORD_ATOM(1152, 9, "ready2");
             mw_ready2();
-            WORD_ATOM(1150, 16, "w");
+            WORD_ATOM(1152, 16, "w");
             incref(var_w);
             push_value(var_w);
-            WORD_ATOM(1150, 18, "~ctx-type");
+            WORD_ATOM(1152, 18, "~ctx-type");
             mw_Word_7E_ctx_type();
-            WORD_ATOM(1150, 28, "!");
+            WORD_ATOM(1152, 28, "!");
             mw_prim_mut_set();
-            WORD_ATOM(1152, 9, "w");
+            WORD_ATOM(1154, 9, "w");
             incref(var_w);
             push_value(var_w);
-            WORD_ATOM(1152, 11, "ab-build-word!");
+            WORD_ATOM(1154, 11, "ab-build-word!");
             push_u64(0);
             incref(var_a);
             push_value(var_a);
@@ -23742,9 +26982,9 @@ static void mw_table_new_21_ (void){
             push_fnptr(&mb_table_new_21__11);
             mw_prim_pack_cons();
             mw_ab_build_word_21_();
-            WORD_ATOM(1175, 11, "drop");
+            WORD_ATOM(1177, 11, "drop");
             mw_prim_drop();
-            WORD_ATOM(1177, 5, "t");
+            WORD_ATOM(1179, 5, "t");
             incref(var_t);
             push_value(var_t);
             decref(var_x);
@@ -23754,9 +26994,9 @@ static void mw_table_new_21_ (void){
         decref(var_w);
         decref(var_t);
     }
-    WORD_ATOM(1180, 5, "dup");
+    WORD_ATOM(1182, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1180, 9, "");
+    WORD_ATOM(1182, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23767,68 +27007,68 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1180, 19, "table-word-new!");
+    WORD_ATOM(1182, 19, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1182, 5, "L0");
+    WORD_ATOM(1184, 5, "L0");
     mw_L0();
-    WORD_ATOM(1182, 8, "CTX");
+    WORD_ATOM(1184, 8, "CTX");
     mw_CTX();
-    WORD_ATOM(1183, 5, "T0");
+    WORD_ATOM(1185, 5, "T0");
     mw_T0();
-    WORD_ATOM(1183, 8, "over3");
+    WORD_ATOM(1185, 8, "over3");
     mw_over3();
-    WORD_ATOM(1183, 14, "TTable");
+    WORD_ATOM(1185, 14, "TTable");
     mw_TTable();
-    WORD_ATOM(1183, 21, "T1");
+    WORD_ATOM(1185, 21, "T1");
     mw_T1();
-    WORD_ATOM(1183, 24, "T->");
+    WORD_ATOM(1185, 24, "T->");
     mw_T__3E_();
-    WORD_ATOM(1184, 5, "ready2");
+    WORD_ATOM(1186, 5, "ready2");
     mw_ready2();
-    WORD_ATOM(1184, 12, "over");
+    WORD_ATOM(1186, 12, "over");
     mw_over();
-    WORD_ATOM(1184, 17, "~ctx-type");
+    WORD_ATOM(1186, 17, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(1184, 27, "!");
+    WORD_ATOM(1186, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1186, 5, "ab-build-word!");
+    WORD_ATOM(1188, 5, "ab-build-word!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__16);
     mw_prim_pack_cons();
     mw_ab_build_word_21_();
-    WORD_ATOM(1199, 5, "drop");
+    WORD_ATOM(1201, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_table_new_21_);
 }
 static void mw_elab_field_21_ (void){
-    WORD_ENTER(mw_elab_field_21_, "elab-field!", "src/mirth/elab.mth", 1208, 5);
-    WORD_ATOM(1208, 5, "sip");
+    WORD_ENTER(mw_elab_field_21_, "elab-field!", "src/mirth/elab.mth", 1210, 5);
+    WORD_ATOM(1210, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_field_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(1208, 15, "args-3");
+    WORD_ATOM(1210, 15, "args-3");
     mw_Token_2E_args_3();
-    WORD_ATOM(1208, 22, "rotl");
+    WORD_ATOM(1210, 22, "rotl");
     mw_rotl();
-    WORD_ATOM(1208, 27, "dup");
+    WORD_ATOM(1210, 27, "dup");
     mw_prim_dup();
-    WORD_ATOM(1208, 31, "value");
+    WORD_ATOM(1210, 31, "value");
     mw_Token_2E_value();
-    WORD_ATOM(1208, 37, "match");
+    WORD_ATOM(1210, 37, "match");
     switch (get_top_data_tag()) {
         case 13LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(1210, 13, "name-undefined?");
+            co_TOKEN_5F_NAME();
+            WORD_ATOM(1212, 13, "name-undefined?");
             mw_name_undefined_3F_();
-            WORD_ATOM(1210, 29, "if");
+            WORD_ATOM(1212, 29, "if");
             if (pop_u64()) {
-                WORD_ATOM(1210, 32, "id");
+                WORD_ATOM(1212, 32, "id");
                 mw_prim_id();
             } else {
-                WORD_ATOM(1211, 17, "drop");
+                WORD_ATOM(1213, 17, "drop");
                 mw_prim_drop();
-                WORD_ATOM(1211, 22, "");
+                WORD_ATOM(1213, 22, "");
                 {
                     static bool vready = false;
                     static VAL v;
@@ -23839,18 +27079,18 @@ static void mw_elab_field_21_ (void){
                     push_value(v);
                     incref(v);
                 }
-                WORD_ATOM(1211, 45, "emit-fatal-error!");
+                WORD_ATOM(1213, 45, "emit-fatal-error!");
                 mw_emit_fatal_error_21_();
             }
-            WORD_ATOM(1212, 13, "field-new!");
+            WORD_ATOM(1214, 13, "field-new!");
             mw_field_new_21_();
-            WORD_ATOM(1212, 24, "drop");
+            WORD_ATOM(1214, 24, "drop");
             mw_prim_drop();
             break;
         default:
-            WORD_ATOM(1214, 13, "drop");
+            WORD_ATOM(1216, 13, "drop");
             mw_prim_drop();
-            WORD_ATOM(1214, 18, "");
+            WORD_ATOM(1216, 18, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -23861,63 +27101,63 @@ static void mw_elab_field_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(1214, 40, "emit-fatal-error!");
+            WORD_ATOM(1216, 40, "emit-fatal-error!");
             mw_emit_fatal_error_21_();
             break;
     
 }    WORD_EXIT(mw_elab_field_21_);
 }
 static void mw_field_new_21_ (void){
-    WORD_ENTER(mw_field_new_21_, "field-new!", "src/mirth/elab.mth", 1218, 5);
-    WORD_ATOM(1218, 5, "Field.alloc!");
+    WORD_ENTER(mw_field_new_21_, "field-new!", "src/mirth/elab.mth", 1220, 5);
+    WORD_ATOM(1220, 5, "Field.alloc!");
     mw_Field_2E_alloc_21_();
-    WORD_ATOM(1219, 5, "tuck");
-    mw_tuck();
-    WORD_ATOM(1219, 10, "dup2");
-    mw_dup2();
-    WORD_ATOM(1219, 15, "~name");
-    mw_Field_7E_name();
-    WORD_ATOM(1219, 21, "!");
-    mw_prim_mut_set();
-    WORD_ATOM(1220, 5, "DEF_FIELD");
-    mw_DEF_5F_FIELD();
-    WORD_ATOM(1220, 15, "swap");
-    mw_prim_swap();
-    WORD_ATOM(1220, 20, "~Def");
-    mw_Name_7E_Def();
-    WORD_ATOM(1220, 25, "!");
-    mw_prim_mut_set();
     WORD_ATOM(1221, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(1221, 10, "~head");
-    mw_Field_7E_head();
-    WORD_ATOM(1221, 16, "!");
+    WORD_ATOM(1221, 10, "dup2");
+    mw_dup2();
+    WORD_ATOM(1221, 15, "~name");
+    mw_Field_7E_name();
+    WORD_ATOM(1221, 21, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1222, 5, "swap");
+    WORD_ATOM(1222, 5, "DEF_FIELD");
+    mw_DEF_5F_FIELD();
+    WORD_ATOM(1222, 15, "swap");
     mw_prim_swap();
-    WORD_ATOM(1222, 10, "delay");
+    WORD_ATOM(1222, 20, "~Def");
+    mw_Name_7E_Def();
+    WORD_ATOM(1222, 25, "!");
+    mw_prim_mut_set();
+    WORD_ATOM(1223, 5, "tuck");
+    mw_tuck();
+    WORD_ATOM(1223, 10, "~head");
+    mw_Field_7E_head();
+    WORD_ATOM(1223, 16, "!");
+    mw_prim_mut_set();
+    WORD_ATOM(1224, 5, "swap");
+    mw_prim_swap();
+    WORD_ATOM(1224, 10, "delay");
     push_u64(0);
     push_fnptr(&mb_field_new_21__1);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(1222, 39, "over");
+    WORD_ATOM(1224, 39, "over");
     mw_over();
-    WORD_ATOM(1222, 44, "~value-type");
+    WORD_ATOM(1224, 44, "~value-type");
     mw_Field_7E_value_type();
-    WORD_ATOM(1222, 56, "!");
+    WORD_ATOM(1224, 56, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1223, 5, "swap");
+    WORD_ATOM(1225, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(1223, 10, "delay");
+    WORD_ATOM(1225, 10, "delay");
     push_u64(0);
     push_fnptr(&mb_field_new_21__2);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(1223, 39, "over");
+    WORD_ATOM(1225, 39, "over");
     mw_over();
-    WORD_ATOM(1223, 44, "~index-type");
+    WORD_ATOM(1225, 44, "~index-type");
     mw_Field_7E_index_type();
-    WORD_ATOM(1223, 56, "!");
+    WORD_ATOM(1225, 56, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_field_new_21_);
 }
@@ -24490,17 +27730,17 @@ static void mw_PrimType_2E_is_physical_3F_ (void){
     WORD_ATOM(51, 5, "PRIM_TYPE_TYPE");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_PRIM_5F_TYPE_5F_TYPE();
             WORD_ATOM(51, 23, "F");
             mw_F();
             break;
         case 1LL:
-            mw_prim_drop();
+            co_PRIM_5F_TYPE_5F_STACK();
             WORD_ATOM(52, 24, "F");
             mw_F();
             break;
         case 2LL:
-            mw_prim_drop();
+            co_PRIM_5F_TYPE_5F_RESOURCE();
             WORD_ATOM(53, 27, "F");
             mw_F();
             break;
@@ -24518,22 +27758,22 @@ static void mw_Type_2E_tycon_name (void){
     WORD_ATOM(58, 5, "TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_TYPE_5F_ERROR();
             WORD_ATOM(58, 19, "NONE");
             mw_NONE();
             break;
         case 1LL:
-            mw_prim_drop();
+            co_TYPE_5F_DONT_5F_CARE();
             WORD_ATOM(59, 23, "NONE");
             mw_NONE();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TPrim();
             WORD_ATOM(60, 14, "tycon-name");
             mw_PrimType_2E_tycon_name();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMeta();
             WORD_ATOM(61, 14, "expand-if");
             push_u64(0);
             push_fnptr(&mb_Type_2E_tycon_name_5);
@@ -24544,62 +27784,61 @@ static void mw_Type_2E_tycon_name (void){
             mw_MetaVar_2E_expand_if();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_THole();
             WORD_ATOM(62, 14, "drop");
             mw_prim_drop();
             WORD_ATOM(62, 19, "NONE");
             mw_NONE();
             break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TVar();
             WORD_ATOM(63, 13, "drop");
             mw_prim_drop();
             WORD_ATOM(63, 18, "NONE");
             mw_NONE();
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TTable();
             WORD_ATOM(64, 15, "name");
             mw_Table_2E_name();
             WORD_ATOM(64, 20, "SOME");
             mw_SOME();
             break;
         case 7LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TData();
             WORD_ATOM(65, 14, "name");
             mw_Data_2E_name();
             WORD_ATOM(65, 19, "SOME");
             mw_SOME();
             break;
         case 9LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMorphism();
             WORD_ATOM(66, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(66, 23, "NONE");
             mw_NONE();
             break;
         case 8LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TTensor();
             WORD_ATOM(67, 16, "drop");
             mw_prim_drop();
             WORD_ATOM(67, 21, "NONE");
             mw_NONE();
             break;
         case 10LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_TApp();
             WORD_ATOM(68, 13, "drop");
             mw_prim_drop();
             WORD_ATOM(68, 18, "tycon-name");
             mw_Type_2E_tycon_name();
             break;
         case 11LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMut();
             WORD_ATOM(69, 13, "tycon-name");
             mw_Type_2E_tycon_name();
             break;
         case 12LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TValue();
             WORD_ATOM(70, 15, "tycon-name");
             mw_Value_2E_tycon_name();
             break;
@@ -24612,22 +27851,22 @@ static void mw_PrimType_2E_tycon_name (void){
     WORD_ATOM(74, 5, "PRIM_TYPE_TYPE");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_PRIM_5F_TYPE_5F_TYPE();
             WORD_ATOM(74, 23, "NONE");
             mw_NONE();
             break;
         case 1LL:
-            mw_prim_drop();
+            co_PRIM_5F_TYPE_5F_STACK();
             WORD_ATOM(75, 24, "NONE");
             mw_NONE();
             break;
         case 2LL:
-            mw_prim_drop();
+            co_PRIM_5F_TYPE_5F_RESOURCE();
             WORD_ATOM(76, 27, "NONE");
             mw_NONE();
             break;
         case 3LL:
-            mw_prim_drop();
+            co_PRIM_5F_TYPE_5F_INT();
             WORD_ATOM(77, 22, "");
             {
                 static bool vready = false;
@@ -24645,7 +27884,7 @@ static void mw_PrimType_2E_tycon_name (void){
             mw_SOME();
             break;
         case 5LL:
-            mw_prim_drop();
+            co_PRIM_5F_TYPE_5F_STR();
             WORD_ATOM(78, 22, "");
             {
                 static bool vready = false;
@@ -24663,7 +27902,7 @@ static void mw_PrimType_2E_tycon_name (void){
             mw_SOME();
             break;
         case 4LL:
-            mw_prim_drop();
+            co_PRIM_5F_TYPE_5F_PTR();
             WORD_ATOM(79, 22, "");
             {
                 static bool vready = false;
@@ -24681,7 +27920,7 @@ static void mw_PrimType_2E_tycon_name (void){
             mw_SOME();
             break;
         case 6LL:
-            mw_prim_drop();
+            co_PRIM_5F_TYPE_5F__2B_PLATFORM();
             WORD_ATOM(80, 28, "");
             {
                 static bool vready = false;
@@ -24707,7 +27946,7 @@ static void mw_Value_2E_tycon_name (void){
     WORD_ATOM(84, 5, "VALUE_INT");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_VALUE_5F_INT();
             WORD_ATOM(84, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(84, 23, "");
@@ -24727,7 +27966,7 @@ static void mw_Value_2E_tycon_name (void){
             mw_SOME();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_VALUE_5F_STR();
             WORD_ATOM(85, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(85, 23, "");
@@ -24747,7 +27986,7 @@ static void mw_Value_2E_tycon_name (void){
             mw_SOME();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_VALUE_5F_BLOCK();
             WORD_ATOM(86, 20, "drop");
             mw_prim_drop();
             WORD_ATOM(86, 25, "NONE");
@@ -24874,12 +28113,12 @@ static void mw_T_2A__2B_ (void){
     WORD_ATOM(106, 57, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_LEFT();
             WORD_ATOM(106, 71, "T*");
             mw_T_2A_();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_RIGHT();
             WORD_ATOM(106, 84, "T+");
             mw_T_2B_();
             break;
@@ -24997,7 +28236,7 @@ static void mw_Type_2E_morphism_3F_ (void){
     WORD_ATOM(130, 54, "match");
     switch (get_top_data_tag()) {
         case 9LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMorphism();
             WORD_ATOM(130, 73, "SOME");
             mw_SOME();
             break;
@@ -25017,7 +28256,7 @@ static void mw_Type_2E_prim_3F_ (void){
     WORD_ATOM(131, 49, "match");
     switch (get_top_data_tag()) {
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TPrim();
             WORD_ATOM(131, 64, "SOME");
             mw_SOME();
             break;
@@ -25035,7 +28274,7 @@ static void mw_Type_3D_meta (void){
     WORD_ATOM(142, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMeta();
             WORD_ATOM(142, 14, "=");
             mw_MetaVar_3D_();
             break;
@@ -25053,7 +28292,7 @@ static void mw_Type_2E_is_physical_3F_ (void){
     WORD_ATOM(146, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMeta();
             WORD_ATOM(146, 14, "expand-if");
             push_u64(0);
             push_fnptr(&mb_Type_2E_is_physical_3F__2);
@@ -25064,7 +28303,7 @@ static void mw_Type_2E_is_physical_3F_ (void){
             mw_MetaVar_2E_expand_if();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TPrim();
             WORD_ATOM(147, 14, "is-physical?");
             mw_PrimType_2E_is_physical_3F_();
             break;
@@ -25146,7 +28385,7 @@ static void mw_Type_2E_expand (void){
     WORD_ATOM(169, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMeta();
             WORD_ATOM(169, 14, "expand");
             mw_MetaVar_2E_expand();
             break;
@@ -25227,13 +28466,13 @@ static void mw_Type_2E_unify_simple_21_ (void){
     WORD_ATOM(188, 5, "TVar");
     switch (get_top_data_tag()) {
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TVar();
             WORD_ATOM(188, 13, "swap");
             mw_prim_swap();
             WORD_ATOM(188, 18, "match");
             switch (get_top_data_tag()) {
                 case 5LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_TVar();
                     WORD_ATOM(188, 32, "unify!");
                     mw_Var_2E_unify_21_();
                     break;
@@ -25251,13 +28490,13 @@ static void mw_Type_2E_unify_simple_21_ (void){
             
 }            break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TPrim();
             WORD_ATOM(189, 14, "swap");
             mw_prim_swap();
             WORD_ATOM(189, 19, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_TPrim();
                     WORD_ATOM(189, 34, "unify!");
                     mw_PrimType_2E_unify_21_();
                     break;
@@ -25275,13 +28514,13 @@ static void mw_Type_2E_unify_simple_21_ (void){
             
 }            break;
         case 7LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TData();
             WORD_ATOM(190, 14, "swap");
             mw_prim_swap();
             WORD_ATOM(190, 19, "match");
             switch (get_top_data_tag()) {
                 case 7LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_TData();
                     WORD_ATOM(190, 34, "unify!");
                     mw_Data_2E_unify_21_();
                     break;
@@ -25299,13 +28538,13 @@ static void mw_Type_2E_unify_simple_21_ (void){
             
 }            break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TTable();
             WORD_ATOM(191, 15, "swap");
             mw_prim_swap();
             WORD_ATOM(191, 20, "match");
             switch (get_top_data_tag()) {
                 case 6LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_TTable();
                     WORD_ATOM(191, 36, "unify!");
                     mw_Table_2E_unify_21_();
                     break;
@@ -25323,13 +28562,13 @@ static void mw_Type_2E_unify_simple_21_ (void){
             
 }            break;
         case 8LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TTensor();
             WORD_ATOM(192, 16, "swap");
             mw_prim_swap();
             WORD_ATOM(192, 21, "match");
             switch (get_top_data_tag()) {
                 case 8LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_TTensor();
                     WORD_ATOM(192, 38, "unify!");
                     mw_StackType_2E_unify_21_();
                     WORD_ATOM(192, 45, ">Type");
@@ -25349,13 +28588,13 @@ static void mw_Type_2E_unify_simple_21_ (void){
             
 }            break;
         case 9LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMorphism();
             WORD_ATOM(193, 18, "swap");
             mw_prim_swap();
             WORD_ATOM(193, 23, "match");
             switch (get_top_data_tag()) {
                 case 9LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_TMorphism();
                     WORD_ATOM(193, 42, "unify!");
                     mw_ArrowType_2E_unify_21_();
                     WORD_ATOM(193, 49, "TMorphism");
@@ -25375,15 +28614,13 @@ static void mw_Type_2E_unify_simple_21_ (void){
             
 }            break;
         case 10LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_TApp();
             WORD_ATOM(194, 13, "rotl");
             mw_rotl();
             WORD_ATOM(194, 18, "match");
             switch (get_top_data_tag()) {
                 case 10LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
-                    mw_prim_pack_uncons(); mw_prim_swap();
+                    co_TApp();
                     WORD_ATOM(194, 32, "unify2!");
                     mw_Type_2E_unify2_21_();
                     WORD_ATOM(194, 40, "TApp");
@@ -25403,13 +28640,13 @@ static void mw_Type_2E_unify_simple_21_ (void){
             
 }            break;
         case 11LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMut();
             WORD_ATOM(195, 13, "swap");
             mw_prim_swap();
             WORD_ATOM(195, 18, "match");
             switch (get_top_data_tag()) {
                 case 11LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_TMut();
                     WORD_ATOM(195, 32, "unify!");
                     mw_Type_2E_unify_21_();
                     WORD_ATOM(195, 39, "TMut");
@@ -25440,42 +28677,42 @@ static void mw_Type_2E_unify_aux_21_ (void){
     WORD_ATOM(200, 5, "TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_TYPE_5F_ERROR();
             WORD_ATOM(200, 19, "drop");
             mw_prim_drop();
             WORD_ATOM(200, 24, "TYPE_ERROR");
             mw_TYPE_5F_ERROR();
             break;
         case 1LL:
-            mw_prim_drop();
+            co_TYPE_5F_DONT_5F_CARE();
             WORD_ATOM(201, 23, "id");
             mw_prim_id();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_THole();
             WORD_ATOM(202, 14, "type-hole-unify!");
             mw_type_hole_unify_21_();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMeta();
             WORD_ATOM(204, 9, "swap");
             mw_prim_swap();
             WORD_ATOM(204, 14, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    mw_prim_drop();
+                    co_TYPE_5F_ERROR();
                     WORD_ATOM(205, 27, "drop");
                     mw_prim_drop();
                     WORD_ATOM(205, 32, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 case 1LL:
-                    mw_prim_drop();
+                    co_TYPE_5F_DONT_5F_CARE();
                     WORD_ATOM(206, 31, "TMeta");
                     mw_TMeta();
                     break;
                 case 4LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_THole();
                     WORD_ATOM(207, 22, "dip");
                     {
                         VAL d6 = pop_value();
@@ -25487,7 +28724,7 @@ static void mw_Type_2E_unify_aux_21_ (void){
                     mw_type_hole_unify_21_();
                     break;
                 case 3LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_TMeta();
                     WORD_ATOM(208, 22, "dip");
                     {
                         VAL d6 = pop_value();
@@ -25499,7 +28736,7 @@ static void mw_Type_2E_unify_aux_21_ (void){
                     mw_MetaVar_2E_unify_21_();
                     break;
                 case 12LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_TValue();
                     WORD_ATOM(209, 23, "dip");
                     {
                         VAL d6 = pop_value();
@@ -25519,25 +28756,25 @@ static void mw_Type_2E_unify_aux_21_ (void){
             
 }            break;
         case 12LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TValue();
             WORD_ATOM(213, 9, "swap");
             mw_prim_swap();
             WORD_ATOM(213, 14, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    mw_prim_drop();
+                    co_TYPE_5F_ERROR();
                     WORD_ATOM(214, 27, "drop");
                     mw_prim_drop();
                     WORD_ATOM(214, 32, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 case 1LL:
-                    mw_prim_drop();
+                    co_TYPE_5F_DONT_5F_CARE();
                     WORD_ATOM(215, 31, "TValue");
                     mw_TValue();
                     break;
                 case 4LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_THole();
                     WORD_ATOM(216, 22, "dip");
                     {
                         VAL d6 = pop_value();
@@ -25549,7 +28786,7 @@ static void mw_Type_2E_unify_aux_21_ (void){
                     mw_type_hole_unify_21_();
                     break;
                 case 3LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_TMeta();
                     WORD_ATOM(217, 22, "dip");
                     {
                         VAL d6 = pop_value();
@@ -25561,7 +28798,7 @@ static void mw_Type_2E_unify_aux_21_ (void){
                     mw_MetaVar_2E_unify_21_();
                     break;
                 case 12LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_TValue();
                     WORD_ATOM(218, 23, "unify!");
                     mw_Value_2E_unify_21_();
                     break;
@@ -25579,29 +28816,29 @@ static void mw_Type_2E_unify_aux_21_ (void){
             WORD_ATOM(222, 14, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    mw_prim_drop();
+                    co_TYPE_5F_ERROR();
                     WORD_ATOM(223, 27, "drop");
                     mw_prim_drop();
                     WORD_ATOM(223, 32, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 case 1LL:
-                    mw_prim_drop();
+                    co_TYPE_5F_DONT_5F_CARE();
                     WORD_ATOM(224, 31, "id");
                     mw_prim_id();
                     break;
                 case 4LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_THole();
                     WORD_ATOM(225, 22, "type-hole-unify!");
                     mw_type_hole_unify_21_();
                     break;
                 case 3LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_TMeta();
                     WORD_ATOM(226, 22, "unify!");
                     mw_MetaVar_2E_unify_21_();
                     break;
                 case 12LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_TValue();
                     WORD_ATOM(227, 23, "unify-type!");
                     mw_Value_2E_unify_type_21_();
                     break;
@@ -25632,13 +28869,13 @@ static void mw_Value_2E_unify_21_ (void){
     WORD_ATOM(237, 10, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_VALUE_5F_INT();
             WORD_ATOM(238, 22, "swap");
             mw_prim_swap();
             WORD_ATOM(238, 27, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_VALUE_5F_INT();
                     WORD_ATOM(239, 26, "dup2");
                     mw_dup2();
                     WORD_ATOM(239, 31, "=");
@@ -25659,7 +28896,7 @@ static void mw_Value_2E_unify_21_ (void){
                     }
                     break;
                 case 1LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_VALUE_5F_STR();
                     WORD_ATOM(241, 17, "drop2");
                     mw_drop2();
                     WORD_ATOM(241, 23, "dup");
@@ -25683,7 +28920,7 @@ static void mw_Value_2E_unify_21_ (void){
                     mw_TYPE_5F_ERROR();
                     break;
                 case 2LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_VALUE_5F_BLOCK();
                     WORD_ATOM(245, 17, "drop2");
                     mw_drop2();
                     WORD_ATOM(245, 23, "dup");
@@ -25710,13 +28947,13 @@ static void mw_Value_2E_unify_21_ (void){
             
 }            break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_VALUE_5F_STR();
             WORD_ATOM(250, 22, "swap");
             mw_prim_swap();
             WORD_ATOM(250, 27, "match");
             switch (get_top_data_tag()) {
                 case 1LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_VALUE_5F_STR();
                     WORD_ATOM(251, 26, "dup2");
                     mw_dup2();
                     WORD_ATOM(251, 31, "=");
@@ -25737,7 +28974,7 @@ static void mw_Value_2E_unify_21_ (void){
                     }
                     break;
                 case 0LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_VALUE_5F_INT();
                     WORD_ATOM(253, 17, "drop2");
                     mw_drop2();
                     WORD_ATOM(253, 23, "dup");
@@ -25761,7 +28998,7 @@ static void mw_Value_2E_unify_21_ (void){
                     mw_TYPE_5F_ERROR();
                     break;
                 case 2LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_VALUE_5F_BLOCK();
                     WORD_ATOM(257, 17, "drop2");
                     mw_drop2();
                     WORD_ATOM(257, 23, "dup");
@@ -25788,13 +29025,13 @@ static void mw_Value_2E_unify_21_ (void){
             
 }            break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_VALUE_5F_BLOCK();
             WORD_ATOM(262, 24, "swap");
             mw_prim_swap();
             WORD_ATOM(262, 29, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_VALUE_5F_BLOCK();
                     WORD_ATOM(264, 17, "dup2");
                     mw_dup2();
                     WORD_ATOM(264, 22, "=");
@@ -25819,7 +29056,7 @@ static void mw_Value_2E_unify_21_ (void){
                     }
                     break;
                 case 0LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_VALUE_5F_INT();
                     WORD_ATOM(269, 17, "drop2");
                     mw_drop2();
                     WORD_ATOM(269, 23, "dup");
@@ -25843,7 +29080,7 @@ static void mw_Value_2E_unify_21_ (void){
                     mw_TYPE_5F_ERROR();
                     break;
                 case 1LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_VALUE_5F_STR();
                     WORD_ATOM(273, 17, "drop2");
                     mw_drop2();
                     WORD_ATOM(273, 23, "dup");
@@ -25878,7 +29115,7 @@ static void mw_Value_2E_unify_type_21_ (void){
     WORD_ATOM(280, 5, "VALUE_INT");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_VALUE_5F_INT();
             WORD_ATOM(280, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(280, 23, "TYPE_INT");
@@ -25887,7 +29124,7 @@ static void mw_Value_2E_unify_type_21_ (void){
             mw_Type_2E_unify_21_();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_VALUE_5F_STR();
             WORD_ATOM(281, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(281, 23, "TYPE_STR");
@@ -25896,7 +29133,7 @@ static void mw_Value_2E_unify_type_21_ (void){
             mw_Type_2E_unify_21_();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_VALUE_5F_BLOCK();
             WORD_ATOM(282, 20, "swap");
             mw_prim_swap();
             WORD_ATOM(282, 25, "unify-block!");
@@ -25913,7 +29150,7 @@ static void mw_Type_2E_unify_block_21_ (void){
     WORD_ATOM(285, 12, "match");
     switch (get_top_data_tag()) {
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMeta();
             WORD_ATOM(286, 18, "over");
             mw_over();
             WORD_ATOM(286, 23, "dip");
@@ -25942,7 +29179,7 @@ static void mw_Type_2E_unify_block_21_ (void){
             mw_ArrowType_3E_Type();
             break;
         case 9LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMorphism();
             WORD_ATOM(287, 22, "block-unify-type!");
             mw_block_unify_type_21_();
             WORD_ATOM(287, 40, ">Type");
@@ -26090,82 +29327,81 @@ static void mw_Type_2E_has_meta_3F_ (void){
     WORD_ATOM(304, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMeta();
             WORD_ATOM(304, 14, "has-meta?");
             mw_MetaVar_2E_has_meta_3F_();
             break;
         case 0LL:
-            mw_prim_drop();
+            co_TYPE_5F_ERROR();
             WORD_ATOM(305, 19, "drop");
             mw_prim_drop();
             WORD_ATOM(305, 24, "F");
             mw_F();
             break;
         case 1LL:
-            mw_prim_drop();
+            co_TYPE_5F_DONT_5F_CARE();
             WORD_ATOM(306, 23, "drop");
             mw_prim_drop();
             WORD_ATOM(306, 28, "F");
             mw_F();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TPrim();
             WORD_ATOM(307, 14, "drop2");
             mw_drop2();
             WORD_ATOM(307, 20, "F");
             mw_F();
             break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TVar();
             WORD_ATOM(308, 13, "drop2");
             mw_drop2();
             WORD_ATOM(308, 19, "F");
             mw_F();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_THole();
             WORD_ATOM(309, 14, "drop2");
             mw_drop2();
             WORD_ATOM(309, 20, "F");
             mw_F();
             break;
         case 8LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TTensor();
             WORD_ATOM(310, 16, "has-meta?");
             mw_StackType_2E_has_meta_3F_();
             break;
         case 9LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMorphism();
             WORD_ATOM(311, 18, "has-meta?");
             mw_ArrowType_2E_has_meta_3F_();
             break;
         case 10LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_TApp();
             WORD_ATOM(312, 13, "has-meta2?");
             mw_Type_2E_has_meta2_3F_();
             break;
         case 7LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TData();
             WORD_ATOM(313, 14, "drop2");
             mw_drop2();
             WORD_ATOM(313, 20, "F");
             mw_F();
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TTable();
             WORD_ATOM(314, 15, "drop2");
             mw_drop2();
             WORD_ATOM(314, 21, "F");
             mw_F();
             break;
         case 12LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TValue();
             WORD_ATOM(315, 15, "has-meta?");
             mw_Value_2E_has_meta_3F_();
             break;
         case 11LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMut();
             WORD_ATOM(316, 13, "has-meta?");
             mw_Type_2E_has_meta_3F_();
             break;
@@ -26209,7 +29445,7 @@ static void mw_Type_2E_trace_sig_21_ (void){
     WORD_ATOM(325, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMeta();
             WORD_ATOM(325, 14, "expand-if");
             push_u64(0);
             push_fnptr(&mb_Type_2E_trace_sig_21__2);
@@ -26220,7 +29456,7 @@ static void mw_Type_2E_trace_sig_21_ (void){
             mw_MetaVar_2E_expand_if();
             break;
         case 0LL:
-            mw_prim_drop();
+            co_TYPE_5F_ERROR();
             WORD_ATOM(326, 19, "");
             {
                 static bool vready = false;
@@ -26236,7 +29472,7 @@ static void mw_Type_2E_trace_sig_21_ (void){
             mw_Str_2E_trace_21_();
             break;
         case 9LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMorphism();
             WORD_ATOM(327, 18, "trace!");
             mw_ArrowType_2E_trace_21_();
             break;
@@ -26252,7 +29488,7 @@ static void mw_Type_2E_trace_21_ (void){
     WORD_ATOM(331, 5, "TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_TYPE_5F_ERROR();
             WORD_ATOM(331, 19, "");
             {
                 static bool vready = false;
@@ -26268,7 +29504,7 @@ static void mw_Type_2E_trace_21_ (void){
             mw_Str_2E_trace_21_();
             break;
         case 1LL:
-            mw_prim_drop();
+            co_TYPE_5F_DONT_5F_CARE();
             WORD_ATOM(332, 23, "");
             {
                 static bool vready = false;
@@ -26284,22 +29520,22 @@ static void mw_Type_2E_trace_21_ (void){
             mw_Str_2E_trace_21_();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TPrim();
             WORD_ATOM(333, 14, "trace!");
             mw_PrimType_2E_trace_21_();
             break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TVar();
             WORD_ATOM(334, 13, "trace!");
             mw_Var_2E_trace_21_();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMeta();
             WORD_ATOM(335, 14, "trace!");
             mw_MetaVar_2E_trace_21_();
             break;
         case 8LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TTensor();
             WORD_ATOM(336, 16, "");
             {
                 static bool vready = false;
@@ -26330,7 +29566,7 @@ static void mw_Type_2E_trace_21_ (void){
             mw_Str_2E_trace_21_();
             break;
         case 9LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMorphism();
             WORD_ATOM(337, 18, "");
             {
                 static bool vready = false;
@@ -26363,39 +29599,38 @@ static void mw_Type_2E_trace_21_ (void){
             mw_Str_2E_trace_21_();
             break;
         case 7LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TData();
             WORD_ATOM(338, 14, "name");
             mw_Data_2E_name();
             WORD_ATOM(338, 19, "trace!");
             mw_Name_2E_trace_21_();
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TTable();
             WORD_ATOM(339, 15, "name");
             mw_Table_2E_name();
             WORD_ATOM(339, 20, "trace!");
             mw_Name_2E_trace_21_();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_THole();
             WORD_ATOM(340, 14, "trace!");
             mw_Name_2E_trace_21_();
             break;
         case 10LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_TApp();
             WORD_ATOM(341, 13, "trace-app!");
             mw_Type_2E_trace_app_21_();
             break;
         case 12LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TValue();
             WORD_ATOM(342, 15, "type");
             mw_Value_2E_type();
             WORD_ATOM(342, 20, "trace!");
             mw_Type_2E_trace_21_();
             break;
         case 11LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMut();
             WORD_ATOM(343, 13, "");
             {
                 static bool vready = false;
@@ -26434,7 +29669,7 @@ static void mw_Value_2E_type (void){
     WORD_ATOM(346, 5, "VALUE_INT");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_VALUE_5F_INT();
             WORD_ATOM(346, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(346, 23, "PRIM_TYPE_INT");
@@ -26443,7 +29678,7 @@ static void mw_Value_2E_type (void){
             mw_TPrim();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_VALUE_5F_STR();
             WORD_ATOM(347, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(347, 23, "PRIM_TYPE_STR");
@@ -26452,7 +29687,7 @@ static void mw_Value_2E_type (void){
             mw_TPrim();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_VALUE_5F_BLOCK();
             WORD_ATOM(348, 20, "type");
             mw_Block_2E_type();
             WORD_ATOM(348, 25, ">Type");
@@ -26467,7 +29702,7 @@ static void mw_PrimType_2E_trace_21_ (void){
     WORD_ATOM(351, 5, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_PRIM_5F_TYPE_5F_TYPE();
             WORD_ATOM(352, 27, "");
             {
                 static bool vready = false;
@@ -26481,7 +29716,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             }
             break;
         case 1LL:
-            mw_prim_drop();
+            co_PRIM_5F_TYPE_5F_STACK();
             WORD_ATOM(353, 28, "");
             {
                 static bool vready = false;
@@ -26495,7 +29730,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             }
             break;
         case 2LL:
-            mw_prim_drop();
+            co_PRIM_5F_TYPE_5F_RESOURCE();
             WORD_ATOM(354, 31, "");
             {
                 static bool vready = false;
@@ -26509,7 +29744,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             }
             break;
         case 3LL:
-            mw_prim_drop();
+            co_PRIM_5F_TYPE_5F_INT();
             WORD_ATOM(355, 26, "");
             {
                 static bool vready = false;
@@ -26523,7 +29758,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             }
             break;
         case 4LL:
-            mw_prim_drop();
+            co_PRIM_5F_TYPE_5F_PTR();
             WORD_ATOM(356, 26, "");
             {
                 static bool vready = false;
@@ -26537,7 +29772,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             }
             break;
         case 5LL:
-            mw_prim_drop();
+            co_PRIM_5F_TYPE_5F_STR();
             WORD_ATOM(357, 26, "");
             {
                 static bool vready = false;
@@ -26551,7 +29786,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             }
             break;
         case 6LL:
-            mw_prim_drop();
+            co_PRIM_5F_TYPE_5F__2B_PLATFORM();
             WORD_ATOM(358, 32, "");
             {
                 static bool vready = false;
@@ -26575,74 +29810,73 @@ static void mw_Type_2E_freshen (void){
     WORD_ATOM(380, 5, "TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_TYPE_5F_ERROR();
             WORD_ATOM(380, 19, "TYPE_ERROR");
             mw_TYPE_5F_ERROR();
             break;
         case 1LL:
-            mw_prim_drop();
+            co_TYPE_5F_DONT_5F_CARE();
             WORD_ATOM(381, 23, "TYPE_DONT_CARE");
             mw_TYPE_5F_DONT_5F_CARE();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TPrim();
             WORD_ATOM(382, 14, "TPrim");
             mw_TPrim();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_THole();
             WORD_ATOM(383, 14, "THole");
             mw_THole();
             break;
         case 7LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TData();
             WORD_ATOM(384, 14, "TData");
             mw_TData();
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TTable();
             WORD_ATOM(385, 15, "TTable");
             mw_TTable();
             break;
         case 12LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TValue();
             WORD_ATOM(386, 15, "TValue");
             mw_TValue();
             break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TVar();
             WORD_ATOM(387, 13, "freshen");
             mw_Var_2E_freshen();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMeta();
             WORD_ATOM(388, 14, "freshen");
             mw_MetaVar_2E_freshen();
             break;
         case 8LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TTensor();
             WORD_ATOM(389, 16, "freshen");
             mw_StackType_2E_freshen();
             WORD_ATOM(389, 24, "TTensor");
             mw_TTensor();
             break;
         case 9LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMorphism();
             WORD_ATOM(390, 18, "freshen");
             mw_ArrowType_2E_freshen();
             WORD_ATOM(390, 26, "TMorphism");
             mw_TMorphism();
             break;
         case 10LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_TApp();
             WORD_ATOM(391, 13, "freshen2");
             mw_Type_2E_freshen2();
             WORD_ATOM(391, 22, "TApp");
             mw_TApp();
             break;
         case 11LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMut();
             WORD_ATOM(392, 13, "freshen");
             mw_Type_2E_freshen();
             WORD_ATOM(392, 21, "TMut");
@@ -26724,7 +29958,7 @@ static void mw_Type_2E_arity (void){
     WORD_ATOM(445, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMeta();
             WORD_ATOM(445, 14, "expand-if");
             push_u64(0);
             push_fnptr(&mb_Type_2E_arity_2);
@@ -26735,13 +29969,12 @@ static void mw_Type_2E_arity (void){
             mw_MetaVar_2E_expand_if();
             break;
         case 7LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TData();
             WORD_ATOM(446, 14, "arity");
             mw_Data_2E_arity();
             break;
         case 10LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_TApp();
             WORD_ATOM(447, 13, "drop");
             mw_prim_drop();
             WORD_ATOM(447, 18, "arity");
@@ -26805,12 +30038,12 @@ static void mw_MetaVar_2E_has_meta_3F_ (void){
     WORD_ATOM(481, 15, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_NONE();
             WORD_ATOM(482, 17, "=");
             mw_MetaVar_3D_();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_SOME();
             WORD_ATOM(483, 17, "nip");
             mw_nip();
             WORD_ATOM(483, 21, "has-meta?");
@@ -26829,7 +30062,7 @@ static void mw_MetaVar_2E_trace_21_ (void){
     WORD_ATOM(487, 15, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_NONE();
             WORD_ATOM(488, 17, "");
             {
                 static bool vready = false;
@@ -26849,7 +30082,7 @@ static void mw_MetaVar_2E_trace_21_ (void){
             mw_Int_2E_trace_21_();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_SOME();
             WORD_ATOM(489, 17, "nip");
             mw_nip();
             WORD_ATOM(489, 21, "trace!");
@@ -26886,13 +30119,13 @@ static void mw_MetaVar_2E_expand_if (void){
         WORD_ATOM(496, 15, "match");
         switch (get_top_data_tag()) {
             case 0LL:
-                mw_prim_drop();
+                co_NONE();
                 WORD_ATOM(497, 17, "g");
                 incref(var_g);
                 run_value(var_g);
                 break;
             case 1LL:
-                mw_prim_pack_uncons(); mw_prim_drop();
+                co_SOME();
                 WORD_ATOM(498, 17, "expand");
                 mw_Type_2E_expand();
                 WORD_ATOM(498, 24, "tuck");
@@ -26937,14 +30170,14 @@ static void mw_MetaVar_2E_unify_21_ (void){
     WORD_ATOM(503, 15, "match");
     switch (get_top_data_tag()) {
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_SOME();
             WORD_ATOM(504, 17, "nip");
             mw_nip();
             WORD_ATOM(504, 21, "unify!");
             mw_Type_2E_unify_21_();
             break;
         case 0LL:
-            mw_prim_drop();
+            co_NONE();
             WORD_ATOM(505, 17, "dup2");
             mw_dup2();
             WORD_ATOM(505, 22, "swap");
@@ -27054,8 +30287,7 @@ static void mw_Type_2E_trace_app_open_21_ (void){
     WORD_ATOM(539, 17, "match");
     switch (get_top_data_tag()) {
         case 10LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_TApp();
             WORD_ATOM(541, 13, "trace-app-open!");
             mw_Type_2E_trace_app_open_21_();
             WORD_ATOM(542, 13, "");
@@ -27153,27 +30385,27 @@ static void mw_Type_3E_StackType (void){
     WORD_ATOM(580, 5, "TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_TYPE_5F_ERROR();
             WORD_ATOM(580, 19, "STACK_TYPE_ERROR");
             mw_STACK_5F_TYPE_5F_ERROR();
             break;
         case 1LL:
-            mw_prim_drop();
+            co_TYPE_5F_DONT_5F_CARE();
             WORD_ATOM(581, 23, "STACK_TYPE_DONT_CARE");
             mw_STACK_5F_TYPE_5F_DONT_5F_CARE();
             break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TVar();
             WORD_ATOM(582, 13, "STVar");
             mw_STVar();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TMeta();
             WORD_ATOM(583, 14, "STMeta");
             mw_STMeta();
             break;
         case 8LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TTensor();
             WORD_ATOM(584, 16, "id");
             mw_prim_id();
             break;
@@ -27200,22 +30432,22 @@ static void mw_StackType_3E_Type (void){
     WORD_ATOM(588, 5, "STACK_TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_STACK_5F_TYPE_5F_ERROR();
             WORD_ATOM(588, 25, "TYPE_ERROR");
             mw_TYPE_5F_ERROR();
             break;
         case 1LL:
-            mw_prim_drop();
+            co_STACK_5F_TYPE_5F_DONT_5F_CARE();
             WORD_ATOM(589, 29, "TYPE_DONT_CARE");
             mw_TYPE_5F_DONT_5F_CARE();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_STVar();
             WORD_ATOM(590, 14, "TVar");
             mw_TVar();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_STMeta();
             WORD_ATOM(591, 15, "TMeta");
             mw_TMeta();
             break;
@@ -27231,7 +30463,7 @@ static void mw_StackType_2E_expand (void){
     WORD_ATOM(595, 5, "STMeta");
     switch (get_top_data_tag()) {
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_STMeta();
             WORD_ATOM(595, 15, "expand");
             mw_MetaVar_2E_expand();
             WORD_ATOM(595, 22, ">StackType");
@@ -27251,7 +30483,7 @@ static void mw_StackType_2E_unit_3F_ (void){
     WORD_ATOM(599, 12, "match");
     switch (get_top_data_tag()) {
         case 2LL:
-            mw_prim_drop();
+            co_STACK_5F_TYPE_5F_UNIT();
             WORD_ATOM(600, 28, "T");
             mw_T();
             break;
@@ -27271,8 +30503,7 @@ static void mw_StackType_2E_split3 (void){
     WORD_ATOM(606, 12, "match");
     switch (get_top_data_tag()) {
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STCons();
             WORD_ATOM(607, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -27291,8 +30522,7 @@ static void mw_StackType_2E_split3 (void){
             }
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STWith();
             WORD_ATOM(608, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -27327,16 +30557,14 @@ static void mw_StackType_2E_top_type (void){
     WORD_ATOM(623, 12, "match");
     switch (get_top_data_tag()) {
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STCons();
             WORD_ATOM(624, 19, "nip");
             mw_nip();
             WORD_ATOM(624, 23, "SOME");
             mw_SOME();
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STWith();
             WORD_ATOM(625, 19, "drop");
             mw_prim_drop();
             WORD_ATOM(625, 24, "top-type");
@@ -27369,16 +30597,14 @@ static void mw_StackType_2E_top_resource (void){
     WORD_ATOM(635, 12, "match");
     switch (get_top_data_tag()) {
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STWith();
             WORD_ATOM(636, 19, "nip");
             mw_nip();
             WORD_ATOM(636, 23, "SOME");
             mw_SOME();
             break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STCons();
             WORD_ATOM(637, 19, "drop");
             mw_prim_drop();
             WORD_ATOM(637, 24, "top-resource");
@@ -27411,41 +30637,40 @@ static void mw_StackType_2E_has_meta_3F_ (void){
     WORD_ATOM(646, 12, "match");
     switch (get_top_data_tag()) {
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_STMeta();
             WORD_ATOM(647, 19, "=");
             mw_MetaVar_3D_();
             break;
         case 0LL:
-            mw_prim_drop();
+            co_STACK_5F_TYPE_5F_ERROR();
             WORD_ATOM(648, 29, "drop");
             mw_prim_drop();
             WORD_ATOM(648, 34, "F");
             mw_F();
             break;
         case 1LL:
-            mw_prim_drop();
+            co_STACK_5F_TYPE_5F_DONT_5F_CARE();
             WORD_ATOM(649, 33, "drop");
             mw_prim_drop();
             WORD_ATOM(649, 38, "F");
             mw_F();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_STVar();
             WORD_ATOM(650, 18, "drop2");
             mw_drop2();
             WORD_ATOM(650, 24, "F");
             mw_F();
             break;
         case 2LL:
-            mw_prim_drop();
+            co_STACK_5F_TYPE_5F_UNIT();
             WORD_ATOM(651, 28, "drop");
             mw_prim_drop();
             WORD_ATOM(651, 33, "F");
             mw_F();
             break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STCons();
             WORD_ATOM(652, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -27467,8 +30692,7 @@ static void mw_StackType_2E_has_meta_3F_ (void){
             }
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STWith();
             WORD_ATOM(653, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -27515,19 +30739,19 @@ static void mw_StackType_2E_unify_21_ (void){
     WORD_ATOM(661, 17, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_STACK_5F_TYPE_5F_ERROR();
             WORD_ATOM(662, 29, "drop");
             mw_prim_drop();
             WORD_ATOM(662, 34, "STACK_TYPE_ERROR");
             mw_STACK_5F_TYPE_5F_ERROR();
             break;
         case 1LL:
-            mw_prim_drop();
+            co_STACK_5F_TYPE_5F_DONT_5F_CARE();
             WORD_ATOM(663, 33, "id");
             mw_prim_id();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_STMeta();
             WORD_ATOM(664, 19, "swap");
             mw_prim_swap();
             WORD_ATOM(664, 24, "expand");
@@ -27535,19 +30759,19 @@ static void mw_StackType_2E_unify_21_ (void){
             WORD_ATOM(664, 31, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    mw_prim_drop();
+                    co_STACK_5F_TYPE_5F_ERROR();
                     WORD_ATOM(665, 33, "drop");
                     mw_prim_drop();
                     WORD_ATOM(665, 38, "STACK_TYPE_ERROR");
                     mw_STACK_5F_TYPE_5F_ERROR();
                     break;
                 case 1LL:
-                    mw_prim_drop();
+                    co_STACK_5F_TYPE_5F_DONT_5F_CARE();
                     WORD_ATOM(666, 37, "STMeta");
                     mw_STMeta();
                     break;
                 case 4LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_STMeta();
                     WORD_ATOM(667, 23, "dip");
                     {
                         VAL d6 = pop_value();
@@ -27573,7 +30797,7 @@ static void mw_StackType_2E_unify_21_ (void){
             
 }            break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_STVar();
             WORD_ATOM(670, 18, "swap");
             mw_prim_swap();
             WORD_ATOM(670, 23, "expand");
@@ -27581,19 +30805,19 @@ static void mw_StackType_2E_unify_21_ (void){
             WORD_ATOM(670, 30, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    mw_prim_drop();
+                    co_STACK_5F_TYPE_5F_ERROR();
                     WORD_ATOM(671, 33, "drop");
                     mw_prim_drop();
                     WORD_ATOM(671, 38, "STACK_TYPE_ERROR");
                     mw_STACK_5F_TYPE_5F_ERROR();
                     break;
                 case 1LL:
-                    mw_prim_drop();
+                    co_STACK_5F_TYPE_5F_DONT_5F_CARE();
                     WORD_ATOM(672, 37, "STVar");
                     mw_STVar();
                     break;
                 case 4LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_STMeta();
                     WORD_ATOM(673, 23, "dip");
                     {
                         VAL d6 = pop_value();
@@ -27607,7 +30831,7 @@ static void mw_StackType_2E_unify_21_ (void){
                     mw_Type_3E_StackType();
                     break;
                 case 3LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_STVar();
                     WORD_ATOM(674, 22, "unify!");
                     mw_Var_2E_unify_21_();
                     WORD_ATOM(674, 29, ">StackType");
@@ -27627,18 +30851,18 @@ static void mw_StackType_2E_unify_21_ (void){
             
 }            break;
         case 2LL:
-            mw_prim_drop();
+            co_STACK_5F_TYPE_5F_UNIT();
             WORD_ATOM(677, 28, "expand");
             mw_StackType_2E_expand();
             WORD_ATOM(677, 35, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    mw_prim_drop();
+                    co_STACK_5F_TYPE_5F_ERROR();
                     WORD_ATOM(678, 33, "STACK_TYPE_ERROR");
                     mw_STACK_5F_TYPE_5F_ERROR();
                     break;
                 case 4LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_STMeta();
                     WORD_ATOM(679, 23, "dip");
                     {
                         VAL d6 = pop_value();
@@ -27654,12 +30878,12 @@ static void mw_StackType_2E_unify_21_ (void){
                     mw_Type_3E_StackType();
                     break;
                 case 1LL:
-                    mw_prim_drop();
+                    co_STACK_5F_TYPE_5F_DONT_5F_CARE();
                     WORD_ATOM(680, 37, "STACK_TYPE_UNIT");
                     mw_STACK_5F_TYPE_5F_UNIT();
                     break;
                 case 2LL:
-                    mw_prim_drop();
+                    co_STACK_5F_TYPE_5F_UNIT();
                     WORD_ATOM(681, 32, "STACK_TYPE_UNIT");
                     mw_STACK_5F_TYPE_5F_UNIT();
                     break;
@@ -27672,8 +30896,7 @@ static void mw_StackType_2E_unify_21_ (void){
             
 }            break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STCons();
             WORD_ATOM(684, 19, "rotl");
             mw_rotl();
             WORD_ATOM(684, 24, "expand");
@@ -27681,14 +30904,14 @@ static void mw_StackType_2E_unify_21_ (void){
             WORD_ATOM(684, 31, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    mw_prim_drop();
+                    co_STACK_5F_TYPE_5F_ERROR();
                     WORD_ATOM(685, 33, "drop2");
                     mw_drop2();
                     WORD_ATOM(685, 39, "STACK_TYPE_ERROR");
                     mw_STACK_5F_TYPE_5F_ERROR();
                     break;
                 case 4LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_STMeta();
                     WORD_ATOM(686, 23, "dip");
                     {
                         VAL d6 = pop_value();
@@ -27704,7 +30927,7 @@ static void mw_StackType_2E_unify_21_ (void){
                     mw_Type_3E_StackType();
                     break;
                 case 1LL:
-                    mw_prim_drop();
+                    co_STACK_5F_TYPE_5F_DONT_5F_CARE();
                     WORD_ATOM(687, 37, "STCons");
                     mw_STCons();
                     break;
@@ -27725,8 +30948,7 @@ static void mw_StackType_2E_unify_21_ (void){
             
 }            break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STWith();
             WORD_ATOM(693, 19, "rotl");
             mw_rotl();
             WORD_ATOM(693, 24, "expand");
@@ -27734,14 +30956,14 @@ static void mw_StackType_2E_unify_21_ (void){
             WORD_ATOM(693, 31, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
-                    mw_prim_drop();
+                    co_STACK_5F_TYPE_5F_ERROR();
                     WORD_ATOM(694, 33, "drop2");
                     mw_drop2();
                     WORD_ATOM(694, 39, "STACK_TYPE_ERROR");
                     mw_STACK_5F_TYPE_5F_ERROR();
                     break;
                 case 4LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
+                    co_STMeta();
                     WORD_ATOM(695, 23, "dip");
                     {
                         VAL d6 = pop_value();
@@ -27757,7 +30979,7 @@ static void mw_StackType_2E_unify_21_ (void){
                     mw_Type_3E_StackType();
                     break;
                 case 1LL:
-                    mw_prim_drop();
+                    co_STACK_5F_TYPE_5F_DONT_5F_CARE();
                     WORD_ATOM(696, 37, "STWith");
                     mw_STWith();
                     break;
@@ -27788,16 +31010,14 @@ static void mw_StackType_2E_force_cons_3F__21_ (void){
     WORD_ATOM(705, 12, "match");
     switch (get_top_data_tag()) {
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STCons();
             WORD_ATOM(706, 19, "pack2");
             mw_pack2();
             WORD_ATOM(706, 25, "SOME");
             mw_SOME();
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STWith();
             WORD_ATOM(707, 19, "swap");
             mw_prim_swap();
             WORD_ATOM(707, 24, "force-cons?!");
@@ -27811,7 +31031,7 @@ static void mw_StackType_2E_force_cons_3F__21_ (void){
             mw_nip();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_STMeta();
             WORD_ATOM(709, 13, "dip");
             {
                 VAL d4 = pop_value();
@@ -27858,16 +31078,14 @@ static void mw_StackType_2E_force_with_3F__21_ (void){
     WORD_ATOM(717, 12, "match");
     switch (get_top_data_tag()) {
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STWith();
             WORD_ATOM(718, 19, "pack2");
             mw_pack2();
             WORD_ATOM(718, 25, "SOME");
             mw_SOME();
             break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STCons();
             WORD_ATOM(719, 19, "swap");
             mw_prim_swap();
             WORD_ATOM(719, 24, "force-with?!");
@@ -27881,7 +31099,7 @@ static void mw_StackType_2E_force_with_3F__21_ (void){
             mw_nip();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_STMeta();
             WORD_ATOM(721, 13, "dip");
             {
                 VAL d4 = pop_value();
@@ -27990,14 +31208,14 @@ static void mw_StackType_2E_trace_base_21_ (void){
     WORD_ATOM(743, 5, "match");
     switch (get_top_data_tag()) {
         case 2LL:
-            mw_prim_drop();
+            co_STACK_5F_TYPE_5F_UNIT();
             WORD_ATOM(744, 28, "id");
             mw_prim_id();
             WORD_ATOM(744, 31, "F");
             mw_F();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_STMeta();
             WORD_ATOM(745, 19, "");
             {
                 static bool vready = false;
@@ -28017,7 +31235,7 @@ static void mw_StackType_2E_trace_base_21_ (void){
             mw_T();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_STVar();
             WORD_ATOM(746, 18, "dup");
             mw_prim_dup();
             WORD_ATOM(746, 22, "trace!");
@@ -28078,13 +31296,12 @@ static void mw_StackType_2E_semifreshen (void){
     WORD_ATOM(775, 12, "match");
     switch (get_top_data_tag()) {
         case 2LL:
-            mw_prim_drop();
+            co_STACK_5F_TYPE_5F_UNIT();
             WORD_ATOM(776, 28, "dup");
             mw_prim_dup();
             break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STCons();
             WORD_ATOM(777, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -28096,8 +31313,7 @@ static void mw_StackType_2E_semifreshen (void){
             mw_STCons();
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STWith();
             WORD_ATOM(778, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -28133,13 +31349,12 @@ static void mw_StackType_2E_freshen (void){
     WORD_ATOM(783, 12, "match");
     switch (get_top_data_tag()) {
         case 2LL:
-            mw_prim_drop();
+            co_STACK_5F_TYPE_5F_UNIT();
             WORD_ATOM(784, 28, "STACK_TYPE_UNIT");
             mw_STACK_5F_TYPE_5F_UNIT();
             break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STCons();
             WORD_ATOM(785, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -28162,8 +31377,7 @@ static void mw_StackType_2E_freshen (void){
             mw_STCons();
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STWith();
             WORD_ATOM(786, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -28203,13 +31417,12 @@ static void mw_StackType_2E_freshen_aux (void){
     WORD_ATOM(791, 12, "match");
     switch (get_top_data_tag()) {
         case 2LL:
-            mw_prim_drop();
+            co_STACK_5F_TYPE_5F_UNIT();
             WORD_ATOM(792, 28, "over");
             mw_over();
             break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STCons();
             WORD_ATOM(793, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -28232,8 +31445,7 @@ static void mw_StackType_2E_freshen_aux (void){
             mw_STCons();
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STWith();
             WORD_ATOM(794, 19, "dip");
             {
                 VAL d4 = pop_value();
@@ -28271,7 +31483,7 @@ static void mw_StackType_2E_num_morphisms_on_top (void){
     WORD_ATOM(808, 5, "STMeta");
     switch (get_top_data_tag()) {
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_STMeta();
             WORD_ATOM(808, 15, "expand-if");
             push_u64(0);
             push_fnptr(&mb_StackType_2E_num_morphisms_on_top_2);
@@ -28282,8 +31494,7 @@ static void mw_StackType_2E_num_morphisms_on_top (void){
             mw_MetaVar_2E_expand_if();
             break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STCons();
             WORD_ATOM(809, 15, "morphism?");
             mw_Type_2E_morphism_3F_();
             WORD_ATOM(809, 25, ".if");
@@ -28296,8 +31507,7 @@ static void mw_StackType_2E_num_morphisms_on_top (void){
             mw_Maybe_2E_if();
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_STWith();
             WORD_ATOM(810, 15, "drop");
             mw_prim_drop();
             WORD_ATOM(810, 20, "num-morphisms-on-top");
@@ -28323,8 +31533,7 @@ static void mw_ArrowType_2E_unpack (void){
     WORD_ATOM(820, 57, "ARROW_TYPE");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_ARROW_5F_TYPE();
             WORD_ATOM(820, 71, "id");
             mw_prim_id();
             break;
@@ -28607,16 +31816,14 @@ static void mw_Subst_2E_has_var_3F_ (void){
     WORD_ATOM(897, 5, "SUBST_NIL");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_SUBST_5F_NIL();
             WORD_ATOM(897, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(897, 23, "F");
             mw_F();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_SUBST_5F_CON();
             WORD_ATOM(898, 18, "nip");
             mw_nip();
             WORD_ATOM(898, 22, "over2");
@@ -28643,16 +31850,14 @@ static void mw_Subst_2E_get_var (void){
     WORD_ATOM(900, 5, "SUBST_NIL");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_SUBST_5F_NIL();
             WORD_ATOM(900, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(900, 23, "TYPE_ERROR");
             mw_TYPE_5F_ERROR();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_SUBST_5F_CON();
             WORD_ATOM(901, 18, "over3");
             mw_over3();
             WORD_ATOM(901, 24, "=");
@@ -31943,7 +35148,7 @@ static void mw_TokenValue_2E_none_3F_ (void){
     WORD_ATOM(32, 43, "TOKEN_NONE");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_TOKEN_5F_NONE();
             WORD_ATOM(32, 57, "T");
             mw_T();
             break;
@@ -31961,7 +35166,7 @@ static void mw_TokenValue_2E_comma_3F_ (void){
     WORD_ATOM(33, 44, "TOKEN_COMMA");
     switch (get_top_data_tag()) {
         case 1LL:
-            mw_prim_drop();
+            co_TOKEN_5F_COMMA();
             WORD_ATOM(33, 59, "T");
             mw_T();
             break;
@@ -31979,7 +35184,7 @@ static void mw_TokenValue_2E_lparen_open_3F_ (void){
     WORD_ATOM(34, 50, "TOKEN_LPAREN_OPEN");
     switch (get_top_data_tag()) {
         case 2LL:
-            mw_prim_drop();
+            co_TOKEN_5F_LPAREN_5F_OPEN();
             WORD_ATOM(34, 71, "T");
             mw_T();
             break;
@@ -31997,7 +35202,7 @@ static void mw_TokenValue_2E_lparen_3F_ (void){
     WORD_ATOM(35, 53, "TOKEN_LPAREN");
     switch (get_top_data_tag()) {
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_LPAREN();
             WORD_ATOM(35, 69, "SOME");
             mw_SOME();
             break;
@@ -32015,7 +35220,7 @@ static void mw_TokenValue_2E_rparen_3F_ (void){
     WORD_ATOM(36, 53, "TOKEN_RPAREN");
     switch (get_top_data_tag()) {
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_RPAREN();
             WORD_ATOM(36, 69, "SOME");
             mw_SOME();
             break;
@@ -32033,7 +35238,7 @@ static void mw_TokenValue_2E_lsquare_open_3F_ (void){
     WORD_ATOM(37, 51, "TOKEN_LSQUARE_OPEN");
     switch (get_top_data_tag()) {
         case 5LL:
-            mw_prim_drop();
+            co_TOKEN_5F_LSQUARE_5F_OPEN();
             WORD_ATOM(37, 73, "T");
             mw_T();
             break;
@@ -32051,7 +35256,7 @@ static void mw_TokenValue_2E_lsquare_3F_ (void){
     WORD_ATOM(38, 54, "TOKEN_LSQUARE");
     switch (get_top_data_tag()) {
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_LSQUARE();
             WORD_ATOM(38, 71, "SOME");
             mw_SOME();
             break;
@@ -32069,7 +35274,7 @@ static void mw_TokenValue_2E_rsquare_3F_ (void){
     WORD_ATOM(39, 54, "TOKEN_RSQUARE");
     switch (get_top_data_tag()) {
         case 7LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_RSQUARE();
             WORD_ATOM(39, 71, "SOME");
             mw_SOME();
             break;
@@ -32087,7 +35292,7 @@ static void mw_TokenValue_2E_lcurly_open_3F_ (void){
     WORD_ATOM(40, 50, "TOKEN_LCURLY_OPEN");
     switch (get_top_data_tag()) {
         case 8LL:
-            mw_prim_drop();
+            co_TOKEN_5F_LCURLY_5F_OPEN();
             WORD_ATOM(40, 71, "T");
             mw_T();
             break;
@@ -32105,7 +35310,7 @@ static void mw_TokenValue_2E_int_3F_ (void){
     WORD_ATOM(43, 48, "TOKEN_INT");
     switch (get_top_data_tag()) {
         case 11LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_INT();
             WORD_ATOM(43, 61, "SOME");
             mw_SOME();
             break;
@@ -32123,7 +35328,7 @@ static void mw_TokenValue_2E_str_3F_ (void){
     WORD_ATOM(44, 48, "TOKEN_STR");
     switch (get_top_data_tag()) {
         case 12LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_STR();
             WORD_ATOM(44, 61, "SOME");
             mw_SOME();
             break;
@@ -32141,7 +35346,7 @@ static void mw_TokenValue_2E_name_3F_ (void){
     WORD_ATOM(45, 50, "TOKEN_NAME");
     switch (get_top_data_tag()) {
         case 13LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_NAME();
             WORD_ATOM(45, 64, "SOME");
             mw_SOME();
             break;
@@ -32159,26 +35364,26 @@ static void mw_TokenValue_2E_arg_end_3F_ (void){
     WORD_ATOM(47, 5, "TOKEN_COMMA");
     switch (get_top_data_tag()) {
         case 1LL:
-            mw_prim_drop();
+            co_TOKEN_5F_COMMA();
             WORD_ATOM(47, 20, "T");
             mw_T();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_RPAREN();
             WORD_ATOM(48, 21, "drop");
             mw_prim_drop();
             WORD_ATOM(48, 26, "T");
             mw_T();
             break;
         case 10LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_RCURLY();
             WORD_ATOM(49, 21, "drop");
             mw_prim_drop();
             WORD_ATOM(49, 26, "T");
             mw_T();
             break;
         case 7LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_RSQUARE();
             WORD_ATOM(50, 22, "drop");
             mw_prim_drop();
             WORD_ATOM(50, 27, "T");
@@ -32198,21 +35403,21 @@ static void mw_TokenValue_2E_left_enclosure_3F_ (void){
     WORD_ATOM(53, 5, "TOKEN_LPAREN");
     switch (get_top_data_tag()) {
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_LPAREN();
             WORD_ATOM(53, 21, "drop");
             mw_prim_drop();
             WORD_ATOM(53, 26, "T");
             mw_T();
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_LSQUARE();
             WORD_ATOM(54, 22, "drop");
             mw_prim_drop();
             WORD_ATOM(54, 27, "T");
             mw_T();
             break;
         case 9LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_LCURLY();
             WORD_ATOM(55, 22, "drop");
             mw_prim_drop();
             WORD_ATOM(55, 27, "T");
@@ -32232,21 +35437,21 @@ static void mw_TokenValue_2E_right_enclosure_3F_ (void){
     WORD_ATOM(58, 5, "TOKEN_RPAREN");
     switch (get_top_data_tag()) {
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_RPAREN();
             WORD_ATOM(58, 21, "drop");
             mw_prim_drop();
             WORD_ATOM(58, 26, "T");
             mw_T();
             break;
         case 7LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_RSQUARE();
             WORD_ATOM(59, 22, "drop");
             mw_prim_drop();
             WORD_ATOM(59, 27, "T");
             mw_T();
             break;
         case 10LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_RCURLY();
             WORD_ATOM(60, 22, "drop");
             mw_prim_drop();
             WORD_ATOM(60, 27, "T");
@@ -32747,28 +35952,28 @@ static void mw_Token_2E_next (void){
     WORD_ATOM(126, 15, "match");
     switch (get_top_data_tag()) {
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_LPAREN();
             WORD_ATOM(127, 25, "nip");
             mw_nip();
             WORD_ATOM(127, 29, "succ");
             mw_Token_2E_succ();
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_LSQUARE();
             WORD_ATOM(128, 26, "nip");
             mw_nip();
             WORD_ATOM(128, 30, "succ");
             mw_Token_2E_succ();
             break;
         case 9LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_LCURLY();
             WORD_ATOM(129, 25, "nip");
             mw_nip();
             WORD_ATOM(129, 29, "succ");
             mw_Token_2E_succ();
             break;
         case 13LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_NAME();
             WORD_ATOM(130, 23, "drop");
             mw_prim_drop();
             WORD_ATOM(130, 28, "succ");
@@ -32803,17 +36008,17 @@ static void mw_Token_2E_prev (void){
     WORD_ATOM(136, 20, "match");
     switch (get_top_data_tag()) {
         case 7LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_RSQUARE();
             WORD_ATOM(137, 26, "nip");
             mw_nip();
             break;
         case 10LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_RCURLY();
             WORD_ATOM(138, 25, "nip");
             mw_nip();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_RPAREN();
             WORD_ATOM(139, 25, "nip");
             mw_nip();
             WORD_ATOM(139, 29, "dup");
@@ -33260,31 +36465,31 @@ static void mw_Token_2E_run_end_3F_ (void){
     WORD_ATOM(248, 11, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_TOKEN_5F_NONE();
             WORD_ATOM(249, 23, "T");
             mw_T();
             break;
         case 1LL:
-            mw_prim_drop();
+            co_TOKEN_5F_COMMA();
             WORD_ATOM(250, 24, "T");
             mw_T();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_RPAREN();
             WORD_ATOM(251, 25, "drop");
             mw_prim_drop();
             WORD_ATOM(251, 30, "T");
             mw_T();
             break;
         case 7LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_RSQUARE();
             WORD_ATOM(252, 26, "drop");
             mw_prim_drop();
             WORD_ATOM(252, 31, "T");
             mw_T();
             break;
         case 10LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_TOKEN_5F_RCURLY();
             WORD_ATOM(253, 25, "drop");
             mw_prim_drop();
             WORD_ATOM(253, 30, "T");
@@ -33539,12 +36744,12 @@ static void mw_Def_3E_Module_3F_ (void){
     WORD_ATOM(32, 5, "DEF_NONE");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_DEF_5F_NONE();
             WORD_ATOM(32, 17, "NONE");
             mw_NONE();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_ALIAS();
             WORD_ATOM(33, 18, "head");
             mw_Alias_2E_head();
             WORD_ATOM(33, 23, ".module");
@@ -33553,21 +36758,21 @@ static void mw_Def_3E_Module_3F_ (void){
             mw_SOME();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_MODULE();
             WORD_ATOM(34, 19, "drop");
             mw_prim_drop();
             WORD_ATOM(34, 24, "NONE");
             mw_NONE();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_TYPE();
             WORD_ATOM(35, 17, "drop");
             mw_prim_drop();
             WORD_ATOM(35, 22, "NONE");
             mw_NONE();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_TAG();
             WORD_ATOM(36, 16, ".data");
             mw_Tag_2E_data();
             WORD_ATOM(36, 22, "head?");
@@ -33579,14 +36784,14 @@ static void mw_Def_3E_Module_3F_ (void){
             mw_Maybe_2E_map();
             break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_PRIM();
             WORD_ATOM(37, 17, "drop");
             mw_prim_drop();
             WORD_ATOM(37, 22, "NONE");
             mw_NONE();
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_WORD();
             WORD_ATOM(38, 17, "head");
             mw_Word_2E_head();
             WORD_ATOM(38, 22, ".module");
@@ -33595,7 +36800,7 @@ static void mw_Def_3E_Module_3F_ (void){
             mw_SOME();
             break;
         case 7LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_BUFFER();
             WORD_ATOM(39, 19, "head");
             mw_Buffer_2E_head();
             WORD_ATOM(39, 24, ".module");
@@ -33604,7 +36809,7 @@ static void mw_Def_3E_Module_3F_ (void){
             mw_SOME();
             break;
         case 8LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_VARIABLE();
             WORD_ATOM(40, 21, "head");
             mw_Variable_2E_head();
             WORD_ATOM(40, 26, ".module");
@@ -33613,7 +36818,7 @@ static void mw_Def_3E_Module_3F_ (void){
             mw_SOME();
             break;
         case 9LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_CONSTANT();
             WORD_ATOM(41, 21, "head");
             mw_Constant_2E_head();
             WORD_ATOM(41, 26, ".module");
@@ -33622,7 +36827,7 @@ static void mw_Def_3E_Module_3F_ (void){
             mw_SOME();
             break;
         case 10LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_EXTERNAL();
             WORD_ATOM(42, 21, "sig");
             mw_External_2E_sig();
             WORD_ATOM(42, 25, ".module");
@@ -33631,7 +36836,7 @@ static void mw_Def_3E_Module_3F_ (void){
             mw_SOME();
             break;
         case 11LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_FIELD();
             WORD_ATOM(43, 18, "head");
             mw_Field_2E_head();
             WORD_ATOM(43, 23, ".module");
@@ -33648,7 +36853,7 @@ static void mw_Def_2E_none_3F_ (void){
     WORD_ATOM(45, 29, "DEF_NONE");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_DEF_5F_NONE();
             WORD_ATOM(45, 41, "T");
             mw_T();
             break;
@@ -33666,7 +36871,7 @@ static void mw_Def_2E_prim_3F_ (void){
     WORD_ATOM(50, 36, "DEF_PRIM");
     switch (get_top_data_tag()) {
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_PRIM();
             WORD_ATOM(50, 48, "SOME");
             mw_SOME();
             break;
@@ -33684,12 +36889,12 @@ static void mw_Def_2E_typecheck_21_ (void){
     WORD_ATOM(59, 5, "DEF_NONE");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_DEF_5F_NONE();
             WORD_ATOM(59, 17, "id");
             mw_prim_id();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_ALIAS();
             WORD_ATOM(60, 18, "target");
             mw_Alias_2E_target();
             WORD_ATOM(60, 25, ">Def");
@@ -33698,62 +36903,62 @@ static void mw_Def_2E_typecheck_21_ (void){
             mw_Def_2E_typecheck_21_();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_MODULE();
             WORD_ATOM(61, 19, "drop");
             mw_prim_drop();
             break;
         case 7LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_BUFFER();
             WORD_ATOM(62, 19, "drop");
             mw_prim_drop();
             break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_PRIM();
             WORD_ATOM(63, 17, "drop");
             mw_prim_drop();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_TYPE();
             WORD_ATOM(64, 17, "drop");
             mw_prim_drop();
             break;
         case 10LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_EXTERNAL();
             WORD_ATOM(65, 21, "type");
             mw_External_2E_type();
             WORD_ATOM(65, 26, "drop");
             mw_prim_drop();
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_WORD();
             WORD_ATOM(66, 17, "arrow");
             mw_Word_2E_arrow();
             WORD_ATOM(66, 23, "drop");
             mw_prim_drop();
             break;
         case 11LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_FIELD();
             WORD_ATOM(67, 18, "type");
             mw_Field_2E_type();
             WORD_ATOM(67, 23, "drop");
             mw_prim_drop();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_TAG();
             WORD_ATOM(68, 16, "type");
             mw_Tag_2E_type();
             WORD_ATOM(68, 21, "drop");
             mw_prim_drop();
             break;
         case 8LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_VARIABLE();
             WORD_ATOM(69, 21, "type");
             mw_Variable_2E_type();
             WORD_ATOM(69, 26, "drop");
             mw_prim_drop();
             break;
         case 9LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_CONSTANT();
             WORD_ATOM(70, 21, "drop");
             mw_prim_drop();
             break;
@@ -33766,12 +36971,12 @@ static void mw_Def_2E_callable_3F_ (void){
     WORD_ATOM(73, 5, "DEF_NONE");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_DEF_5F_NONE();
             WORD_ATOM(73, 17, "F");
             mw_F();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_ALIAS();
             WORD_ATOM(74, 18, "target");
             mw_Alias_2E_target();
             WORD_ATOM(74, 25, ">Def");
@@ -33780,70 +36985,70 @@ static void mw_Def_2E_callable_3F_ (void){
             mw_Def_2E_callable_3F_();
             break;
         case 2LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_MODULE();
             WORD_ATOM(75, 19, "drop");
             mw_prim_drop();
             WORD_ATOM(75, 24, "F");
             mw_F();
             break;
         case 7LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_BUFFER();
             WORD_ATOM(76, 19, "drop");
             mw_prim_drop();
             WORD_ATOM(76, 24, "T");
             mw_T();
             break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_PRIM();
             WORD_ATOM(77, 17, "drop");
             mw_prim_drop();
             WORD_ATOM(77, 22, "T");
             mw_T();
             break;
         case 3LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_TYPE();
             WORD_ATOM(78, 17, "drop");
             mw_prim_drop();
             WORD_ATOM(78, 22, "F");
             mw_F();
             break;
         case 10LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_EXTERNAL();
             WORD_ATOM(79, 21, "drop");
             mw_prim_drop();
             WORD_ATOM(79, 26, "T");
             mw_T();
             break;
         case 6LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_WORD();
             WORD_ATOM(80, 17, "drop");
             mw_prim_drop();
             WORD_ATOM(80, 22, "T");
             mw_T();
             break;
         case 11LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_FIELD();
             WORD_ATOM(81, 18, "drop");
             mw_prim_drop();
             WORD_ATOM(81, 23, "T");
             mw_T();
             break;
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_TAG();
             WORD_ATOM(82, 16, "drop");
             mw_prim_drop();
             WORD_ATOM(82, 21, "T");
             mw_T();
             break;
         case 8LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_VARIABLE();
             WORD_ATOM(83, 21, "drop");
             mw_prim_drop();
             WORD_ATOM(83, 26, "T");
             mw_T();
             break;
         case 9LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_CONSTANT();
             WORD_ATOM(84, 21, "drop");
             mw_prim_drop();
             WORD_ATOM(84, 26, "T");
@@ -34075,12 +37280,12 @@ static void mw_Hash_2E_keep_going_3F_ (void){
     WORD_ATOM(49, 20, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_NONE();
             WORD_ATOM(50, 17, "F");
             mw_F();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_SOME();
             WORD_ATOM(51, 17, ">Str");
             mw_Name_3E_Str();
             WORD_ATOM(51, 22, "over2");
@@ -34133,7 +37338,7 @@ static void mw_Str_3E_Name (void){
     WORD_ATOM(62, 20, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
+            co_NONE();
             WORD_ATOM(64, 13, "Name.alloc!");
             mw_Name_2E_alloc_21_();
             WORD_ATOM(65, 13, "tuck");
@@ -34171,7 +37376,7 @@ static void mw_Str_3E_Name (void){
             mw_prim_mut_set();
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_SOME();
             WORD_ATOM(70, 13, "dip");
             {
                 VAL d4 = pop_value();
@@ -34589,9 +37794,7 @@ static void mw_Location_2E_unpack (void){
     WORD_ATOM(20, 50, "LOCATION");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            mw_prim_pack_uncons(); mw_prim_swap();
+            co_LOCATION();
             WORD_ATOM(20, 62, "id");
             mw_prim_id();
             break;
@@ -35021,19 +38224,19 @@ static void mb_init_prims_21__16 (void) {
 }
 
 static void mb_typecheck_everything_21__1 (void) {
-    WORD_ENTER(mb_typecheck_everything_21__1, "typecheck-everything! block", "src/mirth/elab.mth", 1025, 14);
+    WORD_ENTER(mb_typecheck_everything_21__1, "typecheck-everything! block", "src/mirth/elab.mth", 1027, 14);
     mw_prim_drop();
-    WORD_ATOM(1025, 14, ">Def");
+    WORD_ATOM(1027, 14, ">Def");
     mw_Name_3E_Def();
-    WORD_ATOM(1025, 19, "typecheck!");
+    WORD_ATOM(1027, 19, "typecheck!");
     mw_Def_2E_typecheck_21_();
     WORD_EXIT(mb_typecheck_everything_21__1);
 }
 
 static void mb_typecheck_everything_21__2 (void) {
-    WORD_ENTER(mb_typecheck_everything_21__2, "typecheck-everything! block", "src/mirth/elab.mth", 1026, 15);
+    WORD_ENTER(mb_typecheck_everything_21__2, "typecheck-everything! block", "src/mirth/elab.mth", 1028, 15);
     mw_prim_drop();
-    WORD_ATOM(1026, 15, "typecheck!");
+    WORD_ATOM(1028, 15, "typecheck!");
     mw_Block_2E_typecheck_21_();
     WORD_EXIT(mb_typecheck_everything_21__2);
 }
@@ -35191,55 +38394,55 @@ static void mb_assert_21__3 (void) {
 }
 
 static void mb_List_2E_cat_1 (void) {
-    WORD_ENTER(mb_List_2E_cat_1, "List.cat block", "src/data/list.mth", 105, 16);
+    WORD_ENTER(mb_List_2E_cat_1, "List.cat block", "src/data/list.mth", 110, 16);
     mw_prim_drop();
-    WORD_ATOM(105, 16, "cat");
+    WORD_ATOM(110, 16, "cat");
     mw_List_2B__2E_cat();
-    WORD_ATOM(105, 20, ">List");
+    WORD_ATOM(110, 20, ">List");
     mw_List_2B__3E_List();
     WORD_EXIT(mb_List_2E_cat_1);
 }
 
 static void mb_List_2B__2E_cat_1 (void) {
-    WORD_ENTER(mb_List_2B__2E_cat_1, "List+.cat block", "src/data/list.mth", 108, 21);
+    WORD_ENTER(mb_List_2B__2E_cat_1, "List+.cat block", "src/data/list.mth", 113, 21);
     mw_prim_drop();
-    WORD_ATOM(108, 21, "swap");
+    WORD_ATOM(113, 21, "swap");
     mw_prim_swap();
-    WORD_ATOM(108, 26, "cat+");
+    WORD_ATOM(113, 26, "cat+");
     mw_List_2B__2E_cat_2B_();
     WORD_EXIT(mb_List_2B__2E_cat_1);
 }
 
 static void mb_List_2E_cat_2B__1 (void) {
-    WORD_ENTER(mb_List_2E_cat_2B__1, "List.cat+ block", "src/data/list.mth", 111, 16);
+    WORD_ENTER(mb_List_2E_cat_2B__1, "List.cat+ block", "src/data/list.mth", 116, 16);
     mw_prim_drop();
-    WORD_ATOM(111, 16, "cat+");
+    WORD_ATOM(116, 16, "cat+");
     mw_List_2B__2E_cat_2B_();
     WORD_EXIT(mb_List_2E_cat_2B__1);
 }
 
 static void mb_List_2E_first_1 (void) {
-    WORD_ENTER(mb_List_2E_first_1, "List.first block", "src/data/list.mth", 168, 53);
+    WORD_ENTER(mb_List_2E_first_1, "List.first block", "src/data/list.mth", 173, 53);
     mw_prim_drop();
-    WORD_ATOM(168, 53, "first");
+    WORD_ATOM(173, 53, "first");
     mw_List_2B__2E_first();
     WORD_EXIT(mb_List_2E_first_1);
 }
 
 static void mb_List_2E_last_1 (void) {
-    WORD_ENTER(mb_List_2E_last_1, "List.last block", "src/data/list.mth", 169, 52);
+    WORD_ENTER(mb_List_2E_last_1, "List.last block", "src/data/list.mth", 174, 52);
     mw_prim_drop();
-    WORD_ATOM(169, 52, "last");
+    WORD_ATOM(174, 52, "last");
     mw_List_2B__2E_last();
     WORD_EXIT(mb_List_2E_last_1);
 }
 
 static void mb_List_2B__2E_filter_5 (void) {
-    WORD_ENTER(mb_List_2B__2E_filter_5, "List+.filter block", "src/data/list.mth", 270, 39);
+    WORD_ENTER(mb_List_2B__2E_filter_5, "List+.filter block", "src/data/list.mth", 275, 39);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(270, 39, "filter");
+    WORD_ATOM(275, 39, "filter");
     incref(var_f);
     push_value(var_f);
     mw_List_2B__2E_filter();
@@ -35248,11 +38451,11 @@ static void mb_List_2B__2E_filter_5 (void) {
 }
 
 static void mb_List_2B__2E_filter_10 (void) {
-    WORD_ENTER(mb_List_2B__2E_filter_10, "List+.filter block", "src/data/list.mth", 273, 18);
+    WORD_ENTER(mb_List_2B__2E_filter_10, "List+.filter block", "src/data/list.mth", 278, 18);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(273, 18, "filter");
+    WORD_ATOM(278, 18, "filter");
     incref(var_f);
     push_value(var_f);
     mw_List_2E_filter();
@@ -35261,11 +38464,11 @@ static void mb_List_2B__2E_filter_10 (void) {
 }
 
 static void mb_List_2E_filter_some_2 (void) {
-    WORD_ENTER(mb_List_2E_filter_some_2, "List.filter-some block", "src/data/list.mth", 279, 24);
+    WORD_ENTER(mb_List_2E_filter_some_2, "List.filter-some block", "src/data/list.mth", 284, 24);
     mw_prim_pack_uncons();
     VAL var_p = pop_value();
     mw_prim_drop();
-    WORD_ATOM(279, 24, "filter-some");
+    WORD_ATOM(284, 24, "filter-some");
     incref(var_p);
     push_value(var_p);
     mw_List_2B__2E_filter_some();
@@ -35274,22 +38477,22 @@ static void mb_List_2E_filter_some_2 (void) {
 }
 
 static void mb_List_2E_filter_some_4 (void) {
-    WORD_ENTER(mb_List_2E_filter_some_4, "List.filter-some block", "src/data/list.mth", 279, 40);
+    WORD_ENTER(mb_List_2E_filter_some_4, "List.filter-some block", "src/data/list.mth", 284, 40);
     mw_prim_pack_uncons();
     VAL var_p = pop_value();
     mw_prim_drop();
-    WORD_ATOM(279, 40, "L0");
+    WORD_ATOM(284, 40, "L0");
     mw_L0();
     decref(var_p);
     WORD_EXIT(mb_List_2E_filter_some_4);
 }
 
 static void mb_List_2B__2E_filter_some_5 (void) {
-    WORD_ENTER(mb_List_2B__2E_filter_some_5, "List+.filter-some block", "src/data/list.mth", 282, 44);
+    WORD_ENTER(mb_List_2B__2E_filter_some_5, "List+.filter-some block", "src/data/list.mth", 287, 44);
     mw_prim_pack_uncons();
     VAL var_p = pop_value();
     mw_prim_drop();
-    WORD_ATOM(282, 44, "filter-some");
+    WORD_ATOM(287, 44, "filter-some");
     incref(var_p);
     push_value(var_p);
     mw_List_2B__2E_filter_some();
@@ -35298,36 +38501,36 @@ static void mb_List_2B__2E_filter_some_5 (void) {
 }
 
 static void mb_List_2B__2E_filter_some_11 (void) {
-    WORD_ENTER(mb_List_2B__2E_filter_some_11, "List+.filter-some block", "src/data/list.mth", 283, 53);
+    WORD_ENTER(mb_List_2B__2E_filter_some_11, "List+.filter-some block", "src/data/list.mth", 288, 53);
     mw_prim_pack_uncons();
     VAL var_p = pop_value();
     mw_prim_drop();
-    WORD_ATOM(283, 53, "snoc");
+    WORD_ATOM(288, 53, "snoc");
     mw_snoc();
     decref(var_p);
     WORD_EXIT(mb_List_2B__2E_filter_some_11);
 }
 
 static void mb_List_2B__2E_filter_some_12 (void) {
-    WORD_ENTER(mb_List_2B__2E_filter_some_12, "List+.filter-some block", "src/data/list.mth", 283, 59);
+    WORD_ENTER(mb_List_2B__2E_filter_some_12, "List+.filter-some block", "src/data/list.mth", 288, 59);
     mw_prim_pack_uncons();
     VAL var_p = pop_value();
     mw_prim_drop();
-    WORD_ATOM(283, 59, "id");
+    WORD_ATOM(288, 59, "id");
     mw_prim_id();
     decref(var_p);
     WORD_EXIT(mb_List_2B__2E_filter_some_12);
 }
 
 static void mb_List_2E_all_2 (void) {
-    WORD_ENTER(mb_List_2E_all_2, "List.all block", "src/data/list.mth", 329, 10);
+    WORD_ENTER(mb_List_2E_all_2, "List.all block", "src/data/list.mth", 334, 10);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(329, 10, "f");
+    WORD_ATOM(334, 10, "f");
     incref(var_f);
     run_value(var_f);
-    WORD_ATOM(329, 12, "not");
+    WORD_ATOM(334, 12, "not");
     mw_Bool_2E_not();
     decref(var_f);
     WORD_EXIT(mb_List_2E_all_2);
@@ -35639,23 +38842,23 @@ static void mb_Str_2E_first_byte_1 (void) {
 }
 
 static void mb_Int_3E_Byte_1 (void) {
-    WORD_ENTER(mb_Int_3E_Byte_1, "Int>Byte block", "src/data/byte.mth", 42, 13);
+    WORD_ENTER(mb_Int_3E_Byte_1, "Int>Byte block", "src/data/byte.mth", 43, 13);
     mw_prim_drop();
-    WORD_ATOM(42, 13, "dup");
+    WORD_ATOM(43, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(42, 17, "");
+    WORD_ATOM(43, 17, "");
     push_i64(0LL);
-    WORD_ATOM(42, 19, "");
+    WORD_ATOM(43, 19, "");
     push_i64(255LL);
-    WORD_ATOM(42, 23, "in-range");
+    WORD_ATOM(43, 23, "in-range");
     mw_Int_2E_in_range();
     WORD_EXIT(mb_Int_3E_Byte_1);
 }
 
 static void mb_Int_3E_Byte_2 (void) {
-    WORD_ENTER(mb_Int_3E_Byte_2, "Int>Byte block", "src/data/byte.mth", 42, 33);
+    WORD_ENTER(mb_Int_3E_Byte_2, "Int>Byte block", "src/data/byte.mth", 43, 33);
     mw_prim_drop();
-    WORD_ATOM(42, 33, "");
+    WORD_ATOM(43, 33, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35670,25 +38873,25 @@ static void mb_Int_3E_Byte_2 (void) {
 }
 
 static void mb_Byte_3D__1 (void) {
-    WORD_ENTER(mb_Byte_3D__1, "Byte= block", "src/data/byte.mth", 51, 37);
+    WORD_ENTER(mb_Byte_3D__1, "Byte= block", "src/data/byte.mth", 52, 37);
     mw_prim_drop();
-    WORD_ATOM(51, 37, ">Int");
+    WORD_ATOM(52, 37, ">Int");
     mw_Byte_3E_Int();
     WORD_EXIT(mb_Byte_3D__1);
 }
 
 static void mb_Byte_3E__1 (void) {
-    WORD_ENTER(mb_Byte_3E__1, "Byte> block", "src/data/byte.mth", 53, 37);
+    WORD_ENTER(mb_Byte_3E__1, "Byte> block", "src/data/byte.mth", 54, 37);
     mw_prim_drop();
-    WORD_ATOM(53, 37, ">Int");
+    WORD_ATOM(54, 37, ">Int");
     mw_Byte_3E_Int();
     WORD_EXIT(mb_Byte_3E__1);
 }
 
 static void mb_Byte_2E_in_range_2 (void) {
-    WORD_ENTER(mb_Byte_2E_in_range_2, "Byte.in-range block", "src/data/byte.mth", 57, 53);
+    WORD_ENTER(mb_Byte_2E_in_range_2, "Byte.in-range block", "src/data/byte.mth", 58, 53);
     mw_prim_drop();
-    WORD_ATOM(57, 53, ">Int");
+    WORD_ATOM(58, 53, ">Int");
     mw_Byte_3E_Int();
     WORD_EXIT(mb_Byte_2E_in_range_2);
 }
@@ -36067,12 +39270,21 @@ static void mb_TokenValue_2E_pat_underscore_3F__1 (void) {
 static void mb_TokenValue_2E_module_header_3F__1 (void) {
     WORD_ENTER(mb_TokenValue_2E_module_header_3F__1, "TokenValue.module-header? block", "src/mirth/data/token.mth", 74, 67);
     mw_prim_drop();
-    WORD_ATOM(74, 67, "PRIM_SYNTAX_MODULE");
-    mw_PRIM_5F_SYNTAX_5F_MODULE();
-    WORD_ATOM(74, 86, "name");
-    mw_Prim_2E_name();
-    WORD_ATOM(74, 91, "=");
-    mw_Name_3D_();
+    WORD_ATOM(74, 67, ">Str");
+    mw_Name_3E_Str();
+    WORD_ATOM(74, 72, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("module", 6);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(74, 81, "=");
+    mw_Str_3D_();
     WORD_EXIT(mb_TokenValue_2E_module_header_3F__1);
 }
 
@@ -36298,55 +39510,15 @@ static void mb_elab_module_import_21__1 (void) {
 }
 
 static void mb_elab_alias_21__1 (void) {
-    WORD_ENTER(mb_elab_alias_21__1, "elab-alias! block", "src/mirth/elab.mth", 895, 9);
+    WORD_ENTER(mb_elab_alias_21__1, "elab-alias! block", "src/mirth/elab.mth", 897, 9);
     mw_prim_drop();
-    WORD_ATOM(895, 9, "next");
+    WORD_ATOM(897, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_alias_21__1);
 }
 
 static void mb_elab_alias_21__2 (void) {
-    WORD_ENTER(mb_elab_alias_21__2, "elab-alias! block", "src/mirth/elab.mth", 896, 25);
-    mw_prim_drop();
-    WORD_ATOM(896, 25, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr("expected word name", 18);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(896, 46, "emit-fatal-error!");
-    mw_emit_fatal_error_21_();
-    WORD_EXIT(mb_elab_alias_21__2);
-}
-
-static void mb_elab_alias_21__4 (void) {
-    WORD_ENTER(mb_elab_alias_21__4, "elab-alias! block", "src/mirth/elab.mth", 897, 26);
-    mw_prim_drop();
-    WORD_ATOM(897, 26, "drop");
-    mw_prim_drop();
-    WORD_ATOM(897, 31, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr("word already defined", 20);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(897, 54, "emit-fatal-error!");
-    mw_emit_fatal_error_21_();
-    WORD_EXIT(mb_elab_alias_21__4);
-}
-
-static void mb_elab_alias_21__5 (void) {
-    WORD_ENTER(mb_elab_alias_21__5, "elab-alias! block", "src/mirth/elab.mth", 898, 25);
+    WORD_ENTER(mb_elab_alias_21__2, "elab-alias! block", "src/mirth/elab.mth", 898, 25);
     mw_prim_drop();
     WORD_ATOM(898, 25, "");
     {
@@ -36361,199 +39533,15 @@ static void mb_elab_alias_21__5 (void) {
     }
     WORD_ATOM(898, 46, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
-    WORD_EXIT(mb_elab_alias_21__5);
+    WORD_EXIT(mb_elab_alias_21__2);
 }
 
-static void mb_elab_def_21__1 (void) {
-    WORD_ENTER(mb_elab_def_21__1, "elab-def! block", "src/mirth/elab.mth", 911, 9);
+static void mb_elab_alias_21__4 (void) {
+    WORD_ENTER(mb_elab_alias_21__4, "elab-alias! block", "src/mirth/elab.mth", 899, 26);
     mw_prim_drop();
-    WORD_ATOM(911, 9, "next");
-    mw_Token_2E_next();
-    WORD_EXIT(mb_elab_def_21__1);
-}
-
-static void mb_elab_def_21__6 (void) {
-    WORD_ENTER(mb_elab_def_21__6, "elab-def! block", "src/mirth/elab.mth", 915, 30);
+    WORD_ATOM(899, 26, "drop");
     mw_prim_drop();
-    WORD_ATOM(915, 30, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr("expected word name", 18);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(915, 51, "emit-fatal-error!");
-    mw_emit_fatal_error_21_();
-    WORD_EXIT(mb_elab_def_21__6);
-}
-
-static void mb_elab_def_21__9 (void) {
-    WORD_ENTER(mb_elab_def_21__9, "elab-def! block", "src/mirth/elab.mth", 922, 9);
-    mw_prim_drop();
-    WORD_ATOM(922, 9, "type-elab-default");
-    mw_type_elab_default();
-    WORD_ATOM(923, 9, "over");
-    mw_over();
-    WORD_ATOM(923, 14, "sig");
-    mw_Word_2E_sig();
-    WORD_ATOM(923, 18, "unwrap-or");
-    push_u64(0);
-    push_fnptr(&mb_elab_def_21__10);
-    mw_prim_pack_cons();
-    mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(924, 9, "elab-type-sig!");
-    mw_elab_type_sig_21_();
-    WORD_ATOM(924, 24, "drop");
-    mw_prim_drop();
-    WORD_ATOM(924, 29, "dip");
-    {
-        VAL d2 = pop_value();
-        WORD_ATOM(924, 33, "type-elab-ctx");
-        mw_type_elab_ctx();
-        push_value(d2);
-    }
-    WORD_ATOM(925, 9, "pack2");
-    mw_pack2();
-    WORD_ATOM(925, 15, "nip");
-    mw_nip();
-    WORD_EXIT(mb_elab_def_21__9);
-}
-
-static void mb_elab_def_21__10 (void) {
-    WORD_ENTER(mb_elab_def_21__10, "elab-def! block", "src/mirth/elab.mth", 923, 28);
-    mw_prim_drop();
-    WORD_ATOM(923, 28, "over");
-    mw_over();
-    WORD_ATOM(923, 33, "head");
-    mw_Word_2E_head();
-    WORD_ATOM(923, 38, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr("need word signature", 19);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(923, 60, "emit-fatal-error!");
-    mw_emit_fatal_error_21_();
-    WORD_EXIT(mb_elab_def_21__10);
-}
-
-static void mb_elab_def_21__12 (void) {
-    WORD_ENTER(mb_elab_def_21__12, "elab-def! block", "src/mirth/elab.mth", 927, 15);
-    mw_prim_drop();
-    WORD_ATOM(927, 15, "elab-def-params!");
-    mw_elab_def_params_21_();
-    WORD_EXIT(mb_elab_def_21__12);
-}
-
-static void mb_elab_def_21__13 (void) {
-    WORD_ENTER(mb_elab_def_21__13, "elab-def! block", "src/mirth/elab.mth", 929, 9);
-    mw_prim_drop();
-    WORD_ATOM(929, 9, "dup");
-    mw_prim_dup();
-    WORD_ATOM(929, 13, "ab-build-word-arrow!");
-    push_u64(0);
-    push_fnptr(&mb_elab_def_21__14);
-    mw_prim_pack_cons();
-    mw_ab_build_word_arrow_21_();
-    WORD_EXIT(mb_elab_def_21__13);
-}
-
-static void mb_elab_def_21__14 (void) {
-    WORD_ENTER(mb_elab_def_21__14, "elab-def! block", "src/mirth/elab.mth", 930, 13);
-    mw_prim_drop();
-    WORD_ATOM(930, 13, "swap");
-    mw_prim_swap();
-    WORD_ATOM(930, 18, "params");
-    mw_Word_2E_params();
-    WORD_ATOM(930, 25, "dup");
-    mw_prim_dup();
-    WORD_ATOM(930, 29, "is-empty");
-    mw_List_2E_is_empty();
-    WORD_ATOM(930, 38, "if");
-    if (pop_u64()) {
-        WORD_ATOM(931, 17, "drop");
-        mw_prim_drop();
-        WORD_ATOM(931, 22, "elab-def-body!");
-        mw_elab_def_body_21_();
-    } else {
-        WORD_ATOM(932, 17, "ab-lambda!");
-        push_u64(0);
-        push_fnptr(&mb_elab_def_21__17);
-        mw_prim_pack_cons();
-        mw_ab_lambda_21_();
-    }
-    WORD_EXIT(mb_elab_def_21__14);
-}
-
-static void mb_elab_def_21__17 (void) {
-    WORD_ENTER(mb_elab_def_21__17, "elab-def! block", "src/mirth/elab.mth", 932, 28);
-    mw_prim_drop();
-    WORD_ATOM(932, 28, "elab-def-body!");
-    mw_elab_def_body_21_();
-    WORD_EXIT(mb_elab_def_21__17);
-}
-
-static void mb_elab_def_missing_21__1 (void) {
-    WORD_ENTER(mb_elab_def_missing_21__1, "elab-def-missing! block", "src/mirth/elab.mth", 904, 39);
-    mw_prim_drop();
-    WORD_ATOM(904, 39, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr("expected name", 13);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(904, 55, "emit-fatal-error!");
-    mw_emit_fatal_error_21_();
-    WORD_EXIT(mb_elab_def_missing_21__1);
-}
-
-static void mb_elab_def_external_21__1 (void) {
-    WORD_ENTER(mb_elab_def_external_21__1, "elab-def-external! block", "src/mirth/elab.mth", 961, 9);
-    mw_prim_drop();
-    WORD_ATOM(961, 9, "next");
-    mw_Token_2E_next();
-    WORD_EXIT(mb_elab_def_external_21__1);
-}
-
-static void mb_elab_def_external_21__2 (void) {
-    WORD_ENTER(mb_elab_def_external_21__2, "elab-def-external! block", "src/mirth/elab.mth", 962, 30);
-    mw_prim_drop();
-    WORD_ATOM(962, 30, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr("expected word name", 18);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(962, 51, "emit-fatal-error!");
-    mw_emit_fatal_error_21_();
-    WORD_EXIT(mb_elab_def_external_21__2);
-}
-
-static void mb_elab_def_external_21__3 (void) {
-    WORD_ENTER(mb_elab_def_external_21__3, "elab-def-external! block", "src/mirth/elab.mth", 963, 26);
-    mw_prim_drop();
-    WORD_ATOM(963, 26, "drop");
-    mw_prim_drop();
-    WORD_ATOM(963, 31, "");
+    WORD_ATOM(899, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36564,48 +39552,272 @@ static void mb_elab_def_external_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(963, 54, "emit-fatal-error!");
+    WORD_ATOM(899, 54, "emit-fatal-error!");
+    mw_emit_fatal_error_21_();
+    WORD_EXIT(mb_elab_alias_21__4);
+}
+
+static void mb_elab_alias_21__5 (void) {
+    WORD_ENTER(mb_elab_alias_21__5, "elab-alias! block", "src/mirth/elab.mth", 900, 25);
+    mw_prim_drop();
+    WORD_ATOM(900, 25, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("expected word name", 18);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(900, 46, "emit-fatal-error!");
+    mw_emit_fatal_error_21_();
+    WORD_EXIT(mb_elab_alias_21__5);
+}
+
+static void mb_elab_def_21__1 (void) {
+    WORD_ENTER(mb_elab_def_21__1, "elab-def! block", "src/mirth/elab.mth", 913, 9);
+    mw_prim_drop();
+    WORD_ATOM(913, 9, "next");
+    mw_Token_2E_next();
+    WORD_EXIT(mb_elab_def_21__1);
+}
+
+static void mb_elab_def_21__6 (void) {
+    WORD_ENTER(mb_elab_def_21__6, "elab-def! block", "src/mirth/elab.mth", 917, 30);
+    mw_prim_drop();
+    WORD_ATOM(917, 30, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("expected word name", 18);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(917, 51, "emit-fatal-error!");
+    mw_emit_fatal_error_21_();
+    WORD_EXIT(mb_elab_def_21__6);
+}
+
+static void mb_elab_def_21__9 (void) {
+    WORD_ENTER(mb_elab_def_21__9, "elab-def! block", "src/mirth/elab.mth", 924, 9);
+    mw_prim_drop();
+    WORD_ATOM(924, 9, "type-elab-default");
+    mw_type_elab_default();
+    WORD_ATOM(925, 9, "over");
+    mw_over();
+    WORD_ATOM(925, 14, "sig");
+    mw_Word_2E_sig();
+    WORD_ATOM(925, 18, "unwrap-or");
+    push_u64(0);
+    push_fnptr(&mb_elab_def_21__10);
+    mw_prim_pack_cons();
+    mw_Maybe_2E_unwrap_or();
+    WORD_ATOM(926, 9, "elab-type-sig!");
+    mw_elab_type_sig_21_();
+    WORD_ATOM(926, 24, "drop");
+    mw_prim_drop();
+    WORD_ATOM(926, 29, "dip");
+    {
+        VAL d2 = pop_value();
+        WORD_ATOM(926, 33, "type-elab-ctx");
+        mw_type_elab_ctx();
+        push_value(d2);
+    }
+    WORD_ATOM(927, 9, "pack2");
+    mw_pack2();
+    WORD_ATOM(927, 15, "nip");
+    mw_nip();
+    WORD_EXIT(mb_elab_def_21__9);
+}
+
+static void mb_elab_def_21__10 (void) {
+    WORD_ENTER(mb_elab_def_21__10, "elab-def! block", "src/mirth/elab.mth", 925, 28);
+    mw_prim_drop();
+    WORD_ATOM(925, 28, "over");
+    mw_over();
+    WORD_ATOM(925, 33, "head");
+    mw_Word_2E_head();
+    WORD_ATOM(925, 38, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("need word signature", 19);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(925, 60, "emit-fatal-error!");
+    mw_emit_fatal_error_21_();
+    WORD_EXIT(mb_elab_def_21__10);
+}
+
+static void mb_elab_def_21__12 (void) {
+    WORD_ENTER(mb_elab_def_21__12, "elab-def! block", "src/mirth/elab.mth", 929, 15);
+    mw_prim_drop();
+    WORD_ATOM(929, 15, "elab-def-params!");
+    mw_elab_def_params_21_();
+    WORD_EXIT(mb_elab_def_21__12);
+}
+
+static void mb_elab_def_21__13 (void) {
+    WORD_ENTER(mb_elab_def_21__13, "elab-def! block", "src/mirth/elab.mth", 931, 9);
+    mw_prim_drop();
+    WORD_ATOM(931, 9, "dup");
+    mw_prim_dup();
+    WORD_ATOM(931, 13, "ab-build-word-arrow!");
+    push_u64(0);
+    push_fnptr(&mb_elab_def_21__14);
+    mw_prim_pack_cons();
+    mw_ab_build_word_arrow_21_();
+    WORD_EXIT(mb_elab_def_21__13);
+}
+
+static void mb_elab_def_21__14 (void) {
+    WORD_ENTER(mb_elab_def_21__14, "elab-def! block", "src/mirth/elab.mth", 932, 13);
+    mw_prim_drop();
+    WORD_ATOM(932, 13, "swap");
+    mw_prim_swap();
+    WORD_ATOM(932, 18, "params");
+    mw_Word_2E_params();
+    WORD_ATOM(932, 25, "dup");
+    mw_prim_dup();
+    WORD_ATOM(932, 29, "is-empty");
+    mw_List_2E_is_empty();
+    WORD_ATOM(932, 38, "if");
+    if (pop_u64()) {
+        WORD_ATOM(933, 17, "drop");
+        mw_prim_drop();
+        WORD_ATOM(933, 22, "elab-def-body!");
+        mw_elab_def_body_21_();
+    } else {
+        WORD_ATOM(934, 17, "ab-lambda!");
+        push_u64(0);
+        push_fnptr(&mb_elab_def_21__17);
+        mw_prim_pack_cons();
+        mw_ab_lambda_21_();
+    }
+    WORD_EXIT(mb_elab_def_21__14);
+}
+
+static void mb_elab_def_21__17 (void) {
+    WORD_ENTER(mb_elab_def_21__17, "elab-def! block", "src/mirth/elab.mth", 934, 28);
+    mw_prim_drop();
+    WORD_ATOM(934, 28, "elab-def-body!");
+    mw_elab_def_body_21_();
+    WORD_EXIT(mb_elab_def_21__17);
+}
+
+static void mb_elab_def_missing_21__1 (void) {
+    WORD_ENTER(mb_elab_def_missing_21__1, "elab-def-missing! block", "src/mirth/elab.mth", 906, 39);
+    mw_prim_drop();
+    WORD_ATOM(906, 39, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("expected name", 13);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(906, 55, "emit-fatal-error!");
+    mw_emit_fatal_error_21_();
+    WORD_EXIT(mb_elab_def_missing_21__1);
+}
+
+static void mb_elab_def_external_21__1 (void) {
+    WORD_ENTER(mb_elab_def_external_21__1, "elab-def-external! block", "src/mirth/elab.mth", 963, 9);
+    mw_prim_drop();
+    WORD_ATOM(963, 9, "next");
+    mw_Token_2E_next();
+    WORD_EXIT(mb_elab_def_external_21__1);
+}
+
+static void mb_elab_def_external_21__2 (void) {
+    WORD_ENTER(mb_elab_def_external_21__2, "elab-def-external! block", "src/mirth/elab.mth", 964, 30);
+    mw_prim_drop();
+    WORD_ATOM(964, 30, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("expected word name", 18);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(964, 51, "emit-fatal-error!");
+    mw_emit_fatal_error_21_();
+    WORD_EXIT(mb_elab_def_external_21__2);
+}
+
+static void mb_elab_def_external_21__3 (void) {
+    WORD_ENTER(mb_elab_def_external_21__3, "elab-def-external! block", "src/mirth/elab.mth", 965, 26);
+    mw_prim_drop();
+    WORD_ATOM(965, 26, "drop");
+    mw_prim_drop();
+    WORD_ATOM(965, 31, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("word already defined", 20);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(965, 54, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_external_21__3);
 }
 
 static void mb_elab_def_external_21__4 (void) {
-    WORD_ENTER(mb_elab_def_external_21__4, "elab-def-external! block", "src/mirth/elab.mth", 970, 9);
+    WORD_ENTER(mb_elab_def_external_21__4, "elab-def-external! block", "src/mirth/elab.mth", 972, 9);
     mw_prim_drop();
-    WORD_ATOM(970, 9, "type-elab-default");
+    WORD_ATOM(972, 9, "type-elab-default");
     mw_type_elab_default();
-    WORD_ATOM(970, 27, "swap");
+    WORD_ATOM(972, 27, "swap");
     mw_prim_swap();
-    WORD_ATOM(970, 32, "sig");
+    WORD_ATOM(972, 32, "sig");
     mw_External_2E_sig();
-    WORD_ATOM(971, 9, "elab-type-sig!");
+    WORD_ATOM(973, 9, "elab-type-sig!");
     mw_elab_type_sig_21_();
-    WORD_ATOM(971, 24, "drop");
+    WORD_ATOM(973, 24, "drop");
     mw_prim_drop();
-    WORD_ATOM(971, 29, "dip");
+    WORD_ATOM(973, 29, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(971, 33, "type-elab-ctx");
+        WORD_ATOM(973, 33, "type-elab-ctx");
         mw_type_elab_ctx();
         push_value(d2);
     }
-    WORD_ATOM(971, 48, "pack2");
+    WORD_ATOM(973, 48, "pack2");
     mw_pack2();
     WORD_EXIT(mb_elab_def_external_21__4);
 }
 
 static void mb_elab_def_type_21__1 (void) {
-    WORD_ENTER(mb_elab_def_type_21__1, "elab-def-type! block", "src/mirth/elab.mth", 976, 9);
+    WORD_ENTER(mb_elab_def_type_21__1, "elab-def-type! block", "src/mirth/elab.mth", 978, 9);
     mw_prim_drop();
-    WORD_ATOM(976, 9, "next");
+    WORD_ATOM(978, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_def_type_21__1);
 }
 
 static void mb_elab_def_type_21__2 (void) {
-    WORD_ENTER(mb_elab_def_type_21__2, "elab-def-type! block", "src/mirth/elab.mth", 977, 33);
+    WORD_ENTER(mb_elab_def_type_21__2, "elab-def-type! block", "src/mirth/elab.mth", 979, 33);
     mw_prim_drop();
-    WORD_ATOM(977, 33, "");
+    WORD_ATOM(979, 33, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36616,17 +39828,17 @@ static void mb_elab_def_type_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(977, 61, "emit-fatal-error!");
+    WORD_ATOM(979, 61, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_type_21__2);
 }
 
 static void mb_elab_def_type_21__3 (void) {
-    WORD_ENTER(mb_elab_def_type_21__3, "elab-def-type! block", "src/mirth/elab.mth", 978, 43);
+    WORD_ENTER(mb_elab_def_type_21__3, "elab-def-type! block", "src/mirth/elab.mth", 980, 43);
     mw_prim_drop();
-    WORD_ATOM(978, 43, "drop");
+    WORD_ATOM(980, 43, "drop");
     mw_prim_drop();
-    WORD_ATOM(978, 48, "");
+    WORD_ATOM(980, 48, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36637,23 +39849,23 @@ static void mb_elab_def_type_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(978, 76, "emit-fatal-error!");
+    WORD_ATOM(980, 76, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_type_21__3);
 }
 
 static void mb_elab_buffer_21__1 (void) {
-    WORD_ENTER(mb_elab_buffer_21__1, "elab-buffer! block", "src/mirth/elab.mth", 983, 9);
+    WORD_ENTER(mb_elab_buffer_21__1, "elab-buffer! block", "src/mirth/elab.mth", 985, 9);
     mw_prim_drop();
-    WORD_ATOM(983, 9, "next");
+    WORD_ATOM(985, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_buffer_21__1);
 }
 
 static void mb_elab_buffer_21__2 (void) {
-    WORD_ENTER(mb_elab_buffer_21__2, "elab-buffer! block", "src/mirth/elab.mth", 984, 30);
+    WORD_ENTER(mb_elab_buffer_21__2, "elab-buffer! block", "src/mirth/elab.mth", 986, 30);
     mw_prim_drop();
-    WORD_ATOM(984, 30, "");
+    WORD_ATOM(986, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36664,17 +39876,17 @@ static void mb_elab_buffer_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(984, 53, "emit-fatal-error!");
+    WORD_ATOM(986, 53, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_buffer_21__2);
 }
 
 static void mb_elab_buffer_21__3 (void) {
-    WORD_ENTER(mb_elab_buffer_21__3, "elab-buffer! block", "src/mirth/elab.mth", 985, 26);
+    WORD_ENTER(mb_elab_buffer_21__3, "elab-buffer! block", "src/mirth/elab.mth", 987, 26);
     mw_prim_drop();
-    WORD_ATOM(985, 26, "drop");
+    WORD_ATOM(987, 26, "drop");
     mw_prim_drop();
-    WORD_ATOM(985, 31, "");
+    WORD_ATOM(987, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36685,15 +39897,15 @@ static void mb_elab_buffer_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(985, 61, "emit-fatal-error!");
+    WORD_ATOM(987, 61, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_buffer_21__3);
 }
 
 static void mb_elab_buffer_21__4 (void) {
-    WORD_ENTER(mb_elab_buffer_21__4, "elab-buffer! block", "src/mirth/elab.mth", 986, 29);
+    WORD_ENTER(mb_elab_buffer_21__4, "elab-buffer! block", "src/mirth/elab.mth", 988, 29);
     mw_prim_drop();
-    WORD_ATOM(986, 29, "");
+    WORD_ATOM(988, 29, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36704,23 +39916,23 @@ static void mb_elab_buffer_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(986, 52, "emit-fatal-error!");
+    WORD_ATOM(988, 52, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_buffer_21__4);
 }
 
 static void mb_elab_variable_21__1 (void) {
-    WORD_ENTER(mb_elab_variable_21__1, "elab-variable! block", "src/mirth/elab.mth", 991, 9);
+    WORD_ENTER(mb_elab_variable_21__1, "elab-variable! block", "src/mirth/elab.mth", 993, 9);
     mw_prim_drop();
-    WORD_ATOM(991, 9, "next");
+    WORD_ATOM(993, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_variable_21__1);
 }
 
 static void mb_elab_variable_21__2 (void) {
-    WORD_ENTER(mb_elab_variable_21__2, "elab-variable! block", "src/mirth/elab.mth", 992, 30);
+    WORD_ENTER(mb_elab_variable_21__2, "elab-variable! block", "src/mirth/elab.mth", 994, 30);
     mw_prim_drop();
-    WORD_ATOM(992, 30, "");
+    WORD_ATOM(994, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36731,17 +39943,17 @@ static void mb_elab_variable_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(992, 55, "emit-fatal-error!");
+    WORD_ATOM(994, 55, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_variable_21__2);
 }
 
 static void mb_elab_variable_21__3 (void) {
-    WORD_ENTER(mb_elab_variable_21__3, "elab-variable! block", "src/mirth/elab.mth", 993, 26);
+    WORD_ENTER(mb_elab_variable_21__3, "elab-variable! block", "src/mirth/elab.mth", 995, 26);
     mw_prim_drop();
-    WORD_ATOM(993, 26, "drop");
+    WORD_ATOM(995, 26, "drop");
     mw_prim_drop();
-    WORD_ATOM(993, 31, "");
+    WORD_ATOM(995, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36752,31 +39964,31 @@ static void mb_elab_variable_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(993, 63, "emit-fatal-error!");
+    WORD_ATOM(995, 63, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_variable_21__3);
 }
 
 static void mb_elab_variable_21__4 (void) {
-    WORD_ENTER(mb_elab_variable_21__4, "elab-variable! block", "src/mirth/elab.mth", 994, 16);
+    WORD_ENTER(mb_elab_variable_21__4, "elab-variable! block", "src/mirth/elab.mth", 996, 16);
     mw_prim_drop();
-    WORD_ATOM(994, 16, "elab-simple-type-arg!");
+    WORD_ATOM(996, 16, "elab-simple-type-arg!");
     mw_elab_simple_type_arg_21_();
     WORD_EXIT(mb_elab_variable_21__4);
 }
 
 static void mb_elab_table_21__1 (void) {
-    WORD_ENTER(mb_elab_table_21__1, "elab-table! block", "src/mirth/elab.mth", 999, 9);
+    WORD_ENTER(mb_elab_table_21__1, "elab-table! block", "src/mirth/elab.mth", 1001, 9);
     mw_prim_drop();
-    WORD_ATOM(999, 9, "next");
+    WORD_ATOM(1001, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_table_21__1);
 }
 
 static void mb_elab_table_21__2 (void) {
-    WORD_ENTER(mb_elab_table_21__2, "elab-table! block", "src/mirth/elab.mth", 1000, 28);
+    WORD_ENTER(mb_elab_table_21__2, "elab-table! block", "src/mirth/elab.mth", 1002, 28);
     mw_prim_drop();
-    WORD_ATOM(1000, 28, "");
+    WORD_ATOM(1002, 28, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36787,17 +39999,17 @@ static void mb_elab_table_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1000, 49, "emit-fatal-error!");
+    WORD_ATOM(1002, 49, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_table_21__2);
 }
 
 static void mb_elab_table_21__3 (void) {
-    WORD_ENTER(mb_elab_table_21__3, "elab-table! block", "src/mirth/elab.mth", 1001, 43);
+    WORD_ENTER(mb_elab_table_21__3, "elab-table! block", "src/mirth/elab.mth", 1003, 43);
     mw_prim_drop();
-    WORD_ATOM(1001, 43, "drop");
+    WORD_ATOM(1003, 43, "drop");
     mw_prim_drop();
-    WORD_ATOM(1001, 48, "");
+    WORD_ATOM(1003, 48, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36808,15 +40020,15 @@ static void mb_elab_table_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1001, 77, "emit-fatal-error!");
+    WORD_ATOM(1003, 77, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_table_21__3);
 }
 
 static void mb_elab_field_21__1 (void) {
-    WORD_ENTER(mb_elab_field_21__1, "elab-field! block", "src/mirth/elab.mth", 1208, 9);
+    WORD_ENTER(mb_elab_field_21__1, "elab-field! block", "src/mirth/elab.mth", 1210, 9);
     mw_prim_drop();
-    WORD_ATOM(1208, 9, "next");
+    WORD_ATOM(1210, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_field_21__1);
 }
@@ -36866,17 +40078,17 @@ static void mb_elab_data_21__3 (void) {
 }
 
 static void mb_elab_target_c99_21__1 (void) {
-    WORD_ENTER(mb_elab_target_c99_21__1, "elab-target-c99! block", "src/mirth/elab.mth", 1007, 9);
+    WORD_ENTER(mb_elab_target_c99_21__1, "elab-target-c99! block", "src/mirth/elab.mth", 1009, 9);
     mw_prim_drop();
-    WORD_ATOM(1007, 9, "next");
+    WORD_ATOM(1009, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_target_c99_21__1);
 }
 
 static void mb_elab_target_c99_21__3 (void) {
-    WORD_ENTER(mb_elab_target_c99_21__3, "elab-target-c99! block", "src/mirth/elab.mth", 1008, 28);
+    WORD_ENTER(mb_elab_target_c99_21__3, "elab-target-c99! block", "src/mirth/elab.mth", 1010, 28);
     mw_prim_drop();
-    WORD_ATOM(1008, 28, "");
+    WORD_ATOM(1010, 28, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36887,23 +40099,23 @@ static void mb_elab_target_c99_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1008, 51, "emit-fatal-error!");
+    WORD_ATOM(1010, 51, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_target_c99_21__3);
 }
 
 static void mb_elab_embed_str_21__1 (void) {
-    WORD_ENTER(mb_elab_embed_str_21__1, "elab-embed-str! block", "src/mirth/elab.mth", 1016, 9);
+    WORD_ENTER(mb_elab_embed_str_21__1, "elab-embed-str! block", "src/mirth/elab.mth", 1018, 9);
     mw_prim_drop();
-    WORD_ATOM(1016, 9, "next");
+    WORD_ATOM(1018, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_embed_str_21__1);
 }
 
 static void mb_elab_embed_str_21__2 (void) {
-    WORD_ENTER(mb_elab_embed_str_21__2, "elab-embed-str! block", "src/mirth/elab.mth", 1017, 25);
+    WORD_ENTER(mb_elab_embed_str_21__2, "elab-embed-str! block", "src/mirth/elab.mth", 1019, 25);
     mw_prim_drop();
-    WORD_ATOM(1017, 25, "");
+    WORD_ATOM(1019, 25, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36914,17 +40126,17 @@ static void mb_elab_embed_str_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1017, 59, "emit-fatal-error!");
+    WORD_ATOM(1019, 59, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_embed_str_21__2);
 }
 
 static void mb_elab_embed_str_21__3 (void) {
-    WORD_ENTER(mb_elab_embed_str_21__3, "elab-embed-str! block", "src/mirth/elab.mth", 1018, 26);
+    WORD_ENTER(mb_elab_embed_str_21__3, "elab-embed-str! block", "src/mirth/elab.mth", 1020, 26);
     mw_prim_drop();
-    WORD_ATOM(1018, 26, "drop");
+    WORD_ATOM(1020, 26, "drop");
     mw_prim_drop();
-    WORD_ATOM(1018, 31, "");
+    WORD_ATOM(1020, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36935,15 +40147,15 @@ static void mb_elab_embed_str_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1018, 72, "emit-fatal-error!");
+    WORD_ATOM(1020, 72, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_embed_str_21__3);
 }
 
 static void mb_elab_embed_str_21__4 (void) {
-    WORD_ENTER(mb_elab_embed_str_21__4, "elab-embed-str! block", "src/mirth/elab.mth", 1019, 29);
+    WORD_ENTER(mb_elab_embed_str_21__4, "elab-embed-str! block", "src/mirth/elab.mth", 1021, 29);
     mw_prim_drop();
-    WORD_ATOM(1019, 29, "");
+    WORD_ATOM(1021, 29, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36954,25 +40166,25 @@ static void mb_elab_embed_str_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1019, 52, "emit-fatal-error!");
+    WORD_ATOM(1021, 52, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_embed_str_21__4);
 }
 
 static void mb_elab_embed_str_21__5 (void) {
-    WORD_ENTER(mb_elab_embed_str_21__5, "elab-embed-str! block", "src/mirth/elab.mth", 1020, 21);
+    WORD_ENTER(mb_elab_embed_str_21__5, "elab-embed-str! block", "src/mirth/elab.mth", 1022, 21);
     mw_prim_drop();
-    WORD_ATOM(1020, 21, "read-file!");
+    WORD_ATOM(1022, 21, "read-file!");
     mw_read_file_21_();
-    WORD_ATOM(1020, 32, "nip");
+    WORD_ATOM(1022, 32, "nip");
     mw_nip();
     WORD_EXIT(mb_elab_embed_str_21__5);
 }
 
 static void mb_elab_embed_str_21__6 (void) {
-    WORD_ENTER(mb_elab_embed_str_21__6, "elab-embed-str! block", "src/mirth/elab.mth", 1020, 37);
+    WORD_ENTER(mb_elab_embed_str_21__6, "elab-embed-str! block", "src/mirth/elab.mth", 1022, 37);
     mw_prim_drop();
-    WORD_ATOM(1020, 37, "");
+    WORD_ATOM(1022, 37, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36983,7 +40195,7 @@ static void mb_elab_embed_str_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1020, 66, "emit-fatal-error!");
+    WORD_ATOM(1022, 66, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_embed_str_21__6);
 }
@@ -37599,127 +40811,210 @@ static void mb_Block_2E_new_deferred_21__1 (void) {
 }
 
 static void mb_make_data_21__3 (void) {
-    WORD_ENTER(mb_make_data_21__3, "make-data! block", "src/mirth/data/data.mth", 65, 9);
+    WORD_ENTER(mb_make_data_21__3, "make-data! block", "src/mirth/data/data.mth", 48, 9);
     mw_prim_drop();
-    WORD_ATOM(65, 9, "dip");
+    WORD_ATOM(48, 9, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(65, 13, "Tag.alloc!");
+        WORD_ATOM(48, 13, "Tag.alloc!");
         mw_Tag_2E_alloc_21_();
-        WORD_ATOM(65, 24, "dup");
+        WORD_ATOM(48, 24, "dup");
         mw_prim_dup();
         push_value(d2);
     }
-    WORD_ATOM(65, 29, "!");
+    WORD_ATOM(48, 29, "!");
     mw_prim_mut_set();
     WORD_EXIT(mb_make_data_21__3);
 }
 
 static void mb_make_data_21__7 (void) {
-    WORD_ENTER(mb_make_data_21__7, "make-data! block", "src/mirth/data/data.mth", 73, 13);
+    WORD_ENTER(mb_make_data_21__7, "make-data! block", "src/mirth/data/data.mth", 56, 13);
     mw_prim_drop();
-    WORD_ATOM(73, 13, "dip");
+    WORD_ATOM(56, 13, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(73, 17, "over");
+        WORD_ATOM(56, 17, "over");
         mw_over();
         push_value(d2);
     }
-    WORD_ATOM(73, 23, "~data");
+    WORD_ATOM(56, 23, "~data");
     mw_Tag_7E_data();
-    WORD_ATOM(73, 29, "!");
+    WORD_ATOM(56, 29, "!");
     mw_prim_mut_set();
     WORD_EXIT(mb_make_data_21__7);
 }
 
 static void mb_make_tag_21__2 (void) {
-    WORD_ENTER(mb_make_tag_21__2, "make-tag! block", "src/mirth/data/data.mth", 83, 13);
+    WORD_ENTER(mb_make_tag_21__2, "make-tag! block", "src/mirth/data/data.mth", 66, 13);
     mw_prim_drop();
-    WORD_ATOM(83, 13, "len");
+    WORD_ATOM(66, 13, "len");
     mw_List_2E_len();
     WORD_EXIT(mb_make_tag_21__2);
 }
 
 static void mb_make_tag_21__3 (void) {
-    WORD_ENTER(mb_make_tag_21__3, "make-tag! block", "src/mirth/data/data.mth", 84, 9);
+    WORD_ENTER(mb_make_tag_21__3, "make-tag! block", "src/mirth/data/data.mth", 67, 9);
     mw_prim_drop();
-    WORD_ATOM(84, 9, "CTX0");
+    WORD_ATOM(67, 9, "CTX0");
     mw_CTX0();
-    WORD_ATOM(84, 14, "rotr");
+    WORD_ATOM(67, 14, "rotr");
     mw_rotr();
-    WORD_ATOM(84, 19, ".data");
+    WORD_ATOM(67, 19, ".data");
     mw_Tag_2E_data();
-    WORD_ATOM(84, 25, "TData");
+    WORD_ATOM(67, 25, "TData");
     mw_TData();
-    WORD_ATOM(84, 31, "T1");
+    WORD_ATOM(67, 31, "T1");
     mw_T1();
-    WORD_ATOM(84, 34, "T->");
+    WORD_ATOM(67, 34, "T->");
     mw_T__3E_();
-    WORD_ATOM(84, 38, "pack2");
+    WORD_ATOM(67, 38, "pack2");
     mw_pack2();
-    WORD_ATOM(84, 44, "LAZY_READY");
+    WORD_ATOM(67, 44, "LAZY_READY");
     mw_LAZY_5F_READY();
     WORD_EXIT(mb_make_tag_21__3);
 }
 
 static void mb_make_tag_21__4 (void) {
-    WORD_ENTER(mb_make_tag_21__4, "make-tag! block", "src/mirth/data/data.mth", 84, 60);
+    WORD_ENTER(mb_make_tag_21__4, "make-tag! block", "src/mirth/data/data.mth", 67, 60);
     mw_prim_drop();
-    WORD_ATOM(84, 60, "~ctx-type");
+    WORD_ATOM(67, 60, "~ctx-type");
     mw_Tag_7E_ctx_type();
-    WORD_ATOM(84, 70, "!");
+    WORD_ATOM(67, 70, "!");
     mw_prim_mut_set();
     WORD_EXIT(mb_make_tag_21__4);
 }
 
 static void mb_make_tag_21__5 (void) {
-    WORD_ENTER(mb_make_tag_21__5, "make-tag! block", "src/mirth/data/data.mth", 85, 9);
+    WORD_ENTER(mb_make_tag_21__5, "make-tag! block", "src/mirth/data/data.mth", 68, 9);
     mw_prim_drop();
-    WORD_ATOM(85, 9, "~num-inputs");
-    mw_Tag_7E_num_inputs();
-    WORD_ATOM(85, 21, "!");
+    WORD_ATOM(68, 9, "~num-type-inputs");
+    mw_Tag_7E_num_type_inputs();
+    WORD_ATOM(68, 26, "!");
     mw_prim_mut_set();
     WORD_EXIT(mb_make_tag_21__5);
 }
 
 static void mb_make_tag_21__6 (void) {
-    WORD_ENTER(mb_make_tag_21__6, "make-tag! block", "src/mirth/data/data.mth", 86, 9);
+    WORD_ENTER(mb_make_tag_21__6, "make-tag! block", "src/mirth/data/data.mth", 69, 9);
     mw_prim_drop();
-    WORD_ATOM(86, 9, "~value");
-    mw_Tag_7E_value();
-    WORD_ATOM(86, 16, "!");
+    WORD_ATOM(69, 9, "");
+    push_i64(0LL);
+    WORD_ATOM(69, 11, "swap");
+    mw_prim_swap();
+    WORD_ATOM(69, 16, "~num-resource-inputs");
+    mw_Tag_7E_num_resource_inputs();
+    WORD_ATOM(69, 37, "!");
     mw_prim_mut_set();
     WORD_EXIT(mb_make_tag_21__6);
 }
 
-static void mb_Data_3D__1 (void) {
-    WORD_ENTER(mb_Data_3D__1, "Data= block", "src/mirth/data/data.mth", 108, 36);
+static void mb_make_tag_21__7 (void) {
+    WORD_ENTER(mb_make_tag_21__7, "make-tag! block", "src/mirth/data/data.mth", 70, 9);
     mw_prim_drop();
-    WORD_ATOM(108, 36, ".id");
+    WORD_ATOM(70, 9, "~value");
+    mw_Tag_7E_value();
+    WORD_ATOM(70, 16, "!");
+    mw_prim_mut_set();
+    WORD_EXIT(mb_make_tag_21__7);
+}
+
+static void mb_Data_3D__1 (void) {
+    WORD_ENTER(mb_Data_3D__1, "Data= block", "src/mirth/data/data.mth", 92, 36);
+    mw_prim_drop();
+    WORD_ATOM(92, 36, ".id");
     mw_Data_2E_id();
     WORD_EXIT(mb_Data_3D__1);
 }
 
-static void mb_Tag_2E_num_inputs_from_sig_1 (void) {
-    WORD_ENTER(mb_Tag_2E_num_inputs_from_sig_1, "Tag.num-inputs-from-sig block", "src/mirth/data/data.mth", 133, 18);
+static void mb_Tag_2E_num_type_inputs_from_sig_1 (void) {
+    WORD_ENTER(mb_Tag_2E_num_type_inputs_from_sig_1, "Tag.num-type-inputs-from-sig block", "src/mirth/data/data.mth", 140, 9);
     mw_prim_drop();
-    WORD_ATOM(133, 18, "run-length");
+    WORD_ATOM(140, 9, "run-length");
     mw_Token_2E_run_length();
-    WORD_EXIT(mb_Tag_2E_num_inputs_from_sig_1);
+    WORD_ATOM(141, 9, "swap");
+    mw_prim_swap();
+    WORD_ATOM(141, 14, "num-resource-inputs-from-sig");
+    mw_Tag_2E_num_resource_inputs_from_sig();
+    WORD_ATOM(141, 43, "-");
+    mw_prim_int_sub();
+    WORD_EXIT(mb_Tag_2E_num_type_inputs_from_sig_1);
 }
 
-static void mb_Tag_2E_num_inputs_from_sig_2 (void) {
-    WORD_ENTER(mb_Tag_2E_num_inputs_from_sig_2, "Tag.num-inputs-from-sig block", "src/mirth/data/data.mth", 133, 30);
+static void mb_Tag_2E_num_type_inputs_from_sig_2 (void) {
+    WORD_ENTER(mb_Tag_2E_num_type_inputs_from_sig_2, "Tag.num-type-inputs-from-sig block", "src/mirth/data/data.mth", 142, 9);
     mw_prim_drop();
-    WORD_ATOM(133, 30, "");
+    WORD_ATOM(142, 9, "drop");
+    mw_prim_drop();
+    WORD_ATOM(142, 14, "");
     push_i64(0LL);
-    WORD_EXIT(mb_Tag_2E_num_inputs_from_sig_2);
+    WORD_EXIT(mb_Tag_2E_num_type_inputs_from_sig_2);
+}
+
+static void mb_Tag_2E_num_resource_inputs_from_sig_1 (void) {
+    WORD_ENTER(mb_Tag_2E_num_resource_inputs_from_sig_1, "Tag.num-resource-inputs-from-sig block", "src/mirth/data/data.mth", 147, 9);
+    mw_prim_drop();
+    WORD_ATOM(147, 9, "run-tokens");
+    mw_Token_2E_run_tokens();
+    WORD_ATOM(147, 20, "filter-some");
+    push_u64(0);
+    push_fnptr(&mb_Tag_2E_num_resource_inputs_from_sig_2);
+    mw_prim_pack_cons();
+    mw_List_2E_filter_some();
+    WORD_ATOM(148, 9, "filter");
+    push_u64(0);
+    push_fnptr(&mb_Tag_2E_num_resource_inputs_from_sig_3);
+    mw_prim_pack_cons();
+    mw_List_2E_filter();
+    WORD_ATOM(149, 9, "len");
+    mw_List_2E_len();
+    WORD_EXIT(mb_Tag_2E_num_resource_inputs_from_sig_1);
+}
+
+static void mb_Tag_2E_num_resource_inputs_from_sig_5 (void) {
+    WORD_ENTER(mb_Tag_2E_num_resource_inputs_from_sig_5, "Tag.num-resource-inputs-from-sig block", "src/mirth/data/data.mth", 150, 9);
+    mw_prim_drop();
+    WORD_ATOM(150, 9, "");
+    push_i64(0LL);
+    WORD_EXIT(mb_Tag_2E_num_resource_inputs_from_sig_5);
+}
+
+static void mb_Tag_2E_num_resource_inputs_from_sig_2 (void) {
+    WORD_ENTER(mb_Tag_2E_num_resource_inputs_from_sig_2, "Tag.num-resource-inputs-from-sig block", "src/mirth/data/data.mth", 147, 32);
+    mw_prim_drop();
+    WORD_ATOM(147, 32, "name?");
+    mw_Token_2E_name_3F_();
+    WORD_EXIT(mb_Tag_2E_num_resource_inputs_from_sig_2);
+}
+
+static void mb_Tag_2E_num_resource_inputs_from_sig_3 (void) {
+    WORD_ENTER(mb_Tag_2E_num_resource_inputs_from_sig_3, "Tag.num-resource-inputs-from-sig block", "src/mirth/data/data.mth", 148, 16);
+    mw_prim_drop();
+    WORD_ATOM(148, 16, "dup");
+    mw_prim_dup();
+    WORD_ATOM(148, 20, "could-be-resource-var");
+    mw_Name_2E_could_be_resource_var();
+    WORD_ATOM(148, 42, "or");
+    push_u64(0);
+    push_fnptr(&mb_Tag_2E_num_resource_inputs_from_sig_4);
+    mw_prim_pack_cons();
+    mw_Bool_2E_or();
+    WORD_EXIT(mb_Tag_2E_num_resource_inputs_from_sig_3);
+}
+
+static void mb_Tag_2E_num_resource_inputs_from_sig_4 (void) {
+    WORD_ENTER(mb_Tag_2E_num_resource_inputs_from_sig_4, "Tag.num-resource-inputs-from-sig block", "src/mirth/data/data.mth", 148, 45);
+    mw_prim_drop();
+    WORD_ATOM(148, 45, "dup");
+    mw_prim_dup();
+    WORD_ATOM(148, 49, "could-be-resource-con");
+    mw_Name_2E_could_be_resource_con();
+    WORD_EXIT(mb_Tag_2E_num_resource_inputs_from_sig_4);
 }
 
 static void mb_Tag_3D__1 (void) {
-    WORD_ENTER(mb_Tag_3D__1, "Tag= block", "src/mirth/data/data.mth", 138, 33);
+    WORD_ENTER(mb_Tag_3D__1, "Tag= block", "src/mirth/data/data.mth", 159, 33);
     mw_prim_drop();
-    WORD_ATOM(138, 33, ".id");
+    WORD_ATOM(159, 33, ".id");
     mw_Tag_2E_id();
     WORD_EXIT(mb_Tag_3D__1);
 }
@@ -37734,7 +41029,7 @@ static void mb_Match_2E_is_exhaustive_3F__1 (void) {
     WORD_ATOM(44, 29, "match");
     switch (get_top_data_tag()) {
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_SOME();
             WORD_ATOM(46, 17, "num-tags");
             mw_Data_2E_num_tags();
             WORD_ATOM(47, 17, "over");
@@ -37747,7 +41042,7 @@ static void mb_Match_2E_is_exhaustive_3F__1 (void) {
             mw_prim_int_eq();
             break;
         case 0LL:
-            mw_prim_drop();
+            co_NONE();
             WORD_ATOM(49, 17, "dup");
             mw_prim_dup();
             WORD_ATOM(49, 21, "cases");
@@ -38827,9 +42122,9 @@ static void mb_token_is_lambda_param_3F__6 (void) {
 }
 
 static void mb_expect_token_arrow_1 (void) {
-    WORD_ENTER(mb_expect_token_arrow_1, "expect-token-arrow block", "src/mirth/elab.mth", 874, 25);
+    WORD_ENTER(mb_expect_token_arrow_1, "expect-token-arrow block", "src/mirth/elab.mth", 876, 25);
     mw_prim_drop();
-    WORD_ATOM(874, 25, "");
+    WORD_ATOM(876, 25, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38840,7 +42135,7 @@ static void mb_expect_token_arrow_1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(874, 43, "emit-fatal-error!");
+    WORD_ATOM(876, 43, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_expect_token_arrow_1);
 }
@@ -38861,7 +42156,7 @@ static void mb_elab_case_pattern_21__6 (void) {
     WORD_ATOM(723, 14, "match");
     switch (get_top_data_tag()) {
         case 4LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
+            co_DEF_5F_TAG();
             WORD_ATOM(727, 17, "dup");
             mw_prim_dup();
             WORD_ATOM(727, 21, "PATTERN_TAG");
@@ -38937,7 +42232,7 @@ static void mb_elab_case_pattern_21__6 (void) {
             mw_Token_2E_succ();
             break;
         case 0LL:
-            mw_prim_drop();
+            co_DEF_5F_NONE();
             WORD_ATOM(744, 17, "");
             {
                 static bool vready = false;
@@ -39340,34 +42635,62 @@ static void mb_elab_data_tag_21__13 (void) {
 static void mb_elab_data_tag_21__15 (void) {
     WORD_ENTER(mb_elab_data_tag_21__15, "elab-data-tag! block", "src/mirth/elab.mth", 871, 9);
     mw_prim_drop();
-    WORD_ATOM(871, 9, "num-inputs-from-sig");
-    mw_Tag_2E_num_inputs_from_sig();
+    WORD_ATOM(871, 9, "num-type-inputs-from-sig");
+    mw_Tag_2E_num_type_inputs_from_sig();
     WORD_EXIT(mb_elab_data_tag_21__15);
 }
 
-static void mb_token_def_args_3 (void) {
-    WORD_ENTER(mb_token_def_args_3, "token-def-args block", "src/mirth/elab.mth", 886, 9);
+static void mb_elab_data_tag_21__16 (void) {
+    WORD_ENTER(mb_elab_data_tag_21__16, "elab-data-tag! block", "src/mirth/elab.mth", 871, 39);
     mw_prim_drop();
-    WORD_ATOM(886, 9, "over");
+    WORD_ATOM(871, 39, "~num-type-inputs");
+    mw_Tag_7E_num_type_inputs();
+    WORD_ATOM(871, 56, "!");
+    mw_prim_mut_set();
+    WORD_EXIT(mb_elab_data_tag_21__16);
+}
+
+static void mb_elab_data_tag_21__17 (void) {
+    WORD_ENTER(mb_elab_data_tag_21__17, "elab-data-tag! block", "src/mirth/elab.mth", 872, 9);
+    mw_prim_drop();
+    WORD_ATOM(872, 9, "num-resource-inputs-from-sig");
+    mw_Tag_2E_num_resource_inputs_from_sig();
+    WORD_EXIT(mb_elab_data_tag_21__17);
+}
+
+static void mb_elab_data_tag_21__18 (void) {
+    WORD_ENTER(mb_elab_data_tag_21__18, "elab-data-tag! block", "src/mirth/elab.mth", 872, 43);
+    mw_prim_drop();
+    WORD_ATOM(872, 43, "~num-resource-inputs");
+    mw_Tag_7E_num_resource_inputs();
+    WORD_ATOM(872, 64, "!");
+    mw_prim_mut_set();
+    WORD_EXIT(mb_elab_data_tag_21__18);
+}
+
+static void mb_token_def_args_3 (void) {
+    WORD_ENTER(mb_token_def_args_3, "token-def-args block", "src/mirth/elab.mth", 888, 9);
+    mw_prim_drop();
+    WORD_ATOM(888, 9, "over");
     mw_over();
-    WORD_ATOM(886, 14, "run-has-arrow?");
+    WORD_ATOM(888, 14, "run-has-arrow?");
     mw_Token_2E_run_has_arrow_3F_();
-    WORD_ATOM(886, 29, "if");
+    WORD_ATOM(888, 29, "if");
     if (pop_u64()) {
-        WORD_ATOM(887, 13, "cons+");
+        WORD_ATOM(889, 13, "cons+");
         mw_List_2B__2E_cons_2B_();
-        WORD_ATOM(887, 19, "dip");
+        WORD_ATOM(889, 19, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(887, 23, "NONE");
+            WORD_ATOM(889, 23, "NONE");
             mw_NONE();
             push_value(d3);
         }
     } else {
-        WORD_ATOM(888, 13, "dip");
+        WORD_ATOM(890, 13, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(888, 17, "SOME");
+            WORD_ATOM(890, 17, "SOME");
             mw_SOME();
             push_value(d3);
         }
@@ -39376,14 +42699,14 @@ static void mb_token_def_args_3 (void) {
 }
 
 static void mb_token_def_args_8 (void) {
-    WORD_ENTER(mb_token_def_args_8, "token-def-args block", "src/mirth/elab.mth", 890, 9);
+    WORD_ENTER(mb_token_def_args_8, "token-def-args block", "src/mirth/elab.mth", 892, 9);
     mw_prim_drop();
-    WORD_ATOM(890, 9, "L1+");
+    WORD_ATOM(892, 9, "L1+");
     mw_L1_2B_();
-    WORD_ATOM(890, 13, "dip");
+    WORD_ATOM(892, 13, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(890, 17, "NONE");
+        WORD_ATOM(892, 17, "NONE");
         mw_NONE();
         push_value(d2);
     }
@@ -39391,31 +42714,31 @@ static void mb_token_def_args_8 (void) {
 }
 
 static void mb_elab_def_params_21__2 (void) {
-    WORD_ENTER(mb_elab_def_params_21__2, "elab-def-params! block", "src/mirth/elab.mth", 942, 9);
+    WORD_ENTER(mb_elab_def_params_21__2, "elab-def-params! block", "src/mirth/elab.mth", 944, 9);
     mw_prim_drop();
-    WORD_ATOM(942, 9, "dup");
+    WORD_ATOM(944, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(942, 13, "sig-param-name?");
+    WORD_ATOM(944, 13, "sig-param-name?");
     mw_Token_2E_sig_param_name_3F_();
-    WORD_ATOM(942, 29, "else");
+    WORD_ATOM(944, 29, "else");
     push_u64(0);
     push_fnptr(&mb_elab_def_params_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(943, 9, "dup");
+    WORD_ATOM(945, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(943, 13, "succ");
+    WORD_ATOM(945, 13, "succ");
     mw_Token_2E_succ();
-    WORD_ATOM(943, 18, "dup");
+    WORD_ATOM(945, 18, "dup");
     mw_prim_dup();
-    WORD_ATOM(943, 22, "run-end?");
+    WORD_ATOM(945, 22, "run-end?");
     mw_Token_2E_run_end_3F_();
-    WORD_ATOM(943, 31, "if");
+    WORD_ATOM(945, 31, "if");
     if (pop_u64()) {
-        WORD_ATOM(943, 34, "drop");
+        WORD_ATOM(945, 34, "drop");
         mw_prim_drop();
     } else {
-        WORD_ATOM(943, 40, "");
+        WORD_ATOM(945, 40, "");
         {
             static bool vready = false;
             static VAL v;
@@ -39426,34 +42749,34 @@ static void mb_elab_def_params_21__2 (void) {
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(943, 72, "emit-fatal-error!");
+        WORD_ATOM(945, 72, "emit-fatal-error!");
         mw_emit_fatal_error_21_();
     }
-    WORD_ATOM(944, 9, "elab-expand-tensor!");
+    WORD_ATOM(946, 9, "elab-expand-tensor!");
     mw_elab_expand_tensor_21_();
-    WORD_ATOM(945, 9, "over");
+    WORD_ATOM(947, 9, "over");
     mw_over();
-    WORD_ATOM(945, 14, "morphism?");
+    WORD_ATOM(947, 14, "morphism?");
     mw_Type_2E_morphism_3F_();
-    WORD_ATOM(945, 24, "else");
+    WORD_ATOM(947, 24, "else");
     push_u64(0);
     push_fnptr(&mb_elab_def_params_21__6);
     mw_prim_pack_cons();
     mw_Maybe_2E_else();
-    WORD_ATOM(947, 9, "name?");
+    WORD_ATOM(949, 9, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(947, 15, "unwrap");
+    WORD_ATOM(949, 15, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(947, 22, "Var.new-auto-run!");
+    WORD_ATOM(949, 22, "Var.new-auto-run!");
     mw_Var_2E_new_auto_run_21_();
-    WORD_ATOM(948, 9, "PARAM");
+    WORD_ATOM(950, 9, "PARAM");
     mw_PARAM();
-    WORD_ATOM(948, 15, "rotr");
+    WORD_ATOM(950, 15, "rotr");
     mw_rotr();
-    WORD_ATOM(948, 20, "dip");
+    WORD_ATOM(950, 20, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(948, 24, "cons");
+        WORD_ATOM(950, 24, "cons");
         mw_List_2E_cons();
         push_value(d2);
     }
@@ -39461,9 +42784,9 @@ static void mb_elab_def_params_21__2 (void) {
 }
 
 static void mb_elab_def_params_21__3 (void) {
-    WORD_ENTER(mb_elab_def_params_21__3, "elab-def-params! block", "src/mirth/elab.mth", 942, 34);
+    WORD_ENTER(mb_elab_def_params_21__3, "elab-def-params! block", "src/mirth/elab.mth", 944, 34);
     mw_prim_drop();
-    WORD_ATOM(942, 34, "");
+    WORD_ATOM(944, 34, "");
     {
         static bool vready = false;
         static VAL v;
@@ -39474,15 +42797,15 @@ static void mb_elab_def_params_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(942, 60, "emit-fatal-error!");
+    WORD_ATOM(944, 60, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_params_21__3);
 }
 
 static void mb_elab_def_params_21__6 (void) {
-    WORD_ENTER(mb_elab_def_params_21__6, "elab-def-params! block", "src/mirth/elab.mth", 946, 13);
+    WORD_ENTER(mb_elab_def_params_21__6, "elab-def-params! block", "src/mirth/elab.mth", 948, 13);
     mw_prim_drop();
-    WORD_ATOM(946, 13, "");
+    WORD_ATOM(948, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -39493,171 +42816,171 @@ static void mb_elab_def_params_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(946, 44, "emit-fatal-error!");
+    WORD_ATOM(948, 44, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_params_21__6);
 }
 
 static void mb_table_new_21__1 (void) {
-    WORD_ENTER(mb_table_new_21__1, "table-new! block", "src/mirth/elab.mth", 1053, 9);
+    WORD_ENTER(mb_table_new_21__1, "table-new! block", "src/mirth/elab.mth", 1055, 9);
     mw_prim_drop();
-    WORD_ATOM(1053, 9, "dup");
+    WORD_ATOM(1055, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1053, 13, "head");
+    WORD_ATOM(1055, 13, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1053, 18, "ab-token");
+    WORD_ATOM(1055, 18, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1053, 27, "!");
+    WORD_ATOM(1055, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1054, 9, "TABLE_MAX_SIZE");
+    WORD_ATOM(1056, 9, "TABLE_MAX_SIZE");
     mw_TABLE_5F_MAX_5F_SIZE();
-    WORD_ATOM(1054, 24, "ab-int!");
+    WORD_ATOM(1056, 24, "ab-int!");
     mw_ab_int_21_();
     WORD_EXIT(mb_table_new_21__1);
 }
 
 static void mb_table_new_21__2 (void) {
-    WORD_ENTER(mb_table_new_21__2, "table-new! block", "src/mirth/elab.mth", 1065, 9);
+    WORD_ENTER(mb_table_new_21__2, "table-new! block", "src/mirth/elab.mth", 1067, 9);
     mw_prim_drop();
-    WORD_ATOM(1065, 9, "dup");
+    WORD_ATOM(1067, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1065, 13, "head");
+    WORD_ATOM(1067, 13, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1065, 18, "ab-token");
+    WORD_ATOM(1067, 18, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1065, 27, "!");
+    WORD_ATOM(1067, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1066, 9, "");
+    WORD_ATOM(1068, 9, "");
     push_i64(0LL);
-    WORD_ATOM(1066, 11, "ab-int!");
+    WORD_ATOM(1068, 11, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1067, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1069, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1067, 26, "ab-prim!");
+    WORD_ATOM(1069, 26, "ab-prim!");
     mw_ab_prim_21_();
     WORD_EXIT(mb_table_new_21__2);
 }
 
 static void mb_table_new_21__3 (void) {
-    WORD_ENTER(mb_table_new_21__3, "table-new! block", "src/mirth/elab.mth", 1084, 9);
+    WORD_ENTER(mb_table_new_21__3, "table-new! block", "src/mirth/elab.mth", 1086, 9);
     mw_prim_drop();
-    WORD_ATOM(1084, 9, "dup");
+    WORD_ATOM(1086, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1084, 13, "head");
+    WORD_ATOM(1086, 13, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1084, 18, "ab-token");
+    WORD_ATOM(1086, 18, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1084, 27, "!");
+    WORD_ATOM(1086, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1085, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1087, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1085, 26, "ab-prim!");
+    WORD_ATOM(1087, 26, "ab-prim!");
     mw_ab_prim_21_();
     WORD_EXIT(mb_table_new_21__3);
 }
 
 static void mb_table_new_21__4 (void) {
-    WORD_ENTER(mb_table_new_21__4, "table-new! block", "src/mirth/elab.mth", 1096, 9);
+    WORD_ENTER(mb_table_new_21__4, "table-new! block", "src/mirth/elab.mth", 1098, 9);
     mw_prim_drop();
-    WORD_ATOM(1096, 9, "dup");
+    WORD_ATOM(1098, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1096, 13, "head");
+    WORD_ATOM(1098, 13, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1096, 18, "ab-token");
+    WORD_ATOM(1098, 18, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1096, 27, "!");
+    WORD_ATOM(1098, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1097, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1099, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1097, 26, "ab-prim!");
+    WORD_ATOM(1099, 26, "ab-prim!");
     mw_ab_prim_21_();
     WORD_EXIT(mb_table_new_21__4);
 }
 
 static void mb_table_new_21__5 (void) {
-    WORD_ENTER(mb_table_new_21__5, "table-new! block", "src/mirth/elab.mth", 1108, 9);
+    WORD_ENTER(mb_table_new_21__5, "table-new! block", "src/mirth/elab.mth", 1110, 9);
     mw_prim_drop();
-    WORD_ATOM(1108, 9, "dup");
+    WORD_ATOM(1110, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1108, 13, "head");
+    WORD_ATOM(1110, 13, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1108, 18, "ab-token");
+    WORD_ATOM(1110, 18, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1108, 27, "!");
+    WORD_ATOM(1110, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1109, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1111, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1109, 26, "ab-prim!");
+    WORD_ATOM(1111, 26, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1110, 9, "");
+    WORD_ATOM(1112, 9, "");
     push_i64(1LL);
-    WORD_ATOM(1110, 11, "ab-int!");
+    WORD_ATOM(1112, 11, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1111, 9, "PRIM_INT_ADD");
+    WORD_ATOM(1113, 9, "PRIM_INT_ADD");
     mw_PRIM_5F_INT_5F_ADD();
-    WORD_ATOM(1111, 22, "ab-prim!");
-    mw_ab_prim_21_();
-    WORD_ATOM(1112, 9, "dup");
-    mw_prim_dup();
-    WORD_ATOM(1112, 13, "num-buffer");
-    mw_Table_2E_num_buffer();
-    WORD_ATOM(1112, 24, "ab-buffer!");
-    mw_ab_buffer_21_();
-    WORD_ATOM(1113, 9, "PRIM_U64_GET");
-    mw_PRIM_5F_U64_5F_GET();
     WORD_ATOM(1113, 22, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1114, 9, "PRIM_UNSAFE_CAST");
-    mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1114, 26, "ab-prim!");
+    WORD_ATOM(1114, 9, "dup");
+    mw_prim_dup();
+    WORD_ATOM(1114, 13, "num-buffer");
+    mw_Table_2E_num_buffer();
+    WORD_ATOM(1114, 24, "ab-buffer!");
+    mw_ab_buffer_21_();
+    WORD_ATOM(1115, 9, "PRIM_U64_GET");
+    mw_PRIM_5F_U64_5F_GET();
+    WORD_ATOM(1115, 22, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1115, 9, "");
+    WORD_ATOM(1116, 9, "PRIM_UNSAFE_CAST");
+    mw_PRIM_5F_UNSAFE_5F_CAST();
+    WORD_ATOM(1116, 26, "ab-prim!");
+    mw_ab_prim_21_();
+    WORD_ATOM(1117, 9, "");
     push_i64(1LL);
-    WORD_ATOM(1115, 11, "ab-int!");
+    WORD_ATOM(1117, 11, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1116, 9, "PRIM_INT_ADD");
+    WORD_ATOM(1118, 9, "PRIM_INT_ADD");
     mw_PRIM_5F_INT_5F_ADD();
-    WORD_ATOM(1116, 22, "ab-prim!");
+    WORD_ATOM(1118, 22, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1117, 9, "PRIM_INT_MOD");
+    WORD_ATOM(1119, 9, "PRIM_INT_MOD");
     mw_PRIM_5F_INT_5F_MOD();
-    WORD_ATOM(1117, 22, "ab-prim!");
+    WORD_ATOM(1119, 22, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1118, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1120, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1118, 26, "ab-prim!");
+    WORD_ATOM(1120, 26, "ab-prim!");
     mw_ab_prim_21_();
     WORD_EXIT(mb_table_new_21__5);
 }
 
 static void mb_table_new_21__6 (void) {
-    WORD_ENTER(mb_table_new_21__6, "table-new! block", "src/mirth/elab.mth", 1129, 9);
+    WORD_ENTER(mb_table_new_21__6, "table-new! block", "src/mirth/elab.mth", 1131, 9);
     mw_prim_drop();
-    WORD_ATOM(1129, 9, "dup");
+    WORD_ATOM(1131, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1129, 13, "head");
+    WORD_ATOM(1131, 13, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1129, 18, "ab-token");
+    WORD_ATOM(1131, 18, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1129, 27, "!");
+    WORD_ATOM(1131, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1130, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1132, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1130, 26, "ab-prim!");
+    WORD_ATOM(1132, 26, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1131, 9, "PRIM_CORE_DUP");
+    WORD_ATOM(1133, 9, "PRIM_CORE_DUP");
     mw_PRIM_5F_CORE_5F_DUP();
-    WORD_ATOM(1131, 23, "ab-prim!");
+    WORD_ATOM(1133, 23, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1132, 9, "");
+    WORD_ATOM(1134, 9, "");
     push_i64(0LL);
-    WORD_ATOM(1132, 11, "ab-int!");
+    WORD_ATOM(1134, 11, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1133, 9, "PRIM_INT_EQ");
+    WORD_ATOM(1135, 9, "PRIM_INT_EQ");
     mw_PRIM_5F_INT_5F_EQ();
-    WORD_ATOM(1133, 21, "ab-prim!");
+    WORD_ATOM(1135, 21, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1134, 9, "ab-if!");
+    WORD_ATOM(1136, 9, "ab-if!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__7);
     mw_prim_pack_cons();
@@ -39665,37 +42988,37 @@ static void mb_table_new_21__6 (void) {
     push_fnptr(&mb_table_new_21__8);
     mw_prim_pack_cons();
     mw_ab_if_21_();
-    WORD_ATOM(1139, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1141, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1139, 26, "ab-prim!");
+    WORD_ATOM(1141, 26, "ab-prim!");
     mw_ab_prim_21_();
     WORD_EXIT(mb_table_new_21__6);
 }
 
 static void mb_table_new_21__7 (void) {
-    WORD_ENTER(mb_table_new_21__7, "table-new! block", "src/mirth/elab.mth", 1135, 13);
+    WORD_ENTER(mb_table_new_21__7, "table-new! block", "src/mirth/elab.mth", 1137, 13);
     mw_prim_drop();
-    WORD_ATOM(1135, 13, "id");
+    WORD_ATOM(1137, 13, "id");
     mw_prim_id();
     WORD_EXIT(mb_table_new_21__7);
 }
 
 static void mb_table_new_21__8 (void) {
-    WORD_ENTER(mb_table_new_21__8, "table-new! block", "src/mirth/elab.mth", 1136, 13);
+    WORD_ENTER(mb_table_new_21__8, "table-new! block", "src/mirth/elab.mth", 1138, 13);
     mw_prim_drop();
-    WORD_ATOM(1136, 13, "");
+    WORD_ATOM(1138, 13, "");
     push_i64(1LL);
-    WORD_ATOM(1136, 15, "ab-int!");
+    WORD_ATOM(1138, 15, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1137, 13, "PRIM_INT_SUB");
+    WORD_ATOM(1139, 13, "PRIM_INT_SUB");
     mw_PRIM_5F_INT_5F_SUB();
-    WORD_ATOM(1137, 26, "ab-prim!");
+    WORD_ATOM(1139, 26, "ab-prim!");
     mw_ab_prim_21_();
     WORD_EXIT(mb_table_new_21__8);
 }
 
 static void mb_table_new_21__11 (void) {
-    WORD_ENTER(mb_table_new_21__11, "table-new! block", "src/mirth/elab.mth", 1153, 13);
+    WORD_ENTER(mb_table_new_21__11, "table-new! block", "src/mirth/elab.mth", 1155, 13);
     mw_prim_pack_uncons();
     VAL var_x = pop_value();
     mw_prim_pack_uncons();
@@ -39707,23 +43030,23 @@ static void mb_table_new_21__11 (void) {
     mw_prim_pack_uncons();
     VAL var_a = pop_value();
     mw_prim_drop();
-    WORD_ATOM(1153, 13, "t");
+    WORD_ATOM(1155, 13, "t");
     incref(var_t);
     push_value(var_t);
-    WORD_ATOM(1153, 15, "head");
+    WORD_ATOM(1155, 15, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1153, 20, "ab-token");
+    WORD_ATOM(1155, 20, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1153, 29, "!");
+    WORD_ATOM(1155, 29, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1154, 13, "x");
+    WORD_ATOM(1156, 13, "x");
     incref(var_x);
     push_value(var_x);
-    WORD_ATOM(1154, 15, "Var>Param");
+    WORD_ATOM(1156, 15, "Var>Param");
     mw_Var_3E_Param();
-    WORD_ATOM(1154, 25, "L1");
+    WORD_ATOM(1156, 25, "L1");
     mw_L1();
-    WORD_ATOM(1154, 28, "ab-lambda!");
+    WORD_ATOM(1156, 28, "ab-lambda!");
     push_u64(0);
     incref(var_a);
     push_value(var_a);
@@ -39752,7 +43075,7 @@ static void mb_table_new_21__11 (void) {
 }
 
 static void mb_table_new_21__12 (void) {
-    WORD_ENTER(mb_table_new_21__12, "table-new! block", "src/mirth/elab.mth", 1155, 17);
+    WORD_ENTER(mb_table_new_21__12, "table-new! block", "src/mirth/elab.mth", 1157, 17);
     mw_prim_pack_uncons();
     VAL var_x = pop_value();
     mw_prim_pack_uncons();
@@ -39764,11 +43087,11 @@ static void mb_table_new_21__12 (void) {
     mw_prim_pack_uncons();
     VAL var_a = pop_value();
     mw_prim_drop();
-    WORD_ATOM(1155, 17, "");
+    WORD_ATOM(1157, 17, "");
     push_i64(1LL);
-    WORD_ATOM(1155, 19, "ab-int!");
+    WORD_ATOM(1157, 19, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1156, 17, "ab-while!");
+    WORD_ATOM(1158, 17, "ab-while!");
     push_u64(0);
     incref(var_a);
     push_value(var_a);
@@ -39806,9 +43129,9 @@ static void mb_table_new_21__12 (void) {
     push_fnptr(&mb_table_new_21__14);
     mw_prim_pack_cons();
     mw_ab_while_21_();
-    WORD_ATOM(1173, 17, "PRIM_CORE_DROP");
+    WORD_ATOM(1175, 17, "PRIM_CORE_DROP");
     mw_PRIM_5F_CORE_5F_DROP();
-    WORD_ATOM(1173, 32, "ab-prim!");
+    WORD_ATOM(1175, 32, "ab-prim!");
     mw_ab_prim_21_();
     decref(var_x);
     decref(var_t);
@@ -39819,7 +43142,7 @@ static void mb_table_new_21__12 (void) {
 }
 
 static void mb_table_new_21__13 (void) {
-    WORD_ENTER(mb_table_new_21__13, "table-new! block", "src/mirth/elab.mth", 1157, 21);
+    WORD_ENTER(mb_table_new_21__13, "table-new! block", "src/mirth/elab.mth", 1159, 21);
     mw_prim_pack_uncons();
     VAL var_x = pop_value();
     mw_prim_pack_uncons();
@@ -39831,36 +43154,36 @@ static void mb_table_new_21__13 (void) {
     mw_prim_pack_uncons();
     VAL var_a = pop_value();
     mw_prim_drop();
-    WORD_ATOM(1157, 21, "PRIM_CORE_DUP");
+    WORD_ATOM(1159, 21, "PRIM_CORE_DUP");
     mw_PRIM_5F_CORE_5F_DUP();
-    WORD_ATOM(1157, 35, "ab-prim!");
+    WORD_ATOM(1159, 35, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1158, 21, "t");
+    WORD_ATOM(1160, 21, "t");
     incref(var_t);
     push_value(var_t);
-    WORD_ATOM(1158, 23, "num-buffer");
+    WORD_ATOM(1160, 23, "num-buffer");
     mw_Table_2E_num_buffer();
-    WORD_ATOM(1158, 34, "ab-buffer!");
+    WORD_ATOM(1160, 34, "ab-buffer!");
     mw_ab_buffer_21_();
-    WORD_ATOM(1159, 21, "PRIM_U64_GET");
+    WORD_ATOM(1161, 21, "PRIM_U64_GET");
     mw_PRIM_5F_U64_5F_GET();
-    WORD_ATOM(1159, 34, "ab-prim!");
+    WORD_ATOM(1161, 34, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1160, 21, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1162, 21, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1160, 38, "ab-prim!");
+    WORD_ATOM(1162, 38, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1161, 21, "");
+    WORD_ATOM(1163, 21, "");
     push_i64(1LL);
-    WORD_ATOM(1161, 23, "ab-int!");
+    WORD_ATOM(1163, 23, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1162, 21, "PRIM_INT_ADD");
+    WORD_ATOM(1164, 21, "PRIM_INT_ADD");
     mw_PRIM_5F_INT_5F_ADD();
-    WORD_ATOM(1162, 34, "ab-prim!");
+    WORD_ATOM(1164, 34, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1163, 21, "PRIM_INT_LT");
+    WORD_ATOM(1165, 21, "PRIM_INT_LT");
     mw_PRIM_5F_INT_5F_LT();
-    WORD_ATOM(1163, 33, "ab-prim!");
+    WORD_ATOM(1165, 33, "ab-prim!");
     mw_ab_prim_21_();
     decref(var_x);
     decref(var_t);
@@ -39871,7 +43194,7 @@ static void mb_table_new_21__13 (void) {
 }
 
 static void mb_table_new_21__14 (void) {
-    WORD_ENTER(mb_table_new_21__14, "table-new! block", "src/mirth/elab.mth", 1165, 21);
+    WORD_ENTER(mb_table_new_21__14, "table-new! block", "src/mirth/elab.mth", 1167, 21);
     mw_prim_pack_uncons();
     VAL var_x = pop_value();
     mw_prim_pack_uncons();
@@ -39883,11 +43206,11 @@ static void mb_table_new_21__14 (void) {
     mw_prim_pack_uncons();
     VAL var_a = pop_value();
     mw_prim_drop();
-    WORD_ATOM(1165, 21, "PRIM_CORE_DUP");
+    WORD_ATOM(1167, 21, "PRIM_CORE_DUP");
     mw_PRIM_5F_CORE_5F_DUP();
-    WORD_ATOM(1165, 35, "ab-prim!");
+    WORD_ATOM(1167, 35, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1166, 21, "ab-dip!");
+    WORD_ATOM(1168, 21, "ab-dip!");
     push_u64(0);
     incref(var_a);
     push_value(var_a);
@@ -39907,13 +43230,13 @@ static void mb_table_new_21__14 (void) {
     push_fnptr(&mb_table_new_21__15);
     mw_prim_pack_cons();
     mw_ab_dip_21_();
-    WORD_ATOM(1170, 21, "");
+    WORD_ATOM(1172, 21, "");
     push_i64(1LL);
-    WORD_ATOM(1170, 23, "ab-int!");
+    WORD_ATOM(1172, 23, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1171, 21, "PRIM_INT_ADD");
+    WORD_ATOM(1173, 21, "PRIM_INT_ADD");
     mw_PRIM_5F_INT_5F_ADD();
-    WORD_ATOM(1171, 34, "ab-prim!");
+    WORD_ATOM(1173, 34, "ab-prim!");
     mw_ab_prim_21_();
     decref(var_x);
     decref(var_t);
@@ -39924,7 +43247,7 @@ static void mb_table_new_21__14 (void) {
 }
 
 static void mb_table_new_21__15 (void) {
-    WORD_ENTER(mb_table_new_21__15, "table-new! block", "src/mirth/elab.mth", 1167, 25);
+    WORD_ENTER(mb_table_new_21__15, "table-new! block", "src/mirth/elab.mth", 1169, 25);
     mw_prim_pack_uncons();
     VAL var_x = pop_value();
     mw_prim_pack_uncons();
@@ -39936,14 +43259,14 @@ static void mb_table_new_21__15 (void) {
     mw_prim_pack_uncons();
     VAL var_a = pop_value();
     mw_prim_drop();
-    WORD_ATOM(1167, 25, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1169, 25, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1167, 42, "ab-prim!");
+    WORD_ATOM(1169, 42, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1168, 25, "x");
+    WORD_ATOM(1170, 25, "x");
     incref(var_x);
     push_value(var_x);
-    WORD_ATOM(1168, 27, "ab-var!");
+    WORD_ATOM(1170, 27, "ab-var!");
     mw_ab_var_21_();
     decref(var_x);
     decref(var_t);
@@ -39954,75 +43277,115 @@ static void mb_table_new_21__15 (void) {
 }
 
 static void mb_table_new_21__16 (void) {
-    WORD_ENTER(mb_table_new_21__16, "table-new! block", "src/mirth/elab.mth", 1187, 9);
+    WORD_ENTER(mb_table_new_21__16, "table-new! block", "src/mirth/elab.mth", 1189, 9);
     mw_prim_drop();
-    WORD_ATOM(1187, 9, "dup");
+    WORD_ATOM(1189, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1187, 13, "head");
+    WORD_ATOM(1189, 13, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1187, 18, "ab-token");
+    WORD_ATOM(1189, 18, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1187, 27, "!");
+    WORD_ATOM(1189, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1188, 9, "dup");
+    WORD_ATOM(1190, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1188, 13, "num-buffer");
+    WORD_ATOM(1190, 13, "num-buffer");
     mw_Table_2E_num_buffer();
-    WORD_ATOM(1188, 24, "ab-buffer!");
+    WORD_ATOM(1190, 24, "ab-buffer!");
     mw_ab_buffer_21_();
-    WORD_ATOM(1189, 9, "PRIM_U64_GET");
+    WORD_ATOM(1191, 9, "PRIM_U64_GET");
     mw_PRIM_5F_U64_5F_GET();
-    WORD_ATOM(1189, 22, "ab-prim!");
+    WORD_ATOM(1191, 22, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1190, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1192, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1190, 26, "ab-prim!");
+    WORD_ATOM(1192, 26, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1191, 9, "");
+    WORD_ATOM(1193, 9, "");
     push_i64(1LL);
-    WORD_ATOM(1191, 11, "ab-int!");
+    WORD_ATOM(1193, 11, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1192, 9, "PRIM_INT_ADD");
+    WORD_ATOM(1194, 9, "PRIM_INT_ADD");
     mw_PRIM_5F_INT_5F_ADD();
-    WORD_ATOM(1192, 22, "ab-prim!");
+    WORD_ATOM(1194, 22, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1193, 9, "PRIM_CORE_DUP");
+    WORD_ATOM(1195, 9, "PRIM_CORE_DUP");
     mw_PRIM_5F_CORE_5F_DUP();
-    WORD_ATOM(1193, 23, "ab-prim!");
+    WORD_ATOM(1195, 23, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1194, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1196, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1194, 26, "ab-prim!");
+    WORD_ATOM(1196, 26, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1195, 9, "dup");
+    WORD_ATOM(1197, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1195, 13, "num-buffer");
+    WORD_ATOM(1197, 13, "num-buffer");
     mw_Table_2E_num_buffer();
-    WORD_ATOM(1195, 24, "ab-buffer!");
+    WORD_ATOM(1197, 24, "ab-buffer!");
     mw_ab_buffer_21_();
-    WORD_ATOM(1196, 9, "PRIM_U64_SET");
+    WORD_ATOM(1198, 9, "PRIM_U64_SET");
     mw_PRIM_5F_U64_5F_SET();
-    WORD_ATOM(1196, 22, "ab-prim!");
+    WORD_ATOM(1198, 22, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1197, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1199, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1197, 26, "ab-prim!");
+    WORD_ATOM(1199, 26, "ab-prim!");
     mw_ab_prim_21_();
     WORD_EXIT(mb_table_new_21__16);
 }
 
-static void mb_field_new_21__1 (void) {
-    WORD_ENTER(mb_field_new_21__1, "field-new! block", "src/mirth/elab.mth", 1222, 16);
+static void mb_run_output_c99_21__3 (void) {
+    WORD_ENTER(mb_run_output_c99_21__3, "run-output-c99! block", "src/mirth/codegen.mth", 172, 13);
     mw_prim_drop();
-    WORD_ATOM(1222, 16, "elab-simple-type-arg!");
+    WORD_ATOM(172, 13, "to-output-path");
+    mw_Path_2E_to_output_path();
+    WORD_ATOM(172, 28, ">Str");
+    mw_Path_3E_Str();
+    WORD_ATOM(173, 13, "create-file!");
+    mw_create_file_21_();
+    WORD_ATOM(173, 26, "codegen-start!");
+    mw_codegen_start_21_();
+    WORD_ATOM(174, 13, "c99-header!");
+    mw_c99_header_21_();
+    WORD_ATOM(175, 13, "c99-tags!");
+    mw_c99_tags_21_();
+    WORD_ATOM(176, 13, "c99-buffers!");
+    mw_c99_buffers_21_();
+    WORD_ATOM(177, 13, "c99-variables!");
+    mw_c99_variables_21_();
+    WORD_ATOM(178, 13, "c99-externals!");
+    mw_c99_externals_21_();
+    WORD_ATOM(179, 13, "c99-word-sigs!");
+    mw_c99_word_sigs_21_();
+    WORD_ATOM(180, 13, "c99-block-sigs!");
+    mw_c99_block_sigs_21_();
+    WORD_ATOM(181, 13, "c99-field-sigs!");
+    mw_c99_field_sigs_21_();
+    WORD_ATOM(182, 13, "c99-main!");
+    mw_c99_main_21_();
+    WORD_ATOM(183, 13, "c99-field-defs!");
+    mw_c99_field_defs_21_();
+    WORD_ATOM(184, 13, "c99-word-defs!");
+    mw_c99_word_defs_21_();
+    WORD_ATOM(185, 13, "c99-block-defs!");
+    mw_c99_block_defs_21_();
+    WORD_ATOM(186, 13, "codegen-end!");
+    mw_codegen_end_21_();
+    WORD_EXIT(mb_run_output_c99_21__3);
+}
+
+static void mb_field_new_21__1 (void) {
+    WORD_ENTER(mb_field_new_21__1, "field-new! block", "src/mirth/elab.mth", 1224, 16);
+    mw_prim_drop();
+    WORD_ATOM(1224, 16, "elab-simple-type-arg!");
     mw_elab_simple_type_arg_21_();
     WORD_EXIT(mb_field_new_21__1);
 }
 
 static void mb_field_new_21__2 (void) {
-    WORD_ENTER(mb_field_new_21__2, "field-new! block", "src/mirth/elab.mth", 1223, 16);
+    WORD_ENTER(mb_field_new_21__2, "field-new! block", "src/mirth/elab.mth", 1225, 16);
     mw_prim_drop();
-    WORD_ATOM(1223, 16, "elab-simple-type-arg!");
+    WORD_ATOM(1225, 16, "elab-simple-type-arg!");
     mw_elab_simple_type_arg_21_();
     WORD_EXIT(mb_field_new_21__2);
 }
@@ -40213,51 +43576,51 @@ static void mb_input_fill_buffer_21__4 (void) {
 }
 
 static void mb_reset_needs_21__1 (void) {
-    WORD_ENTER(mb_reset_needs_21__1, "reset-needs! block", "src/mirth/codegen.mth", 47, 15);
+    WORD_ENTER(mb_reset_needs_21__1, "reset-needs! block", "src/mirth/codegen.mth", 43, 15);
     mw_prim_drop();
-    WORD_ATOM(47, 15, "F");
+    WORD_ATOM(43, 15, "F");
     mw_F();
-    WORD_ATOM(47, 17, "swap");
+    WORD_ATOM(43, 17, "swap");
     mw_prim_swap();
-    WORD_ATOM(47, 22, "block-needed");
+    WORD_ATOM(43, 22, "block-needed");
     mw_block_needed();
-    WORD_ATOM(47, 35, "!");
+    WORD_ATOM(43, 35, "!");
     mw_prim_mut_set();
     WORD_EXIT(mb_reset_needs_21__1);
 }
 
 static void mb_reset_needs_21__2 (void) {
-    WORD_ENTER(mb_reset_needs_21__2, "reset-needs! block", "src/mirth/codegen.mth", 48, 14);
+    WORD_ENTER(mb_reset_needs_21__2, "reset-needs! block", "src/mirth/codegen.mth", 44, 14);
     mw_prim_drop();
-    WORD_ATOM(48, 14, "F");
+    WORD_ATOM(44, 14, "F");
     mw_F();
-    WORD_ATOM(48, 16, "swap");
+    WORD_ATOM(44, 16, "swap");
     mw_prim_swap();
-    WORD_ATOM(48, 21, "word-needed");
+    WORD_ATOM(44, 21, "word-needed");
     mw_word_needed();
-    WORD_ATOM(48, 33, "!");
+    WORD_ATOM(44, 33, "!");
     mw_prim_mut_set();
     WORD_EXIT(mb_reset_needs_21__2);
 }
 
 static void mb_for_needed_words_2 (void) {
-    WORD_ENTER(mb_for_needed_words_2, "for-needed-words block", "src/mirth/codegen.mth", 51, 14);
+    WORD_ENTER(mb_for_needed_words_2, "for-needed-words block", "src/mirth/codegen.mth", 47, 14);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(51, 14, "dup");
+    WORD_ATOM(47, 14, "dup");
     mw_prim_dup();
-    WORD_ATOM(51, 18, "word-needed");
+    WORD_ATOM(47, 18, "word-needed");
     mw_word_needed();
-    WORD_ATOM(51, 30, "@");
+    WORD_ATOM(47, 30, "@");
     mw_prim_mut_get();
-    WORD_ATOM(51, 32, "if");
+    WORD_ATOM(47, 32, "if");
     if (pop_u64()) {
-        WORD_ATOM(51, 35, "f");
+        WORD_ATOM(47, 35, "f");
         incref(var_f);
         run_value(var_f);
     } else {
-        WORD_ATOM(51, 38, "drop");
+        WORD_ATOM(47, 38, "drop");
         mw_prim_drop();
     }
     decref(var_f);
@@ -40265,23 +43628,23 @@ static void mb_for_needed_words_2 (void) {
 }
 
 static void mb_for_needed_blocks_2 (void) {
-    WORD_ENTER(mb_for_needed_blocks_2, "for-needed-blocks block", "src/mirth/codegen.mth", 53, 15);
+    WORD_ENTER(mb_for_needed_blocks_2, "for-needed-blocks block", "src/mirth/codegen.mth", 49, 15);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(53, 15, "dup");
+    WORD_ATOM(49, 15, "dup");
     mw_prim_dup();
-    WORD_ATOM(53, 19, "block-needed");
+    WORD_ATOM(49, 19, "block-needed");
     mw_block_needed();
-    WORD_ATOM(53, 32, "@");
+    WORD_ATOM(49, 32, "@");
     mw_prim_mut_get();
-    WORD_ATOM(53, 34, "if");
+    WORD_ATOM(49, 34, "if");
     if (pop_u64()) {
-        WORD_ATOM(53, 37, "f");
+        WORD_ATOM(49, 37, "f");
         incref(var_f);
         run_value(var_f);
     } else {
-        WORD_ATOM(53, 40, "drop");
+        WORD_ATOM(49, 40, "drop");
         mw_prim_drop();
     }
     decref(var_f);
@@ -40289,38 +43652,38 @@ static void mb_for_needed_blocks_2 (void) {
 }
 
 static void mb_need_arrow_run_1 (void) {
-    WORD_ENTER(mb_need_arrow_run_1, "need-arrow-run block", "src/mirth/codegen.mth", 76, 41);
+    WORD_ENTER(mb_need_arrow_run_1, "need-arrow-run block", "src/mirth/codegen.mth", 72, 41);
     mw_prim_drop();
-    WORD_ATOM(76, 41, "need-atom-run");
+    WORD_ATOM(72, 41, "need-atom-run");
     mw_need_atom_run();
     WORD_EXIT(mb_need_arrow_run_1);
 }
 
 static void mb_determine_transitive_needs_21__1 (void) {
-    WORD_ENTER(mb_determine_transitive_needs_21__1, "determine-transitive-needs! block", "src/mirth/codegen.mth", 71, 16);
+    WORD_ENTER(mb_determine_transitive_needs_21__1, "determine-transitive-needs! block", "src/mirth/codegen.mth", 67, 16);
     mw_prim_drop();
-    WORD_ATOM(71, 16, "needs-stack");
+    WORD_ATOM(67, 16, "needs-stack");
     mw_needs_stack();
-    WORD_ATOM(71, 28, "pop!");
+    WORD_ATOM(67, 28, "pop!");
     mw_Stack_2E_pop_21_();
     WORD_EXIT(mb_determine_transitive_needs_21__1);
 }
 
 static void mb_determine_transitive_needs_21__2 (void) {
-    WORD_ENTER(mb_determine_transitive_needs_21__2, "determine-transitive-needs! block", "src/mirth/codegen.mth", 71, 34);
+    WORD_ENTER(mb_determine_transitive_needs_21__2, "determine-transitive-needs! block", "src/mirth/codegen.mth", 67, 34);
     mw_prim_drop();
-    WORD_ATOM(71, 34, "match");
+    WORD_ATOM(67, 34, "match");
     switch (get_top_data_tag()) {
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(72, 23, "need-block-run");
+            co_NEED_5F_BLOCK();
+            WORD_ATOM(68, 23, "need-block-run");
             mw_need_block_run();
             break;
         case 0LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(73, 22, "arrow");
+            co_NEED_5F_WORD();
+            WORD_ATOM(69, 22, "arrow");
             mw_Word_2E_arrow();
-            WORD_ATOM(73, 28, "need-arrow-run");
+            WORD_ATOM(69, 28, "need-arrow-run");
             mw_need_arrow_run();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -40329,183 +43692,133 @@ static void mb_determine_transitive_needs_21__2 (void) {
 }
 
 static void mb_need_atom_run_1 (void) {
-    WORD_ENTER(mb_need_atom_run_1, "need-atom-run block", "src/mirth/codegen.mth", 78, 9);
+    WORD_ENTER(mb_need_atom_run_1, "need-atom-run block", "src/mirth/codegen.mth", 74, 9);
     mw_prim_drop();
-    WORD_ATOM(78, 9, "args");
+    WORD_ATOM(74, 9, "args");
     mw_Atom_2E_args();
     WORD_EXIT(mb_need_atom_run_1);
 }
 
 static void mb_need_args_push_1 (void) {
-    WORD_ENTER(mb_need_args_push_1, "need-args-push block", "src/mirth/codegen.mth", 95, 39);
+    WORD_ENTER(mb_need_args_push_1, "need-args-push block", "src/mirth/codegen.mth", 91, 39);
     mw_prim_drop();
-    WORD_ATOM(95, 39, "need-arg-push");
+    WORD_ATOM(91, 39, "need-arg-push");
     mw_need_arg_push();
     WORD_EXIT(mb_need_args_push_1);
 }
 
 static void mb_need_match_1 (void) {
-    WORD_ENTER(mb_need_match_1, "need-match block", "src/mirth/codegen.mth", 122, 37);
+    WORD_ENTER(mb_need_match_1, "need-match block", "src/mirth/codegen.mth", 118, 37);
     mw_prim_drop();
-    WORD_ATOM(122, 37, "body");
+    WORD_ATOM(118, 37, "body");
     mw_Case_2E_body();
-    WORD_ATOM(122, 42, "need-arrow-run");
+    WORD_ATOM(118, 42, "need-arrow-run");
     mw_need_arrow_run();
     WORD_EXIT(mb_need_match_1);
 }
 
-static void mb_codegen_flush_21__2 (void) {
-    WORD_ENTER(mb_codegen_flush_21__2, "codegen-flush! block", "src/mirth/codegen.mth", 139, 17);
+static void mb_Str_2B_C99_2E__1 (void) {
+    WORD_ENTER(mb_Str_2B_C99_2E__1, "Str+C99. block", "src/mirth/codegen.mth", 139, 27);
     mw_prim_drop();
-    WORD_ATOM(139, 17, "dup");
-    mw_prim_dup();
-    WORD_ATOM(139, 21, "0>");
-    mw_0_3E_();
-    WORD_EXIT(mb_codegen_flush_21__2);
-}
-
-static void mb_codegen_flush_21__3 (void) {
-    WORD_ENTER(mb_codegen_flush_21__3, "codegen-flush! block", "src/mirth/codegen.mth", 139, 25);
-    mw_prim_drop();
-    WORD_ATOM(139, 25, "");
+    WORD_ATOM(139, 27, "");
     {
         static bool vready = false;
         static VAL v;
         if (! vready) {
-            v = mkstr("codegen write failed", 20);
+            v = mkstr("", 0);
             vready = true;
         }
         push_value(v);
         incref(v);
     }
-    WORD_EXIT(mb_codegen_flush_21__3);
+    WORD_EXIT(mb_Str_2B_C99_2E__1);
 }
 
-static void mb_codegen_flush_21__4 (void) {
-    WORD_ENTER(mb_codegen_flush_21__4, "codegen-flush! block", "src/mirth/codegen.mth", 140, 17);
+static void mb_Str_2B_C99_2E__2 (void) {
+    WORD_ENTER(mb_Str_2B_C99_2E__2, "Str+C99. block", "src/mirth/codegen.mth", 142, 43);
     mw_prim_drop();
-    WORD_ATOM(140, 17, "dup");
-    mw_prim_dup();
-    WORD_ATOM(140, 21, "codegen-length");
-    mw_codegen_length();
-    WORD_ATOM(140, 36, "@");
-    mw_prim_mut_get();
-    WORD_ATOM(140, 38, "=");
-    mw_prim_int_eq();
-    WORD_EXIT(mb_codegen_flush_21__4);
+    WORD_ATOM(142, 43, "codegen-flush!");
+    mw_codegen_flush_21_();
+    WORD_EXIT(mb_Str_2B_C99_2E__2);
 }
 
-static void mb_codegen_flush_21__5 (void) {
-    WORD_ENTER(mb_codegen_flush_21__5, "codegen-flush! block", "src/mirth/codegen.mth", 140, 41);
+static void mb_codegen_flush_21__1 (void) {
+    WORD_ENTER(mb_codegen_flush_21__1, "codegen-flush! block", "src/mirth/codegen.mth", 155, 27);
     mw_prim_drop();
-    WORD_ATOM(140, 41, "");
+    WORD_ATOM(155, 27, "");
     {
         static bool vready = false;
         static VAL v;
         if (! vready) {
-            v = mkstr("codegen wrote fewer bytes than expected", 39);
+            v = mkstr("", 0);
             vready = true;
         }
         push_value(v);
         incref(v);
     }
-    WORD_EXIT(mb_codegen_flush_21__5);
-}
-
-static void mb__2E_b_3 (void) {
-    WORD_ENTER(mb__2E_b_3, ".b block", "src/mirth/codegen.mth", 149, 27);
-    mw_prim_drop();
-    WORD_ATOM(149, 27, "dup");
-    mw_prim_dup();
-    WORD_ATOM(149, 31, "1+");
-    mw_prim_int_succ();
-    WORD_EXIT(mb__2E_b_3);
-}
-
-static void mb__2E__6 (void) {
-    WORD_ENTER(mb__2E__6, ". block", "src/mirth/codegen.mth", 165, 13);
-    mw_prim_drop();
-    WORD_ATOM(165, 13, "codegen-length");
-    mw_codegen_length();
-    WORD_ATOM(165, 28, "@");
-    mw_prim_mut_get();
-    WORD_ATOM(165, 30, "CODEGEN_BUF");
-    mw_CODEGEN_5F_BUF();
-    WORD_ATOM(165, 42, ".offset-unsafe");
-    mw_prim_ptr_add();
-    WORD_ATOM(165, 57, "prim-ptr-copy");
-    mw_prim_ptr_copy();
-    WORD_EXIT(mb__2E__6);
-}
-
-static void mb__2E__7 (void) {
-    WORD_ENTER(mb__2E__7, ". block", "src/mirth/codegen.mth", 166, 31);
-    mw_prim_drop();
-    WORD_ATOM(166, 31, "+");
-    mw_prim_int_add();
-    WORD_EXIT(mb__2E__7);
+    WORD_EXIT(mb_codegen_flush_21__1);
 }
 
 static void mb_c99_tags_21__1 (void) {
-    WORD_ENTER(mb_c99_tags_21__1, "c99-tags! block", "src/mirth/codegen.mth", 233, 28);
+    WORD_ENTER(mb_c99_tags_21__1, "c99-tags! block", "src/mirth/codegen.mth", 216, 38);
     mw_prim_drop();
-    WORD_ATOM(233, 28, "c99-tag!");
+    WORD_ATOM(216, 38, "c99-tag!");
     mw_c99_tag_21_();
     WORD_EXIT(mb_c99_tags_21__1);
 }
 
 static void mb_c99_buffers_21__1 (void) {
-    WORD_ENTER(mb_c99_buffers_21__1, "c99-buffers! block", "src/mirth/codegen.mth", 218, 34);
+    WORD_ENTER(mb_c99_buffers_21__1, "c99-buffers! block", "src/mirth/codegen.mth", 201, 44);
     mw_prim_drop();
-    WORD_ATOM(218, 34, "c99-buffer!");
+    WORD_ATOM(201, 44, "c99-buffer!");
     mw_c99_buffer_21_();
     WORD_EXIT(mb_c99_buffers_21__1);
 }
 
 static void mb_c99_variables_21__1 (void) {
-    WORD_ENTER(mb_c99_variables_21__1, "c99-variables! block", "src/mirth/codegen.mth", 226, 38);
+    WORD_ENTER(mb_c99_variables_21__1, "c99-variables! block", "src/mirth/codegen.mth", 209, 48);
     mw_prim_drop();
-    WORD_ATOM(226, 38, "c99-variable!");
+    WORD_ATOM(209, 48, "c99-variable!");
     mw_c99_variable_21_();
     WORD_EXIT(mb_c99_variables_21__1);
 }
 
 static void mb_c99_externals_21__1 (void) {
-    WORD_ENTER(mb_c99_externals_21__1, "c99-externals! block", "src/mirth/codegen.mth", 251, 18);
+    WORD_ENTER(mb_c99_externals_21__1, "c99-externals! block", "src/mirth/codegen.mth", 265, 18);
     mw_prim_drop();
-    WORD_ATOM(251, 18, "c99-external!");
+    WORD_ATOM(265, 18, "c99-external!");
     mw_c99_external_21_();
     WORD_EXIT(mb_c99_externals_21__1);
 }
 
 static void mb_c99_word_sigs_21__1 (void) {
-    WORD_ENTER(mb_c99_word_sigs_21__1, "c99-word-sigs! block", "src/mirth/codegen.mth", 548, 42);
+    WORD_ENTER(mb_c99_word_sigs_21__1, "c99-word-sigs! block", "src/mirth/codegen.mth", 558, 52);
     mw_prim_drop();
-    WORD_ATOM(548, 42, "c99-word-sig!");
+    WORD_ATOM(558, 52, "c99-word-sig!");
     mw_c99_word_sig_21_();
     WORD_EXIT(mb_c99_word_sigs_21__1);
 }
 
 static void mb_c99_block_sigs_21__1 (void) {
-    WORD_ENTER(mb_c99_block_sigs_21__1, "c99-block-sigs! block", "src/mirth/codegen.mth", 552, 44);
+    WORD_ENTER(mb_c99_block_sigs_21__1, "c99-block-sigs! block", "src/mirth/codegen.mth", 562, 54);
     mw_prim_drop();
-    WORD_ATOM(552, 44, "c99-block-sig!");
+    WORD_ATOM(562, 54, "c99-block-sig!");
     mw_c99_block_sig_21_();
     WORD_EXIT(mb_c99_block_sigs_21__1);
 }
 
 static void mb_c99_field_sigs_21__1 (void) {
-    WORD_ENTER(mb_c99_field_sigs_21__1, "c99-field-sigs! block", "src/mirth/codegen.mth", 556, 36);
+    WORD_ENTER(mb_c99_field_sigs_21__1, "c99-field-sigs! block", "src/mirth/codegen.mth", 566, 46);
     mw_prim_drop();
-    WORD_ATOM(556, 36, "c99-field-sig!");
+    WORD_ATOM(566, 46, "c99-field-sig!");
     mw_c99_field_sig_21_();
     WORD_EXIT(mb_c99_field_sigs_21__1);
 }
 
 static void mb_c99_main_21__1 (void) {
-    WORD_ENTER(mb_c99_main_21__1, "c99-main! block", "src/mirth/codegen.mth", 642, 14);
+    WORD_ENTER(mb_c99_main_21__1, "c99-main! block", "src/mirth/codegen.mth", 652, 14);
     mw_prim_drop();
-    WORD_ATOM(642, 14, "");
+    WORD_ATOM(652, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40516,37 +43829,37 @@ static void mb_c99_main_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(642, 51, ".");
-    mw__2E_();
+    WORD_ATOM(652, 51, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_main_21__1);
 }
 
 static void mb_c99_main_21__2 (void) {
-    WORD_ENTER(mb_c99_main_21__2, "c99-main! block", "src/mirth/codegen.mth", 644, 9);
+    WORD_ENTER(mb_c99_main_21__2, "c99-main! block", "src/mirth/codegen.mth", 654, 9);
     mw_prim_drop();
-    WORD_ATOM(644, 9, "c99-line");
+    WORD_ATOM(654, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(645, 9, "c99-line");
+    WORD_ATOM(655, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__4);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(646, 9, "c99-line");
+    WORD_ATOM(656, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__5);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(652, 9, "c99-arrow!");
+    WORD_ATOM(662, 9, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(653, 9, "c99-line");
+    WORD_ATOM(663, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__6);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(654, 9, "c99-line");
+    WORD_ATOM(664, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_main_21__7);
     mw_prim_pack_cons();
@@ -40555,9 +43868,9 @@ static void mb_c99_main_21__2 (void) {
 }
 
 static void mb_c99_main_21__3 (void) {
-    WORD_ENTER(mb_c99_main_21__3, "c99-main! block", "src/mirth/codegen.mth", 644, 18);
+    WORD_ENTER(mb_c99_main_21__3, "c99-main! block", "src/mirth/codegen.mth", 654, 18);
     mw_prim_drop();
-    WORD_ATOM(644, 18, "");
+    WORD_ATOM(654, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40568,15 +43881,15 @@ static void mb_c99_main_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(644, 40, ".");
-    mw__2E_();
+    WORD_ATOM(654, 40, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_main_21__3);
 }
 
 static void mb_c99_main_21__4 (void) {
-    WORD_ENTER(mb_c99_main_21__4, "c99-main! block", "src/mirth/codegen.mth", 645, 18);
+    WORD_ENTER(mb_c99_main_21__4, "c99-main! block", "src/mirth/codegen.mth", 655, 18);
     mw_prim_drop();
-    WORD_ATOM(645, 18, "");
+    WORD_ATOM(655, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40587,15 +43900,15 @@ static void mb_c99_main_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(645, 40, ".");
-    mw__2E_();
+    WORD_ATOM(655, 40, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_main_21__4);
 }
 
 static void mb_c99_main_21__5 (void) {
-    WORD_ENTER(mb_c99_main_21__5, "c99-main! block", "src/mirth/codegen.mth", 646, 18);
+    WORD_ENTER(mb_c99_main_21__5, "c99-main! block", "src/mirth/codegen.mth", 656, 18);
     mw_prim_drop();
-    WORD_ATOM(646, 18, "");
+    WORD_ATOM(656, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40606,9 +43919,9 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(646, 32, ".");
-    mw__2E_();
-    WORD_ATOM(647, 13, "");
+    WORD_ATOM(656, 32, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(657, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40619,9 +43932,9 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(647, 34, ".");
-    mw__2E_();
-    WORD_ATOM(648, 13, "");
+    WORD_ATOM(657, 34, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(658, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40632,21 +43945,21 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(648, 28, ".");
-    mw__2E_();
-    WORD_ATOM(649, 13, "dup");
+    WORD_ATOM(658, 28, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(659, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(649, 17, "token-start");
+    WORD_ATOM(659, 17, "token-start");
     mw_Arrow_2E_token_start();
-    WORD_ATOM(649, 29, ".module");
+    WORD_ATOM(659, 29, ".module");
     mw_Token_2E_module();
-    WORD_ATOM(649, 37, "source-path");
+    WORD_ATOM(659, 37, "source-path");
     mw_Module_2E_source_path();
-    WORD_ATOM(649, 49, ">Str");
+    WORD_ATOM(659, 49, ">Str");
     mw_Path_3E_Str();
-    WORD_ATOM(649, 54, ".str");
+    WORD_ATOM(659, 54, ".str");
     mw__2E_str();
-    WORD_ATOM(649, 59, "");
+    WORD_ATOM(659, 59, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40657,19 +43970,19 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(649, 64, ".");
-    mw__2E_();
-    WORD_ATOM(650, 13, "dup");
+    WORD_ATOM(659, 64, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(660, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(650, 17, "token-start");
+    WORD_ATOM(660, 17, "token-start");
     mw_Arrow_2E_token_start();
-    WORD_ATOM(650, 29, "row");
+    WORD_ATOM(660, 29, "row");
     mw_Token_2E_row();
-    WORD_ATOM(650, 33, ">Int");
+    WORD_ATOM(660, 33, ">Int");
     mw_Row_3E_Int();
-    WORD_ATOM(650, 38, ".n");
-    mw__2E_n();
-    WORD_ATOM(650, 41, "");
+    WORD_ATOM(660, 38, ".n");
+    mw_Int_2B_C99_2E_n();
+    WORD_ATOM(660, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40680,19 +43993,19 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(650, 46, ".");
-    mw__2E_();
-    WORD_ATOM(651, 13, "dup");
+    WORD_ATOM(660, 46, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(661, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(651, 17, "token-start");
+    WORD_ATOM(661, 17, "token-start");
     mw_Arrow_2E_token_start();
-    WORD_ATOM(651, 29, "col");
+    WORD_ATOM(661, 29, "col");
     mw_Token_2E_col();
-    WORD_ATOM(651, 33, ">Int");
+    WORD_ATOM(661, 33, ">Int");
     mw_Col_3E_Int();
-    WORD_ATOM(651, 38, ".n");
-    mw__2E_n();
-    WORD_ATOM(651, 41, "");
+    WORD_ATOM(661, 38, ".n");
+    mw_Int_2B_C99_2E_n();
+    WORD_ATOM(661, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40703,15 +44016,15 @@ static void mb_c99_main_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(651, 46, ".");
-    mw__2E_();
+    WORD_ATOM(661, 46, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_main_21__5);
 }
 
 static void mb_c99_main_21__6 (void) {
-    WORD_ENTER(mb_c99_main_21__6, "c99-main! block", "src/mirth/codegen.mth", 653, 18);
+    WORD_ENTER(mb_c99_main_21__6, "c99-main! block", "src/mirth/codegen.mth", 663, 18);
     mw_prim_drop();
-    WORD_ATOM(653, 18, "");
+    WORD_ATOM(663, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40722,15 +44035,15 @@ static void mb_c99_main_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(653, 49, ".");
-    mw__2E_();
+    WORD_ATOM(663, 49, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_main_21__6);
 }
 
 static void mb_c99_main_21__7 (void) {
-    WORD_ENTER(mb_c99_main_21__7, "c99-main! block", "src/mirth/codegen.mth", 654, 18);
+    WORD_ENTER(mb_c99_main_21__7, "c99-main! block", "src/mirth/codegen.mth", 664, 18);
     mw_prim_drop();
-    WORD_ATOM(654, 18, "");
+    WORD_ATOM(664, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40741,15 +44054,15 @@ static void mb_c99_main_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(654, 30, ".");
-    mw__2E_();
+    WORD_ATOM(664, 30, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_main_21__7);
 }
 
 static void mb_c99_main_21__8 (void) {
-    WORD_ENTER(mb_c99_main_21__8, "c99-main! block", "src/mirth/codegen.mth", 656, 14);
+    WORD_ENTER(mb_c99_main_21__8, "c99-main! block", "src/mirth/codegen.mth", 666, 14);
     mw_prim_drop();
-    WORD_ATOM(656, 14, "");
+    WORD_ATOM(666, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40760,72 +44073,207 @@ static void mb_c99_main_21__8 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(656, 18, ".");
-    mw__2E_();
+    WORD_ATOM(666, 18, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_main_21__8);
 }
 
 static void mb_c99_field_defs_21__1 (void) {
-    WORD_ENTER(mb_c99_field_defs_21__1, "c99-field-defs! block", "src/mirth/codegen.mth", 622, 36);
+    WORD_ENTER(mb_c99_field_defs_21__1, "c99-field-defs! block", "src/mirth/codegen.mth", 632, 46);
     mw_prim_drop();
-    WORD_ATOM(622, 36, "c99-field-def!");
+    WORD_ATOM(632, 46, "c99-field-def!");
     mw_c99_field_def_21_();
     WORD_EXIT(mb_c99_field_defs_21__1);
 }
 
 static void mb_c99_word_defs_21__1 (void) {
-    WORD_ENTER(mb_c99_word_defs_21__1, "c99-word-defs! block", "src/mirth/codegen.mth", 611, 42);
+    WORD_ENTER(mb_c99_word_defs_21__1, "c99-word-defs! block", "src/mirth/codegen.mth", 621, 52);
     mw_prim_drop();
-    WORD_ATOM(611, 42, "c99-word-def!");
+    WORD_ATOM(621, 52, "c99-word-def!");
     mw_c99_word_def_21_();
     WORD_EXIT(mb_c99_word_defs_21__1);
 }
 
 static void mb_c99_block_defs_21__1 (void) {
-    WORD_ENTER(mb_c99_block_defs_21__1, "c99-block-defs! block", "src/mirth/codegen.mth", 575, 44);
+    WORD_ENTER(mb_c99_block_defs_21__1, "c99-block-defs! block", "src/mirth/codegen.mth", 585, 54);
     mw_prim_drop();
-    WORD_ATOM(575, 44, "c99-block-def!");
+    WORD_ATOM(585, 54, "c99-block-def!");
     mw_c99_block_def_21_();
     WORD_EXIT(mb_c99_block_defs_21__1);
 }
 
-static void mb_c99_tag_21__5 (void) {
-    WORD_ENTER(mb_c99_tag_21__5, "c99-tag! block", "src/mirth/codegen.mth", 242, 38);
+static void mb_c99_tag_21__3 (void) {
+    WORD_ENTER(mb_c99_tag_21__3, "c99-tag! block", "src/mirth/codegen.mth", 224, 13);
     mw_prim_drop();
-    WORD_ATOM(242, 38, "");
+    WORD_ATOM(224, 13, "");
     {
         static bool vready = false;
         static VAL v;
         if (! vready) {
-            v = mkstr("    car = mkcons(car, pop_value());", 35);
+            v = mkstr("pop_value());", 13);
             vready = true;
         }
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(242, 76, ";");
-    mw__3B_();
-    WORD_EXIT(mb_c99_tag_21__5);
+    WORD_ATOM(224, 29, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(225, 13, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("    car = mkcons(car, ", 22);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(225, 38, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_EXIT(mb_c99_tag_21__3);
+}
+
+static void mb_c99_tag_21__4 (void) {
+    WORD_ENTER(mb_c99_tag_21__4, "c99-tag! block", "src/mirth/codegen.mth", 228, 13);
+    mw_prim_drop();
+    WORD_ATOM(228, 13, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("pop_resource());", 16);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(228, 32, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(229, 13, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("    car = mkcons(car, ", 22);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(229, 38, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_EXIT(mb_c99_tag_21__4);
+}
+
+static void mb_c99_tag_21__11 (void) {
+    WORD_ENTER(mb_c99_tag_21__11, "c99-tag! block", "src/mirth/codegen.mth", 249, 13);
+    mw_prim_drop();
+    WORD_ATOM(249, 13, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("    value_uncons_c(car, &car, &cdr);", 36);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(249, 52, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(250, 13, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(250, 15, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("cdr);", 5);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(250, 23, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(251, 13, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("    push_resource(", 18);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_EXIT(mb_c99_tag_21__11);
+}
+
+static void mb_c99_tag_21__12 (void) {
+    WORD_ENTER(mb_c99_tag_21__12, "c99-tag! block", "src/mirth/codegen.mth", 254, 13);
+    mw_prim_drop();
+    WORD_ATOM(254, 13, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("    value_uncons_c(car, &car, &cdr);", 36);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(254, 52, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(255, 13, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(255, 15, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("cdr);", 5);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(255, 23, ";");
+    mw_Str_2B_C99_3B_();
+    WORD_ATOM(256, 13, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("    push_value(", 15);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_EXIT(mb_c99_tag_21__12);
 }
 
 static void mb_c99_external_21__5 (void) {
-    WORD_ENTER(mb_c99_external_21__5, "c99-external! block", "src/mirth/codegen.mth", 264, 10);
+    WORD_ENTER(mb_c99_external_21__5, "c99-external! block", "src/mirth/codegen.mth", 278, 10);
     mw_prim_drop();
-    WORD_ATOM(264, 10, "dup");
+    WORD_ATOM(278, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(264, 14, "name");
+    WORD_ATOM(278, 14, "name");
     mw_External_2E_name();
-    WORD_ATOM(264, 19, ">Str");
+    WORD_ATOM(278, 19, ">Str");
     mw_Name_3E_Str();
-    WORD_ATOM(264, 24, ".");
-    mw__2E_();
+    WORD_ATOM(278, 24, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_external_21__5);
 }
 
 static void mb_c99_external_21__7 (void) {
-    WORD_ENTER(mb_c99_external_21__7, "c99-external! block", "src/mirth/codegen.mth", 267, 42);
+    WORD_ENTER(mb_c99_external_21__7, "c99-external! block", "src/mirth/codegen.mth", 281, 42);
     mw_prim_drop();
-    WORD_ATOM(267, 42, "");
+    WORD_ATOM(281, 42, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40836,27 +44284,27 @@ static void mb_c99_external_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(267, 54, ".");
-    mw__2E_();
+    WORD_ATOM(281, 54, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_external_21__7);
 }
 
 static void mb_c99_external_21__9 (void) {
-    WORD_ENTER(mb_c99_external_21__9, "c99-external! block", "src/mirth/codegen.mth", 270, 30);
+    WORD_ENTER(mb_c99_external_21__9, "c99-external! block", "src/mirth/codegen.mth", 284, 30);
     mw_prim_drop();
-    WORD_ATOM(270, 30, "dup");
+    WORD_ATOM(284, 30, "dup");
     mw_prim_dup();
-    WORD_ATOM(270, 34, "name");
+    WORD_ATOM(284, 34, "name");
     mw_External_2E_name();
-    WORD_ATOM(270, 39, ".name");
-    mw__2E_name();
+    WORD_ATOM(284, 39, ".name");
+    mw_Name_2B_C99_2E_name();
     WORD_EXIT(mb_c99_external_21__9);
 }
 
 static void mb_c99_external_21__10 (void) {
-    WORD_ENTER(mb_c99_external_21__10, "c99-external! block", "src/mirth/codegen.mth", 271, 20);
+    WORD_ENTER(mb_c99_external_21__10, "c99-external! block", "src/mirth/codegen.mth", 285, 20);
     mw_prim_drop();
-    WORD_ATOM(271, 20, "");
+    WORD_ATOM(285, 20, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40867,11 +44315,11 @@ static void mb_c99_external_21__10 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(271, 36, ".");
-    mw__2E_();
-    WORD_ATOM(271, 38, ".n");
-    mw__2E_n();
-    WORD_ATOM(271, 41, "");
+    WORD_ATOM(285, 36, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(285, 38, ".n");
+    mw_Int_2B_C99_2E_n();
+    WORD_ATOM(285, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40882,29 +44330,29 @@ static void mb_c99_external_21__10 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(271, 57, ";");
-    mw__3B_();
+    WORD_ATOM(285, 57, ";");
+    mw_Str_2B_C99_3B_();
     WORD_EXIT(mb_c99_external_21__10);
 }
 
 static void mb_c99_external_21__13 (void) {
-    WORD_ENTER(mb_c99_external_21__13, "c99-external! block", "src/mirth/codegen.mth", 273, 10);
+    WORD_ENTER(mb_c99_external_21__13, "c99-external! block", "src/mirth/codegen.mth", 287, 10);
     mw_prim_drop();
-    WORD_ATOM(273, 10, "dup");
+    WORD_ATOM(287, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(273, 14, "name");
+    WORD_ATOM(287, 14, "name");
     mw_External_2E_name();
-    WORD_ATOM(273, 19, ">Str");
+    WORD_ATOM(287, 19, ">Str");
     mw_Name_3E_Str();
-    WORD_ATOM(273, 24, ".");
-    mw__2E_();
+    WORD_ATOM(287, 24, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_external_21__13);
 }
 
 static void mb_c99_external_21__16 (void) {
-    WORD_ENTER(mb_c99_external_21__16, "c99-external! block", "src/mirth/codegen.mth", 276, 26);
+    WORD_ENTER(mb_c99_external_21__16, "c99-external! block", "src/mirth/codegen.mth", 290, 26);
     mw_prim_drop();
-    WORD_ATOM(276, 26, "");
+    WORD_ATOM(290, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40915,11 +44363,11 @@ static void mb_c99_external_21__16 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(276, 30, ".");
-    mw__2E_();
-    WORD_ATOM(276, 32, ".n");
-    mw__2E_n();
-    WORD_ATOM(276, 35, "");
+    WORD_ATOM(290, 30, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(290, 32, ".n");
+    mw_Int_2B_C99_2E_n();
+    WORD_ATOM(290, 35, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40930,37 +44378,15 @@ static void mb_c99_external_21__16 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(276, 40, ".");
-    mw__2E_();
+    WORD_ATOM(290, 40, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_external_21__16);
 }
 
-static void mb_c99_nest_2 (void) {
-    WORD_ENTER(mb_c99_nest_2, "c99-nest block", "src/mirth/codegen.mth", 285, 22);
-    mw_prim_pack_uncons();
-    VAL var_f = pop_value();
-    mw_prim_drop();
-    WORD_ATOM(285, 22, "1+");
-    mw_prim_int_succ();
-    decref(var_f);
-    WORD_EXIT(mb_c99_nest_2);
-}
-
-static void mb_c99_nest_3 (void) {
-    WORD_ENTER(mb_c99_nest_3, "c99-nest block", "src/mirth/codegen.mth", 287, 22);
-    mw_prim_pack_uncons();
-    VAL var_f = pop_value();
-    mw_prim_drop();
-    WORD_ATOM(287, 22, "1-");
-    mw_prim_int_pred();
-    decref(var_f);
-    WORD_EXIT(mb_c99_nest_3);
-}
-
 static void mb_c99_indent_1 (void) {
-    WORD_ENTER(mb_c99_indent_1, "c99-indent block", "src/mirth/codegen.mth", 289, 40);
+    WORD_ENTER(mb_c99_indent_1, "c99-indent block", "src/mirth/codegen.mth", 303, 45);
     mw_prim_drop();
-    WORD_ATOM(289, 40, "");
+    WORD_ATOM(303, 45, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40971,15 +44397,15 @@ static void mb_c99_indent_1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(289, 47, ".");
-    mw__2E_();
+    WORD_ATOM(303, 52, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_indent_1);
 }
 
 static void mb_c99_call_21__2 (void) {
-    WORD_ENTER(mb_c99_call_21__2, "c99-call! block", "src/mirth/codegen.mth", 294, 14);
+    WORD_ENTER(mb_c99_call_21__2, "c99-call! block", "src/mirth/codegen.mth", 308, 14);
     mw_prim_drop();
-    WORD_ATOM(294, 14, "");
+    WORD_ATOM(308, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -40990,11 +44416,11 @@ static void mb_c99_call_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(294, 20, ".");
-    mw__2E_();
-    WORD_ATOM(294, 22, ".name");
-    mw__2E_name();
-    WORD_ATOM(294, 28, "");
+    WORD_ATOM(308, 20, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(308, 22, ".name");
+    mw_Name_2B_C99_2E_name();
+    WORD_ATOM(308, 28, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41005,31 +44431,31 @@ static void mb_c99_call_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(294, 34, ".");
-    mw__2E_();
+    WORD_ATOM(308, 34, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_call_21__2);
 }
 
 static void mb_c99_args_push_21__1 (void) {
-    WORD_ENTER(mb_c99_args_push_21__1, "c99-args-push! block", "src/mirth/codegen.mth", 439, 9);
+    WORD_ENTER(mb_c99_args_push_21__1, "c99-args-push! block", "src/mirth/codegen.mth", 453, 9);
     mw_prim_drop();
-    WORD_ATOM(439, 9, "c99-arg-push!");
+    WORD_ATOM(453, 9, "c99-arg-push!");
     mw_c99_arg_push_21_();
     WORD_EXIT(mb_c99_args_push_21__1);
 }
 
 static void mb_c99_arrow_21__1 (void) {
-    WORD_ENTER(mb_c99_arrow_21__1, "c99-arrow! block", "src/mirth/codegen.mth", 296, 37);
+    WORD_ENTER(mb_c99_arrow_21__1, "c99-arrow! block", "src/mirth/codegen.mth", 310, 47);
     mw_prim_drop();
-    WORD_ATOM(296, 37, "c99-atom!");
+    WORD_ATOM(310, 47, "c99-atom!");
     mw_c99_atom_21_();
     WORD_EXIT(mb_c99_arrow_21__1);
 }
 
 static void mb_c99_atom_21__1 (void) {
-    WORD_ENTER(mb_c99_atom_21__1, "c99-atom! block", "src/mirth/codegen.mth", 298, 14);
+    WORD_ENTER(mb_c99_atom_21__1, "c99-atom! block", "src/mirth/codegen.mth", 312, 14);
     mw_prim_drop();
-    WORD_ATOM(298, 14, "");
+    WORD_ATOM(312, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41040,19 +44466,19 @@ static void mb_c99_atom_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(298, 27, ".");
-    mw__2E_();
-    WORD_ATOM(299, 9, "dup");
+    WORD_ATOM(312, 27, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(313, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(299, 13, "token");
+    WORD_ATOM(313, 13, "token");
     mw_Atom_2E_token();
-    WORD_ATOM(299, 19, "row");
+    WORD_ATOM(313, 19, "row");
     mw_Token_2E_row();
-    WORD_ATOM(299, 23, ">Int");
+    WORD_ATOM(313, 23, ">Int");
     mw_Row_3E_Int();
-    WORD_ATOM(299, 28, ".n");
-    mw__2E_n();
-    WORD_ATOM(299, 31, "");
+    WORD_ATOM(313, 28, ".n");
+    mw_Int_2B_C99_2E_n();
+    WORD_ATOM(313, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41063,19 +44489,19 @@ static void mb_c99_atom_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(299, 36, ".");
-    mw__2E_();
-    WORD_ATOM(300, 9, "dup");
+    WORD_ATOM(313, 36, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(314, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(300, 13, "token");
+    WORD_ATOM(314, 13, "token");
     mw_Atom_2E_token();
-    WORD_ATOM(300, 19, "col");
+    WORD_ATOM(314, 19, "col");
     mw_Token_2E_col();
-    WORD_ATOM(300, 23, ">Int");
+    WORD_ATOM(314, 23, ">Int");
     mw_Col_3E_Int();
-    WORD_ATOM(300, 28, ".n");
-    mw__2E_n();
-    WORD_ATOM(300, 31, "");
+    WORD_ATOM(314, 28, ".n");
+    mw_Int_2B_C99_2E_n();
+    WORD_ATOM(314, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41086,15 +44512,15 @@ static void mb_c99_atom_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(300, 36, ".");
-    mw__2E_();
-    WORD_ATOM(301, 9, "dup");
+    WORD_ATOM(314, 36, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(315, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(301, 13, "token");
+    WORD_ATOM(315, 13, "token");
     mw_Atom_2E_token();
-    WORD_ATOM(301, 19, "name?");
+    WORD_ATOM(315, 19, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(301, 25, "if-some");
+    WORD_ATOM(315, 25, "if-some");
     push_u64(0);
     push_fnptr(&mb_c99_atom_21__2);
     mw_prim_pack_cons();
@@ -41102,9 +44528,9 @@ static void mb_c99_atom_21__1 (void) {
     push_fnptr(&mb_c99_atom_21__3);
     mw_prim_pack_cons();
     mw_Maybe_2E_if_some();
-    WORD_ATOM(301, 43, ".str");
+    WORD_ATOM(315, 43, ".str");
     mw__2E_str();
-    WORD_ATOM(302, 9, "");
+    WORD_ATOM(316, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41115,23 +44541,23 @@ static void mb_c99_atom_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(302, 14, ".");
-    mw__2E_();
+    WORD_ATOM(316, 14, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_atom_21__1);
 }
 
 static void mb_c99_atom_21__2 (void) {
-    WORD_ENTER(mb_c99_atom_21__2, "c99-atom! block", "src/mirth/codegen.mth", 301, 33);
+    WORD_ENTER(mb_c99_atom_21__2, "c99-atom! block", "src/mirth/codegen.mth", 315, 33);
     mw_prim_drop();
-    WORD_ATOM(301, 33, ">Str");
+    WORD_ATOM(315, 33, ">Str");
     mw_Name_3E_Str();
     WORD_EXIT(mb_c99_atom_21__2);
 }
 
 static void mb_c99_atom_21__3 (void) {
-    WORD_ENTER(mb_c99_atom_21__3, "c99-atom! block", "src/mirth/codegen.mth", 301, 39);
+    WORD_ENTER(mb_c99_atom_21__3, "c99-atom! block", "src/mirth/codegen.mth", 315, 39);
     mw_prim_drop();
-    WORD_ATOM(301, 39, "");
+    WORD_ATOM(315, 39, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41146,25 +44572,25 @@ static void mb_c99_atom_21__3 (void) {
 }
 
 static void mb_c99_atom_21__4 (void) {
-    WORD_ENTER(mb_c99_atom_21__4, "c99-atom! block", "src/mirth/codegen.mth", 303, 9);
+    WORD_ENTER(mb_c99_atom_21__4, "c99-atom! block", "src/mirth/codegen.mth", 317, 9);
     mw_prim_drop();
-    WORD_ATOM(303, 9, "args");
+    WORD_ATOM(317, 9, "args");
     mw_Atom_2E_args();
     WORD_EXIT(mb_c99_atom_21__4);
 }
 
 static void mb__2E_str_1 (void) {
-    WORD_ENTER(mb__2E_str_1, ".str block", "src/mirth/codegen.mth", 354, 40);
+    WORD_ENTER(mb__2E_str_1, ".str block", "src/mirth/codegen.mth", 368, 50);
     mw_prim_drop();
-    WORD_ATOM(354, 40, "c99-string-byte!");
+    WORD_ATOM(368, 50, "c99-string-byte!");
     mw_c99_string_byte_21_();
     WORD_EXIT(mb__2E_str_1);
 }
 
 static void mb_c99_int_21__1 (void) {
-    WORD_ENTER(mb_c99_int_21__1, "c99-int! block", "src/mirth/codegen.mth", 324, 14);
+    WORD_ENTER(mb_c99_int_21__1, "c99-int! block", "src/mirth/codegen.mth", 338, 14);
     mw_prim_drop();
-    WORD_ATOM(324, 14, "");
+    WORD_ATOM(338, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41175,11 +44601,11 @@ static void mb_c99_int_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(324, 26, ".");
-    mw__2E_();
-    WORD_ATOM(324, 28, ".n");
-    mw__2E_n();
-    WORD_ATOM(324, 31, "");
+    WORD_ATOM(338, 26, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(338, 28, ".n");
+    mw_Int_2B_C99_2E_n();
+    WORD_ATOM(338, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41190,15 +44616,15 @@ static void mb_c99_int_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(324, 38, ".");
-    mw__2E_();
+    WORD_ATOM(338, 38, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_int_21__1);
 }
 
 static void mb_c99_str_21__1 (void) {
-    WORD_ENTER(mb_c99_str_21__1, "c99-str! block", "src/mirth/codegen.mth", 327, 14);
+    WORD_ENTER(mb_c99_str_21__1, "c99-str! block", "src/mirth/codegen.mth", 341, 14);
     mw_prim_drop();
-    WORD_ATOM(327, 14, "");
+    WORD_ATOM(341, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41209,45 +44635,45 @@ static void mb_c99_str_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(327, 18, ".");
-    mw__2E_();
+    WORD_ATOM(341, 18, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__1);
 }
 
 static void mb_c99_str_21__2 (void) {
-    WORD_ENTER(mb_c99_str_21__2, "c99-str! block", "src/mirth/codegen.mth", 329, 9);
+    WORD_ENTER(mb_c99_str_21__2, "c99-str! block", "src/mirth/codegen.mth", 343, 9);
     mw_prim_drop();
-    WORD_ATOM(329, 9, "c99-line");
+    WORD_ATOM(343, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__3);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(330, 9, "c99-line");
+    WORD_ATOM(344, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__4);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(331, 9, "c99-line");
+    WORD_ATOM(345, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__5);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(332, 9, "c99-nest");
+    WORD_ATOM(346, 9, "c99-nest");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__6);
     mw_prim_pack_cons();
     mw_c99_nest();
-    WORD_ATOM(347, 9, "c99-line");
+    WORD_ATOM(361, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__17);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(348, 9, "c99-line");
+    WORD_ATOM(362, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__18);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(349, 9, "c99-line");
+    WORD_ATOM(363, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__19);
     mw_prim_pack_cons();
@@ -41256,9 +44682,9 @@ static void mb_c99_str_21__2 (void) {
 }
 
 static void mb_c99_str_21__3 (void) {
-    WORD_ENTER(mb_c99_str_21__3, "c99-str! block", "src/mirth/codegen.mth", 329, 18);
+    WORD_ENTER(mb_c99_str_21__3, "c99-str! block", "src/mirth/codegen.mth", 343, 18);
     mw_prim_drop();
-    WORD_ATOM(329, 18, "");
+    WORD_ATOM(343, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41269,15 +44695,15 @@ static void mb_c99_str_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(329, 48, ".");
-    mw__2E_();
+    WORD_ATOM(343, 48, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__3);
 }
 
 static void mb_c99_str_21__4 (void) {
-    WORD_ENTER(mb_c99_str_21__4, "c99-str! block", "src/mirth/codegen.mth", 330, 18);
+    WORD_ENTER(mb_c99_str_21__4, "c99-str! block", "src/mirth/codegen.mth", 344, 18);
     mw_prim_drop();
-    WORD_ATOM(330, 18, "");
+    WORD_ATOM(344, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41288,15 +44714,15 @@ static void mb_c99_str_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(330, 34, ".");
-    mw__2E_();
+    WORD_ATOM(344, 34, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__4);
 }
 
 static void mb_c99_str_21__5 (void) {
-    WORD_ENTER(mb_c99_str_21__5, "c99-str! block", "src/mirth/codegen.mth", 331, 18);
+    WORD_ENTER(mb_c99_str_21__5, "c99-str! block", "src/mirth/codegen.mth", 345, 18);
     mw_prim_drop();
-    WORD_ATOM(331, 18, "");
+    WORD_ATOM(345, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41307,25 +44733,25 @@ static void mb_c99_str_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(331, 36, ".");
-    mw__2E_();
+    WORD_ATOM(345, 36, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__5);
 }
 
 static void mb_c99_str_21__6 (void) {
-    WORD_ENTER(mb_c99_str_21__6, "c99-str! block", "src/mirth/codegen.mth", 333, 13);
+    WORD_ENTER(mb_c99_str_21__6, "c99-str! block", "src/mirth/codegen.mth", 347, 13);
     mw_prim_drop();
-    WORD_ATOM(333, 13, "dup");
+    WORD_ATOM(347, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(333, 17, "num-bytes");
+    WORD_ATOM(347, 17, "num-bytes");
     mw_prim_str_num_bytes();
-    WORD_ATOM(333, 27, "");
+    WORD_ATOM(347, 27, "");
     push_i64(4090LL);
-    WORD_ATOM(333, 32, ">");
+    WORD_ATOM(347, 32, ">");
     mw_Int_3E_();
-    WORD_ATOM(333, 34, "if");
+    WORD_ATOM(347, 34, "if");
     if (pop_u64()) {
-        WORD_ATOM(334, 17, "");
+        WORD_ATOM(348, 17, "");
         {
             static bool vready = false;
             static VAL v;
@@ -41336,31 +44762,31 @@ static void mb_c99_str_21__6 (void) {
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(334, 42, ".");
-        mw__2E_();
-        WORD_ATOM(335, 17, "c99-nest");
+        WORD_ATOM(348, 42, ".");
+        mw_Str_2B_C99_2E_();
+        WORD_ATOM(349, 17, "c99-nest");
         push_u64(0);
         push_fnptr(&mb_c99_str_21__8);
         mw_prim_pack_cons();
         mw_c99_nest();
-        WORD_ATOM(341, 17, "c99-line");
+        WORD_ATOM(355, 17, "c99-line");
         push_u64(0);
         push_fnptr(&mb_c99_str_21__12);
         mw_prim_pack_cons();
         mw_c99_line();
-        WORD_ATOM(342, 17, "c99-line");
+        WORD_ATOM(356, 17, "c99-line");
         push_u64(0);
         push_fnptr(&mb_c99_str_21__13);
         mw_prim_pack_cons();
         mw_c99_line();
     } else {
-        WORD_ATOM(343, 17, "c99-line");
+        WORD_ATOM(357, 17, "c99-line");
         push_u64(0);
         push_fnptr(&mb_c99_str_21__15);
         mw_prim_pack_cons();
         mw_c99_line();
     }
-    WORD_ATOM(345, 13, "c99-line");
+    WORD_ATOM(359, 13, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__16);
     mw_prim_pack_cons();
@@ -41369,32 +44795,32 @@ static void mb_c99_str_21__6 (void) {
 }
 
 static void mb_c99_str_21__8 (void) {
-    WORD_ENTER(mb_c99_str_21__8, "c99-str! block", "src/mirth/codegen.mth", 336, 21);
+    WORD_ENTER(mb_c99_str_21__8, "c99-str! block", "src/mirth/codegen.mth", 350, 21);
     mw_prim_drop();
-    WORD_ATOM(336, 21, "c99-indent");
+    WORD_ATOM(350, 21, "c99-indent");
     mw_c99_indent();
-    WORD_ATOM(336, 32, "dup");
+    WORD_ATOM(350, 32, "dup");
     mw_prim_dup();
-    WORD_ATOM(336, 36, "str-bytes-for");
+    WORD_ATOM(350, 36, "str-bytes-for");
     push_u64(0);
     push_fnptr(&mb_c99_str_21__9);
     mw_prim_pack_cons();
     mw_str_bytes_for();
-    WORD_ATOM(339, 23, ".lf");
-    mw__2E_lf();
+    WORD_ATOM(353, 23, ".lf");
+    mw__2B_C99_2E_lf();
     WORD_EXIT(mb_c99_str_21__8);
 }
 
 static void mb_c99_str_21__9 (void) {
-    WORD_ENTER(mb_c99_str_21__9, "c99-str! block", "src/mirth/codegen.mth", 337, 25);
+    WORD_ENTER(mb_c99_str_21__9, "c99-str! block", "src/mirth/codegen.mth", 351, 25);
     mw_prim_drop();
-    WORD_ATOM(337, 25, ">Int");
+    WORD_ATOM(351, 25, ">Int");
     mw_Byte_3E_Int();
-    WORD_ATOM(337, 30, "dup");
+    WORD_ATOM(351, 30, "dup");
     mw_prim_dup();
-    WORD_ATOM(337, 34, ".n");
-    mw__2E_n();
-    WORD_ATOM(337, 37, "");
+    WORD_ATOM(351, 34, ".n");
+    mw_Int_2B_C99_2E_n();
+    WORD_ATOM(351, 37, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41405,29 +44831,29 @@ static void mb_c99_str_21__9 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(337, 41, ".");
-    mw__2E_();
-    WORD_ATOM(338, 25, "");
+    WORD_ATOM(351, 41, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(352, 25, "");
     push_i64(10LL);
-    WORD_ATOM(338, 28, "=");
+    WORD_ATOM(352, 28, "=");
     mw_prim_int_eq();
-    WORD_ATOM(338, 30, "if");
+    WORD_ATOM(352, 30, "if");
     if (pop_u64()) {
-        WORD_ATOM(338, 33, ".lf");
-        mw__2E_lf();
-        WORD_ATOM(338, 37, "c99-indent");
+        WORD_ATOM(352, 33, ".lf");
+        mw__2B_C99_2E_lf();
+        WORD_ATOM(352, 37, "c99-indent");
         mw_c99_indent();
     } else {
-        WORD_ATOM(338, 49, "id");
+        WORD_ATOM(352, 49, "id");
         mw_prim_id();
     }
     WORD_EXIT(mb_c99_str_21__9);
 }
 
 static void mb_c99_str_21__12 (void) {
-    WORD_ENTER(mb_c99_str_21__12, "c99-str! block", "src/mirth/codegen.mth", 341, 26);
+    WORD_ENTER(mb_c99_str_21__12, "c99-str! block", "src/mirth/codegen.mth", 355, 26);
     mw_prim_drop();
-    WORD_ATOM(341, 26, "");
+    WORD_ATOM(355, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41438,15 +44864,15 @@ static void mb_c99_str_21__12 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(341, 31, ".");
-    mw__2E_();
+    WORD_ATOM(355, 31, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__12);
 }
 
 static void mb_c99_str_21__13 (void) {
-    WORD_ENTER(mb_c99_str_21__13, "c99-str! block", "src/mirth/codegen.mth", 342, 26);
+    WORD_ENTER(mb_c99_str_21__13, "c99-str! block", "src/mirth/codegen.mth", 356, 26);
     mw_prim_drop();
-    WORD_ATOM(342, 26, "");
+    WORD_ATOM(356, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41457,15 +44883,15 @@ static void mb_c99_str_21__13 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(342, 49, ".");
-    mw__2E_();
-    WORD_ATOM(342, 51, "dup");
+    WORD_ATOM(356, 49, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(356, 51, "dup");
     mw_prim_dup();
-    WORD_ATOM(342, 55, "num-bytes");
+    WORD_ATOM(356, 55, "num-bytes");
     mw_prim_str_num_bytes();
-    WORD_ATOM(342, 65, ".n");
-    mw__2E_n();
-    WORD_ATOM(342, 68, "");
+    WORD_ATOM(356, 65, ".n");
+    mw_Int_2B_C99_2E_n();
+    WORD_ATOM(356, 68, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41476,15 +44902,15 @@ static void mb_c99_str_21__13 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(342, 73, ".");
-    mw__2E_();
+    WORD_ATOM(356, 73, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__13);
 }
 
 static void mb_c99_str_21__15 (void) {
-    WORD_ENTER(mb_c99_str_21__15, "c99-str! block", "src/mirth/codegen.mth", 343, 26);
+    WORD_ENTER(mb_c99_str_21__15, "c99-str! block", "src/mirth/codegen.mth", 357, 26);
     mw_prim_drop();
-    WORD_ATOM(343, 26, "");
+    WORD_ATOM(357, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41495,13 +44921,13 @@ static void mb_c99_str_21__15 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(343, 39, ".");
-    mw__2E_();
-    WORD_ATOM(343, 41, "dup");
+    WORD_ATOM(357, 39, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(357, 41, "dup");
     mw_prim_dup();
-    WORD_ATOM(343, 45, ".str");
+    WORD_ATOM(357, 45, ".str");
     mw__2E_str();
-    WORD_ATOM(343, 50, "");
+    WORD_ATOM(357, 50, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41512,15 +44938,15 @@ static void mb_c99_str_21__15 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(343, 55, ".");
-    mw__2E_();
-    WORD_ATOM(343, 57, "dup");
+    WORD_ATOM(357, 55, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(357, 57, "dup");
     mw_prim_dup();
-    WORD_ATOM(343, 61, "num-bytes");
+    WORD_ATOM(357, 61, "num-bytes");
     mw_prim_str_num_bytes();
-    WORD_ATOM(343, 71, ".n");
-    mw__2E_n();
-    WORD_ATOM(343, 74, "");
+    WORD_ATOM(357, 71, ".n");
+    mw_Int_2B_C99_2E_n();
+    WORD_ATOM(357, 74, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41531,15 +44957,15 @@ static void mb_c99_str_21__15 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(343, 79, ".");
-    mw__2E_();
+    WORD_ATOM(357, 79, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__15);
 }
 
 static void mb_c99_str_21__16 (void) {
-    WORD_ENTER(mb_c99_str_21__16, "c99-str! block", "src/mirth/codegen.mth", 345, 22);
+    WORD_ENTER(mb_c99_str_21__16, "c99-str! block", "src/mirth/codegen.mth", 359, 22);
     mw_prim_drop();
-    WORD_ATOM(345, 22, "");
+    WORD_ATOM(359, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41550,15 +44976,15 @@ static void mb_c99_str_21__16 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(345, 39, ".");
-    mw__2E_();
+    WORD_ATOM(359, 39, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__16);
 }
 
 static void mb_c99_str_21__17 (void) {
-    WORD_ENTER(mb_c99_str_21__17, "c99-str! block", "src/mirth/codegen.mth", 347, 18);
+    WORD_ENTER(mb_c99_str_21__17, "c99-str! block", "src/mirth/codegen.mth", 361, 18);
     mw_prim_drop();
-    WORD_ATOM(347, 18, "");
+    WORD_ATOM(361, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41569,15 +44995,15 @@ static void mb_c99_str_21__17 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(347, 22, ".");
-    mw__2E_();
+    WORD_ATOM(361, 22, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__17);
 }
 
 static void mb_c99_str_21__18 (void) {
-    WORD_ENTER(mb_c99_str_21__18, "c99-str! block", "src/mirth/codegen.mth", 348, 18);
+    WORD_ENTER(mb_c99_str_21__18, "c99-str! block", "src/mirth/codegen.mth", 362, 18);
     mw_prim_drop();
-    WORD_ATOM(348, 18, "");
+    WORD_ATOM(362, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41588,15 +45014,15 @@ static void mb_c99_str_21__18 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(348, 35, ".");
-    mw__2E_();
+    WORD_ATOM(362, 35, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__18);
 }
 
 static void mb_c99_str_21__19 (void) {
-    WORD_ENTER(mb_c99_str_21__19, "c99-str! block", "src/mirth/codegen.mth", 349, 18);
+    WORD_ENTER(mb_c99_str_21__19, "c99-str! block", "src/mirth/codegen.mth", 363, 18);
     mw_prim_drop();
-    WORD_ATOM(349, 18, "");
+    WORD_ATOM(363, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41607,15 +45033,15 @@ static void mb_c99_str_21__19 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(349, 31, ".");
-    mw__2E_();
+    WORD_ATOM(363, 31, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__19);
 }
 
 static void mb_c99_str_21__20 (void) {
-    WORD_ENTER(mb_c99_str_21__20, "c99-str! block", "src/mirth/codegen.mth", 351, 14);
+    WORD_ENTER(mb_c99_str_21__20, "c99-str! block", "src/mirth/codegen.mth", 365, 14);
     mw_prim_drop();
-    WORD_ATOM(351, 14, "");
+    WORD_ATOM(365, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41626,145 +45052,13 @@ static void mb_c99_str_21__20 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(351, 18, ".");
-    mw__2E_();
+    WORD_ATOM(365, 18, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_str_21__20);
 }
 
 static void mb_c99_prim_21__3 (void) {
-    WORD_ENTER(mb_c99_prim_21__3, "c99-prim! block", "src/mirth/codegen.mth", 381, 26);
-    mw_prim_drop();
-    WORD_ATOM(381, 26, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr("{", 1);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(381, 30, ".");
-    mw__2E_();
-    WORD_EXIT(mb_c99_prim_21__3);
-}
-
-static void mb_c99_prim_21__4 (void) {
-    WORD_ENTER(mb_c99_prim_21__4, "c99-prim! block", "src/mirth/codegen.mth", 383, 21);
-    mw_prim_drop();
-    WORD_ATOM(383, 21, "c99-line");
-    push_u64(0);
-    push_fnptr(&mb_c99_prim_21__5);
-    mw_prim_pack_cons();
-    mw_c99_line();
-    WORD_ATOM(384, 21, "c99-arg-run!");
-    mw_c99_arg_run_21_();
-    WORD_ATOM(385, 21, "c99-line");
-    push_u64(0);
-    push_fnptr(&mb_c99_prim_21__6);
-    mw_prim_pack_cons();
-    mw_c99_line();
-    WORD_EXIT(mb_c99_prim_21__4);
-}
-
-static void mb_c99_prim_21__5 (void) {
-    WORD_ENTER(mb_c99_prim_21__5, "c99-prim! block", "src/mirth/codegen.mth", 383, 30);
-    mw_prim_drop();
-    WORD_ATOM(383, 30, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr("VAL d", 5);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(383, 38, ".");
-    mw__2E_();
-    WORD_ATOM(383, 40, "c99-depth");
-    mw_c99_depth();
-    WORD_ATOM(383, 50, "@");
-    mw_prim_mut_get();
-    WORD_ATOM(383, 52, ".n");
-    mw__2E_n();
-    WORD_ATOM(383, 55, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr(" = pop_value();", 15);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(383, 73, ".");
-    mw__2E_();
-    WORD_EXIT(mb_c99_prim_21__5);
-}
-
-static void mb_c99_prim_21__6 (void) {
-    WORD_ENTER(mb_c99_prim_21__6, "c99-prim! block", "src/mirth/codegen.mth", 385, 30);
-    mw_prim_drop();
-    WORD_ATOM(385, 30, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr("push_value(d", 12);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(385, 45, ".");
-    mw__2E_();
-    WORD_ATOM(385, 47, "c99-depth");
-    mw_c99_depth();
-    WORD_ATOM(385, 57, "@");
-    mw_prim_mut_get();
-    WORD_ATOM(385, 59, ".n");
-    mw__2E_n();
-    WORD_ATOM(385, 62, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr(");", 2);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(385, 67, ".");
-    mw__2E_();
-    WORD_EXIT(mb_c99_prim_21__6);
-}
-
-static void mb_c99_prim_21__7 (void) {
-    WORD_ENTER(mb_c99_prim_21__7, "c99-prim! block", "src/mirth/codegen.mth", 387, 26);
-    mw_prim_drop();
-    WORD_ATOM(387, 26, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr("}", 1);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(387, 30, ".");
-    mw__2E_();
-    WORD_EXIT(mb_c99_prim_21__7);
-}
-
-static void mb_c99_prim_21__11 (void) {
-    WORD_ENTER(mb_c99_prim_21__11, "c99-prim! block", "src/mirth/codegen.mth", 395, 26);
+    WORD_ENTER(mb_c99_prim_21__3, "c99-prim! block", "src/mirth/codegen.mth", 395, 26);
     mw_prim_drop();
     WORD_ATOM(395, 26, "");
     {
@@ -41778,30 +45072,30 @@ static void mb_c99_prim_21__11 (void) {
         incref(v);
     }
     WORD_ATOM(395, 30, ".");
-    mw__2E_();
-    WORD_EXIT(mb_c99_prim_21__11);
+    mw_Str_2B_C99_2E_();
+    WORD_EXIT(mb_c99_prim_21__3);
 }
 
-static void mb_c99_prim_21__12 (void) {
-    WORD_ENTER(mb_c99_prim_21__12, "c99-prim! block", "src/mirth/codegen.mth", 397, 21);
+static void mb_c99_prim_21__4 (void) {
+    WORD_ENTER(mb_c99_prim_21__4, "c99-prim! block", "src/mirth/codegen.mth", 397, 21);
     mw_prim_drop();
     WORD_ATOM(397, 21, "c99-line");
     push_u64(0);
-    push_fnptr(&mb_c99_prim_21__13);
+    push_fnptr(&mb_c99_prim_21__5);
     mw_prim_pack_cons();
     mw_c99_line();
     WORD_ATOM(398, 21, "c99-arg-run!");
     mw_c99_arg_run_21_();
     WORD_ATOM(399, 21, "c99-line");
     push_u64(0);
-    push_fnptr(&mb_c99_prim_21__14);
+    push_fnptr(&mb_c99_prim_21__6);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_EXIT(mb_c99_prim_21__12);
+    WORD_EXIT(mb_c99_prim_21__4);
 }
 
-static void mb_c99_prim_21__13 (void) {
-    WORD_ENTER(mb_c99_prim_21__13, "c99-prim! block", "src/mirth/codegen.mth", 397, 30);
+static void mb_c99_prim_21__5 (void) {
+    WORD_ENTER(mb_c99_prim_21__5, "c99-prim! block", "src/mirth/codegen.mth", 397, 30);
     mw_prim_drop();
     WORD_ATOM(397, 30, "");
     {
@@ -41815,52 +45109,48 @@ static void mb_c99_prim_21__13 (void) {
         incref(v);
     }
     WORD_ATOM(397, 38, ".");
-    mw__2E_();
-    WORD_ATOM(397, 40, "c99-depth");
-    mw_c99_depth();
-    WORD_ATOM(397, 50, "@");
-    mw_prim_mut_get();
-    WORD_ATOM(397, 52, ".n");
-    mw__2E_n();
-    WORD_ATOM(397, 55, "");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(397, 40, "depth@");
+    mw__2B_C99_2E_depth_40_();
+    WORD_ATOM(397, 47, ".n");
+    mw_Int_2B_C99_2E_n();
+    WORD_ATOM(397, 50, "");
     {
         static bool vready = false;
         static VAL v;
         if (! vready) {
-            v = mkstr(" = pop_resource();", 18);
+            v = mkstr(" = pop_value();", 15);
             vready = true;
         }
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(397, 76, ".");
-    mw__2E_();
-    WORD_EXIT(mb_c99_prim_21__13);
+    WORD_ATOM(397, 68, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_EXIT(mb_c99_prim_21__5);
 }
 
-static void mb_c99_prim_21__14 (void) {
-    WORD_ENTER(mb_c99_prim_21__14, "c99-prim! block", "src/mirth/codegen.mth", 399, 30);
+static void mb_c99_prim_21__6 (void) {
+    WORD_ENTER(mb_c99_prim_21__6, "c99-prim! block", "src/mirth/codegen.mth", 399, 30);
     mw_prim_drop();
     WORD_ATOM(399, 30, "");
     {
         static bool vready = false;
         static VAL v;
         if (! vready) {
-            v = mkstr("push_resource(d", 15);
+            v = mkstr("push_value(d", 12);
             vready = true;
         }
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(399, 48, ".");
-    mw__2E_();
-    WORD_ATOM(399, 50, "c99-depth");
-    mw_c99_depth();
-    WORD_ATOM(399, 60, "@");
-    mw_prim_mut_get();
-    WORD_ATOM(399, 62, ".n");
-    mw__2E_n();
-    WORD_ATOM(399, 65, "");
+    WORD_ATOM(399, 45, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(399, 47, "depth@");
+    mw__2B_C99_2E_depth_40_();
+    WORD_ATOM(399, 54, ".n");
+    mw_Int_2B_C99_2E_n();
+    WORD_ATOM(399, 57, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41871,13 +45161,13 @@ static void mb_c99_prim_21__14 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(399, 70, ".");
-    mw__2E_();
-    WORD_EXIT(mb_c99_prim_21__14);
+    WORD_ATOM(399, 62, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_EXIT(mb_c99_prim_21__6);
 }
 
-static void mb_c99_prim_21__15 (void) {
-    WORD_ENTER(mb_c99_prim_21__15, "c99-prim! block", "src/mirth/codegen.mth", 401, 26);
+static void mb_c99_prim_21__7 (void) {
+    WORD_ENTER(mb_c99_prim_21__7, "c99-prim! block", "src/mirth/codegen.mth", 401, 26);
     mw_prim_drop();
     WORD_ATOM(401, 26, "");
     {
@@ -41891,70 +45181,123 @@ static void mb_c99_prim_21__15 (void) {
         incref(v);
     }
     WORD_ATOM(401, 30, ".");
-    mw__2E_();
-    WORD_EXIT(mb_c99_prim_21__15);
+    mw_Str_2B_C99_2E_();
+    WORD_EXIT(mb_c99_prim_21__7);
 }
 
-static void mb_c99_prim_21__19 (void) {
-    WORD_ENTER(mb_c99_prim_21__19, "c99-prim! block", "src/mirth/codegen.mth", 409, 26);
+static void mb_c99_prim_21__11 (void) {
+    WORD_ENTER(mb_c99_prim_21__11, "c99-prim! block", "src/mirth/codegen.mth", 409, 26);
     mw_prim_drop();
     WORD_ATOM(409, 26, "");
     {
         static bool vready = false;
         static VAL v;
         if (! vready) {
-            v = mkstr("if (pop_u64()) {", 16);
+            v = mkstr("{", 1);
             vready = true;
         }
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(409, 45, ".");
-    mw__2E_();
-    WORD_EXIT(mb_c99_prim_21__19);
+    WORD_ATOM(409, 30, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_EXIT(mb_c99_prim_21__11);
 }
 
-static void mb_c99_prim_21__20 (void) {
-    WORD_ENTER(mb_c99_prim_21__20, "c99-prim! block", "src/mirth/codegen.mth", 410, 26);
+static void mb_c99_prim_21__12 (void) {
+    WORD_ENTER(mb_c99_prim_21__12, "c99-prim! block", "src/mirth/codegen.mth", 411, 21);
     mw_prim_drop();
-    WORD_ATOM(410, 26, "swap");
-    mw_prim_swap();
-    WORD_ATOM(410, 31, "c99-arg-run!");
+    WORD_ATOM(411, 21, "c99-line");
+    push_u64(0);
+    push_fnptr(&mb_c99_prim_21__13);
+    mw_prim_pack_cons();
+    mw_c99_line();
+    WORD_ATOM(412, 21, "c99-arg-run!");
     mw_c99_arg_run_21_();
-    WORD_EXIT(mb_c99_prim_21__20);
+    WORD_ATOM(413, 21, "c99-line");
+    push_u64(0);
+    push_fnptr(&mb_c99_prim_21__14);
+    mw_prim_pack_cons();
+    mw_c99_line();
+    WORD_EXIT(mb_c99_prim_21__12);
 }
 
-static void mb_c99_prim_21__21 (void) {
-    WORD_ENTER(mb_c99_prim_21__21, "c99-prim! block", "src/mirth/codegen.mth", 411, 26);
+static void mb_c99_prim_21__13 (void) {
+    WORD_ENTER(mb_c99_prim_21__13, "c99-prim! block", "src/mirth/codegen.mth", 411, 30);
     mw_prim_drop();
-    WORD_ATOM(411, 26, "");
+    WORD_ATOM(411, 30, "");
     {
         static bool vready = false;
         static VAL v;
         if (! vready) {
-            v = mkstr("} else {", 8);
+            v = mkstr("VAL d", 5);
             vready = true;
         }
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(411, 37, ".");
-    mw__2E_();
-    WORD_EXIT(mb_c99_prim_21__21);
+    WORD_ATOM(411, 38, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(411, 40, "depth@");
+    mw__2B_C99_2E_depth_40_();
+    WORD_ATOM(411, 47, ".n");
+    mw_Int_2B_C99_2E_n();
+    WORD_ATOM(411, 50, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr(" = pop_resource();", 18);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(411, 71, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_EXIT(mb_c99_prim_21__13);
 }
 
-static void mb_c99_prim_21__22 (void) {
-    WORD_ENTER(mb_c99_prim_21__22, "c99-prim! block", "src/mirth/codegen.mth", 412, 26);
+static void mb_c99_prim_21__14 (void) {
+    WORD_ENTER(mb_c99_prim_21__14, "c99-prim! block", "src/mirth/codegen.mth", 413, 30);
     mw_prim_drop();
-    WORD_ATOM(412, 26, "c99-arg-run!");
-    mw_c99_arg_run_21_();
-    WORD_EXIT(mb_c99_prim_21__22);
+    WORD_ATOM(413, 30, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("push_resource(d", 15);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(413, 48, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(413, 50, "depth@");
+    mw__2B_C99_2E_depth_40_();
+    WORD_ATOM(413, 57, ".n");
+    mw_Int_2B_C99_2E_n();
+    WORD_ATOM(413, 60, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr(");", 2);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(413, 65, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_EXIT(mb_c99_prim_21__14);
 }
 
-static void mb_c99_prim_21__23 (void) {
-    WORD_ENTER(mb_c99_prim_21__23, "c99-prim! block", "src/mirth/codegen.mth", 413, 26);
+static void mb_c99_prim_21__15 (void) {
+    WORD_ENTER(mb_c99_prim_21__15, "c99-prim! block", "src/mirth/codegen.mth", 415, 26);
     mw_prim_drop();
-    WORD_ATOM(413, 26, "");
+    WORD_ATOM(415, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -41965,68 +45308,69 @@ static void mb_c99_prim_21__23 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(413, 30, ".");
-    mw__2E_();
-    WORD_EXIT(mb_c99_prim_21__23);
+    WORD_ATOM(415, 30, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_EXIT(mb_c99_prim_21__15);
 }
 
-static void mb_c99_prim_21__27 (void) {
-    WORD_ENTER(mb_c99_prim_21__27, "c99-prim! block", "src/mirth/codegen.mth", 421, 26);
+static void mb_c99_prim_21__19 (void) {
+    WORD_ENTER(mb_c99_prim_21__19, "c99-prim! block", "src/mirth/codegen.mth", 423, 26);
     mw_prim_drop();
-    WORD_ATOM(421, 26, "");
+    WORD_ATOM(423, 26, "");
     {
         static bool vready = false;
         static VAL v;
         if (! vready) {
-            v = mkstr("while(1) {", 10);
+            v = mkstr("if (pop_u64()) {", 16);
             vready = true;
         }
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(421, 39, ".");
-    mw__2E_();
-    WORD_EXIT(mb_c99_prim_21__27);
+    WORD_ATOM(423, 45, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_EXIT(mb_c99_prim_21__19);
 }
 
-static void mb_c99_prim_21__28 (void) {
-    WORD_ENTER(mb_c99_prim_21__28, "c99-prim! block", "src/mirth/codegen.mth", 423, 21);
+static void mb_c99_prim_21__20 (void) {
+    WORD_ENTER(mb_c99_prim_21__20, "c99-prim! block", "src/mirth/codegen.mth", 424, 26);
     mw_prim_drop();
-    WORD_ATOM(423, 21, "swap");
+    WORD_ATOM(424, 26, "swap");
     mw_prim_swap();
-    WORD_ATOM(423, 26, "c99-arg-run!");
+    WORD_ATOM(424, 31, "c99-arg-run!");
     mw_c99_arg_run_21_();
-    WORD_ATOM(424, 21, "c99-line");
-    push_u64(0);
-    push_fnptr(&mb_c99_prim_21__29);
-    mw_prim_pack_cons();
-    mw_c99_line();
-    WORD_ATOM(425, 21, "c99-arg-run!");
-    mw_c99_arg_run_21_();
-    WORD_EXIT(mb_c99_prim_21__28);
+    WORD_EXIT(mb_c99_prim_21__20);
 }
 
-static void mb_c99_prim_21__29 (void) {
-    WORD_ENTER(mb_c99_prim_21__29, "c99-prim! block", "src/mirth/codegen.mth", 424, 30);
+static void mb_c99_prim_21__21 (void) {
+    WORD_ENTER(mb_c99_prim_21__21, "c99-prim! block", "src/mirth/codegen.mth", 425, 26);
     mw_prim_drop();
-    WORD_ATOM(424, 30, "");
+    WORD_ATOM(425, 26, "");
     {
         static bool vready = false;
         static VAL v;
         if (! vready) {
-            v = mkstr("if (! pop_u64()) break;", 23);
+            v = mkstr("} else {", 8);
             vready = true;
         }
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(424, 56, ".");
-    mw__2E_();
-    WORD_EXIT(mb_c99_prim_21__29);
+    WORD_ATOM(425, 37, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_EXIT(mb_c99_prim_21__21);
 }
 
-static void mb_c99_prim_21__30 (void) {
-    WORD_ENTER(mb_c99_prim_21__30, "c99-prim! block", "src/mirth/codegen.mth", 427, 26);
+static void mb_c99_prim_21__22 (void) {
+    WORD_ENTER(mb_c99_prim_21__22, "c99-prim! block", "src/mirth/codegen.mth", 426, 26);
+    mw_prim_drop();
+    WORD_ATOM(426, 26, "c99-arg-run!");
+    mw_c99_arg_run_21_();
+    WORD_EXIT(mb_c99_prim_21__22);
+}
+
+static void mb_c99_prim_21__23 (void) {
+    WORD_ENTER(mb_c99_prim_21__23, "c99-prim! block", "src/mirth/codegen.mth", 427, 26);
     mw_prim_drop();
     WORD_ATOM(427, 26, "");
     {
@@ -42040,16 +45384,90 @@ static void mb_c99_prim_21__30 (void) {
         incref(v);
     }
     WORD_ATOM(427, 30, ".");
-    mw__2E_();
+    mw_Str_2B_C99_2E_();
+    WORD_EXIT(mb_c99_prim_21__23);
+}
+
+static void mb_c99_prim_21__27 (void) {
+    WORD_ENTER(mb_c99_prim_21__27, "c99-prim! block", "src/mirth/codegen.mth", 435, 26);
+    mw_prim_drop();
+    WORD_ATOM(435, 26, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("while(1) {", 10);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(435, 39, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_EXIT(mb_c99_prim_21__27);
+}
+
+static void mb_c99_prim_21__28 (void) {
+    WORD_ENTER(mb_c99_prim_21__28, "c99-prim! block", "src/mirth/codegen.mth", 437, 21);
+    mw_prim_drop();
+    WORD_ATOM(437, 21, "swap");
+    mw_prim_swap();
+    WORD_ATOM(437, 26, "c99-arg-run!");
+    mw_c99_arg_run_21_();
+    WORD_ATOM(438, 21, "c99-line");
+    push_u64(0);
+    push_fnptr(&mb_c99_prim_21__29);
+    mw_prim_pack_cons();
+    mw_c99_line();
+    WORD_ATOM(439, 21, "c99-arg-run!");
+    mw_c99_arg_run_21_();
+    WORD_EXIT(mb_c99_prim_21__28);
+}
+
+static void mb_c99_prim_21__29 (void) {
+    WORD_ENTER(mb_c99_prim_21__29, "c99-prim! block", "src/mirth/codegen.mth", 438, 30);
+    mw_prim_drop();
+    WORD_ATOM(438, 30, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("if (! pop_u64()) break;", 23);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(438, 56, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_EXIT(mb_c99_prim_21__29);
+}
+
+static void mb_c99_prim_21__30 (void) {
+    WORD_ENTER(mb_c99_prim_21__30, "c99-prim! block", "src/mirth/codegen.mth", 441, 26);
+    mw_prim_drop();
+    WORD_ATOM(441, 26, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr("}", 1);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(441, 30, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_prim_21__30);
 }
 
 static void mb_c99_match_21__3 (void) {
-    WORD_ENTER(mb_c99_match_21__3, "c99-match! block", "src/mirth/codegen.mth", 512, 19);
+    WORD_ENTER(mb_c99_match_21__3, "c99-match! block", "src/mirth/codegen.mth", 526, 19);
     mw_prim_drop();
-    WORD_ATOM(512, 19, "token");
+    WORD_ATOM(526, 19, "token");
     mw_Match_2E_token();
-    WORD_ATOM(512, 25, "");
+    WORD_ATOM(526, 25, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42060,15 +45478,15 @@ static void mb_c99_match_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(512, 71, "emit-fatal-error!");
+    WORD_ATOM(526, 71, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_c99_match_21__3);
 }
 
 static void mb_c99_match_21__5 (void) {
-    WORD_ENTER(mb_c99_match_21__5, "c99-match! block", "src/mirth/codegen.mth", 514, 22);
+    WORD_ENTER(mb_c99_match_21__5, "c99-match! block", "src/mirth/codegen.mth", 528, 22);
     mw_prim_drop();
-    WORD_ATOM(514, 22, "");
+    WORD_ATOM(528, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42079,15 +45497,15 @@ static void mb_c99_match_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(514, 63, ".");
-    mw__2E_();
+    WORD_ATOM(528, 63, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_match_21__5);
 }
 
 static void mb_c99_match_21__7 (void) {
-    WORD_ENTER(mb_c99_match_21__7, "c99-match! block", "src/mirth/codegen.mth", 515, 22);
+    WORD_ENTER(mb_c99_match_21__7, "c99-match! block", "src/mirth/codegen.mth", 529, 22);
     mw_prim_drop();
-    WORD_ATOM(515, 22, "");
+    WORD_ATOM(529, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42098,26 +45516,26 @@ static void mb_c99_match_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(515, 54, ".");
-    mw__2E_();
+    WORD_ATOM(529, 54, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_match_21__7);
 }
 
 static void mb_c99_match_21__8 (void) {
-    WORD_ENTER(mb_c99_match_21__8, "c99-match! block", "src/mirth/codegen.mth", 518, 13);
+    WORD_ENTER(mb_c99_match_21__8, "c99-match! block", "src/mirth/codegen.mth", 532, 13);
     mw_prim_drop();
-    WORD_ATOM(518, 13, "dup");
+    WORD_ATOM(532, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(518, 17, "cases");
+    WORD_ATOM(532, 17, "cases");
     mw_Match_2E_cases();
-    WORD_ATOM(518, 23, "for");
+    WORD_ATOM(532, 23, "for");
     push_u64(0);
     push_fnptr(&mb_c99_match_21__9);
     mw_prim_pack_cons();
     mw_List_2E_for();
-    WORD_ATOM(519, 13, "has-default-case?");
+    WORD_ATOM(533, 13, "has-default-case?");
     mw_Match_2E_has_default_case_3F_();
-    WORD_ATOM(519, 31, "else");
+    WORD_ATOM(533, 31, "else");
     push_u64(0);
     push_fnptr(&mb_c99_match_21__10);
     mw_prim_pack_cons();
@@ -42126,17 +45544,17 @@ static void mb_c99_match_21__8 (void) {
 }
 
 static void mb_c99_match_21__9 (void) {
-    WORD_ENTER(mb_c99_match_21__9, "c99-match! block", "src/mirth/codegen.mth", 518, 27);
+    WORD_ENTER(mb_c99_match_21__9, "c99-match! block", "src/mirth/codegen.mth", 532, 27);
     mw_prim_drop();
-    WORD_ATOM(518, 27, "c99-case!");
+    WORD_ATOM(532, 27, "c99-case!");
     mw_c99_case_21_();
     WORD_EXIT(mb_c99_match_21__9);
 }
 
 static void mb_c99_match_21__10 (void) {
-    WORD_ENTER(mb_c99_match_21__10, "c99-match! block", "src/mirth/codegen.mth", 520, 17);
+    WORD_ENTER(mb_c99_match_21__10, "c99-match! block", "src/mirth/codegen.mth", 534, 17);
     mw_prim_drop();
-    WORD_ATOM(520, 17, "c99-line");
+    WORD_ATOM(534, 17, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_match_21__11);
     mw_prim_pack_cons();
@@ -42145,9 +45563,9 @@ static void mb_c99_match_21__10 (void) {
 }
 
 static void mb_c99_match_21__11 (void) {
-    WORD_ENTER(mb_c99_match_21__11, "c99-match! block", "src/mirth/codegen.mth", 520, 26);
+    WORD_ENTER(mb_c99_match_21__11, "c99-match! block", "src/mirth/codegen.mth", 534, 26);
     mw_prim_drop();
-    WORD_ATOM(520, 26, "");
+    WORD_ATOM(534, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42158,15 +45576,15 @@ static void mb_c99_match_21__11 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(520, 118, ".");
-    mw__2E_();
+    WORD_ATOM(534, 118, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_match_21__11);
 }
 
 static void mb_c99_match_21__12 (void) {
-    WORD_ENTER(mb_c99_match_21__12, "c99-match! block", "src/mirth/codegen.mth", 523, 18);
+    WORD_ENTER(mb_c99_match_21__12, "c99-match! block", "src/mirth/codegen.mth", 537, 18);
     mw_prim_drop();
-    WORD_ATOM(523, 18, "");
+    WORD_ATOM(537, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42181,9 +45599,9 @@ static void mb_c99_match_21__12 (void) {
 }
 
 static void mb_c99_lambda_21__1 (void) {
-    WORD_ENTER(mb_c99_lambda_21__1, "c99-lambda! block", "src/mirth/codegen.mth", 495, 14);
+    WORD_ENTER(mb_c99_lambda_21__1, "c99-lambda! block", "src/mirth/codegen.mth", 509, 14);
     mw_prim_drop();
-    WORD_ATOM(495, 14, "");
+    WORD_ATOM(509, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42194,32 +45612,32 @@ static void mb_c99_lambda_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(495, 18, ".");
-    mw__2E_();
+    WORD_ATOM(509, 18, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_lambda_21__1);
 }
 
 static void mb_c99_lambda_21__2 (void) {
-    WORD_ENTER(mb_c99_lambda_21__2, "c99-lambda! block", "src/mirth/codegen.mth", 497, 9);
+    WORD_ENTER(mb_c99_lambda_21__2, "c99-lambda! block", "src/mirth/codegen.mth", 511, 9);
     mw_prim_drop();
-    WORD_ATOM(497, 9, "dup");
+    WORD_ATOM(511, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(497, 13, "params");
+    WORD_ATOM(511, 13, "params");
     mw_Lambda_2E_params();
-    WORD_ATOM(497, 20, "reverse-for");
+    WORD_ATOM(511, 20, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__3);
     mw_prim_pack_cons();
     mw_List_2E_reverse_for();
-    WORD_ATOM(500, 9, "dup");
+    WORD_ATOM(514, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(500, 13, "body");
+    WORD_ATOM(514, 13, "body");
     mw_Lambda_2E_body();
-    WORD_ATOM(500, 18, "c99-arrow!");
+    WORD_ATOM(514, 18, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(501, 9, "params");
+    WORD_ATOM(515, 9, "params");
     mw_Lambda_2E_params();
-    WORD_ATOM(501, 16, "reverse-for");
+    WORD_ATOM(515, 16, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__5);
     mw_prim_pack_cons();
@@ -42228,9 +45646,9 @@ static void mb_c99_lambda_21__2 (void) {
 }
 
 static void mb_c99_lambda_21__3 (void) {
-    WORD_ENTER(mb_c99_lambda_21__3, "c99-lambda! block", "src/mirth/codegen.mth", 498, 13);
+    WORD_ENTER(mb_c99_lambda_21__3, "c99-lambda! block", "src/mirth/codegen.mth", 512, 13);
     mw_prim_drop();
-    WORD_ATOM(498, 13, "c99-line");
+    WORD_ATOM(512, 13, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__4);
     mw_prim_pack_cons();
@@ -42239,9 +45657,9 @@ static void mb_c99_lambda_21__3 (void) {
 }
 
 static void mb_c99_lambda_21__4 (void) {
-    WORD_ENTER(mb_c99_lambda_21__4, "c99-lambda! block", "src/mirth/codegen.mth", 498, 22);
+    WORD_ENTER(mb_c99_lambda_21__4, "c99-lambda! block", "src/mirth/codegen.mth", 512, 22);
     mw_prim_drop();
-    WORD_ATOM(498, 22, "");
+    WORD_ATOM(512, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42252,11 +45670,11 @@ static void mb_c99_lambda_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(498, 29, ".");
-    mw__2E_();
-    WORD_ATOM(498, 31, ".param");
-    mw__2E_param();
-    WORD_ATOM(498, 38, "");
+    WORD_ATOM(512, 29, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(512, 31, ".param");
+    mw_Param_2B_C99_2E_param();
+    WORD_ATOM(512, 38, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42267,15 +45685,15 @@ static void mb_c99_lambda_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(498, 56, ".");
-    mw__2E_();
+    WORD_ATOM(512, 56, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_lambda_21__4);
 }
 
 static void mb_c99_lambda_21__5 (void) {
-    WORD_ENTER(mb_c99_lambda_21__5, "c99-lambda! block", "src/mirth/codegen.mth", 502, 13);
+    WORD_ENTER(mb_c99_lambda_21__5, "c99-lambda! block", "src/mirth/codegen.mth", 516, 13);
     mw_prim_drop();
-    WORD_ATOM(502, 13, "c99-line");
+    WORD_ATOM(516, 13, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_lambda_21__6);
     mw_prim_pack_cons();
@@ -42284,9 +45702,9 @@ static void mb_c99_lambda_21__5 (void) {
 }
 
 static void mb_c99_lambda_21__6 (void) {
-    WORD_ENTER(mb_c99_lambda_21__6, "c99-lambda! block", "src/mirth/codegen.mth", 502, 22);
+    WORD_ENTER(mb_c99_lambda_21__6, "c99-lambda! block", "src/mirth/codegen.mth", 516, 22);
     mw_prim_drop();
-    WORD_ATOM(502, 22, "");
+    WORD_ATOM(516, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42297,11 +45715,11 @@ static void mb_c99_lambda_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(502, 32, ".");
-    mw__2E_();
-    WORD_ATOM(502, 34, ".param");
-    mw__2E_param();
-    WORD_ATOM(502, 41, "");
+    WORD_ATOM(516, 32, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(516, 34, ".param");
+    mw_Param_2B_C99_2E_param();
+    WORD_ATOM(516, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42312,15 +45730,15 @@ static void mb_c99_lambda_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(502, 46, ".");
-    mw__2E_();
+    WORD_ATOM(516, 46, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_lambda_21__6);
 }
 
 static void mb_c99_lambda_21__7 (void) {
-    WORD_ENTER(mb_c99_lambda_21__7, "c99-lambda! block", "src/mirth/codegen.mth", 505, 14);
+    WORD_ENTER(mb_c99_lambda_21__7, "c99-lambda! block", "src/mirth/codegen.mth", 519, 14);
     mw_prim_drop();
-    WORD_ATOM(505, 14, "");
+    WORD_ATOM(519, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42331,15 +45749,15 @@ static void mb_c99_lambda_21__7 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(505, 18, ".");
-    mw__2E_();
+    WORD_ATOM(519, 18, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_lambda_21__7);
 }
 
 static void mb_c99_block_push_21__3 (void) {
-    WORD_ENTER(mb_c99_block_push_21__3, "c99-block-push! block", "src/mirth/codegen.mth", 477, 22);
+    WORD_ENTER(mb_c99_block_push_21__3, "c99-block-push! block", "src/mirth/codegen.mth", 491, 22);
     mw_prim_drop();
-    WORD_ATOM(477, 22, "");
+    WORD_ATOM(491, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42350,11 +45768,11 @@ static void mb_c99_block_push_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(477, 37, ".");
-    mw__2E_();
-    WORD_ATOM(477, 39, ".block");
-    mw__2E_block();
-    WORD_ATOM(477, 46, "");
+    WORD_ATOM(491, 37, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(491, 39, ".block");
+    mw_Block_2B_C99_2E_block();
+    WORD_ATOM(491, 46, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42365,15 +45783,15 @@ static void mb_c99_block_push_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(477, 51, ".");
-    mw__2E_();
+    WORD_ATOM(491, 51, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_block_push_21__3);
 }
 
 static void mb_c99_block_push_21__4 (void) {
-    WORD_ENTER(mb_c99_block_push_21__4, "c99-block-push! block", "src/mirth/codegen.mth", 478, 22);
+    WORD_ENTER(mb_c99_block_push_21__4, "c99-block-push! block", "src/mirth/codegen.mth", 492, 22);
     mw_prim_drop();
-    WORD_ATOM(478, 22, "");
+    WORD_ATOM(492, 22, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42384,15 +45802,15 @@ static void mb_c99_block_push_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(478, 45, ".");
-    mw__2E_();
+    WORD_ATOM(492, 45, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_block_push_21__4);
 }
 
 static void mb_c99_pack_ctx_21__1 (void) {
-    WORD_ENTER(mb_c99_pack_ctx_21__1, "c99-pack-ctx! block", "src/mirth/codegen.mth", 454, 14);
+    WORD_ENTER(mb_c99_pack_ctx_21__1, "c99-pack-ctx! block", "src/mirth/codegen.mth", 468, 14);
     mw_prim_drop();
-    WORD_ATOM(454, 14, "");
+    WORD_ATOM(468, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42403,17 +45821,17 @@ static void mb_c99_pack_ctx_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(454, 29, ".");
-    mw__2E_();
+    WORD_ATOM(468, 29, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_pack_ctx_21__1);
 }
 
 static void mb_c99_pack_ctx_21__2 (void) {
-    WORD_ENTER(mb_c99_pack_ctx_21__2, "c99-pack-ctx! block", "src/mirth/codegen.mth", 456, 9);
+    WORD_ENTER(mb_c99_pack_ctx_21__2, "c99-pack-ctx! block", "src/mirth/codegen.mth", 470, 9);
     mw_prim_drop();
-    WORD_ATOM(456, 9, "c99-var-push!");
+    WORD_ATOM(470, 9, "c99-var-push!");
     mw_c99_var_push_21_();
-    WORD_ATOM(457, 9, "c99-line");
+    WORD_ATOM(471, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_pack_ctx_21__3);
     mw_prim_pack_cons();
@@ -42422,9 +45840,9 @@ static void mb_c99_pack_ctx_21__2 (void) {
 }
 
 static void mb_c99_pack_ctx_21__3 (void) {
-    WORD_ENTER(mb_c99_pack_ctx_21__3, "c99-pack-ctx! block", "src/mirth/codegen.mth", 457, 18);
+    WORD_ENTER(mb_c99_pack_ctx_21__3, "c99-pack-ctx! block", "src/mirth/codegen.mth", 471, 18);
     mw_prim_drop();
-    WORD_ATOM(457, 18, "");
+    WORD_ATOM(471, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42435,15 +45853,15 @@ static void mb_c99_pack_ctx_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(457, 41, ".");
-    mw__2E_();
+    WORD_ATOM(471, 41, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_pack_ctx_21__3);
 }
 
 static void mb_c99_var_push_21__1 (void) {
-    WORD_ENTER(mb_c99_var_push_21__1, "c99-var-push! block", "src/mirth/codegen.mth", 490, 14);
+    WORD_ENTER(mb_c99_var_push_21__1, "c99-var-push! block", "src/mirth/codegen.mth", 504, 14);
     mw_prim_drop();
-    WORD_ATOM(490, 14, "");
+    WORD_ATOM(504, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42454,13 +45872,13 @@ static void mb_c99_var_push_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(490, 24, ".");
-    mw__2E_();
-    WORD_ATOM(490, 26, "dup");
+    WORD_ATOM(504, 24, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(504, 26, "dup");
     mw_prim_dup();
-    WORD_ATOM(490, 30, ".var");
-    mw__2E_var();
-    WORD_ATOM(490, 35, "");
+    WORD_ATOM(504, 30, ".var");
+    mw_Var_2B_C99_2E_var();
+    WORD_ATOM(504, 35, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42471,15 +45889,15 @@ static void mb_c99_var_push_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(490, 40, ".");
-    mw__2E_();
+    WORD_ATOM(504, 40, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_var_push_21__1);
 }
 
 static void mb_c99_var_push_21__2 (void) {
-    WORD_ENTER(mb_c99_var_push_21__2, "c99-var-push! block", "src/mirth/codegen.mth", 491, 14);
+    WORD_ENTER(mb_c99_var_push_21__2, "c99-var-push! block", "src/mirth/codegen.mth", 505, 14);
     mw_prim_drop();
-    WORD_ATOM(491, 14, "");
+    WORD_ATOM(505, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42490,13 +45908,13 @@ static void mb_c99_var_push_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(491, 28, ".");
-    mw__2E_();
-    WORD_ATOM(491, 30, "dup");
+    WORD_ATOM(505, 28, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(505, 30, "dup");
     mw_prim_dup();
-    WORD_ATOM(491, 34, ".var");
-    mw__2E_var();
-    WORD_ATOM(491, 39, "");
+    WORD_ATOM(505, 34, ".var");
+    mw_Var_2B_C99_2E_var();
+    WORD_ATOM(505, 39, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42507,20 +45925,20 @@ static void mb_c99_var_push_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(491, 44, ".");
-    mw__2E_();
+    WORD_ATOM(505, 44, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_var_push_21__2);
 }
 
 static void mb_c99_unpack_ctx_21__1 (void) {
-    WORD_ENTER(mb_c99_unpack_ctx_21__1, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 462, 9);
+    WORD_ENTER(mb_c99_unpack_ctx_21__1, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 476, 9);
     mw_prim_drop();
-    WORD_ATOM(462, 9, "c99-line");
+    WORD_ATOM(476, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_unpack_ctx_21__2);
     mw_prim_pack_cons();
     mw_c99_line();
-    WORD_ATOM(463, 9, "c99-line");
+    WORD_ATOM(477, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_unpack_ctx_21__3);
     mw_prim_pack_cons();
@@ -42529,9 +45947,9 @@ static void mb_c99_unpack_ctx_21__1 (void) {
 }
 
 static void mb_c99_unpack_ctx_21__2 (void) {
-    WORD_ENTER(mb_c99_unpack_ctx_21__2, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 462, 18);
+    WORD_ENTER(mb_c99_unpack_ctx_21__2, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 476, 18);
     mw_prim_drop();
-    WORD_ATOM(462, 18, "");
+    WORD_ATOM(476, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42542,15 +45960,15 @@ static void mb_c99_unpack_ctx_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(462, 43, ".");
-    mw__2E_();
+    WORD_ATOM(476, 43, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_unpack_ctx_21__2);
 }
 
 static void mb_c99_unpack_ctx_21__3 (void) {
-    WORD_ENTER(mb_c99_unpack_ctx_21__3, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 463, 18);
+    WORD_ENTER(mb_c99_unpack_ctx_21__3, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 477, 18);
     mw_prim_drop();
-    WORD_ATOM(463, 18, "");
+    WORD_ATOM(477, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42561,11 +45979,11 @@ static void mb_c99_unpack_ctx_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(463, 25, ".");
-    mw__2E_();
-    WORD_ATOM(463, 27, ".var");
-    mw__2E_var();
-    WORD_ATOM(463, 32, "");
+    WORD_ATOM(477, 25, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(477, 27, ".var");
+    mw_Var_2B_C99_2E_var();
+    WORD_ATOM(477, 32, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42576,15 +45994,15 @@ static void mb_c99_unpack_ctx_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(463, 50, ".");
-    mw__2E_();
+    WORD_ATOM(477, 50, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_unpack_ctx_21__3);
 }
 
 static void mb_c99_unpack_ctx_21__4 (void) {
-    WORD_ENTER(mb_c99_unpack_ctx_21__4, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 465, 14);
+    WORD_ENTER(mb_c99_unpack_ctx_21__4, "c99-unpack-ctx! block", "src/mirth/codegen.mth", 479, 14);
     mw_prim_drop();
-    WORD_ATOM(465, 14, "");
+    WORD_ATOM(479, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42595,15 +46013,15 @@ static void mb_c99_unpack_ctx_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(465, 32, ".");
-    mw__2E_();
+    WORD_ATOM(479, 32, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_unpack_ctx_21__4);
 }
 
 static void mb_c99_decref_ctx_21__1 (void) {
-    WORD_ENTER(mb_c99_decref_ctx_21__1, "c99-decref-ctx! block", "src/mirth/codegen.mth", 469, 9);
+    WORD_ENTER(mb_c99_decref_ctx_21__1, "c99-decref-ctx! block", "src/mirth/codegen.mth", 483, 9);
     mw_prim_drop();
-    WORD_ATOM(469, 9, "c99-line");
+    WORD_ATOM(483, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_decref_ctx_21__2);
     mw_prim_pack_cons();
@@ -42612,9 +46030,9 @@ static void mb_c99_decref_ctx_21__1 (void) {
 }
 
 static void mb_c99_decref_ctx_21__2 (void) {
-    WORD_ENTER(mb_c99_decref_ctx_21__2, "c99-decref-ctx! block", "src/mirth/codegen.mth", 469, 18);
+    WORD_ENTER(mb_c99_decref_ctx_21__2, "c99-decref-ctx! block", "src/mirth/codegen.mth", 483, 18);
     mw_prim_drop();
-    WORD_ATOM(469, 18, "");
+    WORD_ATOM(483, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42625,11 +46043,11 @@ static void mb_c99_decref_ctx_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(469, 28, ".");
-    mw__2E_();
-    WORD_ATOM(469, 30, ".var");
-    mw__2E_var();
-    WORD_ATOM(469, 35, "");
+    WORD_ATOM(483, 28, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(483, 30, ".var");
+    mw_Var_2B_C99_2E_var();
+    WORD_ATOM(483, 35, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42640,15 +46058,15 @@ static void mb_c99_decref_ctx_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(469, 40, ".");
-    mw__2E_();
+    WORD_ATOM(483, 40, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_decref_ctx_21__2);
 }
 
 static void mb_c99_var_run_21__1 (void) {
-    WORD_ENTER(mb_c99_var_run_21__1, "c99-var-run! block", "src/mirth/codegen.mth", 485, 14);
+    WORD_ENTER(mb_c99_var_run_21__1, "c99-var-run! block", "src/mirth/codegen.mth", 499, 14);
     mw_prim_drop();
-    WORD_ATOM(485, 14, "");
+    WORD_ATOM(499, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42659,13 +46077,13 @@ static void mb_c99_var_run_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(485, 24, ".");
-    mw__2E_();
-    WORD_ATOM(485, 26, "dup");
+    WORD_ATOM(499, 24, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(499, 26, "dup");
     mw_prim_dup();
-    WORD_ATOM(485, 30, ".var");
-    mw__2E_var();
-    WORD_ATOM(485, 35, "");
+    WORD_ATOM(499, 30, ".var");
+    mw_Var_2B_C99_2E_var();
+    WORD_ATOM(499, 35, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42676,15 +46094,15 @@ static void mb_c99_var_run_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(485, 40, ".");
-    mw__2E_();
+    WORD_ATOM(499, 40, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_var_run_21__1);
 }
 
 static void mb_c99_var_run_21__2 (void) {
-    WORD_ENTER(mb_c99_var_run_21__2, "c99-var-run! block", "src/mirth/codegen.mth", 486, 14);
+    WORD_ENTER(mb_c99_var_run_21__2, "c99-var-run! block", "src/mirth/codegen.mth", 500, 14);
     mw_prim_drop();
-    WORD_ATOM(486, 14, "");
+    WORD_ATOM(500, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42695,13 +46113,13 @@ static void mb_c99_var_run_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(486, 27, ".");
-    mw__2E_();
-    WORD_ATOM(486, 29, "dup");
+    WORD_ATOM(500, 27, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(500, 29, "dup");
     mw_prim_dup();
-    WORD_ATOM(486, 33, ".var");
-    mw__2E_var();
-    WORD_ATOM(486, 38, "");
+    WORD_ATOM(500, 33, ".var");
+    mw_Var_2B_C99_2E_var();
+    WORD_ATOM(500, 38, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42712,19 +46130,19 @@ static void mb_c99_var_run_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(486, 43, ".");
-    mw__2E_();
+    WORD_ATOM(500, 43, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_var_run_21__2);
 }
 
 static void mb_c99_case_21__1 (void) {
-    WORD_ENTER(mb_c99_case_21__1, "c99-case! block", "src/mirth/codegen.mth", 529, 9);
+    WORD_ENTER(mb_c99_case_21__1, "c99-case! block", "src/mirth/codegen.mth", 543, 9);
     mw_prim_drop();
-    WORD_ATOM(529, 9, "body");
+    WORD_ATOM(543, 9, "body");
     mw_Case_2E_body();
-    WORD_ATOM(529, 14, "c99-arrow!");
+    WORD_ATOM(543, 14, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(530, 9, "c99-line");
+    WORD_ATOM(544, 9, "c99-line");
     push_u64(0);
     push_fnptr(&mb_c99_case_21__2);
     mw_prim_pack_cons();
@@ -42733,9 +46151,9 @@ static void mb_c99_case_21__1 (void) {
 }
 
 static void mb_c99_case_21__2 (void) {
-    WORD_ENTER(mb_c99_case_21__2, "c99-case! block", "src/mirth/codegen.mth", 530, 18);
+    WORD_ENTER(mb_c99_case_21__2, "c99-case! block", "src/mirth/codegen.mth", 544, 18);
     mw_prim_drop();
-    WORD_ATOM(530, 18, "");
+    WORD_ATOM(544, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42746,15 +46164,15 @@ static void mb_c99_case_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(530, 27, ".");
-    mw__2E_();
+    WORD_ATOM(544, 27, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_case_21__2);
 }
 
 static void mb_c99_pattern_21__2 (void) {
-    WORD_ENTER(mb_c99_pattern_21__2, "c99-pattern! block", "src/mirth/codegen.mth", 535, 18);
+    WORD_ENTER(mb_c99_pattern_21__2, "c99-pattern! block", "src/mirth/codegen.mth", 549, 18);
     mw_prim_drop();
-    WORD_ATOM(535, 18, "");
+    WORD_ATOM(549, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42765,15 +46183,15 @@ static void mb_c99_pattern_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(535, 29, ".");
-    mw__2E_();
+    WORD_ATOM(549, 29, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_pattern_21__2);
 }
 
 static void mb_c99_pattern_21__4 (void) {
-    WORD_ENTER(mb_c99_pattern_21__4, "c99-pattern! block", "src/mirth/codegen.mth", 538, 18);
+    WORD_ENTER(mb_c99_pattern_21__4, "c99-pattern! block", "src/mirth/codegen.mth", 552, 18);
     mw_prim_drop();
-    WORD_ATOM(538, 18, "");
+    WORD_ATOM(552, 18, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42784,15 +46202,15 @@ static void mb_c99_pattern_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(538, 26, ".");
-    mw__2E_();
-    WORD_ATOM(538, 28, "dup");
+    WORD_ATOM(552, 26, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(552, 28, "dup");
     mw_prim_dup();
-    WORD_ATOM(538, 32, "value");
+    WORD_ATOM(552, 32, "value");
     mw_Tag_2E_value();
-    WORD_ATOM(538, 38, ".n");
-    mw__2E_n();
-    WORD_ATOM(538, 41, "");
+    WORD_ATOM(552, 38, ".n");
+    mw_Int_2B_C99_2E_n();
+    WORD_ATOM(552, 41, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42803,118 +46221,62 @@ static void mb_c99_pattern_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(538, 47, ".");
-    mw__2E_();
+    WORD_ATOM(552, 47, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_pattern_21__4);
 }
 
 static void mb_c99_pattern_21__5 (void) {
-    WORD_ENTER(mb_c99_pattern_21__5, "c99-pattern! block", "src/mirth/codegen.mth", 540, 13);
+    WORD_ENTER(mb_c99_pattern_21__5, "c99-pattern! block", "src/mirth/codegen.mth", 554, 13);
     mw_prim_drop();
-    WORD_ATOM(540, 13, "num-inputs");
-    mw_Tag_2E_num_inputs();
-    WORD_ATOM(540, 24, "dup");
-    mw_prim_dup();
-    WORD_ATOM(540, 28, "0>");
-    mw_0_3E_();
-    WORD_ATOM(540, 31, "if");
-    if (pop_u64()) {
-        WORD_ATOM(541, 17, "c99-line");
-        push_u64(0);
-        push_fnptr(&mb_c99_pattern_21__7);
-        mw_prim_pack_cons();
-        mw_c99_line();
-        WORD_ATOM(542, 17, "1-");
-        mw_prim_int_pred();
-        WORD_ATOM(542, 20, "repeat");
-        push_u64(0);
-        push_fnptr(&mb_c99_pattern_21__8);
-        mw_prim_pack_cons();
-        mw_repeat();
-    } else {
-        WORD_ATOM(543, 17, "drop");
-        mw_prim_drop();
-        WORD_ATOM(543, 22, "c99-line");
-        push_u64(0);
-        push_fnptr(&mb_c99_pattern_21__11);
-        mw_prim_pack_cons();
-        mw_c99_line();
-    }
+    WORD_ATOM(554, 13, "c99-line");
+    push_u64(0);
+    push_fnptr(&mb_c99_pattern_21__6);
+    mw_prim_pack_cons();
+    mw_c99_line();
     WORD_EXIT(mb_c99_pattern_21__5);
 }
 
-static void mb_c99_pattern_21__7 (void) {
-    WORD_ENTER(mb_c99_pattern_21__7, "c99-pattern! block", "src/mirth/codegen.mth", 541, 26);
+static void mb_c99_pattern_21__6 (void) {
+    WORD_ENTER(mb_c99_pattern_21__6, "c99-pattern! block", "src/mirth/codegen.mth", 554, 22);
     mw_prim_drop();
-    WORD_ATOM(541, 26, "");
+    WORD_ATOM(554, 22, "");
     {
         static bool vready = false;
         static VAL v;
         if (! vready) {
-            v = mkstr("mw_prim_pack_uncons(); mw_prim_drop();", 38);
+            v = mkstr("co_", 3);
             vready = true;
         }
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(541, 67, ".");
-    mw__2E_();
-    WORD_EXIT(mb_c99_pattern_21__7);
-}
-
-static void mb_c99_pattern_21__8 (void) {
-    WORD_ENTER(mb_c99_pattern_21__8, "c99-pattern! block", "src/mirth/codegen.mth", 542, 27);
-    mw_prim_drop();
-    WORD_ATOM(542, 27, "c99-line");
-    push_u64(0);
-    push_fnptr(&mb_c99_pattern_21__9);
-    mw_prim_pack_cons();
-    mw_c99_line();
-    WORD_EXIT(mb_c99_pattern_21__8);
-}
-
-static void mb_c99_pattern_21__9 (void) {
-    WORD_ENTER(mb_c99_pattern_21__9, "c99-pattern! block", "src/mirth/codegen.mth", 542, 36);
-    mw_prim_drop();
-    WORD_ATOM(542, 36, "");
+    WORD_ATOM(554, 28, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(554, 30, "name");
+    mw_Tag_2E_name();
+    WORD_ATOM(554, 35, ".name");
+    mw_Name_2B_C99_2E_name();
+    WORD_ATOM(554, 41, "");
     {
         static bool vready = false;
         static VAL v;
         if (! vready) {
-            v = mkstr("mw_prim_pack_uncons(); mw_prim_swap();", 38);
+            v = mkstr("();", 3);
             vready = true;
         }
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(542, 77, ".");
-    mw__2E_();
-    WORD_EXIT(mb_c99_pattern_21__9);
-}
-
-static void mb_c99_pattern_21__11 (void) {
-    WORD_ENTER(mb_c99_pattern_21__11, "c99-pattern! block", "src/mirth/codegen.mth", 543, 31);
-    mw_prim_drop();
-    WORD_ATOM(543, 31, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr("mw_prim_drop();", 15);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(543, 49, ".");
-    mw__2E_();
-    WORD_EXIT(mb_c99_pattern_21__11);
+    WORD_ATOM(554, 47, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_EXIT(mb_c99_pattern_21__6);
 }
 
 static void mb_c99_word_sig_21__1 (void) {
-    WORD_ENTER(mb_c99_word_sig_21__1, "c99-word-sig! block", "src/mirth/codegen.mth", 550, 14);
+    WORD_ENTER(mb_c99_word_sig_21__1, "c99-word-sig! block", "src/mirth/codegen.mth", 560, 14);
     mw_prim_drop();
-    WORD_ATOM(550, 14, "");
+    WORD_ATOM(560, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42925,13 +46287,13 @@ static void mb_c99_word_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(550, 32, ".");
-    mw__2E_();
-    WORD_ATOM(550, 34, "name");
+    WORD_ATOM(560, 32, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(560, 34, "name");
     mw_Word_2E_name();
-    WORD_ATOM(550, 39, ".name");
-    mw__2E_name();
-    WORD_ATOM(550, 45, "");
+    WORD_ATOM(560, 39, ".name");
+    mw_Name_2B_C99_2E_name();
+    WORD_ATOM(560, 45, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42942,15 +46304,15 @@ static void mb_c99_word_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(550, 56, ".");
-    mw__2E_();
+    WORD_ATOM(560, 56, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_word_sig_21__1);
 }
 
 static void mb_c99_block_sig_21__1 (void) {
-    WORD_ENTER(mb_c99_block_sig_21__1, "c99-block-sig! block", "src/mirth/codegen.mth", 554, 14);
+    WORD_ENTER(mb_c99_block_sig_21__1, "c99-block-sig! block", "src/mirth/codegen.mth", 564, 14);
     mw_prim_drop();
-    WORD_ATOM(554, 14, "");
+    WORD_ATOM(564, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42961,11 +46323,11 @@ static void mb_c99_block_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(554, 29, ".");
-    mw__2E_();
-    WORD_ATOM(554, 31, ".block");
-    mw__2E_block();
-    WORD_ATOM(554, 38, "");
+    WORD_ATOM(564, 29, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(564, 31, ".block");
+    mw_Block_2B_C99_2E_block();
+    WORD_ATOM(564, 38, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42976,15 +46338,15 @@ static void mb_c99_block_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(554, 49, ".");
-    mw__2E_();
+    WORD_ATOM(564, 49, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_block_sig_21__1);
 }
 
 static void mb_c99_field_sig_21__1 (void) {
-    WORD_ENTER(mb_c99_field_sig_21__1, "c99-field-sig! block", "src/mirth/codegen.mth", 558, 14);
+    WORD_ENTER(mb_c99_field_sig_21__1, "c99-field-sig! block", "src/mirth/codegen.mth", 568, 14);
     mw_prim_drop();
-    WORD_ATOM(558, 14, "");
+    WORD_ATOM(568, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -42995,13 +46357,13 @@ static void mb_c99_field_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(558, 32, ".");
-    mw__2E_();
-    WORD_ATOM(558, 34, "name");
+    WORD_ATOM(568, 32, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(568, 34, "name");
     mw_Field_2E_name();
-    WORD_ATOM(558, 39, ".name");
-    mw__2E_name();
-    WORD_ATOM(558, 45, "");
+    WORD_ATOM(568, 39, ".name");
+    mw_Name_2B_C99_2E_name();
+    WORD_ATOM(568, 45, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43012,15 +46374,15 @@ static void mb_c99_field_sig_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(558, 56, ".");
-    mw__2E_();
+    WORD_ATOM(568, 56, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_field_sig_21__1);
 }
 
 static void mb_c99_block_enter_21__1 (void) {
-    WORD_ENTER(mb_c99_block_enter_21__1, "c99-block-enter! block", "src/mirth/codegen.mth", 561, 14);
+    WORD_ENTER(mb_c99_block_enter_21__1, "c99-block-enter! block", "src/mirth/codegen.mth", 571, 14);
     mw_prim_drop();
-    WORD_ATOM(561, 14, "");
+    WORD_ATOM(571, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43031,13 +46393,13 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(561, 28, ".");
-    mw__2E_();
-    WORD_ATOM(562, 9, "dup");
+    WORD_ATOM(571, 28, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(572, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(562, 13, ".block");
-    mw__2E_block();
-    WORD_ATOM(562, 20, "");
+    WORD_ATOM(572, 13, ".block");
+    mw_Block_2B_C99_2E_block();
+    WORD_ATOM(572, 20, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43048,19 +46410,19 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(562, 25, ".");
-    mw__2E_();
-    WORD_ATOM(563, 9, "dup");
+    WORD_ATOM(572, 25, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(573, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(563, 13, "arrow");
+    WORD_ATOM(573, 13, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(563, 19, "home");
+    WORD_ATOM(573, 19, "home");
     mw_Arrow_2E_home();
-    WORD_ATOM(563, 24, "match");
+    WORD_ATOM(573, 24, "match");
     switch (get_top_data_tag()) {
         case 0LL:
-            mw_prim_drop();
-            WORD_ATOM(564, 21, "");
+            co_NONE();
+            WORD_ATOM(574, 21, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -43073,12 +46435,12 @@ static void mb_c99_block_enter_21__1 (void) {
             }
             break;
         case 1LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(565, 21, "name");
+            co_SOME();
+            WORD_ATOM(575, 21, "name");
             mw_Word_2E_name();
-            WORD_ATOM(565, 26, ">Str");
+            WORD_ATOM(575, 26, ">Str");
             mw_Name_3E_Str();
-            WORD_ATOM(565, 31, "");
+            WORD_ATOM(575, 31, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -43089,14 +46451,14 @@ static void mb_c99_block_enter_21__1 (void) {
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(565, 40, "cat");
+            WORD_ATOM(575, 40, "cat");
             mw_prim_str_cat();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
     
-}    WORD_ATOM(566, 11, ".str");
+}    WORD_ATOM(576, 11, ".str");
     mw__2E_str();
-    WORD_ATOM(566, 16, "");
+    WORD_ATOM(576, 16, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43107,21 +46469,21 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(566, 21, ".");
-    mw__2E_();
-    WORD_ATOM(567, 9, "dup");
+    WORD_ATOM(576, 21, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(577, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(567, 13, "token");
+    WORD_ATOM(577, 13, "token");
     mw_Block_2E_token();
-    WORD_ATOM(567, 19, ".module");
+    WORD_ATOM(577, 19, ".module");
     mw_Token_2E_module();
-    WORD_ATOM(567, 27, "source-path");
+    WORD_ATOM(577, 27, "source-path");
     mw_Module_2E_source_path();
-    WORD_ATOM(567, 39, ">Str");
+    WORD_ATOM(577, 39, ">Str");
     mw_Path_3E_Str();
-    WORD_ATOM(567, 44, ".str");
+    WORD_ATOM(577, 44, ".str");
     mw__2E_str();
-    WORD_ATOM(567, 49, "");
+    WORD_ATOM(577, 49, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43132,19 +46494,19 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(567, 54, ".");
-    mw__2E_();
-    WORD_ATOM(568, 9, "dup");
+    WORD_ATOM(577, 54, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(578, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(568, 13, "token");
+    WORD_ATOM(578, 13, "token");
     mw_Block_2E_token();
-    WORD_ATOM(568, 19, "row");
+    WORD_ATOM(578, 19, "row");
     mw_Token_2E_row();
-    WORD_ATOM(568, 23, ">Int");
+    WORD_ATOM(578, 23, ">Int");
     mw_Row_3E_Int();
-    WORD_ATOM(568, 28, ".n");
-    mw__2E_n();
-    WORD_ATOM(568, 31, "");
+    WORD_ATOM(578, 28, ".n");
+    mw_Int_2B_C99_2E_n();
+    WORD_ATOM(578, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43155,19 +46517,19 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(568, 36, ".");
-    mw__2E_();
-    WORD_ATOM(569, 9, "dup");
+    WORD_ATOM(578, 36, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(579, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(569, 13, "token");
+    WORD_ATOM(579, 13, "token");
     mw_Block_2E_token();
-    WORD_ATOM(569, 19, "col");
+    WORD_ATOM(579, 19, "col");
     mw_Token_2E_col();
-    WORD_ATOM(569, 23, ">Int");
+    WORD_ATOM(579, 23, ">Int");
     mw_Col_3E_Int();
-    WORD_ATOM(569, 28, ".n");
-    mw__2E_n();
-    WORD_ATOM(569, 31, "");
+    WORD_ATOM(579, 28, ".n");
+    mw_Int_2B_C99_2E_n();
+    WORD_ATOM(579, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43178,15 +46540,15 @@ static void mb_c99_block_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(569, 36, ".");
-    mw__2E_();
+    WORD_ATOM(579, 36, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_block_enter_21__1);
 }
 
 static void mb_c99_block_exit_21__1 (void) {
-    WORD_ENTER(mb_c99_block_exit_21__1, "c99-block-exit! block", "src/mirth/codegen.mth", 573, 14);
+    WORD_ENTER(mb_c99_block_exit_21__1, "c99-block-exit! block", "src/mirth/codegen.mth", 583, 14);
     mw_prim_drop();
-    WORD_ATOM(573, 14, "");
+    WORD_ATOM(583, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43197,11 +46559,11 @@ static void mb_c99_block_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(573, 27, ".");
-    mw__2E_();
-    WORD_ATOM(573, 29, ".block");
-    mw__2E_block();
-    WORD_ATOM(573, 36, "");
+    WORD_ATOM(583, 27, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(583, 29, ".block");
+    mw_Block_2B_C99_2E_block();
+    WORD_ATOM(583, 36, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43212,15 +46574,15 @@ static void mb_c99_block_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(573, 41, ".");
-    mw__2E_();
+    WORD_ATOM(583, 41, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_block_exit_21__1);
 }
 
 static void mb_c99_block_def_21__1 (void) {
-    WORD_ENTER(mb_c99_block_def_21__1, "c99-block-def! block", "src/mirth/codegen.mth", 577, 14);
+    WORD_ENTER(mb_c99_block_def_21__1, "c99-block-def! block", "src/mirth/codegen.mth", 587, 14);
     mw_prim_drop();
-    WORD_ATOM(577, 14, "");
+    WORD_ATOM(587, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43231,13 +46593,13 @@ static void mb_c99_block_def_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(577, 29, ".");
-    mw__2E_();
-    WORD_ATOM(577, 31, "dup");
+    WORD_ATOM(587, 29, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(587, 31, "dup");
     mw_prim_dup();
-    WORD_ATOM(577, 35, ".block");
-    mw__2E_block();
-    WORD_ATOM(577, 42, "");
+    WORD_ATOM(587, 35, ".block");
+    mw_Block_2B_C99_2E_block();
+    WORD_ATOM(587, 42, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43248,45 +46610,45 @@ static void mb_c99_block_def_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(577, 54, ".");
-    mw__2E_();
+    WORD_ATOM(587, 54, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_block_def_21__1);
 }
 
 static void mb_c99_block_def_21__2 (void) {
-    WORD_ENTER(mb_c99_block_def_21__2, "c99-block-def! block", "src/mirth/codegen.mth", 579, 9);
+    WORD_ENTER(mb_c99_block_def_21__2, "c99-block-def! block", "src/mirth/codegen.mth", 589, 9);
     mw_prim_drop();
-    WORD_ATOM(579, 9, "dup");
+    WORD_ATOM(589, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(579, 13, "c99-block-enter!");
+    WORD_ATOM(589, 13, "c99-block-enter!");
     mw_c99_block_enter_21_();
-    WORD_ATOM(580, 9, "dup");
+    WORD_ATOM(590, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(580, 13, "arrow");
+    WORD_ATOM(590, 13, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(581, 9, "dup");
+    WORD_ATOM(591, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(581, 13, "ctx");
+    WORD_ATOM(591, 13, "ctx");
     mw_Arrow_2E_ctx();
-    WORD_ATOM(581, 17, "c99-unpack-ctx!");
+    WORD_ATOM(591, 17, "c99-unpack-ctx!");
     mw_c99_unpack_ctx_21_();
-    WORD_ATOM(582, 9, "dup");
+    WORD_ATOM(592, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(582, 13, "c99-arrow!");
+    WORD_ATOM(592, 13, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(583, 9, "ctx");
+    WORD_ATOM(593, 9, "ctx");
     mw_Arrow_2E_ctx();
-    WORD_ATOM(583, 13, "c99-decref-ctx!");
+    WORD_ATOM(593, 13, "c99-decref-ctx!");
     mw_c99_decref_ctx_21_();
-    WORD_ATOM(584, 9, "c99-block-exit!");
+    WORD_ATOM(594, 9, "c99-block-exit!");
     mw_c99_block_exit_21_();
     WORD_EXIT(mb_c99_block_def_21__2);
 }
 
 static void mb_c99_block_def_21__3 (void) {
-    WORD_ENTER(mb_c99_block_def_21__3, "c99-block-def! block", "src/mirth/codegen.mth", 586, 14);
+    WORD_ENTER(mb_c99_block_def_21__3, "c99-block-def! block", "src/mirth/codegen.mth", 596, 14);
     mw_prim_drop();
-    WORD_ATOM(586, 14, "");
+    WORD_ATOM(596, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43297,15 +46659,15 @@ static void mb_c99_block_def_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(586, 18, ".");
-    mw__2E_();
+    WORD_ATOM(596, 18, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_block_def_21__3);
 }
 
 static void mb_c99_word_enter_21__1 (void) {
-    WORD_ENTER(mb_c99_word_enter_21__1, "c99-word-enter! block", "src/mirth/codegen.mth", 598, 14);
+    WORD_ENTER(mb_c99_word_enter_21__1, "c99-word-enter! block", "src/mirth/codegen.mth", 608, 14);
     mw_prim_drop();
-    WORD_ATOM(598, 14, "");
+    WORD_ATOM(608, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43316,9 +46678,9 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(598, 28, ".");
-    mw__2E_();
-    WORD_ATOM(599, 9, "");
+    WORD_ATOM(608, 28, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(609, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43329,15 +46691,15 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(599, 15, ".");
-    mw__2E_();
-    WORD_ATOM(599, 17, "dup");
+    WORD_ATOM(609, 15, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(609, 17, "dup");
     mw_prim_dup();
-    WORD_ATOM(599, 21, "name");
+    WORD_ATOM(609, 21, "name");
     mw_Word_2E_name();
-    WORD_ATOM(599, 26, ".name");
-    mw__2E_name();
-    WORD_ATOM(599, 32, "");
+    WORD_ATOM(609, 26, ".name");
+    mw_Name_2B_C99_2E_name();
+    WORD_ATOM(609, 32, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43348,17 +46710,17 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(599, 37, ".");
-    mw__2E_();
-    WORD_ATOM(600, 9, "dup");
+    WORD_ATOM(609, 37, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(610, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(600, 13, "name");
+    WORD_ATOM(610, 13, "name");
     mw_Word_2E_name();
-    WORD_ATOM(600, 18, ">Str");
+    WORD_ATOM(610, 18, ">Str");
     mw_Name_3E_Str();
-    WORD_ATOM(600, 23, ".str");
+    WORD_ATOM(610, 23, ".str");
     mw__2E_str();
-    WORD_ATOM(600, 28, "");
+    WORD_ATOM(610, 28, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43369,21 +46731,21 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(600, 33, ".");
-    mw__2E_();
-    WORD_ATOM(601, 9, "dup");
+    WORD_ATOM(610, 33, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(611, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(601, 13, "body");
+    WORD_ATOM(611, 13, "body");
     mw_Word_2E_body();
-    WORD_ATOM(601, 18, ".module");
+    WORD_ATOM(611, 18, ".module");
     mw_Token_2E_module();
-    WORD_ATOM(601, 26, "source-path");
+    WORD_ATOM(611, 26, "source-path");
     mw_Module_2E_source_path();
-    WORD_ATOM(601, 38, ">Str");
+    WORD_ATOM(611, 38, ">Str");
     mw_Path_3E_Str();
-    WORD_ATOM(601, 43, ".str");
+    WORD_ATOM(611, 43, ".str");
     mw__2E_str();
-    WORD_ATOM(601, 48, "");
+    WORD_ATOM(611, 48, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43394,19 +46756,19 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(601, 53, ".");
-    mw__2E_();
-    WORD_ATOM(602, 9, "dup");
+    WORD_ATOM(611, 53, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(612, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(602, 13, "body");
+    WORD_ATOM(612, 13, "body");
     mw_Word_2E_body();
-    WORD_ATOM(602, 18, "row");
+    WORD_ATOM(612, 18, "row");
     mw_Token_2E_row();
-    WORD_ATOM(602, 22, ">Int");
+    WORD_ATOM(612, 22, ">Int");
     mw_Row_3E_Int();
-    WORD_ATOM(602, 27, ".n");
-    mw__2E_n();
-    WORD_ATOM(602, 30, "");
+    WORD_ATOM(612, 27, ".n");
+    mw_Int_2B_C99_2E_n();
+    WORD_ATOM(612, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43417,19 +46779,19 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(602, 35, ".");
-    mw__2E_();
-    WORD_ATOM(603, 9, "dup");
+    WORD_ATOM(612, 35, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(613, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(603, 13, "body");
+    WORD_ATOM(613, 13, "body");
     mw_Word_2E_body();
-    WORD_ATOM(603, 18, "col");
+    WORD_ATOM(613, 18, "col");
     mw_Token_2E_col();
-    WORD_ATOM(603, 22, ">Int");
+    WORD_ATOM(613, 22, ">Int");
     mw_Col_3E_Int();
-    WORD_ATOM(603, 27, ".n");
-    mw__2E_n();
-    WORD_ATOM(603, 30, "");
+    WORD_ATOM(613, 27, ".n");
+    mw_Int_2B_C99_2E_n();
+    WORD_ATOM(613, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43440,15 +46802,15 @@ static void mb_c99_word_enter_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(603, 35, ".");
-    mw__2E_();
+    WORD_ATOM(613, 35, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_word_enter_21__1);
 }
 
 static void mb_c99_word_exit_21__1 (void) {
-    WORD_ENTER(mb_c99_word_exit_21__1, "c99-word-exit! block", "src/mirth/codegen.mth", 607, 14);
+    WORD_ENTER(mb_c99_word_exit_21__1, "c99-word-exit! block", "src/mirth/codegen.mth", 617, 14);
     mw_prim_drop();
-    WORD_ATOM(607, 14, "");
+    WORD_ATOM(617, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43459,9 +46821,9 @@ static void mb_c99_word_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(607, 27, ".");
-    mw__2E_();
-    WORD_ATOM(608, 9, "");
+    WORD_ATOM(617, 27, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(618, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43472,15 +46834,15 @@ static void mb_c99_word_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(608, 15, ".");
-    mw__2E_();
-    WORD_ATOM(608, 17, "dup");
+    WORD_ATOM(618, 15, ".");
+    mw_Str_2B_C99_2E_();
+    WORD_ATOM(618, 17, "dup");
     mw_prim_dup();
-    WORD_ATOM(608, 21, "name");
+    WORD_ATOM(618, 21, "name");
     mw_Word_2E_name();
-    WORD_ATOM(608, 26, ".name");
-    mw__2E_name();
-    WORD_ATOM(608, 32, "");
+    WORD_ATOM(618, 26, ".name");
+    mw_Name_2B_C99_2E_name();
+    WORD_ATOM(618, 32, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43491,21 +46853,21 @@ static void mb_c99_word_exit_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(608, 37, ".");
-    mw__2E_();
+    WORD_ATOM(618, 37, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_word_exit_21__1);
 }
 
 static void mb_c99_word_def_21__1 (void) {
-    WORD_ENTER(mb_c99_word_def_21__1, "c99-word-def! block", "src/mirth/codegen.mth", 613, 14);
+    WORD_ENTER(mb_c99_word_def_21__1, "c99-word-def! block", "src/mirth/codegen.mth", 623, 14);
     mw_prim_drop();
-    WORD_ATOM(613, 14, "dup");
+    WORD_ATOM(623, 14, "dup");
     mw_prim_dup();
-    WORD_ATOM(613, 18, "name");
+    WORD_ATOM(623, 18, "name");
     mw_Word_2E_name();
-    WORD_ATOM(613, 23, ".w");
-    mw__2E_w();
-    WORD_ATOM(613, 26, "");
+    WORD_ATOM(623, 23, ".w");
+    mw_Name_2B_C99_2E_w();
+    WORD_ATOM(623, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43516,35 +46878,35 @@ static void mb_c99_word_def_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(613, 30, ".");
-    mw__2E_();
+    WORD_ATOM(623, 30, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_word_def_21__1);
 }
 
 static void mb_c99_word_def_21__2 (void) {
-    WORD_ENTER(mb_c99_word_def_21__2, "c99-word-def! block", "src/mirth/codegen.mth", 615, 9);
+    WORD_ENTER(mb_c99_word_def_21__2, "c99-word-def! block", "src/mirth/codegen.mth", 625, 9);
     mw_prim_drop();
-    WORD_ATOM(615, 9, "dup");
+    WORD_ATOM(625, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(615, 13, "c99-word-enter!");
+    WORD_ATOM(625, 13, "c99-word-enter!");
     mw_c99_word_enter_21_();
-    WORD_ATOM(616, 9, "dup");
+    WORD_ATOM(626, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(616, 13, "arrow");
+    WORD_ATOM(626, 13, "arrow");
     mw_Word_2E_arrow();
-    WORD_ATOM(616, 19, "c99-arrow!");
+    WORD_ATOM(626, 19, "c99-arrow!");
     mw_c99_arrow_21_();
-    WORD_ATOM(617, 9, "dup");
+    WORD_ATOM(627, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(617, 13, "c99-word-exit!");
+    WORD_ATOM(627, 13, "c99-word-exit!");
     mw_c99_word_exit_21_();
     WORD_EXIT(mb_c99_word_def_21__2);
 }
 
 static void mb_c99_word_def_21__3 (void) {
-    WORD_ENTER(mb_c99_word_def_21__3, "c99-word-def! block", "src/mirth/codegen.mth", 619, 14);
+    WORD_ENTER(mb_c99_word_def_21__3, "c99-word-def! block", "src/mirth/codegen.mth", 629, 14);
     mw_prim_drop();
-    WORD_ATOM(619, 14, "");
+    WORD_ATOM(629, 14, "");
     {
         static bool vready = false;
         static VAL v;
@@ -43555,8 +46917,8 @@ static void mb_c99_word_def_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(619, 18, ".");
-    mw__2E_();
+    WORD_ATOM(629, 18, ".");
+    mw_Str_2B_C99_2E_();
     WORD_EXIT(mb_c99_word_def_21__3);
 }
 

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -3614,8 +3614,10 @@ static void mw_elab_type_arg_21_ (void);
 static void mw_elab_type_atom_21_ (void);
 static void mw_elab_stack_var_21_ (void);
 static void mw_elab_type_var_21_ (void);
+static void mw_elab_resource_var_21_ (void);
 static void mw_elab_implicit_var_21_ (void);
 static void mw_elab_type_con_21_ (void);
+static void mw_elab_resource_con_21_ (void);
 static void mw_elab_type_args_21_ (void);
 static void mw_elab_type_hole_21_ (void);
 static void mw_elab_type_dont_care_21_ (void);
@@ -3776,6 +3778,7 @@ static void mw_def_type_21_ (void);
 static void mw_init_types_21_ (void);
 static void mw_T_2B_ (void);
 static void mw_T_2A_ (void);
+static void mw_T_2A__2B_ (void);
 static void mw_T__3E_ (void);
 static void mw_TT (void);
 static void mw_T0 (void);
@@ -3907,6 +3910,8 @@ static void mw_TokenValue_2E_sig_type_hole_3F_ (void);
 static void mw_TokenValue_2E_sig_type_var_3F_ (void);
 static void mw_TokenValue_2E_sig_param_name_3F_ (void);
 static void mw_TokenValue_2E_sig_stack_var_3F_ (void);
+static void mw_TokenValue_2E_sig_resource_var_3F_ (void);
+static void mw_TokenValue_2E_sig_resource_con_3F_ (void);
 static void mw_TokenValue_2E_sig_dashes_3F_ (void);
 static void mw_TokenValue_2E_pat_arrow_3F_ (void);
 static void mw_TokenValue_2E_pat_underscore_3F_ (void);
@@ -3939,6 +3944,8 @@ static void mw_Token_2E_sig_type_hole_3F_ (void);
 static void mw_Token_2E_sig_type_var_3F_ (void);
 static void mw_Token_2E_sig_param_name_3F_ (void);
 static void mw_Token_2E_sig_stack_var_3F_ (void);
+static void mw_Token_2E_sig_resource_var_3F_ (void);
+static void mw_Token_2E_sig_resource_con_3F_ (void);
 static void mw_Token_2E_sig_dashes_3F_ (void);
 static void mw_Token_2E_pat_arrow_3F_ (void);
 static void mw_Token_2E_pat_underscore_3F_ (void);
@@ -4006,6 +4013,8 @@ static void mw_Name_2E_could_be_type_con (void);
 static void mw_Name_2E_is_type_hole (void);
 static void mw_Name_2E_is_underscore (void);
 static void mw_Name_2E_could_be_stack_var (void);
+static void mw_Name_2E_could_be_resource_var (void);
+static void mw_Name_2E_could_be_resource_con (void);
 static void mw_Name_2E_mangle_compute_21_ (void);
 static void mw_Name_2E_could_be_relative (void);
 static void mw_Name_2E_to_overload_suffix (void);
@@ -4120,6 +4129,8 @@ static void mb_TokenValue_2E_sig_type_con_3F__1 (void);
 static void mb_TokenValue_2E_sig_type_hole_3F__1 (void);
 static void mb_TokenValue_2E_sig_type_var_3F__1 (void);
 static void mb_TokenValue_2E_sig_stack_var_3F__1 (void);
+static void mb_TokenValue_2E_sig_resource_var_3F__1 (void);
+static void mb_TokenValue_2E_sig_resource_con_3F__1 (void);
 static void mb_TokenValue_2E_sig_dashes_3F__1 (void);
 static void mb_TokenValue_2E_pat_arrow_3F__1 (void);
 static void mb_TokenValue_2E_pat_underscore_3F__1 (void);
@@ -4220,10 +4231,12 @@ static void mb_StackType_2E_unify_21__42 (void);
 static void mb_StackType_2E_unify_21__46 (void);
 static void mb_StackType_2E_force_cons_3F__21__3 (void);
 static void mb_StackType_2E_force_with_3F__21__3 (void);
-static void mb_StackType_2E_trace_base_21__2 (void);
+static void mb_StackType_2E_trace_base_21__4 (void);
 static void mb_StackType_2E_trace_21__1 (void);
 static void mb_StackType_2E_trace_21__3 (void);
 static void mb_StackType_2E_trace_21__4 (void);
+static void mb_StackType_2E_trace_21__5 (void);
+static void mb_StackType_2E_trace_21__6 (void);
 static void mb_StackType_2E_num_morphisms_on_top_2 (void);
 static void mb_StackType_2E_num_morphisms_on_top_3 (void);
 static void mb_StackType_2E_num_morphisms_on_top_5 (void);
@@ -4265,8 +4278,8 @@ static void mb_elab_type_sig_21__11 (void);
 static void mb_elab_type_sig_params_21__1 (void);
 static void mb_elab_type_sig_params_21__5 (void);
 static void mb_elab_type_sig_params_21__3 (void);
-static void mb_elab_type_atom_21__10 (void);
-static void mb_elab_type_atom_21__11 (void);
+static void mb_elab_type_atom_21__19 (void);
+static void mb_elab_type_atom_21__21 (void);
 static void mb_elab_implicit_var_21__1 (void);
 static void mb_elab_implicit_var_21__2 (void);
 static void mb_elab_implicit_var_21__4 (void);
@@ -4321,9 +4334,9 @@ static void mb_elab_data_header_21__2 (void);
 static void mb_elab_data_tag_21__1 (void);
 static void mb_elab_data_tag_21__2 (void);
 static void mb_elab_data_tag_21__9 (void);
-static void mb_elab_data_tag_21__11 (void);
 static void mb_elab_data_tag_21__12 (void);
-static void mb_elab_data_tag_21__14 (void);
+static void mb_elab_data_tag_21__13 (void);
+static void mb_elab_data_tag_21__15 (void);
 static void mb_token_def_args_3 (void);
 static void mb_token_def_args_8 (void);
 static void mb_elab_def_params_21__2 (void);
@@ -8258,19 +8271,19 @@ static void mw_while_some (void){
     WORD_EXIT(mw_while_some);
 }
 static void mw_Bool_26__26_ (void){
-    WORD_ENTER(mw_Bool_26__26_, "Bool&&", "src/prelude.mth", 38, 32);
-    WORD_ATOM(38, 32, "T");
+    WORD_ENTER(mw_Bool_26__26_, "Bool&&", "src/prelude.mth", 43, 32);
+    WORD_ATOM(43, 32, "T");
     switch (get_top_data_tag()) {
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(38, 37, "id");
+            WORD_ATOM(43, 37, "id");
             mw_prim_id();
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(38, 46, "drop");
+            WORD_ATOM(43, 46, "drop");
             mw_prim_drop();
-            WORD_ATOM(38, 51, "F");
+            WORD_ATOM(43, 51, "F");
             mw_F();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -8278,19 +8291,19 @@ static void mw_Bool_26__26_ (void){
 }    WORD_EXIT(mw_Bool_26__26_);
 }
 static void mw_Bool_7C__7C_ (void){
-    WORD_ENTER(mw_Bool_7C__7C_, "Bool||", "src/prelude.mth", 39, 32);
-    WORD_ATOM(39, 32, "T");
+    WORD_ENTER(mw_Bool_7C__7C_, "Bool||", "src/prelude.mth", 44, 32);
+    WORD_ATOM(44, 32, "T");
     switch (get_top_data_tag()) {
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(39, 37, "drop");
+            WORD_ATOM(44, 37, "drop");
             mw_prim_drop();
-            WORD_ATOM(39, 42, "T");
+            WORD_ATOM(44, 42, "T");
             mw_T();
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(39, 50, "id");
+            WORD_ATOM(44, 50, "id");
             mw_prim_id();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -8298,17 +8311,17 @@ static void mw_Bool_7C__7C_ (void){
 }    WORD_EXIT(mw_Bool_7C__7C_);
 }
 static void mw_Bool_2E_not (void){
-    WORD_ENTER(mw_Bool_2E_not, "Bool.not", "src/prelude.mth", 40, 29);
-    WORD_ATOM(40, 29, "T");
+    WORD_ENTER(mw_Bool_2E_not, "Bool.not", "src/prelude.mth", 45, 29);
+    WORD_ATOM(45, 29, "T");
     switch (get_top_data_tag()) {
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(40, 34, "F");
+            WORD_ATOM(45, 34, "F");
             mw_F();
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(40, 42, "T");
+            WORD_ATOM(45, 42, "T");
             mw_T();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -8316,16 +8329,16 @@ static void mw_Bool_2E_not (void){
 }    WORD_EXIT(mw_Bool_2E_not);
 }
 static void mw_Bool_2E_or (void){
-    WORD_ENTER(mw_Bool_2E_or, "Bool.or", "src/prelude.mth", 41, 54);
-    WORD_ATOM(41, 54, "if");
+    WORD_ENTER(mw_Bool_2E_or, "Bool.or", "src/prelude.mth", 46, 54);
+    WORD_ATOM(46, 54, "if");
     {
         VAL var_p = pop_value();
-        WORD_ATOM(41, 54, "if");
+        WORD_ATOM(46, 54, "if");
         if (pop_u64()) {
-            WORD_ATOM(41, 57, "T");
+            WORD_ATOM(46, 57, "T");
             mw_T();
         } else {
-            WORD_ATOM(41, 60, "p");
+            WORD_ATOM(46, 60, "p");
             incref(var_p);
             run_value(var_p);
         }
@@ -8334,17 +8347,17 @@ static void mw_Bool_2E_or (void){
     WORD_EXIT(mw_Bool_2E_or);
 }
 static void mw_Bool_2E_and (void){
-    WORD_ENTER(mw_Bool_2E_and, "Bool.and", "src/prelude.mth", 42, 54);
-    WORD_ATOM(42, 54, "if");
+    WORD_ENTER(mw_Bool_2E_and, "Bool.and", "src/prelude.mth", 47, 54);
+    WORD_ATOM(47, 54, "if");
     {
         VAL var_p = pop_value();
-        WORD_ATOM(42, 54, "if");
+        WORD_ATOM(47, 54, "if");
         if (pop_u64()) {
-            WORD_ATOM(42, 57, "p");
+            WORD_ATOM(47, 57, "p");
             incref(var_p);
             run_value(var_p);
         } else {
-            WORD_ATOM(42, 60, "F");
+            WORD_ATOM(47, 60, "F");
             mw_F();
         }
         decref(var_p);
@@ -8352,21 +8365,21 @@ static void mw_Bool_2E_and (void){
     WORD_EXIT(mw_Bool_2E_and);
 }
 static void mw_Bool_2E_then (void){
-    WORD_ENTER(mw_Bool_2E_then, "Bool.then", "src/prelude.mth", 48, 5);
-    WORD_ATOM(48, 5, "T");
+    WORD_ENTER(mw_Bool_2E_then, "Bool.then", "src/prelude.mth", 53, 5);
+    WORD_ATOM(53, 5, "T");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(48, 5, "T");
+        WORD_ATOM(53, 5, "T");
         switch (get_top_data_tag()) {
             case 1LL:
                 mw_prim_drop();
-                WORD_ATOM(48, 10, "f");
+                WORD_ATOM(53, 10, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
             case 0LL:
                 mw_prim_drop();
-                WORD_ATOM(49, 10, "id");
+                WORD_ATOM(54, 10, "id");
                 mw_prim_id();
                 break;
             default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -8376,20 +8389,20 @@ static void mw_Bool_2E_then (void){
     WORD_EXIT(mw_Bool_2E_then);
 }
 static void mw_Bool_2E_else (void){
-    WORD_ENTER(mw_Bool_2E_else, "Bool.else", "src/prelude.mth", 51, 5);
-    WORD_ATOM(51, 5, "T");
+    WORD_ENTER(mw_Bool_2E_else, "Bool.else", "src/prelude.mth", 56, 5);
+    WORD_ATOM(56, 5, "T");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(51, 5, "T");
+        WORD_ATOM(56, 5, "T");
         switch (get_top_data_tag()) {
             case 1LL:
                 mw_prim_drop();
-                WORD_ATOM(51, 10, "id");
+                WORD_ATOM(56, 10, "id");
                 mw_prim_id();
                 break;
             case 0LL:
                 mw_prim_drop();
-                WORD_ATOM(52, 10, "f");
+                WORD_ATOM(57, 10, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
@@ -8400,72 +8413,72 @@ static void mw_Bool_2E_else (void){
     WORD_EXIT(mw_Bool_2E_else);
 }
 static void mw_Ptr_2E_offset (void){
-    WORD_ENTER(mw_Ptr_2E_offset, "Ptr.offset", "src/prelude.mth", 65, 5);
-    WORD_ATOM(65, 5, "dup");
+    WORD_ENTER(mw_Ptr_2E_offset, "Ptr.offset", "src/prelude.mth", 70, 5);
+    WORD_ATOM(70, 5, "dup");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(65, 5, "dup");
+        WORD_ATOM(70, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(65, 9, "dip");
+        WORD_ATOM(70, 9, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(65, 13, "prim-ptr-add");
+            WORD_ATOM(70, 13, "prim-ptr-add");
             mw_prim_ptr_add();
-            WORD_ATOM(65, 26, "f");
+            WORD_ATOM(70, 26, "f");
             incref(var_f);
             run_value(var_f);
             push_value(d3);
         }
-        WORD_ATOM(65, 29, "drop");
+        WORD_ATOM(70, 29, "drop");
         mw_prim_drop();
         decref(var_f);
     }
     WORD_EXIT(mw_Ptr_2E_offset);
 }
 static void mw_Int_3E_OS (void){
-    WORD_ENTER(mw_Int_3E_OS, "Int>OS", "src/prelude.mth", 97, 5);
-    WORD_ATOM(97, 5, "dup");
+    WORD_ENTER(mw_Int_3E_OS, "Int>OS", "src/prelude.mth", 102, 5);
+    WORD_ATOM(102, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(97, 9, "");
+    WORD_ATOM(102, 9, "");
     push_i64(1LL);
-    WORD_ATOM(97, 11, "=");
+    WORD_ATOM(102, 11, "=");
     mw_prim_int_eq();
-    WORD_ATOM(97, 13, "if");
+    WORD_ATOM(102, 13, "if");
     if (pop_u64()) {
-        WORD_ATOM(98, 9, "drop");
+        WORD_ATOM(103, 9, "drop");
         mw_prim_drop();
-        WORD_ATOM(98, 14, "OS_WINDOWS");
+        WORD_ATOM(103, 14, "OS_WINDOWS");
         mw_OS_5F_WINDOWS();
     } else {
-        WORD_ATOM(99, 5, "dup");
+        WORD_ATOM(104, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(99, 9, "");
+        WORD_ATOM(104, 9, "");
         push_i64(2LL);
-        WORD_ATOM(99, 11, "=");
+        WORD_ATOM(104, 11, "=");
         mw_prim_int_eq();
-        WORD_ATOM(99, 13, "if");
+        WORD_ATOM(104, 13, "if");
         if (pop_u64()) {
-            WORD_ATOM(100, 9, "drop");
+            WORD_ATOM(105, 9, "drop");
             mw_prim_drop();
-            WORD_ATOM(100, 14, "OS_LINUX");
+            WORD_ATOM(105, 14, "OS_LINUX");
             mw_OS_5F_LINUX();
         } else {
-            WORD_ATOM(101, 5, "dup");
+            WORD_ATOM(106, 5, "dup");
             mw_prim_dup();
-            WORD_ATOM(101, 9, "");
+            WORD_ATOM(106, 9, "");
             push_i64(3LL);
-            WORD_ATOM(101, 11, "=");
+            WORD_ATOM(106, 11, "=");
             mw_prim_int_eq();
-            WORD_ATOM(101, 13, "if");
+            WORD_ATOM(106, 13, "if");
             if (pop_u64()) {
-                WORD_ATOM(102, 9, "drop");
+                WORD_ATOM(107, 9, "drop");
                 mw_prim_drop();
-                WORD_ATOM(102, 14, "OS_MACOS");
+                WORD_ATOM(107, 14, "OS_MACOS");
                 mw_OS_5F_MACOS();
             } else {
-                WORD_ATOM(103, 9, "drop");
+                WORD_ATOM(108, 9, "drop");
                 mw_prim_drop();
-                WORD_ATOM(103, 14, "OS_UNKNOWN");
+                WORD_ATOM(108, 14, "OS_UNKNOWN");
                 mw_OS_5F_UNKNOWN();
             }
         }
@@ -8473,183 +8486,183 @@ static void mw_Int_3E_OS (void){
     WORD_EXIT(mw_Int_3E_OS);
 }
 static void mw_RUNNING_5F_OS (void){
-    WORD_ENTER(mw_RUNNING_5F_OS, "RUNNING_OS", "src/prelude.mth", 108, 21);
-    WORD_ATOM(108, 21, "prim-sys-os");
+    WORD_ENTER(mw_RUNNING_5F_OS, "RUNNING_OS", "src/prelude.mth", 113, 21);
+    WORD_ATOM(113, 21, "prim-sys-os");
     mw_prim_sys_os();
-    WORD_ATOM(108, 33, ">OS");
+    WORD_ATOM(113, 33, ">OS");
     mw_Int_3E_OS();
     WORD_EXIT(mw_RUNNING_5F_OS);
 }
 static void mw_posix_open_21_ (void){
-    WORD_ENTER(mw_posix_open_21_, "posix-open!", "src/prelude.mth", 115, 5);
-    WORD_ATOM(115, 5, "rotl");
+    WORD_ENTER(mw_posix_open_21_, "posix-open!", "src/prelude.mth", 120, 5);
+    WORD_ATOM(120, 5, "rotl");
     mw_rotl();
-    WORD_ATOM(115, 10, "dup");
+    WORD_ATOM(120, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(115, 14, "dip");
+    WORD_ATOM(120, 14, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(116, 9, "prim-str-base");
+        WORD_ATOM(121, 9, "prim-str-base");
         mw_prim_str_base();
-        WORD_ATOM(116, 23, "rotr");
+        WORD_ATOM(121, 23, "rotr");
         mw_rotr();
-        WORD_ATOM(117, 9, "prim-posix-open");
+        WORD_ATOM(122, 9, "prim-posix-open");
         mw_prim_posix_open();
         push_value(d2);
     }
-    WORD_ATOM(118, 7, "drop");
+    WORD_ATOM(123, 7, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_posix_open_21_);
 }
 static void mw_rotr (void){
-    WORD_ENTER(mw_rotr, "rotr", "src/prelude.mth", 122, 27);
-    WORD_ATOM(122, 27, "swap");
+    WORD_ENTER(mw_rotr, "rotr", "src/prelude.mth", 127, 27);
+    WORD_ATOM(127, 27, "swap");
     mw_prim_swap();
-    WORD_ATOM(122, 32, "dip");
+    WORD_ATOM(127, 32, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(122, 36, "swap");
+        WORD_ATOM(127, 36, "swap");
         mw_prim_swap();
         push_value(d2);
     }
     WORD_EXIT(mw_rotr);
 }
 static void mw_rotl (void){
-    WORD_ENTER(mw_rotl, "rotl", "src/prelude.mth", 123, 27);
-    WORD_ATOM(123, 27, "dip");
+    WORD_ENTER(mw_rotl, "rotl", "src/prelude.mth", 128, 27);
+    WORD_ATOM(128, 27, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(123, 31, "swap");
+        WORD_ATOM(128, 31, "swap");
         mw_prim_swap();
         push_value(d2);
     }
-    WORD_ATOM(123, 37, "swap");
+    WORD_ATOM(128, 37, "swap");
     mw_prim_swap();
     WORD_EXIT(mw_rotl);
 }
 static void mw_over (void){
-    WORD_ENTER(mw_over, "over", "src/prelude.mth", 125, 25);
-    WORD_ATOM(125, 25, "dip");
+    WORD_ENTER(mw_over, "over", "src/prelude.mth", 130, 25);
+    WORD_ATOM(130, 25, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(125, 29, "dup");
+        WORD_ATOM(130, 29, "dup");
         mw_prim_dup();
         push_value(d2);
     }
-    WORD_ATOM(125, 34, "swap");
+    WORD_ATOM(130, 34, "swap");
     mw_prim_swap();
     WORD_EXIT(mw_over);
 }
 static void mw_over2 (void){
-    WORD_ENTER(mw_over2, "over2", "src/prelude.mth", 126, 34);
-    WORD_ATOM(126, 34, "dip");
+    WORD_ENTER(mw_over2, "over2", "src/prelude.mth", 131, 34);
+    WORD_ATOM(131, 34, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(126, 38, "over");
+        WORD_ATOM(131, 38, "over");
         mw_over();
         push_value(d2);
     }
-    WORD_ATOM(126, 44, "swap");
+    WORD_ATOM(131, 44, "swap");
     mw_prim_swap();
     WORD_EXIT(mw_over2);
 }
 static void mw_over3 (void){
-    WORD_ENTER(mw_over3, "over3", "src/prelude.mth", 127, 40);
-    WORD_ATOM(127, 40, "dip");
+    WORD_ENTER(mw_over3, "over3", "src/prelude.mth", 132, 40);
+    WORD_ATOM(132, 40, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(127, 44, "over2");
+        WORD_ATOM(132, 44, "over2");
         mw_over2();
         push_value(d2);
     }
-    WORD_ATOM(127, 51, "swap");
+    WORD_ATOM(132, 51, "swap");
     mw_prim_swap();
     WORD_EXIT(mw_over3);
 }
 static void mw_tuck (void){
-    WORD_ENTER(mw_tuck, "tuck", "src/prelude.mth", 130, 25);
-    WORD_ATOM(130, 25, "dup");
+    WORD_ENTER(mw_tuck, "tuck", "src/prelude.mth", 135, 25);
+    WORD_ATOM(135, 25, "dup");
     mw_prim_dup();
-    WORD_ATOM(130, 29, "dip");
+    WORD_ATOM(135, 29, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(130, 33, "swap");
+        WORD_ATOM(135, 33, "swap");
         mw_prim_swap();
         push_value(d2);
     }
     WORD_EXIT(mw_tuck);
 }
 static void mw_nip (void){
-    WORD_ENTER(mw_nip, "nip", "src/prelude.mth", 132, 20);
-    WORD_ATOM(132, 20, "dip");
+    WORD_ENTER(mw_nip, "nip", "src/prelude.mth", 137, 20);
+    WORD_ATOM(137, 20, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(132, 24, "drop");
+        WORD_ATOM(137, 24, "drop");
         mw_prim_drop();
         push_value(d2);
     }
     WORD_EXIT(mw_nip);
 }
 static void mw_dup2 (void){
-    WORD_ENTER(mw_dup2, "dup2", "src/prelude.mth", 134, 34);
-    WORD_ATOM(134, 34, "over");
+    WORD_ENTER(mw_dup2, "dup2", "src/prelude.mth", 139, 34);
+    WORD_ATOM(139, 34, "over");
     mw_over();
-    WORD_ATOM(134, 39, "over");
+    WORD_ATOM(139, 39, "over");
     mw_over();
     WORD_EXIT(mw_dup2);
 }
 static void mw_dip_3F_ (void){
-    WORD_ENTER(mw_dip_3F_, "dip?", "src/prelude.mth", 137, 49);
-    WORD_ATOM(137, 49, "dip");
+    WORD_ENTER(mw_dip_3F_, "dip?", "src/prelude.mth", 142, 49);
+    WORD_ATOM(142, 49, "dip");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(137, 49, "dip");
+        WORD_ATOM(142, 49, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(137, 53, "f");
+            WORD_ATOM(142, 53, "f");
             incref(var_f);
             run_value(var_f);
             push_value(d3);
         }
-        WORD_ATOM(137, 56, "swap");
+        WORD_ATOM(142, 56, "swap");
         mw_prim_swap();
         decref(var_f);
     }
     WORD_EXIT(mw_dip_3F_);
 }
 static void mw_dip_27_ (void){
-    WORD_ENTER(mw_dip_27_, "dip'", "src/prelude.mth", 138, 47);
-    WORD_ATOM(138, 47, "swap");
+    WORD_ENTER(mw_dip_27_, "dip'", "src/prelude.mth", 143, 47);
+    WORD_ATOM(143, 47, "swap");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(138, 47, "swap");
+        WORD_ATOM(143, 47, "swap");
         mw_prim_swap();
-        WORD_ATOM(138, 52, "dip");
+        WORD_ATOM(143, 52, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(138, 56, "f");
+            WORD_ATOM(143, 56, "f");
             incref(var_f);
             run_value(var_f);
             push_value(d3);
         }
-        WORD_ATOM(138, 59, "swap");
+        WORD_ATOM(143, 59, "swap");
         mw_prim_swap();
         decref(var_f);
     }
     WORD_EXIT(mw_dip_27_);
 }
 static void mw_dip2 (void){
-    WORD_ENTER(mw_dip2, "dip2", "src/prelude.mth", 141, 5);
-    WORD_ATOM(141, 5, "dip");
+    WORD_ENTER(mw_dip2, "dip2", "src/prelude.mth", 146, 5);
+    WORD_ATOM(146, 5, "dip");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(141, 5, "dip");
+        WORD_ATOM(146, 5, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(141, 9, "dip");
+            WORD_ATOM(146, 9, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(141, 13, "f");
+                WORD_ATOM(146, 13, "f");
                 incref(var_f);
                 run_value(var_f);
                 push_value(d4);
@@ -8661,16 +8674,16 @@ static void mw_dip2 (void){
     WORD_EXIT(mw_dip2);
 }
 static void mw_sip (void){
-    WORD_ENTER(mw_sip, "sip", "src/prelude.mth", 146, 5);
-    WORD_ATOM(146, 5, "dup");
+    WORD_ENTER(mw_sip, "sip", "src/prelude.mth", 151, 5);
+    WORD_ATOM(151, 5, "dup");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(146, 5, "dup");
+        WORD_ATOM(151, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(146, 9, "dip");
+        WORD_ATOM(151, 9, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(146, 13, "f");
+            WORD_ATOM(151, 13, "f");
             incref(var_f);
             run_value(var_f);
             push_value(d3);
@@ -8680,19 +8693,19 @@ static void mw_sip (void){
     WORD_EXIT(mw_sip);
 }
 static void mw_both (void){
-    WORD_ENTER(mw_both, "both", "src/prelude.mth", 150, 35);
-    WORD_ATOM(150, 35, "dip");
+    WORD_ENTER(mw_both, "both", "src/prelude.mth", 155, 35);
+    WORD_ATOM(155, 35, "dip");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(150, 35, "dip");
+        WORD_ATOM(155, 35, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(150, 39, "f");
+            WORD_ATOM(155, 39, "f");
             incref(var_f);
             run_value(var_f);
             push_value(d3);
         }
-        WORD_ATOM(150, 42, "f");
+        WORD_ATOM(155, 42, "f");
         incref(var_f);
         run_value(var_f);
         decref(var_f);
@@ -8700,88 +8713,88 @@ static void mw_both (void){
     WORD_EXIT(mw_both);
 }
 static void mw_drop2 (void){
-    WORD_ENTER(mw_drop2, "drop2", "src/prelude.mth", 153, 20);
-    WORD_ATOM(153, 20, "drop");
+    WORD_ENTER(mw_drop2, "drop2", "src/prelude.mth", 158, 20);
+    WORD_ATOM(158, 20, "drop");
     mw_prim_drop();
-    WORD_ATOM(153, 25, "drop");
+    WORD_ATOM(158, 25, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_drop2);
 }
 static void mw_drop3 (void){
-    WORD_ENTER(mw_drop3, "drop3", "src/prelude.mth", 154, 22);
-    WORD_ATOM(154, 22, "drop");
+    WORD_ENTER(mw_drop3, "drop3", "src/prelude.mth", 159, 22);
+    WORD_ATOM(159, 22, "drop");
     mw_prim_drop();
-    WORD_ATOM(154, 27, "drop");
+    WORD_ATOM(159, 27, "drop");
     mw_prim_drop();
-    WORD_ATOM(154, 32, "drop");
+    WORD_ATOM(159, 32, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_drop3);
 }
 static void mw_rot4r (void){
-    WORD_ENTER(mw_rot4r, "rot4r", "src/prelude.mth", 157, 32);
-    WORD_ATOM(157, 32, "swap");
+    WORD_ENTER(mw_rot4r, "rot4r", "src/prelude.mth", 162, 32);
+    WORD_ATOM(162, 32, "swap");
     mw_prim_swap();
-    WORD_ATOM(157, 37, "dip");
+    WORD_ATOM(162, 37, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(157, 41, "rotr");
+        WORD_ATOM(162, 41, "rotr");
         mw_rotr();
         push_value(d2);
     }
     WORD_EXIT(mw_rot4r);
 }
 static void mw_rot4l (void){
-    WORD_ENTER(mw_rot4l, "rot4l", "src/prelude.mth", 158, 32);
-    WORD_ATOM(158, 32, "dip");
+    WORD_ENTER(mw_rot4l, "rot4l", "src/prelude.mth", 163, 32);
+    WORD_ATOM(163, 32, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(158, 36, "rotl");
+        WORD_ATOM(163, 36, "rotl");
         mw_rotl();
         push_value(d2);
     }
-    WORD_ATOM(158, 42, "swap");
+    WORD_ATOM(163, 42, "swap");
     mw_prim_swap();
     WORD_EXIT(mw_rot4l);
 }
 static void mw_repeat (void){
-    WORD_ENTER(mw_repeat, "repeat", "src/prelude.mth", 161, 5);
-    WORD_ATOM(161, 5, "while");
+    WORD_ENTER(mw_repeat, "repeat", "src/prelude.mth", 166, 5);
+    WORD_ATOM(166, 5, "while");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(161, 5, "while");
+        WORD_ATOM(166, 5, "while");
         while(1) {
-            WORD_ATOM(161, 11, "dup");
+            WORD_ATOM(166, 11, "dup");
             mw_prim_dup();
-            WORD_ATOM(161, 15, "0>");
+            WORD_ATOM(166, 15, "0>");
             mw_0_3E_();
             if (! pop_u64()) break;
-            WORD_ATOM(161, 19, "dip");
+            WORD_ATOM(166, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(161, 23, "f");
+                WORD_ATOM(166, 23, "f");
                 incref(var_f);
                 run_value(var_f);
                 push_value(d4);
             }
-            WORD_ATOM(161, 26, "1-");
+            WORD_ATOM(166, 26, "1-");
             mw_prim_int_pred();
         }
-        WORD_ATOM(161, 30, "drop");
+        WORD_ATOM(166, 30, "drop");
         mw_prim_drop();
         decref(var_f);
     }
     WORD_EXIT(mw_repeat);
 }
 static void mw_count (void){
-    WORD_ENTER(mw_count, "count", "src/prelude.mth", 164, 5);
-    WORD_ATOM(164, 5, "");
+    WORD_ENTER(mw_count, "count", "src/prelude.mth", 169, 5);
+    WORD_ATOM(169, 5, "");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(164, 5, "");
+        WORD_ATOM(169, 5, "");
         push_i64(0LL);
-        WORD_ATOM(164, 7, "swap");
+        WORD_ATOM(169, 7, "swap");
         mw_prim_swap();
-        WORD_ATOM(164, 12, "repeat");
+        WORD_ATOM(169, 12, "repeat");
         push_u64(0);
         incref(var_f);
         push_value(var_f);
@@ -8789,24 +8802,24 @@ static void mw_count (void){
         push_fnptr(&mb_count_2);
         mw_prim_pack_cons();
         mw_repeat();
-        WORD_ATOM(164, 34, "drop");
+        WORD_ATOM(169, 34, "drop");
         mw_prim_drop();
         decref(var_f);
     }
     WORD_EXIT(mw_count);
 }
 static void mw_countdown (void){
-    WORD_ENTER(mw_countdown, "countdown", "src/prelude.mth", 166, 5);
-    WORD_ATOM(166, 5, "dup");
+    WORD_ENTER(mw_countdown, "countdown", "src/prelude.mth", 171, 5);
+    WORD_ATOM(171, 5, "dup");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(166, 5, "dup");
+        WORD_ATOM(171, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(166, 9, "1-");
+        WORD_ATOM(171, 9, "1-");
         mw_prim_int_pred();
-        WORD_ATOM(166, 12, "swap");
+        WORD_ATOM(171, 12, "swap");
         mw_prim_swap();
-        WORD_ATOM(166, 17, "repeat");
+        WORD_ATOM(171, 17, "repeat");
         push_u64(0);
         incref(var_f);
         push_value(var_f);
@@ -8814,41 +8827,41 @@ static void mw_countdown (void){
         push_fnptr(&mb_countdown_2);
         mw_prim_pack_cons();
         mw_repeat();
-        WORD_ATOM(166, 39, "drop");
+        WORD_ATOM(171, 39, "drop");
         mw_prim_drop();
         decref(var_f);
     }
     WORD_EXIT(mw_countdown);
 }
 static void mw_U8_5F_MAX (void){
-    WORD_ENTER(mw_U8_5F_MAX, "U8_MAX", "src/prelude.mth", 171, 18);
-    WORD_ATOM(171, 18, "");
+    WORD_ENTER(mw_U8_5F_MAX, "U8_MAX", "src/prelude.mth", 176, 18);
+    WORD_ATOM(176, 18, "");
     push_i64(255LL);
     WORD_EXIT(mw_U8_5F_MAX);
 }
 static void mw_U8_5F_MIN (void){
-    WORD_ENTER(mw_U8_5F_MIN, "U8_MIN", "src/prelude.mth", 179, 18);
-    WORD_ATOM(179, 18, "");
+    WORD_ENTER(mw_U8_5F_MIN, "U8_MIN", "src/prelude.mth", 184, 18);
+    WORD_ATOM(184, 18, "");
     push_i64(0LL);
     WORD_EXIT(mw_U8_5F_MIN);
 }
 static void mw_Comparison_2E_is_eq (void){
-    WORD_ENTER(mw_Comparison_2E_is_eq, "Comparison.is-eq", "src/prelude.mth", 188, 43);
-    WORD_ATOM(188, 43, "LT");
+    WORD_ENTER(mw_Comparison_2E_is_eq, "Comparison.is-eq", "src/prelude.mth", 193, 43);
+    WORD_ATOM(193, 43, "LT");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(188, 49, "F");
+            WORD_ATOM(193, 49, "F");
             mw_F();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(188, 58, "T");
+            WORD_ATOM(193, 58, "T");
             mw_T();
             break;
         case 2LL:
             mw_prim_drop();
-            WORD_ATOM(188, 67, "F");
+            WORD_ATOM(193, 67, "F");
             mw_F();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -8856,22 +8869,22 @@ static void mw_Comparison_2E_is_eq (void){
 }    WORD_EXIT(mw_Comparison_2E_is_eq);
 }
 static void mw_Comparison_2E_is_ne (void){
-    WORD_ENTER(mw_Comparison_2E_is_ne, "Comparison.is-ne", "src/prelude.mth", 193, 43);
-    WORD_ATOM(193, 43, "LT");
+    WORD_ENTER(mw_Comparison_2E_is_ne, "Comparison.is-ne", "src/prelude.mth", 198, 43);
+    WORD_ATOM(198, 43, "LT");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(193, 49, "T");
+            WORD_ATOM(198, 49, "T");
             mw_T();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(193, 58, "F");
+            WORD_ATOM(198, 58, "F");
             mw_F();
             break;
         case 2LL:
             mw_prim_drop();
-            WORD_ATOM(193, 67, "T");
+            WORD_ATOM(198, 67, "T");
             mw_T();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -8879,165 +8892,165 @@ static void mw_Comparison_2E_is_ne (void){
 }    WORD_EXIT(mw_Comparison_2E_is_ne);
 }
 static void mw_Int_3E_ (void){
-    WORD_ENTER(mw_Int_3E_, "Int>", "src/prelude.mth", 197, 29);
-    WORD_ATOM(197, 29, "swap");
+    WORD_ENTER(mw_Int_3E_, "Int>", "src/prelude.mth", 202, 29);
+    WORD_ATOM(202, 29, "swap");
     mw_prim_swap();
-    WORD_ATOM(197, 34, "<");
+    WORD_ATOM(202, 34, "<");
     mw_prim_int_lt();
     WORD_EXIT(mw_Int_3E_);
 }
 static void mw_Int_3E__3D_ (void){
-    WORD_ENTER(mw_Int_3E__3D_, "Int>=", "src/prelude.mth", 198, 29);
-    WORD_ATOM(198, 29, "<");
+    WORD_ENTER(mw_Int_3E__3D_, "Int>=", "src/prelude.mth", 203, 29);
+    WORD_ATOM(203, 29, "<");
     mw_prim_int_lt();
-    WORD_ATOM(198, 31, "not");
+    WORD_ATOM(203, 31, "not");
     mw_Bool_2E_not();
     WORD_EXIT(mw_Int_3E__3D_);
 }
 static void mw_Int_3C__3D_ (void){
-    WORD_ENTER(mw_Int_3C__3D_, "Int<=", "src/prelude.mth", 199, 29);
-    WORD_ATOM(199, 29, "swap");
+    WORD_ENTER(mw_Int_3C__3D_, "Int<=", "src/prelude.mth", 204, 29);
+    WORD_ATOM(204, 29, "swap");
     mw_prim_swap();
-    WORD_ATOM(199, 34, "<");
+    WORD_ATOM(204, 34, "<");
     mw_prim_int_lt();
-    WORD_ATOM(199, 36, "not");
+    WORD_ATOM(204, 36, "not");
     mw_Bool_2E_not();
     WORD_EXIT(mw_Int_3C__3D_);
 }
 static void mw_Int_2E_cmp (void){
-    WORD_ENTER(mw_Int_2E_cmp, "Int.cmp", "src/prelude.mth", 201, 37);
-    WORD_ATOM(201, 37, "dup2");
+    WORD_ENTER(mw_Int_2E_cmp, "Int.cmp", "src/prelude.mth", 206, 37);
+    WORD_ATOM(206, 37, "dup2");
     mw_dup2();
-    WORD_ATOM(201, 42, "=");
+    WORD_ATOM(206, 42, "=");
     mw_prim_int_eq();
-    WORD_ATOM(201, 44, "if");
+    WORD_ATOM(206, 44, "if");
     if (pop_u64()) {
-        WORD_ATOM(201, 47, "drop2");
+        WORD_ATOM(206, 47, "drop2");
         mw_drop2();
-        WORD_ATOM(201, 53, "EQ");
+        WORD_ATOM(206, 53, "EQ");
         mw_EQ();
     } else {
-        WORD_ATOM(201, 57, "<");
+        WORD_ATOM(206, 57, "<");
         mw_prim_int_lt();
-        WORD_ATOM(201, 59, "if");
+        WORD_ATOM(206, 59, "if");
         if (pop_u64()) {
-            WORD_ATOM(201, 62, "LT");
+            WORD_ATOM(206, 62, "LT");
             mw_LT();
         } else {
-            WORD_ATOM(201, 66, "GT");
+            WORD_ATOM(206, 66, "GT");
             mw_GT();
         }
     }
     WORD_EXIT(mw_Int_2E_cmp);
 }
 static void mw_Int_2E_in_range (void){
-    WORD_ENTER(mw_Int_2E_in_range, "Int.in-range", "src/prelude.mth", 204, 40);
-    WORD_ATOM(204, 40, "dip");
+    WORD_ENTER(mw_Int_2E_in_range, "Int.in-range", "src/prelude.mth", 209, 40);
+    WORD_ATOM(209, 40, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(204, 44, "over");
+        WORD_ATOM(209, 44, "over");
         mw_over();
-        WORD_ATOM(204, 49, "dip");
+        WORD_ATOM(209, 49, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(204, 53, ">=");
+            WORD_ATOM(209, 53, ">=");
             mw_Int_3E__3D_();
             push_value(d3);
         }
         push_value(d2);
     }
-    WORD_ATOM(204, 58, "<=");
+    WORD_ATOM(209, 58, "<=");
     mw_Int_3C__3D_();
-    WORD_ATOM(204, 61, "&&");
+    WORD_ATOM(209, 61, "&&");
     mw_Bool_26__26_();
     WORD_EXIT(mw_Int_2E_in_range);
 }
 static void mw_Str_2E_cmp (void){
-    WORD_ENTER(mw_Str_2E_cmp, "Str.cmp", "src/prelude.mth", 206, 37);
-    WORD_ATOM(206, 37, "prim-str-cmp");
+    WORD_ENTER(mw_Str_2E_cmp, "Str.cmp", "src/prelude.mth", 211, 37);
+    WORD_ATOM(211, 37, "prim-str-cmp");
     mw_prim_str_cmp();
-    WORD_ATOM(206, 50, "");
+    WORD_ATOM(211, 50, "");
     push_i64(0LL);
-    WORD_ATOM(206, 52, ".cmp");
+    WORD_ATOM(211, 52, ".cmp");
     mw_Int_2E_cmp();
     WORD_EXIT(mw_Str_2E_cmp);
 }
 static void mw_Str_3D_ (void){
-    WORD_ENTER(mw_Str_3D_, "Str=", "src/prelude.mth", 207, 29);
-    WORD_ATOM(207, 29, ".cmp");
+    WORD_ENTER(mw_Str_3D_, "Str=", "src/prelude.mth", 212, 29);
+    WORD_ATOM(212, 29, ".cmp");
     mw_Str_2E_cmp();
-    WORD_ATOM(207, 34, ".is-eq");
+    WORD_ATOM(212, 34, ".is-eq");
     mw_Comparison_2E_is_eq();
     WORD_EXIT(mw_Str_3D_);
 }
 static void mw_Str_3C__3E_ (void){
-    WORD_ENTER(mw_Str_3C__3E_, "Str<>", "src/prelude.mth", 212, 29);
-    WORD_ATOM(212, 29, ".cmp");
+    WORD_ENTER(mw_Str_3C__3E_, "Str<>", "src/prelude.mth", 217, 29);
+    WORD_ATOM(217, 29, ".cmp");
     mw_Str_2E_cmp();
-    WORD_ATOM(212, 34, ".is-ne");
+    WORD_ATOM(217, 34, ".is-ne");
     mw_Comparison_2E_is_ne();
     WORD_EXIT(mw_Str_3C__3E_);
 }
 static void mw_prim_int_succ (void){
-    WORD_ENTER(mw_prim_int_succ, "prim-int-succ", "src/prelude.mth", 216, 40);
-    WORD_ATOM(216, 40, "");
+    WORD_ENTER(mw_prim_int_succ, "prim-int-succ", "src/prelude.mth", 221, 40);
+    WORD_ATOM(221, 40, "");
     push_i64(1LL);
-    WORD_ATOM(216, 42, "+");
+    WORD_ATOM(221, 42, "+");
     mw_prim_int_add();
     WORD_EXIT(mw_prim_int_succ);
 }
 static void mw_prim_int_pred (void){
-    WORD_ENTER(mw_prim_int_pred, "prim-int-pred", "src/prelude.mth", 217, 40);
-    WORD_ATOM(217, 40, "");
+    WORD_ENTER(mw_prim_int_pred, "prim-int-pred", "src/prelude.mth", 222, 40);
+    WORD_ATOM(222, 40, "");
     push_i64(1LL);
-    WORD_ATOM(217, 42, "-");
+    WORD_ATOM(222, 42, "-");
     mw_prim_int_sub();
     WORD_EXIT(mw_prim_int_pred);
 }
 static void mw_0_3D_ (void){
-    WORD_ENTER(mw_0_3D_, "0=", "src/prelude.mth", 225, 22);
-    WORD_ATOM(225, 22, "");
+    WORD_ENTER(mw_0_3D_, "0=", "src/prelude.mth", 230, 22);
+    WORD_ATOM(230, 22, "");
     push_i64(0LL);
-    WORD_ATOM(225, 24, "=");
+    WORD_ATOM(230, 24, "=");
     mw_prim_int_eq();
     WORD_EXIT(mw_0_3D_);
 }
 static void mw_0_3C_ (void){
-    WORD_ENTER(mw_0_3C_, "0<", "src/prelude.mth", 226, 22);
-    WORD_ATOM(226, 22, "");
+    WORD_ENTER(mw_0_3C_, "0<", "src/prelude.mth", 231, 22);
+    WORD_ATOM(231, 22, "");
     push_i64(0LL);
-    WORD_ATOM(226, 24, "<");
+    WORD_ATOM(231, 24, "<");
     mw_prim_int_lt();
     WORD_EXIT(mw_0_3C_);
 }
 static void mw_0_3E_ (void){
-    WORD_ENTER(mw_0_3E_, "0>", "src/prelude.mth", 227, 22);
-    WORD_ATOM(227, 22, "");
+    WORD_ENTER(mw_0_3E_, "0>", "src/prelude.mth", 232, 22);
+    WORD_ATOM(232, 22, "");
     push_i64(0LL);
-    WORD_ATOM(227, 24, ">");
+    WORD_ATOM(232, 24, ">");
     mw_Int_3E_();
     WORD_EXIT(mw_0_3E_);
 }
 static void mw_0_3E__3D_ (void){
-    WORD_ENTER(mw_0_3E__3D_, "0>=", "src/prelude.mth", 228, 23);
-    WORD_ATOM(228, 23, "");
+    WORD_ENTER(mw_0_3E__3D_, "0>=", "src/prelude.mth", 233, 23);
+    WORD_ATOM(233, 23, "");
     push_i64(0LL);
-    WORD_ATOM(228, 25, ">=");
+    WORD_ATOM(233, 25, ">=");
     mw_Int_3E__3D_();
     WORD_EXIT(mw_0_3E__3D_);
 }
 static void mw_Ptr_40__40_Ptr (void){
-    WORD_ENTER(mw_Ptr_40__40_Ptr, "Ptr@@Ptr", "src/prelude.mth", 235, 34);
-    WORD_ATOM(235, 34, "dip");
+    WORD_ENTER(mw_Ptr_40__40_Ptr, "Ptr@@Ptr", "src/prelude.mth", 240, 34);
+    WORD_ATOM(240, 34, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(235, 38, "Ptr.sizeof");
+        WORD_ATOM(240, 38, "Ptr.sizeof");
         mw_prim_ptr_size();
-        WORD_ATOM(235, 49, "*");
+        WORD_ATOM(240, 49, "*");
         mw_prim_int_mul();
         push_value(d2);
     }
-    WORD_ATOM(235, 51, ".offset");
+    WORD_ATOM(240, 51, ".offset");
     push_u64(0);
     push_fnptr(&mb_Ptr_40__40_Ptr_2);
     mw_prim_pack_cons();
@@ -9045,17 +9058,17 @@ static void mw_Ptr_40__40_Ptr (void){
     WORD_EXIT(mw_Ptr_40__40_Ptr);
 }
 static void mw_Ptr_40__40_I64 (void){
-    WORD_ENTER(mw_Ptr_40__40_I64, "Ptr@@I64", "src/prelude.mth", 245, 34);
-    WORD_ATOM(245, 34, "dip");
+    WORD_ENTER(mw_Ptr_40__40_I64, "Ptr@@I64", "src/prelude.mth", 250, 34);
+    WORD_ATOM(250, 34, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(245, 38, "");
+        WORD_ATOM(250, 38, "");
         push_i64(8LL);
-        WORD_ATOM(245, 40, "*");
+        WORD_ATOM(250, 40, "*");
         mw_prim_int_mul();
         push_value(d2);
     }
-    WORD_ATOM(245, 42, ".offset");
+    WORD_ATOM(250, 42, ".offset");
     push_u64(0);
     push_fnptr(&mb_Ptr_40__40_I64_2);
     mw_prim_pack_cons();
@@ -9063,8 +9076,8 @@ static void mw_Ptr_40__40_I64 (void){
     WORD_EXIT(mw_Ptr_40__40_I64);
 }
 static void mw_Ptr_21__21_U8 (void){
-    WORD_ENTER(mw_Ptr_21__21_U8, "Ptr!!U8", "src/prelude.mth", 247, 42);
-    WORD_ATOM(247, 42, ".offset");
+    WORD_ENTER(mw_Ptr_21__21_U8, "Ptr!!U8", "src/prelude.mth", 252, 42);
+    WORD_ATOM(252, 42, ".offset");
     push_u64(0);
     push_fnptr(&mb_Ptr_21__21_U8_1);
     mw_prim_pack_cons();
@@ -9072,17 +9085,17 @@ static void mw_Ptr_21__21_U8 (void){
     WORD_EXIT(mw_Ptr_21__21_U8);
 }
 static void mw_Ptr_21__21_I64 (void){
-    WORD_ENTER(mw_Ptr_21__21_I64, "Ptr!!I64", "src/prelude.mth", 254, 34);
-    WORD_ATOM(254, 34, "dip");
+    WORD_ENTER(mw_Ptr_21__21_I64, "Ptr!!I64", "src/prelude.mth", 259, 34);
+    WORD_ATOM(259, 34, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(254, 38, "");
+        WORD_ATOM(259, 38, "");
         push_i64(8LL);
-        WORD_ATOM(254, 40, "*");
+        WORD_ATOM(259, 40, "*");
         mw_prim_int_mul();
         push_value(d2);
     }
-    WORD_ATOM(254, 42, ".offset");
+    WORD_ATOM(259, 42, ".offset");
     push_u64(0);
     push_fnptr(&mb_Ptr_21__21_I64_2);
     mw_prim_pack_cons();
@@ -9090,46 +9103,46 @@ static void mw_Ptr_21__21_I64 (void){
     WORD_EXIT(mw_Ptr_21__21_I64);
 }
 static void mw_U8_3E_Int (void){
-    WORD_ENTER(mw_U8_3E_Int, "U8>Int", "src/prelude.mth", 256, 26);
-    WORD_ATOM(256, 26, "prim-unsafe-cast");
+    WORD_ENTER(mw_U8_3E_Int, "U8>Int", "src/prelude.mth", 261, 26);
+    WORD_ATOM(261, 26, "prim-unsafe-cast");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_U8_3E_Int);
 }
 static void mw_I64_3E_Int (void){
-    WORD_ENTER(mw_I64_3E_Int, "I64>Int", "src/prelude.mth", 266, 26);
-    WORD_ATOM(266, 26, "prim-unsafe-cast");
+    WORD_ENTER(mw_I64_3E_Int, "I64>Int", "src/prelude.mth", 271, 26);
+    WORD_ATOM(271, 26, "prim-unsafe-cast");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_I64_3E_Int);
 }
 static void mw_Int_3E_U8_3F_ (void){
-    WORD_ENTER(mw_Int_3E_U8_3F_, "Int>U8?", "src/prelude.mth", 281, 34);
-    WORD_ATOM(281, 34, "dup");
+    WORD_ENTER(mw_Int_3E_U8_3F_, "Int>U8?", "src/prelude.mth", 286, 34);
+    WORD_ATOM(286, 34, "dup");
     mw_prim_dup();
-    WORD_ATOM(281, 38, "U8_MIN");
+    WORD_ATOM(286, 38, "U8_MIN");
     mw_U8_5F_MIN();
-    WORD_ATOM(281, 46, "U8_MAX");
+    WORD_ATOM(286, 46, "U8_MAX");
     mw_U8_5F_MAX();
-    WORD_ATOM(281, 54, ".in-range");
+    WORD_ATOM(286, 54, ".in-range");
     mw_Int_2E_in_range();
-    WORD_ATOM(281, 64, "if");
+    WORD_ATOM(286, 64, "if");
     if (pop_u64()) {
-        WORD_ATOM(281, 68, ">U8-unsafe");
+        WORD_ATOM(286, 68, ">U8-unsafe");
         mw_Int_3E_U8_unsafe();
-        WORD_ATOM(281, 79, "SOME");
+        WORD_ATOM(286, 79, "SOME");
         mw_SOME();
     } else {
-        WORD_ATOM(281, 85, "drop");
+        WORD_ATOM(286, 85, "drop");
         mw_prim_drop();
-        WORD_ATOM(281, 90, "NONE");
+        WORD_ATOM(286, 90, "NONE");
         mw_NONE();
     }
     WORD_EXIT(mw_Int_3E_U8_3F_);
 }
 static void mw_Int_3E_U8 (void){
-    WORD_ENTER(mw_Int_3E_U8, "Int>U8", "src/prelude.mth", 285, 26);
-    WORD_ATOM(285, 26, "Int>U8?");
+    WORD_ENTER(mw_Int_3E_U8, "Int>U8", "src/prelude.mth", 290, 26);
+    WORD_ATOM(290, 26, "Int>U8?");
     mw_Int_3E_U8_3F_();
-    WORD_ATOM(285, 35, "unwrap-or");
+    WORD_ATOM(290, 35, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_Int_3E_U8_1);
     mw_prim_pack_cons();
@@ -9137,99 +9150,99 @@ static void mw_Int_3E_U8 (void){
     WORD_EXIT(mw_Int_3E_U8);
 }
 static void mw_Int_3E_I64 (void){
-    WORD_ENTER(mw_Int_3E_I64, "Int>I64", "src/prelude.mth", 297, 26);
-    WORD_ATOM(297, 26, ">I64-unsafe");
+    WORD_ENTER(mw_Int_3E_I64, "Int>I64", "src/prelude.mth", 302, 26);
+    WORD_ATOM(302, 26, ">I64-unsafe");
     mw_Int_3E_I64_unsafe();
     WORD_EXIT(mw_Int_3E_I64);
 }
 static void mw_pack1 (void){
-    WORD_ENTER(mw_pack1, "pack1", "src/prelude.mth", 309, 22);
-    WORD_ATOM(309, 22, "dip");
+    WORD_ENTER(mw_pack1, "pack1", "src/prelude.mth", 314, 22);
+    WORD_ATOM(314, 22, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(309, 26, "pack0");
+        WORD_ATOM(314, 26, "pack0");
         mw_prim_pack_nil();
         push_value(d2);
     }
-    WORD_ATOM(309, 33, "prim-pack-cons");
+    WORD_ATOM(314, 33, "prim-pack-cons");
     mw_prim_pack_cons();
     WORD_EXIT(mw_pack1);
 }
 static void mw_pack2 (void){
-    WORD_ENTER(mw_pack2, "pack2", "src/prelude.mth", 310, 26);
-    WORD_ATOM(310, 26, "dip");
+    WORD_ENTER(mw_pack2, "pack2", "src/prelude.mth", 315, 26);
+    WORD_ATOM(315, 26, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(310, 30, "pack1");
+        WORD_ATOM(315, 30, "pack1");
         mw_pack1();
         push_value(d2);
     }
-    WORD_ATOM(310, 37, "prim-pack-cons");
+    WORD_ATOM(315, 37, "prim-pack-cons");
     mw_prim_pack_cons();
     WORD_EXIT(mw_pack2);
 }
 static void mw_unpack1 (void){
-    WORD_ENTER(mw_unpack1, "unpack1", "src/prelude.mth", 316, 24);
-    WORD_ATOM(316, 24, "prim-pack-uncons");
+    WORD_ENTER(mw_unpack1, "unpack1", "src/prelude.mth", 321, 24);
+    WORD_ATOM(321, 24, "prim-pack-uncons");
     mw_prim_pack_uncons();
-    WORD_ATOM(316, 41, "nip");
+    WORD_ATOM(321, 41, "nip");
     mw_nip();
     WORD_EXIT(mw_unpack1);
 }
 static void mw_unpack2 (void){
-    WORD_ENTER(mw_unpack2, "unpack2", "src/prelude.mth", 317, 28);
-    WORD_ATOM(317, 28, "prim-pack-uncons");
+    WORD_ENTER(mw_unpack2, "unpack2", "src/prelude.mth", 322, 28);
+    WORD_ATOM(322, 28, "prim-pack-uncons");
     mw_prim_pack_uncons();
-    WORD_ATOM(317, 45, "dip");
+    WORD_ATOM(322, 45, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(317, 49, "unpack1");
+        WORD_ATOM(322, 49, "unpack1");
         mw_unpack1();
         push_value(d2);
     }
     WORD_EXIT(mw_unpack2);
 }
 static void mw_modify (void){
-    WORD_ENTER(mw_modify, "modify", "src/prelude.mth", 325, 48);
-    WORD_ATOM(325, 48, "dup");
+    WORD_ENTER(mw_modify, "modify", "src/prelude.mth", 330, 48);
+    WORD_ATOM(330, 48, "dup");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(325, 48, "dup");
+        WORD_ATOM(330, 48, "dup");
         mw_prim_dup();
-        WORD_ATOM(325, 52, "dip");
+        WORD_ATOM(330, 52, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(325, 56, "@");
+            WORD_ATOM(330, 56, "@");
             mw_prim_mut_get();
-            WORD_ATOM(325, 58, "f");
+            WORD_ATOM(330, 58, "f");
             incref(var_f);
             run_value(var_f);
             push_value(d3);
         }
-        WORD_ATOM(325, 61, "!");
+        WORD_ATOM(330, 61, "!");
         mw_prim_mut_set();
         decref(var_f);
     }
     WORD_EXIT(mw_modify);
 }
 static void mw_expect_21_ (void){
-    WORD_ENTER(mw_expect_21_, "expect!", "src/prelude.mth", 329, 5);
-    WORD_ATOM(329, 5, "f");
+    WORD_ENTER(mw_expect_21_, "expect!", "src/prelude.mth", 334, 5);
+    WORD_ATOM(334, 5, "f");
     {
         VAL var_g = pop_value();
         VAL var_f = pop_value();
-        WORD_ATOM(329, 5, "f");
+        WORD_ATOM(334, 5, "f");
         incref(var_f);
         run_value(var_f);
-        WORD_ATOM(329, 7, "if");
+        WORD_ATOM(334, 7, "if");
         if (pop_u64()) {
-            WORD_ATOM(329, 10, "id");
+            WORD_ATOM(334, 10, "id");
             mw_prim_id();
         } else {
-            WORD_ATOM(329, 14, "g");
+            WORD_ATOM(334, 14, "g");
             incref(var_g);
             run_value(var_g);
-            WORD_ATOM(329, 16, "panic!");
+            WORD_ATOM(334, 16, "panic!");
             mw_prim_panic();
         }
         decref(var_g);
@@ -9238,12 +9251,12 @@ static void mw_expect_21_ (void){
     WORD_EXIT(mw_expect_21_);
 }
 static void mw_assert_21_ (void){
-    WORD_ENTER(mw_assert_21_, "assert!", "src/prelude.mth", 331, 5);
-    WORD_ATOM(331, 5, "expect!");
+    WORD_ENTER(mw_assert_21_, "assert!", "src/prelude.mth", 336, 5);
+    WORD_ATOM(336, 5, "expect!");
     {
         VAL var_g = pop_value();
         VAL var_f = pop_value();
-        WORD_ATOM(331, 5, "expect!");
+        WORD_ATOM(336, 5, "expect!");
         incref(var_f);
         push_value(var_f);
         push_u64(0);
@@ -18717,8 +18730,8 @@ static void mw_elab_type_stack_rest_21_ (void){
             VAL d3 = pop_value();
             WORD_ATOM(77, 13, "swap");
             mw_prim_swap();
-            WORD_ATOM(77, 18, "T*");
-            mw_T_2A_();
+            WORD_ATOM(77, 18, "T*+");
+            mw_T_2A__2B_();
             push_value(d3);
         }
     }
@@ -18728,16 +18741,45 @@ static void mw_elab_type_arg_21_ (void){
     WORD_ENTER(mw_elab_type_arg_21_, "elab-type-arg!", "src/mirth/elab.mth", 81, 5);
     WORD_ATOM(81, 5, "elab-type-atom!");
     mw_elab_type_atom_21_();
-    WORD_ATOM(82, 5, "dup");
+    WORD_ATOM(82, 5, "swap");
+    mw_prim_swap();
+    WORD_ATOM(82, 10, "match");
+    switch (get_top_data_tag()) {
+        case 0LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(83, 17, "swap");
+            mw_prim_swap();
+            break;
+        case 1LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(84, 18, "drop");
+            mw_prim_drop();
+            WORD_ATOM(84, 23, "");
+            {
+                static bool vready = false;
+                static VAL v;
+                if (! vready) {
+                    v = mkstr("Expected type, not resource.", 28);
+                    vready = true;
+                }
+                push_value(v);
+                incref(v);
+            }
+            WORD_ATOM(84, 54, "emit-fatal-error!");
+            mw_emit_fatal_error_21_();
+            break;
+        default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
+    
+}    WORD_ATOM(86, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(82, 9, "arg-end?");
+    WORD_ATOM(86, 9, "arg-end?");
     mw_Token_2E_arg_end_3F_();
-    WORD_ATOM(82, 18, "if");
+    WORD_ATOM(86, 18, "if");
     if (pop_u64()) {
-        WORD_ATOM(83, 9, "id");
+        WORD_ATOM(87, 9, "id");
         mw_prim_id();
     } else {
-        WORD_ATOM(84, 9, "");
+        WORD_ATOM(88, 9, "");
         {
             static bool vready = false;
             static VAL v;
@@ -18748,68 +18790,129 @@ static void mw_elab_type_arg_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(84, 40, "emit-fatal-error!");
+        WORD_ATOM(88, 40, "emit-fatal-error!");
         mw_emit_fatal_error_21_();
     }
     WORD_EXIT(mw_elab_type_arg_21_);
 }
 static void mw_elab_type_atom_21_ (void){
-    WORD_ENTER(mw_elab_type_atom_21_, "elab-type-atom!", "src/mirth/elab.mth", 89, 5);
-    WORD_ATOM(89, 5, "dup");
+    WORD_ENTER(mw_elab_type_atom_21_, "elab-type-atom!", "src/mirth/elab.mth", 93, 5);
+    WORD_ATOM(93, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(89, 9, "sig-type-var?");
+    WORD_ATOM(93, 9, "sig-type-var?");
     mw_Token_2E_sig_type_var_3F_();
-    WORD_ATOM(89, 23, "if");
+    WORD_ATOM(93, 23, "if");
     if (pop_u64()) {
-        WORD_ATOM(90, 9, "elab-type-var!");
+        WORD_ATOM(94, 9, "elab-type-var!");
         mw_elab_type_var_21_();
-        WORD_ATOM(90, 24, "dip");
+        WORD_ATOM(94, 24, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(90, 28, "TVar");
+            WORD_ATOM(94, 28, "TVar");
             mw_TVar();
+            WORD_ATOM(94, 33, "LEFT");
+            mw_LEFT();
             push_value(d3);
         }
     } else {
-        WORD_ATOM(92, 5, "dup");
+        WORD_ATOM(96, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(92, 9, "sig-type-con?");
+        WORD_ATOM(96, 9, "sig-type-con?");
         mw_Token_2E_sig_type_con_3F_();
-        WORD_ATOM(92, 23, "if");
+        WORD_ATOM(96, 23, "if");
         if (pop_u64()) {
-            WORD_ATOM(93, 9, "elab-type-con!");
+            WORD_ATOM(97, 9, "elab-type-con!");
             mw_elab_type_con_21_();
+            WORD_ATOM(97, 24, "dip");
+            {
+                VAL d4 = pop_value();
+                WORD_ATOM(97, 28, "LEFT");
+                mw_LEFT();
+                push_value(d4);
+            }
         } else {
-            WORD_ATOM(95, 5, "dup");
+            WORD_ATOM(99, 5, "dup");
             mw_prim_dup();
-            WORD_ATOM(95, 9, "pat-underscore?");
-            mw_Token_2E_pat_underscore_3F_();
-            WORD_ATOM(95, 25, "if");
+            WORD_ATOM(99, 9, "sig-resource-var?");
+            mw_Token_2E_sig_resource_var_3F_();
+            WORD_ATOM(99, 27, "if");
             if (pop_u64()) {
-                WORD_ATOM(96, 9, "elab-type-dont-care!");
-                mw_elab_type_dont_care_21_();
+                WORD_ATOM(100, 9, "elab-resource-var!");
+                mw_elab_resource_var_21_();
+                WORD_ATOM(100, 28, "dip");
+                {
+                    VAL d5 = pop_value();
+                    WORD_ATOM(100, 32, "TVar");
+                    mw_TVar();
+                    WORD_ATOM(100, 37, "RESOURCE");
+                    mw_RESOURCE();
+                    WORD_ATOM(100, 46, "RIGHT");
+                    mw_RIGHT();
+                    push_value(d5);
+                }
             } else {
-                WORD_ATOM(98, 5, "dup");
+                WORD_ATOM(102, 5, "dup");
                 mw_prim_dup();
-                WORD_ATOM(98, 9, "sig-type-hole?");
-                mw_Token_2E_sig_type_hole_3F_();
-                WORD_ATOM(98, 24, "if");
+                WORD_ATOM(102, 9, "sig-resource-con?");
+                mw_Token_2E_sig_resource_con_3F_();
+                WORD_ATOM(102, 27, "if");
                 if (pop_u64()) {
-                    WORD_ATOM(99, 9, "elab-type-hole!");
-                    mw_elab_type_hole_21_();
+                    WORD_ATOM(103, 9, "elab-resource-con!");
+                    mw_elab_resource_con_21_();
+                    WORD_ATOM(103, 28, "dip");
+                    {
+                        VAL d6 = pop_value();
+                        WORD_ATOM(103, 32, "RIGHT");
+                        mw_RIGHT();
+                        push_value(d6);
+                    }
                 } else {
-                    WORD_ATOM(101, 5, "dup");
+                    WORD_ATOM(105, 5, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(101, 9, "lsquare?");
-                    mw_Token_2E_lsquare_3F_();
-                    WORD_ATOM(101, 18, ".if");
-                    push_u64(0);
-                    push_fnptr(&mb_elab_type_atom_21__10);
-                    mw_prim_pack_cons();
-                    push_u64(0);
-                    push_fnptr(&mb_elab_type_atom_21__11);
-                    mw_prim_pack_cons();
-                    mw_Maybe_2E_if();
+                    WORD_ATOM(105, 9, "pat-underscore?");
+                    mw_Token_2E_pat_underscore_3F_();
+                    WORD_ATOM(105, 25, "if");
+                    if (pop_u64()) {
+                        WORD_ATOM(106, 9, "elab-type-dont-care!");
+                        mw_elab_type_dont_care_21_();
+                        WORD_ATOM(106, 30, "dip");
+                        {
+                            VAL d7 = pop_value();
+                            WORD_ATOM(106, 34, "LEFT");
+                            mw_LEFT();
+                            push_value(d7);
+                        }
+                    } else {
+                        WORD_ATOM(108, 5, "dup");
+                        mw_prim_dup();
+                        WORD_ATOM(108, 9, "sig-type-hole?");
+                        mw_Token_2E_sig_type_hole_3F_();
+                        WORD_ATOM(108, 24, "if");
+                        if (pop_u64()) {
+                            WORD_ATOM(109, 9, "elab-type-hole!");
+                            mw_elab_type_hole_21_();
+                            WORD_ATOM(109, 25, "dip");
+                            {
+                                VAL d8 = pop_value();
+                                WORD_ATOM(109, 29, "LEFT");
+                                mw_LEFT();
+                                push_value(d8);
+                            }
+                        } else {
+                            WORD_ATOM(111, 5, "dup");
+                            mw_prim_dup();
+                            WORD_ATOM(111, 9, "lsquare?");
+                            mw_Token_2E_lsquare_3F_();
+                            WORD_ATOM(111, 18, ".if");
+                            push_u64(0);
+                            push_fnptr(&mb_elab_type_atom_21__19);
+                            mw_prim_pack_cons();
+                            push_u64(0);
+                            push_fnptr(&mb_elab_type_atom_21__21);
+                            mw_prim_pack_cons();
+                            mw_Maybe_2E_if();
+                        }
+                    }
                 }
             }
         }
@@ -18817,63 +18920,71 @@ static void mw_elab_type_atom_21_ (void){
     WORD_EXIT(mw_elab_type_atom_21_);
 }
 static void mw_elab_stack_var_21_ (void){
-    WORD_ENTER(mw_elab_stack_var_21_, "elab-stack-var!", "src/mirth/elab.mth", 109, 5);
-    WORD_ATOM(109, 5, "TYPE_STACK");
+    WORD_ENTER(mw_elab_stack_var_21_, "elab-stack-var!", "src/mirth/elab.mth", 119, 5);
+    WORD_ATOM(119, 5, "TYPE_STACK");
     mw_TYPE_5F_STACK();
-    WORD_ATOM(109, 16, "elab-implicit-var!");
+    WORD_ATOM(119, 16, "elab-implicit-var!");
     mw_elab_implicit_var_21_();
     WORD_EXIT(mw_elab_stack_var_21_);
 }
 static void mw_elab_type_var_21_ (void){
-    WORD_ENTER(mw_elab_type_var_21_, "elab-type-var!", "src/mirth/elab.mth", 112, 5);
-    WORD_ATOM(112, 5, "TYPE_TYPE");
+    WORD_ENTER(mw_elab_type_var_21_, "elab-type-var!", "src/mirth/elab.mth", 122, 5);
+    WORD_ATOM(122, 5, "TYPE_TYPE");
     mw_TYPE_5F_TYPE();
-    WORD_ATOM(112, 15, "elab-implicit-var!");
+    WORD_ATOM(122, 15, "elab-implicit-var!");
     mw_elab_implicit_var_21_();
     WORD_EXIT(mw_elab_type_var_21_);
 }
+static void mw_elab_resource_var_21_ (void){
+    WORD_ENTER(mw_elab_resource_var_21_, "elab-resource-var!", "src/mirth/elab.mth", 125, 5);
+    WORD_ATOM(125, 5, "TYPE_RESOURCE");
+    mw_TYPE_5F_RESOURCE();
+    WORD_ATOM(125, 19, "elab-implicit-var!");
+    mw_elab_implicit_var_21_();
+    WORD_EXIT(mw_elab_resource_var_21_);
+}
 static void mw_elab_implicit_var_21_ (void){
-    WORD_ENTER(mw_elab_implicit_var_21_, "elab-implicit-var!", "src/mirth/elab.mth", 115, 5);
-    WORD_ATOM(115, 5, "dip2");
+    WORD_ENTER(mw_elab_implicit_var_21_, "elab-implicit-var!", "src/mirth/elab.mth", 128, 5);
+    WORD_ATOM(128, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_elab_implicit_var_21__1);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(115, 26, "over");
+    WORD_ATOM(128, 26, "over");
     mw_over();
-    WORD_ATOM(116, 5, "dip2");
+    WORD_ATOM(129, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_elab_implicit_var_21__2);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(117, 5, "rotl");
+    WORD_ATOM(130, 5, "rotl");
     mw_rotl();
-    WORD_ATOM(117, 10, "match");
+    WORD_ATOM(130, 10, "match");
     switch (get_top_data_tag()) {
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(119, 13, "rotr");
+            WORD_ATOM(132, 13, "rotr");
             mw_rotr();
-            WORD_ATOM(119, 18, "dip2");
+            WORD_ATOM(132, 18, "dip2");
             push_u64(0);
             push_fnptr(&mb_elab_implicit_var_21__4);
             mw_prim_pack_cons();
             mw_dip2();
-            WORD_ATOM(120, 13, "elab-type-unify!");
+            WORD_ATOM(133, 13, "elab-type-unify!");
             mw_elab_type_unify_21_();
-            WORD_ATOM(120, 30, "nip");
+            WORD_ATOM(133, 30, "nip");
             mw_nip();
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(122, 13, "dip");
+            WORD_ATOM(135, 13, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(123, 17, "swap");
+                WORD_ATOM(136, 17, "swap");
                 mw_prim_swap();
-                WORD_ATOM(123, 22, "Var.new!");
+                WORD_ATOM(136, 22, "Var.new!");
                 mw_Var_2E_new_21_();
-                WORD_ATOM(124, 17, "sip");
+                WORD_ATOM(137, 17, "sip");
                 push_u64(0);
                 push_fnptr(&mb_elab_implicit_var_21__7);
                 mw_prim_pack_cons();
@@ -18883,9 +18994,9 @@ static void mw_elab_implicit_var_21_ (void){
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
     
-}    WORD_ATOM(127, 5, "next");
+}    WORD_ATOM(140, 5, "next");
     mw_Token_2E_next();
-    WORD_ATOM(128, 5, "dip2");
+    WORD_ATOM(141, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_elab_implicit_var_21__8);
     mw_prim_pack_cons();
@@ -18893,16 +19004,16 @@ static void mw_elab_implicit_var_21_ (void){
     WORD_EXIT(mw_elab_implicit_var_21_);
 }
 static void mw_elab_type_con_21_ (void){
-    WORD_ENTER(mw_elab_type_con_21_, "elab-type-con!", "src/mirth/elab.mth", 131, 5);
-    WORD_ATOM(131, 5, "dup");
+    WORD_ENTER(mw_elab_type_con_21_, "elab-type-con!", "src/mirth/elab.mth", 144, 5);
+    WORD_ATOM(144, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(131, 9, "name?");
+    WORD_ATOM(144, 9, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(131, 15, "unwrap");
+    WORD_ATOM(144, 15, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(131, 22, ">Str");
+    WORD_ATOM(144, 22, ">Str");
     mw_Name_3E_Str();
-    WORD_ATOM(131, 27, "");
+    WORD_ATOM(144, 27, "");
     {
         static bool vready = false;
         static VAL v;
@@ -18913,57 +19024,57 @@ static void mw_elab_type_con_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(131, 33, "=");
+    WORD_ATOM(144, 33, "=");
     mw_Str_3D_();
-    WORD_ATOM(131, 35, "if");
+    WORD_ATOM(144, 35, "if");
     if (pop_u64()) {
-        WORD_ATOM(132, 9, "tuck");
+        WORD_ATOM(145, 9, "tuck");
         mw_tuck();
-        WORD_ATOM(132, 14, "args-1");
+        WORD_ATOM(145, 14, "args-1");
         mw_Token_2E_args_1();
-        WORD_ATOM(132, 21, "elab-type-arg!");
+        WORD_ATOM(145, 21, "elab-type-arg!");
         mw_elab_type_arg_21_();
-        WORD_ATOM(132, 36, "drop");
+        WORD_ATOM(145, 36, "drop");
         mw_prim_drop();
-        WORD_ATOM(132, 41, "TMut");
+        WORD_ATOM(145, 41, "TMut");
         mw_TMut();
-        WORD_ATOM(133, 9, "rotl");
+        WORD_ATOM(146, 9, "rotl");
         mw_rotl();
-        WORD_ATOM(133, 14, "next");
+        WORD_ATOM(146, 14, "next");
         mw_Token_2E_next();
     } else {
-        WORD_ATOM(135, 9, "dup");
+        WORD_ATOM(148, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(135, 13, "name?");
+        WORD_ATOM(148, 13, "name?");
         mw_Token_2E_name_3F_();
-        WORD_ATOM(135, 19, "unwrap");
+        WORD_ATOM(148, 19, "unwrap");
         mw_Maybe_2E_unwrap();
-        WORD_ATOM(135, 26, ">Def");
+        WORD_ATOM(148, 26, ">Def");
         mw_Name_3E_Def();
-        WORD_ATOM(135, 31, "match");
+        WORD_ATOM(148, 31, "match");
         switch (get_top_data_tag()) {
             case 3LL:
                 mw_prim_pack_uncons(); mw_prim_drop();
-                WORD_ATOM(137, 17, "over");
+                WORD_ATOM(150, 17, "over");
                 mw_over();
-                WORD_ATOM(137, 22, "num-args");
+                WORD_ATOM(150, 22, "num-args");
                 mw_Token_2E_num_args();
-                WORD_ATOM(138, 17, "over");
+                WORD_ATOM(151, 17, "over");
                 mw_over();
-                WORD_ATOM(138, 22, "arity");
+                WORD_ATOM(151, 22, "arity");
                 mw_Type_2E_arity();
-                WORD_ATOM(138, 28, "=");
+                WORD_ATOM(151, 28, "=");
                 mw_prim_int_eq();
-                WORD_ATOM(138, 30, "if");
+                WORD_ATOM(151, 30, "if");
                 if (pop_u64()) {
-                    WORD_ATOM(139, 21, "elab-type-args!");
+                    WORD_ATOM(152, 21, "elab-type-args!");
                     mw_elab_type_args_21_();
                 } else {
-                    WORD_ATOM(141, 21, "drop");
+                    WORD_ATOM(154, 21, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(141, 26, "dup");
+                    WORD_ATOM(154, 26, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(142, 21, "");
+                    WORD_ATOM(155, 21, "");
                     {
                         static bool vready = false;
                         static VAL v;
@@ -18974,17 +19085,17 @@ static void mw_elab_type_con_21_ (void){
                         push_value(v);
                         incref(v);
                     }
-                    WORD_ATOM(142, 59, "emit-error!");
+                    WORD_ATOM(155, 59, "emit-error!");
                     mw_emit_error_21_();
-                    WORD_ATOM(143, 21, "TYPE_ERROR");
+                    WORD_ATOM(156, 21, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                 }
                 break;
             case 0LL:
                 mw_prim_drop();
-                WORD_ATOM(146, 17, "dup");
+                WORD_ATOM(159, 17, "dup");
                 mw_prim_dup();
-                WORD_ATOM(146, 21, "");
+                WORD_ATOM(159, 21, "");
                 {
                     static bool vready = false;
                     static VAL v;
@@ -18995,17 +19106,17 @@ static void mw_elab_type_con_21_ (void){
                     push_value(v);
                     incref(v);
                 }
-                WORD_ATOM(146, 37, "emit-error!");
+                WORD_ATOM(159, 37, "emit-error!");
                 mw_emit_error_21_();
-                WORD_ATOM(146, 49, "TYPE_ERROR");
+                WORD_ATOM(159, 49, "TYPE_ERROR");
                 mw_TYPE_5F_ERROR();
                 break;
             default:
-                WORD_ATOM(148, 17, "drop");
+                WORD_ATOM(161, 17, "drop");
                 mw_prim_drop();
-                WORD_ATOM(148, 22, "dup");
+                WORD_ATOM(161, 22, "dup");
                 mw_prim_dup();
-                WORD_ATOM(148, 26, "");
+                WORD_ATOM(161, 26, "");
                 {
                     static bool vready = false;
                     static VAL v;
@@ -19016,111 +19127,124 @@ static void mw_elab_type_con_21_ (void){
                     push_value(v);
                     incref(v);
                 }
-                WORD_ATOM(148, 40, "emit-error!");
+                WORD_ATOM(161, 40, "emit-error!");
                 mw_emit_error_21_();
-                WORD_ATOM(148, 52, "TYPE_ERROR");
+                WORD_ATOM(161, 52, "TYPE_ERROR");
                 mw_TYPE_5F_ERROR();
                 break;
         
-}        WORD_ATOM(150, 9, "swap");
+}        WORD_ATOM(163, 9, "swap");
         mw_prim_swap();
-        WORD_ATOM(150, 14, "next");
+        WORD_ATOM(163, 14, "next");
         mw_Token_2E_next();
     }
     WORD_EXIT(mw_elab_type_con_21_);
 }
+static void mw_elab_resource_con_21_ (void){
+    WORD_ENTER(mw_elab_resource_con_21_, "elab-resource-con!", "src/mirth/elab.mth", 167, 5);
+    WORD_ATOM(167, 5, "elab-type-con!");
+    mw_elab_type_con_21_();
+    WORD_ATOM(167, 20, "dip");
+    {
+        VAL d2 = pop_value();
+        WORD_ATOM(167, 24, "RESOURCE");
+        mw_RESOURCE();
+        push_value(d2);
+    }
+    WORD_EXIT(mw_elab_resource_con_21_);
+}
 static void mw_elab_type_args_21_ (void){
-    WORD_ENTER(mw_elab_type_args_21_, "elab-type-args!", "src/mirth/elab.mth", 154, 5);
-    WORD_ATOM(154, 5, "over");
+    WORD_ENTER(mw_elab_type_args_21_, "elab-type-args!", "src/mirth/elab.mth", 170, 5);
+    WORD_ATOM(170, 5, "over");
     mw_over();
-    WORD_ATOM(154, 10, "has-args?");
+    WORD_ATOM(170, 10, "has-args?");
     mw_Token_2E_has_args_3F_();
-    WORD_ATOM(154, 20, "if");
+    WORD_ATOM(170, 20, "if");
     if (pop_u64()) {
-        WORD_ATOM(155, 9, "dip");
+        WORD_ATOM(171, 9, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(155, 13, "tuck");
+            WORD_ATOM(171, 13, "tuck");
             mw_tuck();
             push_value(d3);
         }
-        WORD_ATOM(155, 19, "swap");
+        WORD_ATOM(171, 19, "swap");
         mw_prim_swap();
-        WORD_ATOM(155, 24, "succ");
+        WORD_ATOM(171, 24, "succ");
         mw_Token_2E_succ();
-        WORD_ATOM(156, 9, "while");
+        WORD_ATOM(172, 9, "while");
         while(1) {
-            WORD_ATOM(156, 15, "dup");
+            WORD_ATOM(172, 15, "dup");
             mw_prim_dup();
-            WORD_ATOM(156, 19, "args-end?");
+            WORD_ATOM(172, 19, "args-end?");
             mw_Token_2E_args_end_3F_();
-            WORD_ATOM(156, 29, "not");
+            WORD_ATOM(172, 29, "not");
             mw_Bool_2E_not();
             if (! pop_u64()) break;
-            WORD_ATOM(157, 13, "succ");
+            WORD_ATOM(173, 13, "succ");
             mw_Token_2E_succ();
-            WORD_ATOM(157, 18, "swap");
+            WORD_ATOM(173, 18, "swap");
             mw_prim_swap();
-            WORD_ATOM(158, 13, "dip");
+            WORD_ATOM(174, 13, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(158, 17, "elab-type-arg!");
+                WORD_ATOM(174, 17, "elab-type-arg!");
                 mw_elab_type_arg_21_();
                 push_value(d4);
             }
-            WORD_ATOM(158, 33, "swap");
+            WORD_ATOM(174, 33, "swap");
             mw_prim_swap();
-            WORD_ATOM(159, 13, "dip");
+            WORD_ATOM(175, 13, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(159, 17, "swap");
+                WORD_ATOM(175, 17, "swap");
                 mw_prim_swap();
-                WORD_ATOM(159, 22, "TApp");
+                WORD_ATOM(175, 22, "TApp");
                 mw_TApp();
                 push_value(d4);
             }
         }
-        WORD_ATOM(160, 9, "drop");
+        WORD_ATOM(176, 9, "drop");
         mw_prim_drop();
-        WORD_ATOM(160, 14, "dip");
+        WORD_ATOM(176, 14, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(160, 18, "swap");
+            WORD_ATOM(176, 18, "swap");
             mw_prim_swap();
             push_value(d3);
         }
     } else {
-        WORD_ATOM(162, 9, "id");
+        WORD_ATOM(178, 9, "id");
         mw_prim_id();
     }
     WORD_EXIT(mw_elab_type_args_21_);
 }
 static void mw_elab_type_hole_21_ (void){
-    WORD_ENTER(mw_elab_type_hole_21_, "elab-type-hole!", "src/mirth/elab.mth", 166, 5);
-    WORD_ATOM(166, 5, "over");
+    WORD_ENTER(mw_elab_type_hole_21_, "elab-type-hole!", "src/mirth/elab.mth", 182, 5);
+    WORD_ATOM(182, 5, "over");
     mw_over();
-    WORD_ATOM(166, 10, "type-elab-holes-allowed");
+    WORD_ATOM(182, 10, "type-elab-holes-allowed");
     mw_type_elab_holes_allowed();
-    WORD_ATOM(166, 34, "if");
+    WORD_ATOM(182, 34, "if");
     if (pop_u64()) {
-        WORD_ATOM(167, 9, "dup");
+        WORD_ATOM(183, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(167, 13, "args-0");
+        WORD_ATOM(183, 13, "args-0");
         mw_Token_2E_args_0();
-        WORD_ATOM(168, 9, "dup");
+        WORD_ATOM(184, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(168, 13, "name?");
+        WORD_ATOM(184, 13, "name?");
         mw_Token_2E_name_3F_();
-        WORD_ATOM(168, 19, "unwrap");
+        WORD_ATOM(184, 19, "unwrap");
         mw_Maybe_2E_unwrap();
-        WORD_ATOM(168, 26, "THole");
+        WORD_ATOM(184, 26, "THole");
         mw_THole();
-        WORD_ATOM(169, 9, "swap");
+        WORD_ATOM(185, 9, "swap");
         mw_prim_swap();
-        WORD_ATOM(169, 14, "next");
+        WORD_ATOM(185, 14, "next");
         mw_Token_2E_next();
     } else {
-        WORD_ATOM(170, 9, "");
+        WORD_ATOM(186, 9, "");
         {
             static bool vready = false;
             static VAL v;
@@ -19131,31 +19255,31 @@ static void mw_elab_type_hole_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(170, 43, "emit-fatal-error!");
+        WORD_ATOM(186, 43, "emit-fatal-error!");
         mw_emit_fatal_error_21_();
     }
     WORD_EXIT(mw_elab_type_hole_21_);
 }
 static void mw_elab_type_dont_care_21_ (void){
-    WORD_ENTER(mw_elab_type_dont_care_21_, "elab-type-dont-care!", "src/mirth/elab.mth", 174, 5);
-    WORD_ATOM(174, 5, "over");
+    WORD_ENTER(mw_elab_type_dont_care_21_, "elab-type-dont-care!", "src/mirth/elab.mth", 190, 5);
+    WORD_ATOM(190, 5, "over");
     mw_over();
-    WORD_ATOM(174, 10, "type-elab-holes-allowed");
+    WORD_ATOM(190, 10, "type-elab-holes-allowed");
     mw_type_elab_holes_allowed();
-    WORD_ATOM(174, 34, "if");
+    WORD_ATOM(190, 34, "if");
     if (pop_u64()) {
-        WORD_ATOM(175, 9, "dup");
+        WORD_ATOM(191, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(175, 13, "args-0");
+        WORD_ATOM(191, 13, "args-0");
         mw_Token_2E_args_0();
-        WORD_ATOM(176, 9, "TYPE_DONT_CARE");
+        WORD_ATOM(192, 9, "TYPE_DONT_CARE");
         mw_TYPE_5F_DONT_5F_CARE();
-        WORD_ATOM(177, 9, "swap");
+        WORD_ATOM(193, 9, "swap");
         mw_prim_swap();
-        WORD_ATOM(177, 14, "next");
+        WORD_ATOM(193, 14, "next");
         mw_Token_2E_next();
     } else {
-        WORD_ATOM(178, 9, "");
+        WORD_ATOM(194, 9, "");
         {
             static bool vready = false;
             static VAL v;
@@ -19166,48 +19290,48 @@ static void mw_elab_type_dont_care_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(178, 42, "emit-fatal-error!");
+        WORD_ATOM(194, 42, "emit-fatal-error!");
         mw_emit_fatal_error_21_();
     }
     WORD_EXIT(mw_elab_type_dont_care_21_);
 }
 static void mw_elab_type_quote_21_ (void){
-    WORD_ENTER(mw_elab_type_quote_21_, "elab-type-quote!", "src/mirth/elab.mth", 182, 5);
-    WORD_ATOM(182, 5, "args-1");
+    WORD_ENTER(mw_elab_type_quote_21_, "elab-type-quote!", "src/mirth/elab.mth", 198, 5);
+    WORD_ATOM(198, 5, "args-1");
     mw_Token_2E_args_1();
-    WORD_ATOM(182, 12, "dup");
+    WORD_ATOM(198, 12, "dup");
     mw_prim_dup();
-    WORD_ATOM(182, 16, "sig-has-dashes?");
+    WORD_ATOM(198, 16, "sig-has-dashes?");
     mw_Token_2E_sig_has_dashes_3F_();
-    WORD_ATOM(182, 32, "if");
+    WORD_ATOM(198, 32, "if");
     if (pop_u64()) {
-        WORD_ATOM(183, 9, "elab-type-sig!");
+        WORD_ATOM(199, 9, "elab-type-sig!");
         mw_elab_type_sig_21_();
-        WORD_ATOM(183, 24, "dip");
+        WORD_ATOM(199, 24, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(183, 28, ">Type");
+            WORD_ATOM(199, 28, ">Type");
             mw_ArrowType_3E_Type();
             push_value(d3);
         }
     } else {
-        WORD_ATOM(184, 9, "elab-type-stack!");
+        WORD_ATOM(200, 9, "elab-type-stack!");
         mw_elab_type_stack_21_();
-        WORD_ATOM(184, 26, "dip");
+        WORD_ATOM(200, 26, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(184, 30, ">Type");
+            WORD_ATOM(200, 30, ">Type");
             mw_StackType_3E_Type();
             push_value(d3);
         }
     }
-    WORD_ATOM(185, 7, "next");
+    WORD_ATOM(201, 7, "next");
     mw_Token_2E_next();
     WORD_EXIT(mw_elab_type_quote_21_);
 }
 static void mw_elab_type_unify_21_ (void){
-    WORD_ENTER(mw_elab_type_unify_21_, "elab-type-unify!", "src/mirth/elab.mth", 188, 5);
-    WORD_ATOM(188, 5, "sip");
+    WORD_ENTER(mw_elab_type_unify_21_, "elab-type-unify!", "src/mirth/elab.mth", 204, 5);
+    WORD_ATOM(204, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_type_unify_21__1);
     mw_prim_pack_cons();
@@ -19215,8 +19339,8 @@ static void mw_elab_type_unify_21_ (void){
     WORD_EXIT(mw_elab_type_unify_21_);
 }
 static void mw_elab_stack_type_unify_21_ (void){
-    WORD_ENTER(mw_elab_stack_type_unify_21_, "elab-stack-type-unify!", "src/mirth/elab.mth", 190, 5);
-    WORD_ATOM(190, 5, "sip");
+    WORD_ENTER(mw_elab_stack_type_unify_21_, "elab-stack-type-unify!", "src/mirth/elab.mth", 206, 5);
+    WORD_ATOM(206, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_stack_type_unify_21__1);
     mw_prim_pack_cons();
@@ -19224,93 +19348,93 @@ static void mw_elab_stack_type_unify_21_ (void){
     WORD_EXIT(mw_elab_stack_type_unify_21_);
 }
 static void mw_elab_simple_type_arg_21_ (void){
-    WORD_ENTER(mw_elab_simple_type_arg_21_, "elab-simple-type-arg!", "src/mirth/elab.mth", 193, 5);
-    WORD_ATOM(193, 5, "dip");
+    WORD_ENTER(mw_elab_simple_type_arg_21_, "elab-simple-type-arg!", "src/mirth/elab.mth", 209, 5);
+    WORD_ATOM(209, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(193, 9, "type-elab-default");
+        WORD_ATOM(209, 9, "type-elab-default");
         mw_type_elab_default();
         push_value(d2);
     }
-    WORD_ATOM(193, 28, "elab-type-arg!");
+    WORD_ATOM(209, 28, "elab-type-arg!");
     mw_elab_type_arg_21_();
-    WORD_ATOM(193, 43, "drop");
+    WORD_ATOM(209, 43, "drop");
     mw_prim_drop();
-    WORD_ATOM(193, 48, "nip");
+    WORD_ATOM(209, 48, "nip");
     mw_nip();
     WORD_EXIT(mw_elab_simple_type_arg_21_);
 }
 static void mw_ab_ctx (void){
-    WORD_ENTER(mw_ab_ctx, "ab-ctx", "src/mirth/elab.mth", 203, 23);
-    WORD_ATOM(203, 23, "ab-arrow");
+    WORD_ENTER(mw_ab_ctx, "ab-ctx", "src/mirth/elab.mth", 219, 23);
+    WORD_ATOM(219, 23, "ab-arrow");
     mw_ab_arrow();
-    WORD_ATOM(203, 32, "@");
+    WORD_ATOM(219, 32, "@");
     mw_prim_mut_get();
-    WORD_ATOM(203, 34, "~ctx");
+    WORD_ATOM(219, 34, "~ctx");
     mw_Arrow_7E_ctx();
     WORD_EXIT(mw_ab_ctx);
 }
 static void mw_ab_token (void){
-    WORD_ENTER(mw_ab_token, "ab-token", "src/mirth/elab.mth", 204, 27);
-    WORD_ATOM(204, 27, "ab-arrow");
+    WORD_ENTER(mw_ab_token, "ab-token", "src/mirth/elab.mth", 220, 27);
+    WORD_ATOM(220, 27, "ab-arrow");
     mw_ab_arrow();
-    WORD_ATOM(204, 36, "@");
+    WORD_ATOM(220, 36, "@");
     mw_prim_mut_get();
-    WORD_ATOM(204, 38, "~token-end");
+    WORD_ATOM(220, 38, "~token-end");
     mw_Arrow_7E_token_end();
     WORD_EXIT(mw_ab_token);
 }
 static void mw_ab_type (void){
-    WORD_ENTER(mw_ab_type, "ab-type", "src/mirth/elab.mth", 205, 30);
-    WORD_ATOM(205, 30, "ab-arrow");
+    WORD_ENTER(mw_ab_type, "ab-type", "src/mirth/elab.mth", 221, 30);
+    WORD_ATOM(221, 30, "ab-arrow");
     mw_ab_arrow();
-    WORD_ATOM(205, 39, "@");
+    WORD_ATOM(221, 39, "@");
     mw_prim_mut_get();
-    WORD_ATOM(205, 41, "~cod");
+    WORD_ATOM(221, 41, "~cod");
     mw_Arrow_7E_cod();
     WORD_EXIT(mw_ab_type);
 }
 static void mw_init_elab_21_ (void){
-    WORD_ENTER(mw_init_elab_21_, "init-elab!", "src/mirth/elab.mth", 208, 5);
-    WORD_ATOM(208, 5, "Arrow.nil");
+    WORD_ENTER(mw_init_elab_21_, "init-elab!", "src/mirth/elab.mth", 224, 5);
+    WORD_ATOM(224, 5, "Arrow.nil");
     mw_Arrow_2E_nil();
-    WORD_ATOM(208, 15, "ab-arrow");
+    WORD_ATOM(224, 15, "ab-arrow");
     mw_ab_arrow();
-    WORD_ATOM(208, 24, "!");
+    WORD_ATOM(224, 24, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_init_elab_21_);
 }
 static void mw_ab_save_21_ (void){
-    WORD_ENTER(mw_ab_save_21_, "ab-save!", "src/mirth/elab.mth", 211, 5);
-    WORD_ATOM(211, 5, "ab-arrow");
+    WORD_ENTER(mw_ab_save_21_, "ab-save!", "src/mirth/elab.mth", 227, 5);
+    WORD_ATOM(227, 5, "ab-arrow");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(211, 5, "ab-arrow");
+        WORD_ATOM(227, 5, "ab-arrow");
         mw_ab_arrow();
-        WORD_ATOM(211, 14, "@");
+        WORD_ATOM(227, 14, "@");
         mw_prim_mut_get();
-        WORD_ATOM(211, 16, "dip");
+        WORD_ATOM(227, 16, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(211, 20, "f");
+            WORD_ATOM(227, 20, "f");
             incref(var_f);
             run_value(var_f);
             push_value(d3);
         }
-        WORD_ATOM(211, 23, "ab-arrow");
+        WORD_ATOM(227, 23, "ab-arrow");
         mw_ab_arrow();
-        WORD_ATOM(211, 32, "!");
+        WORD_ATOM(227, 32, "!");
         mw_prim_mut_set();
         decref(var_f);
     }
     WORD_EXIT(mw_ab_save_21_);
 }
 static void mw_ab_build_21_ (void){
-    WORD_ENTER(mw_ab_build_21_, "ab-build!", "src/mirth/elab.mth", 214, 5);
-    WORD_ATOM(214, 5, "ab-save!");
+    WORD_ENTER(mw_ab_build_21_, "ab-build!", "src/mirth/elab.mth", 230, 5);
+    WORD_ATOM(230, 5, "ab-save!");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(214, 5, "ab-save!");
+        WORD_ATOM(230, 5, "ab-save!");
         push_u64(0);
         incref(var_f);
         push_value(var_f);
@@ -19323,20 +19447,20 @@ static void mw_ab_build_21_ (void){
     WORD_EXIT(mw_ab_build_21_);
 }
 static void mw_ab_build_hom_21_ (void){
-    WORD_ENTER(mw_ab_build_hom_21_, "ab-build-hom!", "src/mirth/elab.mth", 232, 5);
-    WORD_ATOM(232, 5, "dip");
+    WORD_ENTER(mw_ab_build_hom_21_, "ab-build-hom!", "src/mirth/elab.mth", 248, 5);
+    WORD_ATOM(248, 5, "dip");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(232, 5, "dip");
+        WORD_ATOM(248, 5, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(232, 9, "unpack");
+            WORD_ATOM(248, 9, "unpack");
             mw_ArrowType_2E_unpack();
-            WORD_ATOM(232, 16, "rotr");
+            WORD_ATOM(248, 16, "rotr");
             mw_rotr();
             push_value(d3);
         }
-        WORD_ATOM(233, 5, "ab-build!");
+        WORD_ATOM(249, 5, "ab-build!");
         push_u64(0);
         incref(var_f);
         push_value(var_f);
@@ -19349,25 +19473,25 @@ static void mw_ab_build_hom_21_ (void){
     WORD_EXIT(mw_ab_build_hom_21_);
 }
 static void mw_ab_build_word_arrow_21_ (void){
-    WORD_ENTER(mw_ab_build_word_arrow_21_, "ab-build-word-arrow!", "src/mirth/elab.mth", 235, 5);
-    WORD_ATOM(235, 5, "dup");
+    WORD_ENTER(mw_ab_build_word_arrow_21_, "ab-build-word-arrow!", "src/mirth/elab.mth", 251, 5);
+    WORD_ATOM(251, 5, "dup");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(235, 5, "dup");
+        WORD_ATOM(251, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(235, 9, "SOME");
+        WORD_ATOM(251, 9, "SOME");
         mw_SOME();
-        WORD_ATOM(235, 14, "ab-home");
+        WORD_ATOM(251, 14, "ab-home");
         mw_ab_home();
-        WORD_ATOM(235, 22, "!");
+        WORD_ATOM(251, 22, "!");
         mw_prim_mut_set();
-        WORD_ATOM(235, 24, "");
+        WORD_ATOM(251, 24, "");
         push_i64(0LL);
-        WORD_ATOM(235, 26, "ab-homeidx");
+        WORD_ATOM(251, 26, "ab-homeidx");
         mw_ab_homeidx();
-        WORD_ATOM(235, 37, "!");
+        WORD_ATOM(251, 37, "!");
         mw_prim_mut_set();
-        WORD_ATOM(236, 5, "sip");
+        WORD_ATOM(252, 5, "sip");
         push_u64(0);
         incref(var_f);
         push_value(var_f);
@@ -19375,28 +19499,28 @@ static void mw_ab_build_word_arrow_21_ (void){
         push_fnptr(&mb_ab_build_word_arrow_21__2);
         mw_prim_pack_cons();
         mw_sip();
-        WORD_ATOM(237, 5, "body");
+        WORD_ATOM(253, 5, "body");
         mw_Word_2E_body();
-        WORD_ATOM(237, 10, "ab-build-hom!");
+        WORD_ATOM(253, 10, "ab-build-hom!");
         incref(var_f);
         push_value(var_f);
         mw_ab_build_hom_21_();
-        WORD_ATOM(238, 5, "NONE");
+        WORD_ATOM(254, 5, "NONE");
         mw_NONE();
-        WORD_ATOM(238, 10, "ab-home");
+        WORD_ATOM(254, 10, "ab-home");
         mw_ab_home();
-        WORD_ATOM(238, 18, "!");
+        WORD_ATOM(254, 18, "!");
         mw_prim_mut_set();
         decref(var_f);
     }
     WORD_EXIT(mw_ab_build_word_arrow_21_);
 }
 static void mw_ab_build_word_21_ (void){
-    WORD_ENTER(mw_ab_build_word_21_, "ab-build-word!", "src/mirth/elab.mth", 240, 5);
-    WORD_ATOM(240, 5, "sip");
+    WORD_ENTER(mw_ab_build_word_21_, "ab-build-word!", "src/mirth/elab.mth", 256, 5);
+    WORD_ATOM(256, 5, "sip");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(240, 5, "sip");
+        WORD_ATOM(256, 5, "sip");
         push_u64(0);
         incref(var_f);
         push_value(var_f);
@@ -19404,241 +19528,241 @@ static void mw_ab_build_word_21_ (void){
         push_fnptr(&mb_ab_build_word_21__2);
         mw_prim_pack_cons();
         mw_sip();
-        WORD_ATOM(241, 5, "tuck");
+        WORD_ATOM(257, 5, "tuck");
         mw_tuck();
-        WORD_ATOM(241, 10, "~arrow");
+        WORD_ATOM(257, 10, "~arrow");
         mw_Word_7E_arrow();
-        WORD_ATOM(241, 17, "!");
+        WORD_ATOM(257, 17, "!");
         mw_prim_mut_set();
         decref(var_f);
     }
     WORD_EXIT(mw_ab_build_word_21_);
 }
 static void mw_ab_unify_type_21_ (void){
-    WORD_ENTER(mw_ab_unify_type_21_, "ab-unify-type!", "src/mirth/elab.mth", 244, 5);
-    WORD_ATOM(244, 5, "dip");
+    WORD_ENTER(mw_ab_unify_type_21_, "ab-unify-type!", "src/mirth/elab.mth", 260, 5);
+    WORD_ATOM(260, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(244, 9, "ab-token");
+        WORD_ATOM(260, 9, "ab-token");
         mw_ab_token();
-        WORD_ATOM(244, 18, "@");
+        WORD_ATOM(260, 18, "@");
         mw_prim_mut_get();
-        WORD_ATOM(244, 20, "GAMMA");
+        WORD_ATOM(260, 20, "GAMMA");
         mw_GAMMA();
-        WORD_ATOM(244, 26, "ab-type");
+        WORD_ATOM(260, 26, "ab-type");
         mw_ab_type();
-        WORD_ATOM(244, 34, "@");
+        WORD_ATOM(260, 34, "@");
         mw_prim_mut_get();
         push_value(d2);
     }
-    WORD_ATOM(244, 37, "unify!");
+    WORD_ATOM(260, 37, "unify!");
     mw_StackType_2E_unify_21_();
-    WORD_ATOM(244, 44, "ab-type");
+    WORD_ATOM(260, 44, "ab-type");
     mw_ab_type();
-    WORD_ATOM(244, 52, "!");
+    WORD_ATOM(260, 52, "!");
     mw_prim_mut_set();
-    WORD_ATOM(244, 54, "drop");
+    WORD_ATOM(260, 54, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_ab_unify_type_21_);
 }
 static void mw_ab_atom_21_ (void){
-    WORD_ENTER(mw_ab_atom_21_, "ab-atom!", "src/mirth/elab.mth", 247, 5);
-    WORD_ATOM(247, 5, "dup");
+    WORD_ENTER(mw_ab_atom_21_, "ab-atom!", "src/mirth/elab.mth", 263, 5);
+    WORD_ATOM(263, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(247, 9, "token");
+    WORD_ATOM(263, 9, "token");
     mw_Atom_2E_token();
-    WORD_ATOM(247, 15, "ab-token");
+    WORD_ATOM(263, 15, "ab-token");
     mw_ab_token();
-    WORD_ATOM(247, 24, "!");
+    WORD_ATOM(263, 24, "!");
     mw_prim_mut_set();
-    WORD_ATOM(251, 5, "dup");
+    WORD_ATOM(267, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(251, 9, "cod");
+    WORD_ATOM(267, 9, "cod");
     mw_Atom_2E_cod();
-    WORD_ATOM(251, 13, "ab-type");
+    WORD_ATOM(267, 13, "ab-type");
     mw_ab_type();
-    WORD_ATOM(251, 21, "!");
+    WORD_ATOM(267, 21, "!");
     mw_prim_mut_set();
-    WORD_ATOM(252, 5, "dip");
+    WORD_ATOM(268, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(252, 9, "ab-arrow");
+        WORD_ATOM(268, 9, "ab-arrow");
         mw_ab_arrow();
-        WORD_ATOM(252, 18, "@");
+        WORD_ATOM(268, 18, "@");
         mw_prim_mut_get();
-        WORD_ATOM(252, 20, "atoms");
+        WORD_ATOM(268, 20, "atoms");
         mw_Arrow_2E_atoms();
         push_value(d2);
     }
-    WORD_ATOM(253, 5, "ab-optimized-snoc!");
+    WORD_ATOM(269, 5, "ab-optimized-snoc!");
     mw_ab_optimized_snoc_21_();
-    WORD_ATOM(254, 5, "ab-arrow");
+    WORD_ATOM(270, 5, "ab-arrow");
     mw_ab_arrow();
-    WORD_ATOM(254, 14, "@");
+    WORD_ATOM(270, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(254, 16, "~atoms");
+    WORD_ATOM(270, 16, "~atoms");
     mw_Arrow_7E_atoms();
-    WORD_ATOM(254, 23, "!");
+    WORD_ATOM(270, 23, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_ab_atom_21_);
 }
 static void mw_ab_optimized_snoc_21_ (void){
-    WORD_ENTER(mw_ab_optimized_snoc_21_, "ab-optimized-snoc!", "src/mirth/elab.mth", 258, 5);
-    WORD_ATOM(258, 5, "while");
+    WORD_ENTER(mw_ab_optimized_snoc_21_, "ab-optimized-snoc!", "src/mirth/elab.mth", 274, 5);
+    WORD_ATOM(274, 5, "while");
     while(1) {
-        WORD_ATOM(258, 11, "dip?");
+        WORD_ATOM(274, 11, "dip?");
         push_u64(0);
         push_fnptr(&mb_ab_optimized_snoc_21__2);
         mw_prim_pack_cons();
         mw_dip_3F_();
-        WORD_ATOM(258, 39, "and");
+        WORD_ATOM(274, 39, "and");
         push_u64(0);
         push_fnptr(&mb_ab_optimized_snoc_21__3);
         mw_prim_pack_cons();
         mw_Bool_2E_and();
         if (! pop_u64()) break;
-        WORD_ATOM(259, 9, "swap");
+        WORD_ATOM(275, 9, "swap");
         mw_prim_swap();
-        WORD_ATOM(259, 14, "atoms-turn-last-block-to-arg");
+        WORD_ATOM(275, 14, "atoms-turn-last-block-to-arg");
         mw_atoms_turn_last_block_to_arg();
-        WORD_ATOM(259, 43, "swap");
+        WORD_ATOM(275, 43, "swap");
         mw_prim_swap();
     }
-    WORD_ATOM(260, 5, "snoc");
+    WORD_ATOM(276, 5, "snoc");
     mw_snoc();
     WORD_EXIT(mw_ab_optimized_snoc_21_);
 }
 static void mw_atom_accepts_args_3F_ (void){
-    WORD_ENTER(mw_atom_accepts_args_3F_, "atom-accepts-args?", "src/mirth/elab.mth", 263, 5);
-    WORD_ATOM(263, 5, "dup");
+    WORD_ENTER(mw_atom_accepts_args_3F_, "atom-accepts-args?", "src/mirth/elab.mth", 279, 5);
+    WORD_ATOM(279, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(263, 9, "op");
+    WORD_ATOM(279, 9, "op");
     mw_Atom_2E_op();
-    WORD_ATOM(263, 12, "match");
+    WORD_ATOM(279, 12, "match");
     switch (get_top_data_tag()) {
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(264, 20, "dip");
+            WORD_ATOM(280, 20, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(264, 24, "dup");
+                WORD_ATOM(280, 24, "dup");
                 mw_prim_dup();
-                WORD_ATOM(264, 28, "args");
+                WORD_ATOM(280, 28, "args");
                 mw_Atom_2E_args();
-                WORD_ATOM(264, 33, "len");
+                WORD_ATOM(280, 33, "len");
                 mw_List_2E_len();
                 push_value(d4);
             }
-            WORD_ATOM(264, 38, "type");
+            WORD_ATOM(280, 38, "type");
             mw_Word_2E_type();
-            WORD_ATOM(264, 43, "max-num-params");
+            WORD_ATOM(280, 43, "max-num-params");
             mw_ArrowType_2E_max_num_params();
-            WORD_ATOM(264, 58, "<");
+            WORD_ATOM(280, 58, "<");
             mw_prim_int_lt();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(266, 13, "match");
+            WORD_ATOM(282, 13, "match");
             switch (get_top_data_tag()) {
                 case 9LL:
                     mw_prim_drop();
-                    WORD_ATOM(267, 34, "dup");
+                    WORD_ATOM(283, 34, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(267, 38, "args");
+                    WORD_ATOM(283, 38, "args");
                     mw_Atom_2E_args();
-                    WORD_ATOM(267, 43, "len");
+                    WORD_ATOM(283, 43, "len");
                     mw_List_2E_len();
-                    WORD_ATOM(267, 47, "");
+                    WORD_ATOM(283, 47, "");
                     push_i64(1LL);
-                    WORD_ATOM(267, 49, "<");
+                    WORD_ATOM(283, 49, "<");
                     mw_prim_int_lt();
                     break;
                 case 4LL:
                     mw_prim_drop();
-                    WORD_ATOM(268, 34, "dup");
+                    WORD_ATOM(284, 34, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(268, 38, "args");
+                    WORD_ATOM(284, 38, "args");
                     mw_Atom_2E_args();
-                    WORD_ATOM(268, 43, "len");
+                    WORD_ATOM(284, 43, "len");
                     mw_List_2E_len();
-                    WORD_ATOM(268, 47, "");
+                    WORD_ATOM(284, 47, "");
                     push_i64(1LL);
-                    WORD_ATOM(268, 49, "<");
+                    WORD_ATOM(284, 49, "<");
                     mw_prim_int_lt();
                     break;
                 case 5LL:
                     mw_prim_drop();
-                    WORD_ATOM(269, 33, "dup");
+                    WORD_ATOM(285, 33, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(269, 37, "args");
+                    WORD_ATOM(285, 37, "args");
                     mw_Atom_2E_args();
-                    WORD_ATOM(269, 42, "len");
+                    WORD_ATOM(285, 42, "len");
                     mw_List_2E_len();
-                    WORD_ATOM(269, 46, "");
+                    WORD_ATOM(285, 46, "");
                     push_i64(2LL);
-                    WORD_ATOM(269, 48, "<");
+                    WORD_ATOM(285, 48, "<");
                     mw_prim_int_lt();
                     break;
                 case 6LL:
                     mw_prim_drop();
-                    WORD_ATOM(270, 36, "dup");
+                    WORD_ATOM(286, 36, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(270, 40, "args");
+                    WORD_ATOM(286, 40, "args");
                     mw_Atom_2E_args();
-                    WORD_ATOM(270, 45, "len");
+                    WORD_ATOM(286, 45, "len");
                     mw_List_2E_len();
-                    WORD_ATOM(270, 49, "");
+                    WORD_ATOM(286, 49, "");
                     push_i64(2LL);
-                    WORD_ATOM(270, 51, "<");
+                    WORD_ATOM(286, 51, "<");
                     mw_prim_int_lt();
                     break;
                 default:
-                    WORD_ATOM(271, 22, "drop");
+                    WORD_ATOM(287, 22, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(271, 27, "F");
+                    WORD_ATOM(287, 27, "F");
                     mw_F();
                     break;
             
 }            break;
         default:
-            WORD_ATOM(273, 14, "drop");
+            WORD_ATOM(289, 14, "drop");
             mw_prim_drop();
-            WORD_ATOM(273, 19, "F");
+            WORD_ATOM(289, 19, "F");
             mw_F();
             break;
     
 }    WORD_EXIT(mw_atom_accepts_args_3F_);
 }
 static void mw_atoms_has_last_block_3F_ (void){
-    WORD_ENTER(mw_atoms_has_last_block_3F_, "atoms-has-last-block?", "src/mirth/elab.mth", 277, 5);
-    WORD_ATOM(277, 5, "dup");
+    WORD_ENTER(mw_atoms_has_last_block_3F_, "atoms-has-last-block?", "src/mirth/elab.mth", 293, 5);
+    WORD_ATOM(293, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(277, 9, "last");
+    WORD_ATOM(293, 9, "last");
     mw_last();
-    WORD_ATOM(277, 14, "match");
+    WORD_ATOM(293, 14, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(278, 17, "F");
+            WORD_ATOM(294, 17, "F");
             mw_F();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(280, 13, "op");
+            WORD_ATOM(296, 13, "op");
             mw_Atom_2E_op();
-            WORD_ATOM(280, 16, "match");
+            WORD_ATOM(296, 16, "match");
             switch (get_top_data_tag()) {
                 case 14LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(281, 29, "drop");
+                    WORD_ATOM(297, 29, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(281, 34, "T");
+                    WORD_ATOM(297, 34, "T");
                     mw_T();
                     break;
                 default:
-                    WORD_ATOM(282, 22, "drop");
+                    WORD_ATOM(298, 22, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(282, 27, "F");
+                    WORD_ATOM(298, 27, "F");
                     mw_F();
                     break;
             
@@ -19648,56 +19772,56 @@ static void mw_atoms_has_last_block_3F_ (void){
 }    WORD_EXIT(mw_atoms_has_last_block_3F_);
 }
 static void mw_atoms_turn_last_block_to_arg (void){
-    WORD_ENTER(mw_atoms_turn_last_block_to_arg, "atoms-turn-last-block-to-arg", "src/mirth/elab.mth", 287, 5);
-    WORD_ATOM(287, 5, ">List+");
+    WORD_ENTER(mw_atoms_turn_last_block_to_arg, "atoms-turn-last-block-to-arg", "src/mirth/elab.mth", 303, 5);
+    WORD_ATOM(303, 5, ">List+");
     mw_List_3E_List_2B_();
-    WORD_ATOM(287, 12, "match");
+    WORD_ATOM(303, 12, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(288, 17, "L0");
+            WORD_ATOM(304, 17, "L0");
             mw_L0();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(290, 13, "unsnoc");
+            WORD_ATOM(306, 13, "unsnoc");
             mw_List_2B__2E_unsnoc();
-            WORD_ATOM(290, 20, "dup");
+            WORD_ATOM(306, 20, "dup");
             mw_prim_dup();
-            WORD_ATOM(290, 24, "op");
+            WORD_ATOM(306, 24, "op");
             mw_Atom_2E_op();
-            WORD_ATOM(290, 27, "match");
+            WORD_ATOM(306, 27, "match");
             switch (get_top_data_tag()) {
                 case 14LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(293, 21, "dip");
+                    WORD_ATOM(309, 21, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(293, 25, "cod");
+                        WORD_ATOM(309, 25, "cod");
                         mw_Atom_2E_cod();
-                        WORD_ATOM(293, 29, "rotl");
+                        WORD_ATOM(309, 29, "rotl");
                         mw_rotl();
-                        WORD_ATOM(293, 34, "tuck");
+                        WORD_ATOM(309, 34, "tuck");
                         mw_tuck();
-                        WORD_ATOM(293, 39, "~dom");
+                        WORD_ATOM(309, 39, "~dom");
                         mw_Atom_7E_dom();
-                        WORD_ATOM(293, 44, "!");
+                        WORD_ATOM(309, 44, "!");
                         mw_prim_mut_set();
                         push_value(d6);
                     }
-                    WORD_ATOM(295, 21, "ARG_BLOCK");
+                    WORD_ATOM(311, 21, "ARG_BLOCK");
                     mw_ARG_5F_BLOCK();
-                    WORD_ATOM(295, 31, "over");
+                    WORD_ATOM(311, 31, "over");
                     mw_over();
-                    WORD_ATOM(295, 36, "add-arg-left!");
+                    WORD_ATOM(311, 36, "add-arg-left!");
                     mw_Atom_2E_add_arg_left_21_();
-                    WORD_ATOM(296, 21, "swap");
+                    WORD_ATOM(312, 21, "swap");
                     mw_prim_swap();
                     break;
                 default:
-                    WORD_ATOM(297, 22, "drop");
+                    WORD_ATOM(313, 22, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(297, 27, "snoc");
+                    WORD_ATOM(313, 27, "snoc");
                     mw_snoc();
                     break;
             
@@ -19707,193 +19831,193 @@ static void mw_atoms_turn_last_block_to_arg (void){
 }    WORD_EXIT(mw_atoms_turn_last_block_to_arg);
 }
 static void mw_block_to_run_var (void){
-    WORD_ENTER(mw_block_to_run_var, "block-to-run-var", "src/mirth/elab.mth", 302, 5);
-    WORD_ATOM(302, 5, "arrow");
+    WORD_ENTER(mw_block_to_run_var, "block-to-run-var", "src/mirth/elab.mth", 318, 5);
+    WORD_ATOM(318, 5, "arrow");
     mw_Block_2E_arrow();
-    WORD_ATOM(302, 11, "arrow-to-run-var");
+    WORD_ATOM(318, 11, "arrow-to-run-var");
     mw_arrow_to_run_var();
     WORD_EXIT(mw_block_to_run_var);
 }
 static void mw_arrow_to_run_var (void){
-    WORD_ENTER(mw_arrow_to_run_var, "arrow-to-run-var", "src/mirth/elab.mth", 305, 5);
-    WORD_ATOM(305, 5, "atoms");
+    WORD_ENTER(mw_arrow_to_run_var, "arrow-to-run-var", "src/mirth/elab.mth", 321, 5);
+    WORD_ATOM(321, 5, "atoms");
     mw_Arrow_2E_atoms();
-    WORD_ATOM(305, 11, "match");
+    WORD_ATOM(321, 11, "match");
     switch (get_top_data_tag()) {
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(306, 15, "atom-to-run-var");
+            WORD_ATOM(322, 15, "atom-to-run-var");
             mw_atom_to_run_var();
             break;
         default:
-            WORD_ATOM(307, 14, "drop");
+            WORD_ATOM(323, 14, "drop");
             mw_prim_drop();
-            WORD_ATOM(307, 19, "NONE");
+            WORD_ATOM(323, 19, "NONE");
             mw_NONE();
             break;
     
 }    WORD_EXIT(mw_arrow_to_run_var);
 }
 static void mw_atom_to_run_var (void){
-    WORD_ENTER(mw_atom_to_run_var, "atom-to-run-var", "src/mirth/elab.mth", 311, 5);
-    WORD_ATOM(311, 5, "op");
+    WORD_ENTER(mw_atom_to_run_var, "atom-to-run-var", "src/mirth/elab.mth", 327, 5);
+    WORD_ATOM(327, 5, "op");
     mw_Atom_2E_op();
-    WORD_ATOM(311, 8, "match");
+    WORD_ATOM(327, 8, "match");
     switch (get_top_data_tag()) {
         case 13LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(312, 19, "dup");
+            WORD_ATOM(328, 19, "dup");
             mw_prim_dup();
-            WORD_ATOM(312, 23, "auto-run?");
+            WORD_ATOM(328, 23, "auto-run?");
             mw_Var_2E_auto_run_3F_();
-            WORD_ATOM(312, 33, "if");
+            WORD_ATOM(328, 33, "if");
             if (pop_u64()) {
-                WORD_ATOM(312, 36, "SOME");
+                WORD_ATOM(328, 36, "SOME");
                 mw_SOME();
             } else {
-                WORD_ATOM(312, 42, "drop");
+                WORD_ATOM(328, 42, "drop");
                 mw_prim_drop();
-                WORD_ATOM(312, 47, "NONE");
+                WORD_ATOM(328, 47, "NONE");
                 mw_NONE();
             }
             break;
         default:
-            WORD_ATOM(313, 14, "drop");
+            WORD_ATOM(329, 14, "drop");
             mw_prim_drop();
-            WORD_ATOM(313, 19, "NONE");
+            WORD_ATOM(329, 19, "NONE");
             mw_NONE();
             break;
     
 }    WORD_EXIT(mw_atom_to_run_var);
 }
 static void mw_ab_op_21_ (void){
-    WORD_ENTER(mw_ab_op_21_, "ab-op!", "src/mirth/elab.mth", 317, 5);
-    WORD_ATOM(317, 5, "Atom.alloc!");
+    WORD_ENTER(mw_ab_op_21_, "ab-op!", "src/mirth/elab.mth", 333, 5);
+    WORD_ATOM(333, 5, "Atom.alloc!");
     mw_Atom_2E_alloc_21_();
-    WORD_ATOM(318, 5, "ab-ctx");
+    WORD_ATOM(334, 5, "ab-ctx");
     mw_ab_ctx();
-    WORD_ATOM(318, 12, "@");
+    WORD_ATOM(334, 12, "@");
     mw_prim_mut_get();
-    WORD_ATOM(318, 14, "over");
+    WORD_ATOM(334, 14, "over");
     mw_over();
-    WORD_ATOM(318, 19, "~ctx");
+    WORD_ATOM(334, 19, "~ctx");
     mw_Atom_7E_ctx();
-    WORD_ATOM(318, 24, "!");
+    WORD_ATOM(334, 24, "!");
     mw_prim_mut_set();
-    WORD_ATOM(319, 5, "ab-token");
+    WORD_ATOM(335, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(319, 14, "@");
+    WORD_ATOM(335, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(319, 16, "over");
+    WORD_ATOM(335, 16, "over");
     mw_over();
-    WORD_ATOM(319, 21, "~token");
+    WORD_ATOM(335, 21, "~token");
     mw_Atom_7E_token();
-    WORD_ATOM(319, 28, "!");
+    WORD_ATOM(335, 28, "!");
     mw_prim_mut_set();
-    WORD_ATOM(320, 5, "dup2");
+    WORD_ATOM(336, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(320, 10, "~op");
+    WORD_ATOM(336, 10, "~op");
     mw_Atom_7E_op();
-    WORD_ATOM(320, 14, "!");
+    WORD_ATOM(336, 14, "!");
     mw_prim_mut_set();
-    WORD_ATOM(321, 5, "swap");
+    WORD_ATOM(337, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(321, 10, "elab-op-fresh-sig!");
+    WORD_ATOM(337, 10, "elab-op-fresh-sig!");
     mw_elab_op_fresh_sig_21_();
-    WORD_ATOM(322, 5, "dip");
+    WORD_ATOM(338, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(322, 9, "over");
+        WORD_ATOM(338, 9, "over");
         mw_over();
-        WORD_ATOM(322, 14, "~subst");
+        WORD_ATOM(338, 14, "~subst");
         mw_Atom_7E_subst();
-        WORD_ATOM(322, 21, "!");
+        WORD_ATOM(338, 21, "!");
         mw_prim_mut_set();
         push_value(d2);
     }
-    WORD_ATOM(323, 5, "ab-expand-opsig!");
+    WORD_ATOM(339, 5, "ab-expand-opsig!");
     mw_ab_expand_opsig_21_();
-    WORD_ATOM(324, 5, "dip");
+    WORD_ATOM(340, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(324, 9, "over");
+        WORD_ATOM(340, 9, "over");
         mw_over();
-        WORD_ATOM(324, 14, "~dom");
+        WORD_ATOM(340, 14, "~dom");
         mw_Atom_7E_dom();
-        WORD_ATOM(324, 19, "!");
+        WORD_ATOM(340, 19, "!");
         mw_prim_mut_set();
         push_value(d2);
     }
-    WORD_ATOM(324, 22, "over");
+    WORD_ATOM(340, 22, "over");
     mw_over();
-    WORD_ATOM(324, 27, "~cod");
+    WORD_ATOM(340, 27, "~cod");
     mw_Atom_7E_cod();
-    WORD_ATOM(324, 32, "!");
+    WORD_ATOM(340, 32, "!");
     mw_prim_mut_set();
-    WORD_ATOM(325, 5, "L0");
+    WORD_ATOM(341, 5, "L0");
     mw_L0();
-    WORD_ATOM(325, 8, "over");
+    WORD_ATOM(341, 8, "over");
     mw_over();
-    WORD_ATOM(325, 13, "~args");
+    WORD_ATOM(341, 13, "~args");
     mw_Atom_7E_args();
-    WORD_ATOM(325, 19, "!");
+    WORD_ATOM(341, 19, "!");
     mw_prim_mut_set();
-    WORD_ATOM(326, 5, "ab-atom!");
+    WORD_ATOM(342, 5, "ab-atom!");
     mw_ab_atom_21_();
     WORD_EXIT(mw_ab_op_21_);
 }
 static void mw_ab_expand_opsig_21_ (void){
-    WORD_ENTER(mw_ab_expand_opsig_21_, "ab-expand-opsig!", "src/mirth/elab.mth", 329, 5);
-    WORD_ATOM(329, 5, "OPSIG_ID");
+    WORD_ENTER(mw_ab_expand_opsig_21_, "ab-expand-opsig!", "src/mirth/elab.mth", 345, 5);
+    WORD_ATOM(345, 5, "OPSIG_ID");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(329, 17, "ab-type");
+            WORD_ATOM(345, 17, "ab-type");
             mw_ab_type();
-            WORD_ATOM(329, 25, "@");
+            WORD_ATOM(345, 25, "@");
             mw_prim_mut_get();
-            WORD_ATOM(329, 27, "dup");
+            WORD_ATOM(345, 27, "dup");
             mw_prim_dup();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(330, 19, "dip");
+            WORD_ATOM(346, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(330, 23, "ab-type");
+                WORD_ATOM(346, 23, "ab-type");
                 mw_ab_type();
-                WORD_ATOM(330, 31, "@");
+                WORD_ATOM(346, 31, "@");
                 mw_prim_mut_get();
-                WORD_ATOM(330, 33, "dup");
+                WORD_ATOM(346, 33, "dup");
                 mw_prim_dup();
                 push_value(d4);
             }
-            WORD_ATOM(330, 38, "STCons");
+            WORD_ATOM(346, 38, "STCons");
             mw_STCons();
             break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(332, 9, "dip");
+            WORD_ATOM(348, 9, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(332, 13, "ab-type");
+                WORD_ATOM(348, 13, "ab-type");
                 mw_ab_type();
-                WORD_ATOM(332, 21, "@");
+                WORD_ATOM(348, 21, "@");
                 mw_prim_mut_get();
                 push_value(d4);
             }
-            WORD_ATOM(332, 24, "unpack");
+            WORD_ATOM(348, 24, "unpack");
             mw_ArrowType_2E_unpack();
-            WORD_ATOM(333, 9, "dip");
+            WORD_ATOM(349, 9, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(333, 13, "ab-token");
+                WORD_ATOM(349, 13, "ab-token");
                 mw_ab_token();
-                WORD_ATOM(333, 22, "@");
+                WORD_ATOM(349, 22, "@");
                 mw_prim_mut_get();
-                WORD_ATOM(333, 24, "elab-stack-type-unify!");
+                WORD_ATOM(349, 24, "elab-stack-type-unify!");
                 mw_elab_stack_type_unify_21_();
-                WORD_ATOM(333, 47, "drop");
+                WORD_ATOM(349, 47, "drop");
                 mw_prim_drop();
                 push_value(d4);
             }
@@ -19903,89 +20027,89 @@ static void mw_ab_expand_opsig_21_ (void){
 }    WORD_EXIT(mw_ab_expand_opsig_21_);
 }
 static void mw_ab_int_21_ (void){
-    WORD_ENTER(mw_ab_int_21_, "ab-int!", "src/mirth/elab.mth", 335, 22);
-    WORD_ATOM(335, 22, "OP_INT");
+    WORD_ENTER(mw_ab_int_21_, "ab-int!", "src/mirth/elab.mth", 351, 22);
+    WORD_ATOM(351, 22, "OP_INT");
     mw_OP_5F_INT();
-    WORD_ATOM(335, 29, "ab-op!");
+    WORD_ATOM(351, 29, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_int_21_);
 }
 static void mw_ab_str_21_ (void){
-    WORD_ENTER(mw_ab_str_21_, "ab-str!", "src/mirth/elab.mth", 336, 22);
-    WORD_ATOM(336, 22, "OP_STR");
+    WORD_ENTER(mw_ab_str_21_, "ab-str!", "src/mirth/elab.mth", 352, 22);
+    WORD_ATOM(352, 22, "OP_STR");
     mw_OP_5F_STR();
-    WORD_ATOM(336, 29, "ab-op!");
+    WORD_ATOM(352, 29, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_str_21_);
 }
 static void mw_ab_buffer_21_ (void){
-    WORD_ENTER(mw_ab_buffer_21_, "ab-buffer!", "src/mirth/elab.mth", 337, 28);
-    WORD_ATOM(337, 28, "OP_BUFFER");
+    WORD_ENTER(mw_ab_buffer_21_, "ab-buffer!", "src/mirth/elab.mth", 353, 28);
+    WORD_ATOM(353, 28, "OP_BUFFER");
     mw_OP_5F_BUFFER();
-    WORD_ATOM(337, 38, "ab-op!");
+    WORD_ATOM(353, 38, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_buffer_21_);
 }
 static void mw_ab_variable_21_ (void){
-    WORD_ENTER(mw_ab_variable_21_, "ab-variable!", "src/mirth/elab.mth", 338, 32);
-    WORD_ATOM(338, 32, "OP_VARIABLE");
+    WORD_ENTER(mw_ab_variable_21_, "ab-variable!", "src/mirth/elab.mth", 354, 32);
+    WORD_ATOM(354, 32, "OP_VARIABLE");
     mw_OP_5F_VARIABLE();
-    WORD_ATOM(338, 44, "ab-op!");
+    WORD_ATOM(354, 44, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_variable_21_);
 }
 static void mw_ab_constant_21_ (void){
-    WORD_ENTER(mw_ab_constant_21_, "ab-constant!", "src/mirth/elab.mth", 339, 32);
-    WORD_ATOM(339, 32, "OP_CONSTANT");
+    WORD_ENTER(mw_ab_constant_21_, "ab-constant!", "src/mirth/elab.mth", 355, 32);
+    WORD_ATOM(355, 32, "OP_CONSTANT");
     mw_OP_5F_CONSTANT();
-    WORD_ATOM(339, 44, "ab-op!");
+    WORD_ATOM(355, 44, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_constant_21_);
 }
 static void mw_ab_field_21_ (void){
-    WORD_ENTER(mw_ab_field_21_, "ab-field!", "src/mirth/elab.mth", 340, 26);
-    WORD_ATOM(340, 26, "OP_FIELD");
+    WORD_ENTER(mw_ab_field_21_, "ab-field!", "src/mirth/elab.mth", 356, 26);
+    WORD_ATOM(356, 26, "OP_FIELD");
     mw_OP_5F_FIELD();
-    WORD_ATOM(340, 35, "ab-op!");
+    WORD_ATOM(356, 35, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_field_21_);
 }
 static void mw_ab_var_21_ (void){
-    WORD_ENTER(mw_ab_var_21_, "ab-var!", "src/mirth/elab.mth", 341, 22);
-    WORD_ATOM(341, 22, "OP_VAR");
+    WORD_ENTER(mw_ab_var_21_, "ab-var!", "src/mirth/elab.mth", 357, 22);
+    WORD_ATOM(357, 22, "OP_VAR");
     mw_OP_5F_VAR();
-    WORD_ATOM(341, 29, "ab-op!");
+    WORD_ATOM(357, 29, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_var_21_);
 }
 static void mw_ab_tag_21_ (void){
-    WORD_ENTER(mw_ab_tag_21_, "ab-tag!", "src/mirth/elab.mth", 342, 22);
-    WORD_ATOM(342, 22, "OP_TAG");
+    WORD_ENTER(mw_ab_tag_21_, "ab-tag!", "src/mirth/elab.mth", 358, 22);
+    WORD_ATOM(358, 22, "OP_TAG");
     mw_OP_5F_TAG();
-    WORD_ATOM(342, 29, "ab-op!");
+    WORD_ATOM(358, 29, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_tag_21_);
 }
 static void mw_ab_prim_21_ (void){
-    WORD_ENTER(mw_ab_prim_21_, "ab-prim!", "src/mirth/elab.mth", 344, 5);
-    WORD_ATOM(344, 5, "dup");
+    WORD_ENTER(mw_ab_prim_21_, "ab-prim!", "src/mirth/elab.mth", 360, 5);
+    WORD_ATOM(360, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(344, 9, "~type");
+    WORD_ATOM(360, 9, "~type");
     mw_Prim_7E_type();
-    WORD_ATOM(344, 15, "mut-is-set");
+    WORD_ATOM(360, 15, "mut-is-set");
     mw_prim_mut_is_set();
-    WORD_ATOM(344, 26, "if");
+    WORD_ATOM(360, 26, "if");
     if (pop_u64()) {
-        WORD_ATOM(345, 9, "OP_PRIM");
+        WORD_ATOM(361, 9, "OP_PRIM");
         mw_OP_5F_PRIM();
-        WORD_ATOM(345, 17, "ab-op!");
+        WORD_ATOM(361, 17, "ab-op!");
         mw_ab_op_21_();
     } else {
-        WORD_ATOM(346, 9, "ab-token");
+        WORD_ATOM(362, 9, "ab-token");
         mw_ab_token();
-        WORD_ATOM(346, 18, "@");
+        WORD_ATOM(362, 18, "@");
         mw_prim_mut_get();
-        WORD_ATOM(346, 20, "");
+        WORD_ATOM(362, 20, "");
         {
             static bool vready = false;
             static VAL v;
@@ -19996,66 +20120,66 @@ static void mw_ab_prim_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(346, 46, "emit-fatal-error!");
+        WORD_ATOM(362, 46, "emit-fatal-error!");
         mw_emit_fatal_error_21_();
     }
     WORD_EXIT(mw_ab_prim_21_);
 }
 static void mw_ab_word_21_ (void){
-    WORD_ENTER(mw_ab_word_21_, "ab-word!", "src/mirth/elab.mth", 348, 24);
-    WORD_ATOM(348, 24, "OP_WORD");
+    WORD_ENTER(mw_ab_word_21_, "ab-word!", "src/mirth/elab.mth", 364, 24);
+    WORD_ATOM(364, 24, "OP_WORD");
     mw_OP_5F_WORD();
-    WORD_ATOM(348, 32, "ab-op!");
+    WORD_ATOM(364, 32, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_word_21_);
 }
 static void mw_ab_external_21_ (void){
-    WORD_ENTER(mw_ab_external_21_, "ab-external!", "src/mirth/elab.mth", 349, 32);
-    WORD_ATOM(349, 32, "OP_EXTERNAL");
+    WORD_ENTER(mw_ab_external_21_, "ab-external!", "src/mirth/elab.mth", 365, 32);
+    WORD_ATOM(365, 32, "OP_EXTERNAL");
     mw_OP_5F_EXTERNAL();
-    WORD_ATOM(349, 44, "ab-op!");
+    WORD_ATOM(365, 44, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_ab_external_21_);
 }
 static void mw_ab_block_at_21_ (void){
-    WORD_ENTER(mw_ab_block_at_21_, "ab-block-at!", "src/mirth/elab.mth", 352, 5);
-    WORD_ATOM(352, 5, "ab-ctx");
+    WORD_ENTER(mw_ab_block_at_21_, "ab-block-at!", "src/mirth/elab.mth", 368, 5);
+    WORD_ATOM(368, 5, "ab-ctx");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(352, 5, "ab-ctx");
+        WORD_ATOM(368, 5, "ab-ctx");
         mw_ab_ctx();
-        WORD_ATOM(352, 12, "@");
+        WORD_ATOM(368, 12, "@");
         mw_prim_mut_get();
-        WORD_ATOM(352, 14, "MetaVar.new!");
+        WORD_ATOM(368, 14, "MetaVar.new!");
         mw_MetaVar_2E_new_21_();
-        WORD_ATOM(352, 27, "STMeta");
+        WORD_ATOM(368, 27, "STMeta");
         mw_STMeta();
-        WORD_ATOM(352, 34, "rotl");
+        WORD_ATOM(368, 34, "rotl");
         mw_rotl();
-        WORD_ATOM(352, 39, "ab-build!");
+        WORD_ATOM(368, 39, "ab-build!");
         incref(var_f);
         push_value(var_f);
         mw_ab_build_21_();
-        WORD_ATOM(353, 5, "Block.new!");
+        WORD_ATOM(369, 5, "Block.new!");
         mw_Block_2E_new_21_();
-        WORD_ATOM(353, 16, "OP_BLOCK");
+        WORD_ATOM(369, 16, "OP_BLOCK");
         mw_OP_5F_BLOCK();
-        WORD_ATOM(353, 25, "ab-op!");
+        WORD_ATOM(369, 25, "ab-op!");
         mw_ab_op_21_();
         decref(var_f);
     }
     WORD_EXIT(mw_ab_block_at_21_);
 }
 static void mw_ab_block_21_ (void){
-    WORD_ENTER(mw_ab_block_21_, "ab-block!", "src/mirth/elab.mth", 356, 5);
-    WORD_ATOM(356, 5, "ab-token");
+    WORD_ENTER(mw_ab_block_21_, "ab-block!", "src/mirth/elab.mth", 372, 5);
+    WORD_ATOM(372, 5, "ab-token");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(356, 5, "ab-token");
+        WORD_ATOM(372, 5, "ab-token");
         mw_ab_token();
-        WORD_ATOM(356, 14, "@");
+        WORD_ATOM(372, 14, "@");
         mw_prim_mut_get();
-        WORD_ATOM(356, 16, "ab-block-at!");
+        WORD_ATOM(372, 16, "ab-block-at!");
         incref(var_f);
         push_value(var_f);
         mw_ab_block_at_21_();
@@ -20064,39 +20188,39 @@ static void mw_ab_block_21_ (void){
     WORD_EXIT(mw_ab_block_21_);
 }
 static void mw_ab_dip_21_ (void){
-    WORD_ENTER(mw_ab_dip_21_, "ab-dip!", "src/mirth/elab.mth", 359, 5);
-    WORD_ATOM(359, 5, "ab-block!");
+    WORD_ENTER(mw_ab_dip_21_, "ab-dip!", "src/mirth/elab.mth", 375, 5);
+    WORD_ATOM(375, 5, "ab-block!");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(359, 5, "ab-block!");
+        WORD_ATOM(375, 5, "ab-block!");
         incref(var_f);
         push_value(var_f);
         mw_ab_block_21_();
-        WORD_ATOM(359, 18, "PRIM_CORE_DIP");
+        WORD_ATOM(375, 18, "PRIM_CORE_DIP");
         mw_PRIM_5F_CORE_5F_DIP();
-        WORD_ATOM(359, 32, "ab-prim!");
+        WORD_ATOM(375, 32, "ab-prim!");
         mw_ab_prim_21_();
         decref(var_f);
     }
     WORD_EXIT(mw_ab_dip_21_);
 }
 static void mw_ab_if_21_ (void){
-    WORD_ENTER(mw_ab_if_21_, "ab-if!", "src/mirth/elab.mth", 362, 5);
-    WORD_ATOM(362, 5, "ab-block!");
+    WORD_ENTER(mw_ab_if_21_, "ab-if!", "src/mirth/elab.mth", 378, 5);
+    WORD_ATOM(378, 5, "ab-block!");
     {
         VAL var_g = pop_value();
         VAL var_f = pop_value();
-        WORD_ATOM(362, 5, "ab-block!");
+        WORD_ATOM(378, 5, "ab-block!");
         incref(var_f);
         push_value(var_f);
         mw_ab_block_21_();
-        WORD_ATOM(362, 18, "ab-block!");
+        WORD_ATOM(378, 18, "ab-block!");
         incref(var_g);
         push_value(var_g);
         mw_ab_block_21_();
-        WORD_ATOM(362, 31, "PRIM_CORE_IF");
+        WORD_ATOM(378, 31, "PRIM_CORE_IF");
         mw_PRIM_5F_CORE_5F_IF();
-        WORD_ATOM(362, 44, "ab-prim!");
+        WORD_ATOM(378, 44, "ab-prim!");
         mw_ab_prim_21_();
         decref(var_g);
         decref(var_f);
@@ -20104,22 +20228,22 @@ static void mw_ab_if_21_ (void){
     WORD_EXIT(mw_ab_if_21_);
 }
 static void mw_ab_while_21_ (void){
-    WORD_ENTER(mw_ab_while_21_, "ab-while!", "src/mirth/elab.mth", 365, 5);
-    WORD_ATOM(365, 5, "ab-block!");
+    WORD_ENTER(mw_ab_while_21_, "ab-while!", "src/mirth/elab.mth", 381, 5);
+    WORD_ATOM(381, 5, "ab-block!");
     {
         VAL var_g = pop_value();
         VAL var_f = pop_value();
-        WORD_ATOM(365, 5, "ab-block!");
+        WORD_ATOM(381, 5, "ab-block!");
         incref(var_f);
         push_value(var_f);
         mw_ab_block_21_();
-        WORD_ATOM(365, 18, "ab-block!");
+        WORD_ATOM(381, 18, "ab-block!");
         incref(var_g);
         push_value(var_g);
         mw_ab_block_21_();
-        WORD_ATOM(365, 31, "PRIM_CORE_WHILE");
+        WORD_ATOM(381, 31, "PRIM_CORE_WHILE");
         mw_PRIM_5F_CORE_5F_WHILE();
-        WORD_ATOM(365, 47, "ab-prim!");
+        WORD_ATOM(381, 47, "ab-prim!");
         mw_ab_prim_21_();
         decref(var_g);
         decref(var_f);
@@ -20127,62 +20251,62 @@ static void mw_ab_while_21_ (void){
     WORD_EXIT(mw_ab_while_21_);
 }
 static void mw_ab_lambda_21_ (void){
-    WORD_ENTER(mw_ab_lambda_21_, "ab-lambda!", "src/mirth/elab.mth", 368, 5);
-    WORD_ATOM(368, 5, "Lambda.alloc!");
+    WORD_ENTER(mw_ab_lambda_21_, "ab-lambda!", "src/mirth/elab.mth", 384, 5);
+    WORD_ATOM(384, 5, "Lambda.alloc!");
     {
         VAL var_f = pop_value();
-        WORD_ATOM(368, 5, "Lambda.alloc!");
+        WORD_ATOM(384, 5, "Lambda.alloc!");
         mw_Lambda_2E_alloc_21_();
-        WORD_ATOM(369, 5, "ab-ctx");
+        WORD_ATOM(385, 5, "ab-ctx");
         mw_ab_ctx();
-        WORD_ATOM(369, 12, "@");
+        WORD_ATOM(385, 12, "@");
         mw_prim_mut_get();
-        WORD_ATOM(369, 14, "over");
+        WORD_ATOM(385, 14, "over");
         mw_over();
-        WORD_ATOM(369, 19, "~outer-ctx");
+        WORD_ATOM(385, 19, "~outer-ctx");
         mw_Lambda_7E_outer_ctx();
-        WORD_ATOM(369, 30, "!");
+        WORD_ATOM(385, 30, "!");
         mw_prim_mut_set();
-        WORD_ATOM(370, 5, "ab-type");
+        WORD_ATOM(386, 5, "ab-type");
         mw_ab_type();
-        WORD_ATOM(370, 13, "@");
+        WORD_ATOM(386, 13, "@");
         mw_prim_mut_get();
-        WORD_ATOM(370, 15, "over");
+        WORD_ATOM(386, 15, "over");
         mw_over();
-        WORD_ATOM(370, 20, "~dom");
+        WORD_ATOM(386, 20, "~dom");
         mw_Lambda_7E_dom();
-        WORD_ATOM(370, 25, "!");
+        WORD_ATOM(386, 25, "!");
         mw_prim_mut_set();
-        WORD_ATOM(371, 5, "ab-token");
+        WORD_ATOM(387, 5, "ab-token");
         mw_ab_token();
-        WORD_ATOM(371, 14, "@");
+        WORD_ATOM(387, 14, "@");
         mw_prim_mut_get();
-        WORD_ATOM(371, 16, "over");
+        WORD_ATOM(387, 16, "over");
         mw_over();
-        WORD_ATOM(371, 21, "~token");
+        WORD_ATOM(387, 21, "~token");
         mw_Lambda_7E_token();
-        WORD_ATOM(371, 28, "!");
+        WORD_ATOM(387, 28, "!");
         mw_prim_mut_set();
-        WORD_ATOM(372, 5, "dup2");
+        WORD_ATOM(388, 5, "dup2");
         mw_dup2();
-        WORD_ATOM(372, 10, "~params");
+        WORD_ATOM(388, 10, "~params");
         mw_Lambda_7E_params();
-        WORD_ATOM(372, 18, "!");
+        WORD_ATOM(388, 18, "!");
         mw_prim_mut_set();
-        WORD_ATOM(373, 5, "dip");
+        WORD_ATOM(389, 5, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(373, 9, "ab-ctx");
+            WORD_ATOM(389, 9, "ab-ctx");
             mw_ab_ctx();
-            WORD_ATOM(373, 16, "@");
+            WORD_ATOM(389, 16, "@");
             mw_prim_mut_get();
-            WORD_ATOM(373, 18, "ab-type");
+            WORD_ATOM(389, 18, "ab-type");
             mw_ab_type();
-            WORD_ATOM(373, 26, "@");
+            WORD_ATOM(389, 26, "@");
             mw_prim_mut_get();
-            WORD_ATOM(373, 28, "rotl");
+            WORD_ATOM(389, 28, "rotl");
             mw_rotl();
-            WORD_ATOM(373, 33, "reverse-for");
+            WORD_ATOM(389, 33, "reverse-for");
             push_u64(0);
             incref(var_f);
             push_value(var_f);
@@ -20192,31 +20316,31 @@ static void mw_ab_lambda_21_ (void){
             mw_List_2E_reverse_for();
             push_value(d3);
         }
-        WORD_ATOM(378, 5, "tuck");
+        WORD_ATOM(394, 5, "tuck");
         mw_tuck();
-        WORD_ATOM(378, 10, "~mid");
+        WORD_ATOM(394, 10, "~mid");
         mw_Lambda_7E_mid();
-        WORD_ATOM(378, 15, "!");
+        WORD_ATOM(394, 15, "!");
         mw_prim_mut_set();
-        WORD_ATOM(379, 5, "tuck");
+        WORD_ATOM(395, 5, "tuck");
         mw_tuck();
-        WORD_ATOM(379, 10, "~inner-ctx");
+        WORD_ATOM(395, 10, "~inner-ctx");
         mw_Lambda_7E_inner_ctx();
-        WORD_ATOM(379, 21, "!");
+        WORD_ATOM(395, 21, "!");
         mw_prim_mut_set();
-        WORD_ATOM(383, 5, "dup");
+        WORD_ATOM(399, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(383, 9, "inner-ctx");
+        WORD_ATOM(399, 9, "inner-ctx");
         mw_Lambda_2E_inner_ctx();
-        WORD_ATOM(384, 5, "over");
+        WORD_ATOM(400, 5, "over");
         mw_over();
-        WORD_ATOM(384, 10, "mid");
+        WORD_ATOM(400, 10, "mid");
         mw_Lambda_2E_mid();
-        WORD_ATOM(385, 5, "ab-token");
+        WORD_ATOM(401, 5, "ab-token");
         mw_ab_token();
-        WORD_ATOM(385, 14, "@");
+        WORD_ATOM(401, 14, "@");
         mw_prim_mut_get();
-        WORD_ATOM(386, 5, "ab-build!");
+        WORD_ATOM(402, 5, "ab-build!");
         push_u64(0);
         incref(var_f);
         push_value(var_f);
@@ -20224,141 +20348,141 @@ static void mw_ab_lambda_21_ (void){
         push_fnptr(&mb_ab_lambda_21__7);
         mw_prim_pack_cons();
         mw_ab_build_21_();
-        WORD_ATOM(390, 5, "over");
+        WORD_ATOM(406, 5, "over");
         mw_over();
-        WORD_ATOM(390, 10, "~body");
+        WORD_ATOM(406, 10, "~body");
         mw_Lambda_7E_body();
-        WORD_ATOM(390, 16, "!");
+        WORD_ATOM(406, 16, "!");
         mw_prim_mut_set();
-        WORD_ATOM(391, 5, "OP_LAMBDA");
+        WORD_ATOM(407, 5, "OP_LAMBDA");
         mw_OP_5F_LAMBDA();
-        WORD_ATOM(391, 15, "ab-op!");
+        WORD_ATOM(407, 15, "ab-op!");
         mw_ab_op_21_();
         decref(var_f);
     }
     WORD_EXIT(mw_ab_lambda_21_);
 }
 static void mw_elab_op_fresh_sig_21_ (void){
-    WORD_ENTER(mw_elab_op_fresh_sig_21_, "elab-op-fresh-sig!", "src/mirth/elab.mth", 399, 5);
-    WORD_ATOM(399, 5, "Subst.nil");
+    WORD_ENTER(mw_elab_op_fresh_sig_21_, "elab-op-fresh-sig!", "src/mirth/elab.mth", 415, 5);
+    WORD_ATOM(415, 5, "Subst.nil");
     mw_Subst_2E_nil();
-    WORD_ATOM(399, 15, "swap");
+    WORD_ATOM(415, 15, "swap");
     mw_prim_swap();
-    WORD_ATOM(399, 20, "match");
+    WORD_ATOM(415, 20, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(400, 20, "OPSIG_ID");
+            WORD_ATOM(416, 20, "OPSIG_ID");
             mw_OPSIG_5F_ID();
             break;
         case 8LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(401, 19, "VALUE_INT");
+            WORD_ATOM(417, 19, "VALUE_INT");
             mw_VALUE_5F_INT();
-            WORD_ATOM(401, 29, "TValue");
+            WORD_ATOM(417, 29, "TValue");
             mw_TValue();
-            WORD_ATOM(401, 36, "OPSIG_PUSH");
+            WORD_ATOM(417, 36, "OPSIG_PUSH");
             mw_OPSIG_5F_PUSH();
             break;
         case 9LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(402, 19, "VALUE_STR");
+            WORD_ATOM(418, 19, "VALUE_STR");
             mw_VALUE_5F_STR();
-            WORD_ATOM(402, 29, "TValue");
+            WORD_ATOM(418, 29, "TValue");
             mw_TValue();
-            WORD_ATOM(402, 36, "OPSIG_PUSH");
+            WORD_ATOM(418, 36, "OPSIG_PUSH");
             mw_OPSIG_5F_PUSH();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(403, 22, "drop");
+            WORD_ATOM(419, 22, "drop");
             mw_prim_drop();
-            WORD_ATOM(403, 27, "TYPE_PTR");
+            WORD_ATOM(419, 27, "TYPE_PTR");
             mw_TYPE_5F_PTR();
-            WORD_ATOM(403, 36, "OPSIG_PUSH");
+            WORD_ATOM(419, 36, "OPSIG_PUSH");
             mw_OPSIG_5F_PUSH();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(404, 24, "type");
+            WORD_ATOM(420, 24, "type");
             mw_Variable_2E_type();
-            WORD_ATOM(404, 29, "TMut");
+            WORD_ATOM(420, 29, "TMut");
             mw_TMut();
-            WORD_ATOM(404, 34, "OPSIG_PUSH");
+            WORD_ATOM(420, 34, "OPSIG_PUSH");
             mw_OPSIG_5F_PUSH();
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(405, 24, "value");
+            WORD_ATOM(421, 24, "value");
             mw_Constant_2E_value();
-            WORD_ATOM(405, 30, "TValue");
+            WORD_ATOM(421, 30, "TValue");
             mw_TValue();
-            WORD_ATOM(405, 37, "OPSIG_PUSH");
+            WORD_ATOM(421, 37, "OPSIG_PUSH");
             mw_OPSIG_5F_PUSH();
             break;
         case 10LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(406, 19, "type");
+            WORD_ATOM(422, 19, "type");
             mw_Tag_2E_type();
-            WORD_ATOM(406, 24, "freshen-sig");
+            WORD_ATOM(422, 24, "freshen-sig");
             mw_ArrowType_2E_freshen_sig();
-            WORD_ATOM(406, 36, "OPSIG_APPLY");
+            WORD_ATOM(422, 36, "OPSIG_APPLY");
             mw_OPSIG_5F_APPLY();
             break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(407, 20, "type");
+            WORD_ATOM(423, 20, "type");
             mw_Word_2E_type();
-            WORD_ATOM(407, 25, "freshen-sig");
+            WORD_ATOM(423, 25, "freshen-sig");
             mw_ArrowType_2E_freshen_sig();
-            WORD_ATOM(407, 37, "OPSIG_APPLY");
+            WORD_ATOM(423, 37, "OPSIG_APPLY");
             mw_OPSIG_5F_APPLY();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(408, 20, "type");
+            WORD_ATOM(424, 20, "type");
             mw_Prim_2E_type();
-            WORD_ATOM(408, 25, "freshen-sig");
+            WORD_ATOM(424, 25, "freshen-sig");
             mw_ArrowType_2E_freshen_sig();
-            WORD_ATOM(408, 37, "OPSIG_APPLY");
+            WORD_ATOM(424, 37, "OPSIG_APPLY");
             mw_OPSIG_5F_APPLY();
             break;
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(409, 24, "type");
+            WORD_ATOM(425, 24, "type");
             mw_External_2E_type();
-            WORD_ATOM(409, 29, "freshen-sig");
+            WORD_ATOM(425, 29, "freshen-sig");
             mw_ArrowType_2E_freshen_sig();
-            WORD_ATOM(409, 41, "OPSIG_APPLY");
+            WORD_ATOM(425, 41, "OPSIG_APPLY");
             mw_OPSIG_5F_APPLY();
             break;
         case 7LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(410, 21, "type");
+            WORD_ATOM(426, 21, "type");
             mw_Field_2E_type();
-            WORD_ATOM(410, 26, "freshen-sig");
+            WORD_ATOM(426, 26, "freshen-sig");
             mw_ArrowType_2E_freshen_sig();
-            WORD_ATOM(410, 38, "OPSIG_APPLY");
+            WORD_ATOM(426, 38, "OPSIG_APPLY");
             mw_OPSIG_5F_APPLY();
             break;
         case 14LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(411, 21, "elab-block-sig!");
+            WORD_ATOM(427, 21, "elab-block-sig!");
             mw_elab_block_sig_21_();
             break;
         case 13LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(412, 19, "elab-var-sig!");
+            WORD_ATOM(428, 19, "elab-var-sig!");
             mw_elab_var_sig_21_();
             break;
         case 11LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(413, 21, "elab-match-sig!");
+            WORD_ATOM(429, 21, "elab-match-sig!");
             mw_elab_match_sig_21_();
             break;
         case 12LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(414, 22, "elab-lambda-sig!");
+            WORD_ATOM(430, 22, "elab-lambda-sig!");
             mw_elab_lambda_sig_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -20366,115 +20490,115 @@ static void mw_elab_op_fresh_sig_21_ (void){
 }    WORD_EXIT(mw_elab_op_fresh_sig_21_);
 }
 static void mw_elab_block_sig_21_ (void){
-    WORD_ENTER(mw_elab_block_sig_21_, "elab-block-sig!", "src/mirth/elab.mth", 418, 5);
-    WORD_ATOM(418, 5, "VALUE_BLOCK");
+    WORD_ENTER(mw_elab_block_sig_21_, "elab-block-sig!", "src/mirth/elab.mth", 434, 5);
+    WORD_ATOM(434, 5, "VALUE_BLOCK");
     mw_VALUE_5F_BLOCK();
-    WORD_ATOM(418, 17, "TValue");
+    WORD_ATOM(434, 17, "TValue");
     mw_TValue();
-    WORD_ATOM(418, 24, "OPSIG_PUSH");
+    WORD_ATOM(434, 24, "OPSIG_PUSH");
     mw_OPSIG_5F_PUSH();
     WORD_EXIT(mw_elab_block_sig_21_);
 }
 static void mw_elab_match_sig_21_ (void){
-    WORD_ENTER(mw_elab_match_sig_21_, "elab-match-sig!", "src/mirth/elab.mth", 421, 5);
-    WORD_ATOM(421, 5, "sip");
+    WORD_ENTER(mw_elab_match_sig_21_, "elab-match-sig!", "src/mirth/elab.mth", 437, 5);
+    WORD_ATOM(437, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_match_sig_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(421, 14, "cod");
+    WORD_ATOM(437, 14, "cod");
     mw_Match_2E_cod();
-    WORD_ATOM(421, 18, "T->");
+    WORD_ATOM(437, 18, "T->");
     mw_T__3E_();
-    WORD_ATOM(421, 22, "OPSIG_APPLY");
+    WORD_ATOM(437, 22, "OPSIG_APPLY");
     mw_OPSIG_5F_APPLY();
     WORD_EXIT(mw_elab_match_sig_21_);
 }
 static void mw_elab_lambda_sig_21_ (void){
-    WORD_ENTER(mw_elab_lambda_sig_21_, "elab-lambda-sig!", "src/mirth/elab.mth", 424, 5);
-    WORD_ATOM(424, 5, "sip");
+    WORD_ENTER(mw_elab_lambda_sig_21_, "elab-lambda-sig!", "src/mirth/elab.mth", 440, 5);
+    WORD_ATOM(440, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_lambda_sig_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(424, 14, "cod");
+    WORD_ATOM(440, 14, "cod");
     mw_Lambda_2E_cod();
-    WORD_ATOM(424, 18, "T->");
+    WORD_ATOM(440, 18, "T->");
     mw_T__3E_();
-    WORD_ATOM(424, 22, "OPSIG_APPLY");
+    WORD_ATOM(440, 22, "OPSIG_APPLY");
     mw_OPSIG_5F_APPLY();
     WORD_EXIT(mw_elab_lambda_sig_21_);
 }
 static void mw_elab_var_sig_21_ (void){
-    WORD_ENTER(mw_elab_var_sig_21_, "elab-var-sig!", "src/mirth/elab.mth", 427, 5);
-    WORD_ATOM(427, 5, "dup");
+    WORD_ENTER(mw_elab_var_sig_21_, "elab-var-sig!", "src/mirth/elab.mth", 443, 5);
+    WORD_ATOM(443, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(427, 9, "auto-run?");
+    WORD_ATOM(443, 9, "auto-run?");
     mw_Var_2E_auto_run_3F_();
-    WORD_ATOM(427, 19, "if");
+    WORD_ATOM(443, 19, "if");
     if (pop_u64()) {
-        WORD_ATOM(428, 9, "type");
+        WORD_ATOM(444, 9, "type");
         mw_Var_2E_type();
-        WORD_ATOM(428, 14, "morphism?");
+        WORD_ATOM(444, 14, "morphism?");
         mw_Type_2E_morphism_3F_();
-        WORD_ATOM(428, 24, "unwrap");
+        WORD_ATOM(444, 24, "unwrap");
         mw_Maybe_2E_unwrap();
-        WORD_ATOM(428, 31, "semifreshen-sig");
+        WORD_ATOM(444, 31, "semifreshen-sig");
         mw_ArrowType_2E_semifreshen_sig();
-        WORD_ATOM(428, 47, "OPSIG_APPLY");
+        WORD_ATOM(444, 47, "OPSIG_APPLY");
         mw_OPSIG_5F_APPLY();
     } else {
-        WORD_ATOM(429, 9, "type");
+        WORD_ATOM(445, 9, "type");
         mw_Var_2E_type();
-        WORD_ATOM(429, 14, "OPSIG_PUSH");
+        WORD_ATOM(445, 14, "OPSIG_PUSH");
         mw_OPSIG_5F_PUSH();
     }
     WORD_EXIT(mw_elab_var_sig_21_);
 }
 static void mw_elab_word_ctx_type_weak_21_ (void){
-    WORD_ENTER(mw_elab_word_ctx_type_weak_21_, "elab-word-ctx-type-weak!", "src/mirth/elab.mth", 433, 5);
-    WORD_ATOM(433, 5, "dup");
+    WORD_ENTER(mw_elab_word_ctx_type_weak_21_, "elab-word-ctx-type-weak!", "src/mirth/elab.mth", 449, 5);
+    WORD_ATOM(449, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(433, 9, "sig");
+    WORD_ATOM(449, 9, "sig");
     mw_Word_2E_sig();
-    WORD_ATOM(433, 13, "match");
+    WORD_ATOM(449, 13, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(434, 17, "~ctx-type");
+            WORD_ATOM(450, 17, "~ctx-type");
             mw_Word_7E_ctx_type();
-            WORD_ATOM(434, 27, "@");
+            WORD_ATOM(450, 27, "@");
             mw_prim_mut_get();
-            WORD_ATOM(434, 29, "match");
+            WORD_ATOM(450, 29, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(435, 27, "unpack2");
+                    WORD_ATOM(451, 27, "unpack2");
                     mw_unpack2();
                     break;
                 default:
-                    WORD_ATOM(436, 18, "drop");
+                    WORD_ATOM(452, 18, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(436, 23, "CTX0");
+                    WORD_ATOM(452, 23, "CTX0");
                     mw_CTX0();
-                    WORD_ATOM(436, 28, "MetaVar.new!");
+                    WORD_ATOM(452, 28, "MetaVar.new!");
                     mw_MetaVar_2E_new_21_();
-                    WORD_ATOM(436, 41, "STMeta");
+                    WORD_ATOM(452, 41, "STMeta");
                     mw_STMeta();
-                    WORD_ATOM(436, 48, "MetaVar.new!");
+                    WORD_ATOM(452, 48, "MetaVar.new!");
                     mw_MetaVar_2E_new_21_();
-                    WORD_ATOM(436, 61, "STMeta");
+                    WORD_ATOM(452, 61, "STMeta");
                     mw_STMeta();
-                    WORD_ATOM(436, 68, "T->");
+                    WORD_ATOM(452, 68, "T->");
                     mw_T__3E_();
                     break;
             
 }            break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(438, 17, "drop");
+            WORD_ATOM(454, 17, "drop");
             mw_prim_drop();
-            WORD_ATOM(438, 22, "ctx-type");
+            WORD_ATOM(454, 22, "ctx-type");
             mw_Word_2E_ctx_type();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -20482,48 +20606,48 @@ static void mw_elab_word_ctx_type_weak_21_ (void){
 }    WORD_EXIT(mw_elab_word_ctx_type_weak_21_);
 }
 static void mw_elab_arrow_21_ (void){
-    WORD_ENTER(mw_elab_arrow_21_, "elab-arrow!", "src/mirth/elab.mth", 442, 5);
-    WORD_ATOM(442, 5, "dip");
+    WORD_ENTER(mw_elab_arrow_21_, "elab-arrow!", "src/mirth/elab.mth", 458, 5);
+    WORD_ATOM(458, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(442, 9, "unpack");
+        WORD_ATOM(458, 9, "unpack");
         mw_ArrowType_2E_unpack();
         push_value(d2);
     }
-    WORD_ATOM(442, 17, "elab-arrow-hom!");
+    WORD_ATOM(458, 17, "elab-arrow-hom!");
     mw_elab_arrow_hom_21_();
     WORD_EXIT(mw_elab_arrow_21_);
 }
 static void mw_elab_arrow_hom_21_ (void){
-    WORD_ENTER(mw_elab_arrow_hom_21_, "elab-arrow-hom!", "src/mirth/elab.mth", 445, 5);
-    WORD_ATOM(445, 5, "swap");
+    WORD_ENTER(mw_elab_arrow_hom_21_, "elab-arrow-hom!", "src/mirth/elab.mth", 461, 5);
+    WORD_ATOM(461, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(445, 10, "dip");
+    WORD_ATOM(461, 10, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(446, 9, "elab-arrow-fwd!");
+        WORD_ATOM(462, 9, "elab-arrow-fwd!");
         mw_elab_arrow_fwd_21_();
-        WORD_ATOM(447, 9, "dup");
+        WORD_ATOM(463, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(447, 13, "token-end");
+        WORD_ATOM(463, 13, "token-end");
         mw_Arrow_2E_token_end();
-        WORD_ATOM(447, 23, "GAMMA");
+        WORD_ATOM(463, 23, "GAMMA");
         mw_GAMMA();
-        WORD_ATOM(448, 9, "over");
+        WORD_ATOM(464, 9, "over");
         mw_over();
-        WORD_ATOM(448, 14, "cod");
+        WORD_ATOM(464, 14, "cod");
         mw_Arrow_2E_cod();
         push_value(d2);
     }
-    WORD_ATOM(450, 5, "unify!");
+    WORD_ATOM(466, 5, "unify!");
     mw_StackType_2E_unify_21_();
-    WORD_ATOM(450, 12, "drop2");
+    WORD_ATOM(466, 12, "drop2");
     mw_drop2();
     WORD_EXIT(mw_elab_arrow_hom_21_);
 }
 static void mw_elab_arrow_fwd_21_ (void){
-    WORD_ENTER(mw_elab_arrow_fwd_21_, "elab-arrow-fwd!", "src/mirth/elab.mth", 453, 5);
-    WORD_ATOM(453, 5, "ab-build!");
+    WORD_ENTER(mw_elab_arrow_fwd_21_, "elab-arrow-fwd!", "src/mirth/elab.mth", 469, 5);
+    WORD_ATOM(469, 5, "ab-build!");
     push_u64(0);
     push_fnptr(&mb_elab_arrow_fwd_21__1);
     mw_prim_pack_cons();
@@ -20531,19 +20655,19 @@ static void mw_elab_arrow_fwd_21_ (void){
     WORD_EXIT(mw_elab_arrow_fwd_21_);
 }
 static void mw_elab_atoms_21_ (void){
-    WORD_ENTER(mw_elab_atoms_21_, "elab-atoms!", "src/mirth/elab.mth", 456, 5);
-    WORD_ATOM(456, 5, "while");
+    WORD_ENTER(mw_elab_atoms_21_, "elab-atoms!", "src/mirth/elab.mth", 472, 5);
+    WORD_ATOM(472, 5, "while");
     while(1) {
-        WORD_ATOM(457, 9, "elab-atoms-done?");
+        WORD_ATOM(473, 9, "elab-atoms-done?");
         mw_elab_atoms_done_3F_();
-        WORD_ATOM(457, 26, "not");
+        WORD_ATOM(473, 26, "not");
         mw_Bool_2E_not();
         if (! pop_u64()) break;
-        WORD_ATOM(458, 9, "elab-atom!");
+        WORD_ATOM(474, 9, "elab-atom!");
         mw_elab_atom_21_();
-        WORD_ATOM(458, 20, "ab-token");
+        WORD_ATOM(474, 20, "ab-token");
         mw_ab_token();
-        WORD_ATOM(458, 29, "modify");
+        WORD_ATOM(474, 29, "modify");
         push_u64(0);
         push_fnptr(&mb_elab_atoms_21__3);
         mw_prim_pack_cons();
@@ -20552,60 +20676,60 @@ static void mw_elab_atoms_21_ (void){
     WORD_EXIT(mw_elab_atoms_21_);
 }
 static void mw_elab_atoms_done_3F_ (void){
-    WORD_ENTER(mw_elab_atoms_done_3F_, "elab-atoms-done?", "src/mirth/elab.mth", 462, 5);
-    WORD_ATOM(462, 5, "ab-token");
+    WORD_ENTER(mw_elab_atoms_done_3F_, "elab-atoms-done?", "src/mirth/elab.mth", 478, 5);
+    WORD_ATOM(478, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(462, 14, "@");
+    WORD_ATOM(478, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(462, 16, "run-end?");
+    WORD_ATOM(478, 16, "run-end?");
     mw_Token_2E_run_end_3F_();
     WORD_EXIT(mw_elab_atoms_done_3F_);
 }
 static void mw_elab_atom_21_ (void){
-    WORD_ENTER(mw_elab_atom_21_, "elab-atom!", "src/mirth/elab.mth", 465, 5);
-    WORD_ATOM(465, 5, "ab-token");
+    WORD_ENTER(mw_elab_atom_21_, "elab-atom!", "src/mirth/elab.mth", 481, 5);
+    WORD_ATOM(481, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(465, 14, "@");
+    WORD_ATOM(481, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(465, 16, "value");
+    WORD_ATOM(481, 16, "value");
     mw_Token_2E_value();
-    WORD_ATOM(465, 22, "match");
+    WORD_ATOM(481, 22, "match");
     switch (get_top_data_tag()) {
         case 13LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(466, 23, "elab-atom-name!");
+            WORD_ATOM(482, 23, "elab-atom-name!");
             mw_elab_atom_name_21_();
             break;
         case 11LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(467, 22, "ab-int!");
+            WORD_ATOM(483, 22, "ab-int!");
             mw_ab_int_21_();
             break;
         case 12LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(468, 22, "ab-str!");
+            WORD_ATOM(484, 22, "ab-str!");
             mw_ab_str_21_();
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(469, 26, "drop");
+            WORD_ATOM(485, 26, "drop");
             mw_prim_drop();
-            WORD_ATOM(469, 31, "elab-atom-block!");
+            WORD_ATOM(485, 31, "elab-atom-block!");
             mw_elab_atom_block_21_();
             break;
         case 9LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(470, 25, "drop");
+            WORD_ATOM(486, 25, "drop");
             mw_prim_drop();
-            WORD_ATOM(470, 30, "elab-atom-assert!");
+            WORD_ATOM(486, 30, "elab-atom-assert!");
             mw_elab_atom_assert_21_();
             break;
         default:
-            WORD_ATOM(471, 14, "ab-token");
+            WORD_ATOM(487, 14, "ab-token");
             mw_ab_token();
-            WORD_ATOM(471, 23, "@");
+            WORD_ATOM(487, 23, "@");
             mw_prim_mut_get();
-            WORD_ATOM(471, 25, "");
+            WORD_ATOM(487, 25, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -20616,49 +20740,49 @@ static void mw_elab_atom_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(471, 58, "emit-fatal-error!");
+            WORD_ATOM(487, 58, "emit-fatal-error!");
             mw_emit_fatal_error_21_();
             break;
     
 }    WORD_EXIT(mw_elab_atom_21_);
 }
 static void mw_elab_atom_block_21_ (void){
-    WORD_ENTER(mw_elab_atom_block_21_, "elab-atom-block!", "src/mirth/elab.mth", 475, 5);
-    WORD_ATOM(475, 5, "ab-token");
+    WORD_ENTER(mw_elab_atom_block_21_, "elab-atom-block!", "src/mirth/elab.mth", 491, 5);
+    WORD_ATOM(491, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(475, 14, "@");
+    WORD_ATOM(491, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(475, 16, "args-1");
+    WORD_ATOM(491, 16, "args-1");
     mw_Token_2E_args_1();
-    WORD_ATOM(475, 23, "elab-block-at!");
+    WORD_ATOM(491, 23, "elab-block-at!");
     mw_elab_block_at_21_();
     WORD_EXIT(mw_elab_atom_block_21_);
 }
 static void mw_elab_block_at_21_ (void){
-    WORD_ENTER(mw_elab_block_at_21_, "elab-block-at!", "src/mirth/elab.mth", 478, 5);
-    WORD_ATOM(478, 5, "ab-ctx");
+    WORD_ENTER(mw_elab_block_at_21_, "elab-block-at!", "src/mirth/elab.mth", 494, 5);
+    WORD_ATOM(494, 5, "ab-ctx");
     mw_ab_ctx();
-    WORD_ATOM(478, 12, "@");
+    WORD_ATOM(494, 12, "@");
     mw_prim_mut_get();
-    WORD_ATOM(478, 14, "swap");
+    WORD_ATOM(494, 14, "swap");
     mw_prim_swap();
-    WORD_ATOM(478, 19, "Block.new-deferred!");
+    WORD_ATOM(494, 19, "Block.new-deferred!");
     mw_Block_2E_new_deferred_21_();
-    WORD_ATOM(478, 39, "OP_BLOCK");
+    WORD_ATOM(494, 39, "OP_BLOCK");
     mw_OP_5F_BLOCK();
-    WORD_ATOM(478, 48, "ab-op!");
+    WORD_ATOM(494, 48, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_elab_block_at_21_);
 }
 static void mw_elab_args_21_ (void){
-    WORD_ENTER(mw_elab_args_21_, "elab-args!", "src/mirth/elab.mth", 481, 5);
-    WORD_ATOM(481, 5, "ab-token");
+    WORD_ENTER(mw_elab_args_21_, "elab-args!", "src/mirth/elab.mth", 497, 5);
+    WORD_ATOM(497, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(481, 14, "@");
+    WORD_ATOM(497, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(481, 16, "args");
+    WORD_ATOM(497, 16, "args");
     mw_Token_2E_args();
-    WORD_ATOM(481, 21, "for");
+    WORD_ATOM(497, 21, "for");
     push_u64(0);
     push_fnptr(&mb_elab_args_21__1);
     mw_prim_pack_cons();
@@ -20666,43 +20790,43 @@ static void mw_elab_args_21_ (void){
     WORD_EXIT(mw_elab_args_21_);
 }
 static void mw_elab_no_args_21_ (void){
-    WORD_ENTER(mw_elab_no_args_21_, "elab-no-args!", "src/mirth/elab.mth", 484, 5);
-    WORD_ATOM(484, 5, "ab-token");
+    WORD_ENTER(mw_elab_no_args_21_, "elab-no-args!", "src/mirth/elab.mth", 500, 5);
+    WORD_ATOM(500, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(484, 14, "@");
+    WORD_ATOM(500, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(484, 16, "args-0");
+    WORD_ATOM(500, 16, "args-0");
     mw_Token_2E_args_0();
     WORD_EXIT(mw_elab_no_args_21_);
 }
 static void mw_elab_atom_name_21_ (void){
-    WORD_ENTER(mw_elab_atom_name_21_, "elab-atom-name!", "src/mirth/elab.mth", 487, 5);
-    WORD_ATOM(487, 5, "dup");
+    WORD_ENTER(mw_elab_atom_name_21_, "elab-atom-name!", "src/mirth/elab.mth", 503, 5);
+    WORD_ATOM(503, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(487, 9, "ab-ctx");
+    WORD_ATOM(503, 9, "ab-ctx");
     mw_ab_ctx();
-    WORD_ATOM(487, 16, "@");
+    WORD_ATOM(503, 16, "@");
     mw_prim_mut_get();
-    WORD_ATOM(487, 18, "lookup");
+    WORD_ATOM(503, 18, "lookup");
     mw_Ctx_2E_lookup();
-    WORD_ATOM(487, 25, "match");
+    WORD_ATOM(503, 25, "match");
     switch (get_top_data_tag()) {
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(488, 17, "nip");
+            WORD_ATOM(504, 17, "nip");
             mw_nip();
-            WORD_ATOM(488, 21, "elab-args!");
+            WORD_ATOM(504, 21, "elab-args!");
             mw_elab_args_21_();
-            WORD_ATOM(488, 32, "ab-var!");
+            WORD_ATOM(504, 32, "ab-var!");
             mw_ab_var_21_();
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(490, 13, "elab-relativize-name!");
+            WORD_ATOM(506, 13, "elab-relativize-name!");
             mw_elab_relativize_name_21_();
-            WORD_ATOM(491, 13, "elab-check-name-visible!");
+            WORD_ATOM(507, 13, "elab-check-name-visible!");
             mw_elab_check_name_visible_21_();
-            WORD_ATOM(492, 13, "elab-atom-name-global!");
+            WORD_ATOM(508, 13, "elab-atom-name-global!");
             mw_elab_atom_name_global_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -20710,42 +20834,42 @@ static void mw_elab_atom_name_21_ (void){
 }    WORD_EXIT(mw_elab_atom_name_21_);
 }
 static void mw_elab_relativize_name_21_ (void){
-    WORD_ENTER(mw_elab_relativize_name_21_, "elab-relativize-name!", "src/mirth/elab.mth", 496, 5);
-    WORD_ATOM(496, 5, "name-undefined?");
+    WORD_ENTER(mw_elab_relativize_name_21_, "elab-relativize-name!", "src/mirth/elab.mth", 512, 5);
+    WORD_ATOM(512, 5, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(496, 21, "and");
+    WORD_ATOM(512, 21, "and");
     push_u64(0);
     push_fnptr(&mb_elab_relativize_name_21__1);
     mw_prim_pack_cons();
     mw_Bool_2E_and();
-    WORD_ATOM(496, 48, "if");
+    WORD_ATOM(512, 48, "if");
     if (pop_u64()) {
-        WORD_ATOM(497, 9, "ab-type");
+        WORD_ATOM(513, 9, "ab-type");
         mw_ab_type();
-        WORD_ATOM(497, 17, "@");
+        WORD_ATOM(513, 17, "@");
         mw_prim_mut_get();
-        WORD_ATOM(497, 19, "top-tycon-name");
+        WORD_ATOM(513, 19, "top-tycon-name");
         mw_StackType_2E_top_tycon_name();
-        WORD_ATOM(497, 34, "for");
+        WORD_ATOM(513, 34, "for");
         push_u64(0);
         push_fnptr(&mb_elab_relativize_name_21__3);
         mw_prim_pack_cons();
         mw_Maybe_2E_for();
     } else {
-        WORD_ATOM(505, 9, "id");
+        WORD_ATOM(521, 9, "id");
         mw_prim_id();
     }
     WORD_EXIT(mw_elab_relativize_name_21_);
 }
 static void mw_elab_check_name_visible_21_ (void){
-    WORD_ENTER(mw_elab_check_name_visible_21_, "elab-check-name-visible!", "src/mirth/elab.mth", 509, 5);
-    WORD_ATOM(509, 5, "dup");
+    WORD_ENTER(mw_elab_check_name_visible_21_, "elab-check-name-visible!", "src/mirth/elab.mth", 525, 5);
+    WORD_ATOM(525, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(509, 9, ">Def");
+    WORD_ATOM(525, 9, ">Def");
     mw_Name_3E_Def();
-    WORD_ATOM(509, 14, ">Module?");
+    WORD_ATOM(525, 14, ">Module?");
     mw_Def_3E_Module_3F_();
-    WORD_ATOM(509, 23, "for");
+    WORD_ATOM(525, 23, "for");
     push_u64(0);
     push_fnptr(&mb_elab_check_name_visible_21__1);
     mw_prim_pack_cons();
@@ -20753,115 +20877,115 @@ static void mw_elab_check_name_visible_21_ (void){
     WORD_EXIT(mw_elab_check_name_visible_21_);
 }
 static void mw_elab_module_is_visible (void){
-    WORD_ENTER(mw_elab_module_is_visible, "elab-module-is-visible", "src/mirth/elab.mth", 516, 5);
-    WORD_ATOM(516, 5, "ab-token");
+    WORD_ENTER(mw_elab_module_is_visible, "elab-module-is-visible", "src/mirth/elab.mth", 532, 5);
+    WORD_ATOM(532, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(516, 14, "@");
+    WORD_ATOM(532, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(516, 16, ".module");
+    WORD_ATOM(532, 16, ".module");
     mw_Token_2E_module();
-    WORD_ATOM(516, 24, "visible");
+    WORD_ATOM(532, 24, "visible");
     mw_Module_2E_visible();
     WORD_EXIT(mw_elab_module_is_visible);
 }
 static void mw_elab_atom_name_global_21_ (void){
-    WORD_ENTER(mw_elab_atom_name_global_21_, "elab-atom-name-global!", "src/mirth/elab.mth", 519, 5);
-    WORD_ATOM(519, 5, "dup");
+    WORD_ENTER(mw_elab_atom_name_global_21_, "elab-atom-name-global!", "src/mirth/elab.mth", 535, 5);
+    WORD_ATOM(535, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(519, 9, ">Def");
+    WORD_ATOM(535, 9, ">Def");
     mw_Name_3E_Def();
-    WORD_ATOM(519, 14, "match");
+    WORD_ATOM(535, 14, "match");
     switch (get_top_data_tag()) {
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(520, 22, "nip");
+            WORD_ATOM(536, 22, "nip");
             mw_nip();
-            WORD_ATOM(520, 26, "target");
+            WORD_ATOM(536, 26, "target");
             mw_Alias_2E_target();
-            WORD_ATOM(520, 33, "elab-atom-name-global!");
+            WORD_ATOM(536, 33, "elab-atom-name-global!");
             mw_elab_atom_name_global_21_();
             break;
         case 7LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(521, 23, "nip");
+            WORD_ATOM(537, 23, "nip");
             mw_nip();
-            WORD_ATOM(521, 27, "elab-no-args!");
+            WORD_ATOM(537, 27, "elab-no-args!");
             mw_elab_no_args_21_();
-            WORD_ATOM(521, 41, "ab-buffer!");
+            WORD_ATOM(537, 41, "ab-buffer!");
             mw_ab_buffer_21_();
             break;
         case 8LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(522, 25, "nip");
+            WORD_ATOM(538, 25, "nip");
             mw_nip();
-            WORD_ATOM(522, 29, "elab-no-args!");
+            WORD_ATOM(538, 29, "elab-no-args!");
             mw_elab_no_args_21_();
-            WORD_ATOM(522, 43, "ab-variable!");
+            WORD_ATOM(538, 43, "ab-variable!");
             mw_ab_variable_21_();
             break;
         case 9LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(523, 25, "nip");
+            WORD_ATOM(539, 25, "nip");
             mw_nip();
-            WORD_ATOM(523, 29, "elab-no-args!");
+            WORD_ATOM(539, 29, "elab-no-args!");
             mw_elab_no_args_21_();
-            WORD_ATOM(523, 43, "ab-constant!");
+            WORD_ATOM(539, 43, "ab-constant!");
             mw_ab_constant_21_();
             break;
         case 10LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(524, 25, "nip");
+            WORD_ATOM(540, 25, "nip");
             mw_nip();
-            WORD_ATOM(524, 29, "elab-no-args!");
+            WORD_ATOM(540, 29, "elab-no-args!");
             mw_elab_no_args_21_();
-            WORD_ATOM(524, 43, "ab-external!");
+            WORD_ATOM(540, 43, "ab-external!");
             mw_ab_external_21_();
             break;
         case 11LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(525, 22, "nip");
+            WORD_ATOM(541, 22, "nip");
             mw_nip();
-            WORD_ATOM(525, 26, "elab-no-args!");
+            WORD_ATOM(541, 26, "elab-no-args!");
             mw_elab_no_args_21_();
-            WORD_ATOM(525, 40, "ab-field!");
+            WORD_ATOM(541, 40, "ab-field!");
             mw_ab_field_21_();
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(526, 21, "nip");
+            WORD_ATOM(542, 21, "nip");
             mw_nip();
-            WORD_ATOM(526, 25, "elab-args!");
+            WORD_ATOM(542, 25, "elab-args!");
             mw_elab_args_21_();
-            WORD_ATOM(526, 36, "ab-word!");
+            WORD_ATOM(542, 36, "ab-word!");
             mw_ab_word_21_();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(527, 20, "nip");
+            WORD_ATOM(543, 20, "nip");
             mw_nip();
-            WORD_ATOM(527, 24, "elab-args!");
+            WORD_ATOM(543, 24, "elab-args!");
             mw_elab_args_21_();
-            WORD_ATOM(527, 35, "ab-tag!");
+            WORD_ATOM(543, 35, "ab-tag!");
             mw_ab_tag_21_();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(528, 21, "nip");
+            WORD_ATOM(544, 21, "nip");
             mw_nip();
-            WORD_ATOM(528, 25, "elab-prim!");
+            WORD_ATOM(544, 25, "elab-prim!");
             mw_elab_prim_21_();
             break;
         default:
-            WORD_ATOM(531, 13, "drop");
+            WORD_ATOM(547, 13, "drop");
             mw_prim_drop();
-            WORD_ATOM(532, 13, "dip");
+            WORD_ATOM(548, 13, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(532, 17, "ab-token");
+                WORD_ATOM(548, 17, "ab-token");
                 mw_ab_token();
-                WORD_ATOM(532, 26, "@");
+                WORD_ATOM(548, 26, "@");
                 mw_prim_mut_get();
-                WORD_ATOM(532, 28, "");
+                WORD_ATOM(548, 28, "");
                 {
                     static bool vready = false;
                     static VAL v;
@@ -20874,223 +20998,223 @@ static void mw_elab_atom_name_global_21_ (void){
                 }
                 push_value(d4);
             }
-            WORD_ATOM(533, 13, ">Str");
+            WORD_ATOM(549, 13, ">Str");
             mw_Name_3E_Str();
-            WORD_ATOM(533, 18, "cat");
+            WORD_ATOM(549, 18, "cat");
             mw_prim_str_cat();
-            WORD_ATOM(533, 22, "emit-error!");
+            WORD_ATOM(549, 22, "emit-error!");
             mw_emit_error_21_();
-            WORD_ATOM(533, 34, "STACK_TYPE_ERROR");
+            WORD_ATOM(549, 34, "STACK_TYPE_ERROR");
             mw_STACK_5F_TYPE_5F_ERROR();
-            WORD_ATOM(533, 51, "ab-type");
+            WORD_ATOM(549, 51, "ab-type");
             mw_ab_type();
-            WORD_ATOM(533, 59, "!");
+            WORD_ATOM(549, 59, "!");
             mw_prim_mut_set();
             break;
     
 }    WORD_EXIT(mw_elab_atom_name_global_21_);
 }
 static void mw_elab_prim_21_ (void){
-    WORD_ENTER(mw_elab_prim_21_, "elab-prim!", "src/mirth/elab.mth", 537, 5);
-    WORD_ATOM(537, 5, "match");
+    WORD_ENTER(mw_elab_prim_21_, "elab-prim!", "src/mirth/elab.mth", 553, 5);
+    WORD_ATOM(553, 5, "match");
     switch (get_top_data_tag()) {
         case 10LL:
             mw_prim_drop();
-            WORD_ATOM(538, 28, "elab-atom-match!");
+            WORD_ATOM(554, 28, "elab-atom-match!");
             mw_elab_atom_match_21_();
             break;
         case 11LL:
             mw_prim_drop();
-            WORD_ATOM(539, 29, "elab-atom-lambda!");
+            WORD_ATOM(555, 29, "elab-atom-lambda!");
             mw_elab_atom_lambda_21_();
             break;
         default:
-            WORD_ATOM(540, 14, "elab-args!");
+            WORD_ATOM(556, 14, "elab-args!");
             mw_elab_args_21_();
-            WORD_ATOM(540, 25, "ab-prim!");
+            WORD_ATOM(556, 25, "ab-prim!");
             mw_ab_prim_21_();
             break;
     
 }    WORD_EXIT(mw_elab_prim_21_);
 }
 static void mw_elab_atom_assert_21_ (void){
-    WORD_ENTER(mw_elab_atom_assert_21_, "elab-atom-assert!", "src/mirth/elab.mth", 544, 5);
-    WORD_ATOM(544, 5, "ab-token");
+    WORD_ENTER(mw_elab_atom_assert_21_, "elab-atom-assert!", "src/mirth/elab.mth", 560, 5);
+    WORD_ATOM(560, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(544, 14, "@");
+    WORD_ATOM(560, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(544, 16, "GAMMA");
+    WORD_ATOM(560, 16, "GAMMA");
     mw_GAMMA();
-    WORD_ATOM(545, 5, "ab-ctx");
+    WORD_ATOM(561, 5, "ab-ctx");
     mw_ab_ctx();
-    WORD_ATOM(545, 12, "@");
+    WORD_ATOM(561, 12, "@");
     mw_prim_mut_get();
-    WORD_ATOM(545, 14, "type-elab-stack-assertion");
+    WORD_ATOM(561, 14, "type-elab-stack-assertion");
     mw_type_elab_stack_assertion();
-    WORD_ATOM(546, 5, "ab-token");
+    WORD_ATOM(562, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(546, 14, "@");
+    WORD_ATOM(562, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(546, 16, "args-1");
+    WORD_ATOM(562, 16, "args-1");
     mw_Token_2E_args_1();
-    WORD_ATOM(546, 23, "elab-type-stack!");
+    WORD_ATOM(562, 23, "elab-type-stack!");
     mw_elab_type_stack_21_();
-    WORD_ATOM(547, 5, "drop");
+    WORD_ATOM(563, 5, "drop");
     mw_prim_drop();
-    WORD_ATOM(547, 10, "nip");
+    WORD_ATOM(563, 10, "nip");
     mw_nip();
-    WORD_ATOM(547, 14, "ab-type");
+    WORD_ATOM(563, 14, "ab-type");
     mw_ab_type();
-    WORD_ATOM(547, 22, "@");
+    WORD_ATOM(563, 22, "@");
     mw_prim_mut_get();
-    WORD_ATOM(547, 24, "swap");
+    WORD_ATOM(563, 24, "swap");
     mw_prim_swap();
-    WORD_ATOM(547, 29, "unify!");
+    WORD_ATOM(563, 29, "unify!");
     mw_StackType_2E_unify_21_();
-    WORD_ATOM(547, 36, "drop2");
+    WORD_ATOM(563, 36, "drop2");
     mw_drop2();
     WORD_EXIT(mw_elab_atom_assert_21_);
 }
 static void mw_elab_atom_lambda_21_ (void){
-    WORD_ENTER(mw_elab_atom_lambda_21_, "elab-atom-lambda!", "src/mirth/elab.mth", 550, 5);
-    WORD_ATOM(550, 5, "Lambda.alloc!");
+    WORD_ENTER(mw_elab_atom_lambda_21_, "elab-atom-lambda!", "src/mirth/elab.mth", 566, 5);
+    WORD_ATOM(566, 5, "Lambda.alloc!");
     mw_Lambda_2E_alloc_21_();
-    WORD_ATOM(551, 5, "ab-ctx");
+    WORD_ATOM(567, 5, "ab-ctx");
     mw_ab_ctx();
-    WORD_ATOM(551, 12, "@");
+    WORD_ATOM(567, 12, "@");
     mw_prim_mut_get();
-    WORD_ATOM(551, 14, "over");
+    WORD_ATOM(567, 14, "over");
     mw_over();
-    WORD_ATOM(551, 19, "~outer-ctx");
+    WORD_ATOM(567, 19, "~outer-ctx");
     mw_Lambda_7E_outer_ctx();
-    WORD_ATOM(551, 30, "!");
+    WORD_ATOM(567, 30, "!");
     mw_prim_mut_set();
-    WORD_ATOM(552, 5, "ab-type");
+    WORD_ATOM(568, 5, "ab-type");
     mw_ab_type();
-    WORD_ATOM(552, 13, "@");
+    WORD_ATOM(568, 13, "@");
     mw_prim_mut_get();
-    WORD_ATOM(552, 15, "over");
+    WORD_ATOM(568, 15, "over");
     mw_over();
-    WORD_ATOM(552, 20, "~dom");
+    WORD_ATOM(568, 20, "~dom");
     mw_Lambda_7E_dom();
-    WORD_ATOM(552, 25, "!");
+    WORD_ATOM(568, 25, "!");
     mw_prim_mut_set();
-    WORD_ATOM(553, 5, "ab-token");
+    WORD_ATOM(569, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(553, 14, "@");
+    WORD_ATOM(569, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(553, 16, "over");
+    WORD_ATOM(569, 16, "over");
     mw_over();
-    WORD_ATOM(553, 21, "~token");
+    WORD_ATOM(569, 21, "~token");
     mw_Lambda_7E_token();
-    WORD_ATOM(553, 28, "!");
+    WORD_ATOM(569, 28, "!");
     mw_prim_mut_set();
-    WORD_ATOM(554, 5, "elab-lambda!");
+    WORD_ATOM(570, 5, "elab-lambda!");
     mw_elab_lambda_21_();
-    WORD_ATOM(555, 5, "OP_LAMBDA");
+    WORD_ATOM(571, 5, "OP_LAMBDA");
     mw_OP_5F_LAMBDA();
-    WORD_ATOM(555, 15, "ab-op!");
+    WORD_ATOM(571, 15, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_elab_atom_lambda_21_);
 }
 static void mw_elab_match_at_21_ (void){
-    WORD_ENTER(mw_elab_match_at_21_, "elab-match-at!", "src/mirth/elab.mth", 561, 5);
-    WORD_ATOM(561, 5, "Match.alloc!");
+    WORD_ENTER(mw_elab_match_at_21_, "elab-match-at!", "src/mirth/elab.mth", 577, 5);
+    WORD_ATOM(577, 5, "Match.alloc!");
     mw_Match_2E_alloc_21_();
-    WORD_ATOM(562, 5, "ab-ctx");
+    WORD_ATOM(578, 5, "ab-ctx");
     mw_ab_ctx();
-    WORD_ATOM(562, 12, "@");
+    WORD_ATOM(578, 12, "@");
     mw_prim_mut_get();
-    WORD_ATOM(562, 14, "over");
+    WORD_ATOM(578, 14, "over");
     mw_over();
-    WORD_ATOM(562, 19, "~ctx");
+    WORD_ATOM(578, 19, "~ctx");
     mw_Match_7E_ctx();
-    WORD_ATOM(562, 24, "!");
+    WORD_ATOM(578, 24, "!");
     mw_prim_mut_set();
-    WORD_ATOM(563, 5, "ab-type");
+    WORD_ATOM(579, 5, "ab-type");
     mw_ab_type();
-    WORD_ATOM(563, 13, "@");
+    WORD_ATOM(579, 13, "@");
     mw_prim_mut_get();
-    WORD_ATOM(563, 15, "over");
+    WORD_ATOM(579, 15, "over");
     mw_over();
-    WORD_ATOM(563, 20, "~dom");
+    WORD_ATOM(579, 20, "~dom");
     mw_Match_7E_dom();
-    WORD_ATOM(563, 25, "!");
+    WORD_ATOM(579, 25, "!");
     mw_prim_mut_set();
-    WORD_ATOM(564, 5, "ab-token");
+    WORD_ATOM(580, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(564, 14, "@");
+    WORD_ATOM(580, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(564, 16, "over");
+    WORD_ATOM(580, 16, "over");
     mw_over();
-    WORD_ATOM(564, 21, "~token");
+    WORD_ATOM(580, 21, "~token");
     mw_Match_7E_token();
-    WORD_ATOM(564, 28, "!");
+    WORD_ATOM(580, 28, "!");
     mw_prim_mut_set();
-    WORD_ATOM(565, 5, "tuck");
+    WORD_ATOM(581, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(565, 10, "~body");
+    WORD_ATOM(581, 10, "~body");
     mw_Match_7E_body();
-    WORD_ATOM(565, 16, "!");
+    WORD_ATOM(581, 16, "!");
     mw_prim_mut_set();
-    WORD_ATOM(566, 5, "tuck");
+    WORD_ATOM(582, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(566, 10, "~cod");
+    WORD_ATOM(582, 10, "~cod");
     mw_Match_7E_cod();
-    WORD_ATOM(566, 15, "!");
+    WORD_ATOM(582, 15, "!");
     mw_prim_mut_set();
-    WORD_ATOM(567, 5, "elab-match-cases!");
+    WORD_ATOM(583, 5, "elab-match-cases!");
     mw_elab_match_cases_21_();
-    WORD_ATOM(568, 5, "elab-match-exhaustive!");
+    WORD_ATOM(584, 5, "elab-match-exhaustive!");
     mw_elab_match_exhaustive_21_();
-    WORD_ATOM(569, 5, "OP_MATCH");
+    WORD_ATOM(585, 5, "OP_MATCH");
     mw_OP_5F_MATCH();
-    WORD_ATOM(569, 14, "ab-op!");
+    WORD_ATOM(585, 14, "ab-op!");
     mw_ab_op_21_();
     WORD_EXIT(mw_elab_match_at_21_);
 }
 static void mw_elab_atom_match_21_ (void){
-    WORD_ENTER(mw_elab_atom_match_21_, "elab-atom-match!", "src/mirth/elab.mth", 572, 5);
-    WORD_ATOM(572, 5, "MetaVar.new!");
+    WORD_ENTER(mw_elab_atom_match_21_, "elab-atom-match!", "src/mirth/elab.mth", 588, 5);
+    WORD_ATOM(588, 5, "MetaVar.new!");
     mw_MetaVar_2E_new_21_();
-    WORD_ATOM(572, 18, "STMeta");
+    WORD_ATOM(588, 18, "STMeta");
     mw_STMeta();
-    WORD_ATOM(573, 5, "ab-token");
+    WORD_ATOM(589, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(573, 14, "@");
+    WORD_ATOM(589, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(573, 16, "args+");
+    WORD_ATOM(589, 16, "args+");
     mw_Token_2E_args_2B_();
-    WORD_ATOM(573, 22, "first+");
+    WORD_ATOM(589, 22, "first+");
     mw_first_2B_();
-    WORD_ATOM(574, 5, "elab-match-at!");
+    WORD_ATOM(590, 5, "elab-match-at!");
     mw_elab_match_at_21_();
     WORD_EXIT(mw_elab_atom_match_21_);
 }
 static void mw_elab_lambda_21_ (void){
-    WORD_ENTER(mw_elab_lambda_21_, "elab-lambda!", "src/mirth/elab.mth", 577, 5);
-    WORD_ATOM(577, 5, "elab-lambda-params!");
+    WORD_ENTER(mw_elab_lambda_21_, "elab-lambda!", "src/mirth/elab.mth", 593, 5);
+    WORD_ATOM(593, 5, "elab-lambda-params!");
     mw_elab_lambda_params_21_();
-    WORD_ATOM(578, 5, "elab-lambda-body!");
+    WORD_ATOM(594, 5, "elab-lambda-body!");
     mw_elab_lambda_body_21_();
     WORD_EXIT(mw_elab_lambda_21_);
 }
 static void mw_elab_expand_tensor_21_ (void){
-    WORD_ENTER(mw_elab_expand_tensor_21_, "elab-expand-tensor!", "src/mirth/elab.mth", 581, 5);
-    WORD_ATOM(581, 5, "swap");
+    WORD_ENTER(mw_elab_expand_tensor_21_, "elab-expand-tensor!", "src/mirth/elab.mth", 597, 5);
+    WORD_ATOM(597, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(581, 10, "expand");
+    WORD_ATOM(597, 10, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(581, 17, "match");
+    WORD_ATOM(597, 17, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(582, 29, "dip");
+            WORD_ATOM(598, 29, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(582, 33, "STACK_TYPE_ERROR");
+                WORD_ATOM(598, 33, "STACK_TYPE_ERROR");
                 mw_STACK_5F_TYPE_5F_ERROR();
-                WORD_ATOM(582, 50, "TYPE_ERROR");
+                WORD_ATOM(598, 50, "TYPE_ERROR");
                 mw_TYPE_5F_ERROR();
                 push_value(d4);
             }
@@ -21098,45 +21222,45 @@ static void mw_elab_expand_tensor_21_ (void){
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(583, 19, "rotl");
+            WORD_ATOM(599, 19, "rotl");
             mw_rotl();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(585, 13, "dip");
+            WORD_ATOM(601, 13, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(585, 17, "MetaVar.new!");
+                WORD_ATOM(601, 17, "MetaVar.new!");
                 mw_MetaVar_2E_new_21_();
-                WORD_ATOM(585, 30, "STMeta");
+                WORD_ATOM(601, 30, "STMeta");
                 mw_STMeta();
-                WORD_ATOM(586, 17, "MetaVar.new!");
+                WORD_ATOM(602, 17, "MetaVar.new!");
                 mw_MetaVar_2E_new_21_();
-                WORD_ATOM(586, 30, "TMeta");
+                WORD_ATOM(602, 30, "TMeta");
                 mw_TMeta();
-                WORD_ATOM(587, 17, "dup2");
+                WORD_ATOM(603, 17, "dup2");
                 mw_dup2();
-                WORD_ATOM(587, 22, "T*");
+                WORD_ATOM(603, 22, "T*");
                 mw_T_2A_();
-                WORD_ATOM(587, 25, ">Type");
+                WORD_ATOM(603, 25, ">Type");
                 mw_StackType_3E_Type();
-                WORD_ATOM(587, 31, "SOME");
+                WORD_ATOM(603, 31, "SOME");
                 mw_SOME();
                 push_value(d4);
             }
-            WORD_ATOM(588, 13, "~type?");
+            WORD_ATOM(604, 13, "~type?");
             mw_MetaVar_7E_type_3F_();
-            WORD_ATOM(588, 20, "!");
+            WORD_ATOM(604, 20, "!");
             mw_prim_mut_set();
-            WORD_ATOM(588, 22, "rotl");
+            WORD_ATOM(604, 22, "rotl");
             mw_rotl();
             break;
         default:
-            WORD_ATOM(590, 13, "drop");
+            WORD_ATOM(606, 13, "drop");
             mw_prim_drop();
-            WORD_ATOM(590, 18, "dup");
+            WORD_ATOM(606, 18, "dup");
             mw_prim_dup();
-            WORD_ATOM(590, 22, "");
+            WORD_ATOM(606, 22, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -21147,14 +21271,14 @@ static void mw_elab_expand_tensor_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(590, 44, "emit-error!");
+            WORD_ATOM(606, 44, "emit-error!");
             mw_emit_error_21_();
-            WORD_ATOM(591, 13, "dip");
+            WORD_ATOM(607, 13, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(591, 17, "STACK_TYPE_ERROR");
+                WORD_ATOM(607, 17, "STACK_TYPE_ERROR");
                 mw_STACK_5F_TYPE_5F_ERROR();
-                WORD_ATOM(591, 34, "TYPE_ERROR");
+                WORD_ATOM(607, 34, "TYPE_ERROR");
                 mw_TYPE_5F_ERROR();
                 push_value(d4);
             }
@@ -21163,19 +21287,19 @@ static void mw_elab_expand_tensor_21_ (void){
 }    WORD_EXIT(mw_elab_expand_tensor_21_);
 }
 static void mw_elab_lambda_pop_from_mid_21_ (void){
-    WORD_ENTER(mw_elab_lambda_pop_from_mid_21_, "elab-lambda-pop-from-mid!", "src/mirth/elab.mth", 609, 5);
-    WORD_ATOM(609, 5, "dip");
+    WORD_ENTER(mw_elab_lambda_pop_from_mid_21_, "elab-lambda-pop-from-mid!", "src/mirth/elab.mth", 625, 5);
+    WORD_ATOM(625, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(609, 9, "dup");
+        WORD_ATOM(625, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(609, 13, "mid");
+        WORD_ATOM(625, 13, "mid");
         mw_Lambda_2E_mid();
         push_value(d2);
     }
-    WORD_ATOM(610, 5, "elab-expand-tensor!");
+    WORD_ATOM(626, 5, "elab-expand-tensor!");
     mw_elab_expand_tensor_21_();
-    WORD_ATOM(611, 5, "dip2");
+    WORD_ATOM(627, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_elab_lambda_pop_from_mid_21__2);
     mw_prim_pack_cons();
@@ -21183,25 +21307,25 @@ static void mw_elab_lambda_pop_from_mid_21_ (void){
     WORD_EXIT(mw_elab_lambda_pop_from_mid_21_);
 }
 static void mw_token_is_lambda_param_3F_ (void){
-    WORD_ENTER(mw_token_is_lambda_param_3F_, "token-is-lambda-param?", "src/mirth/elab.mth", 614, 5);
-    WORD_ATOM(614, 5, "dup");
+    WORD_ENTER(mw_token_is_lambda_param_3F_, "token-is-lambda-param?", "src/mirth/elab.mth", 630, 5);
+    WORD_ATOM(630, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(614, 9, "sig-type-var?");
+    WORD_ATOM(630, 9, "sig-type-var?");
     mw_Token_2E_sig_type_var_3F_();
-    WORD_ATOM(614, 23, "if");
+    WORD_ATOM(630, 23, "if");
     if (pop_u64()) {
-        WORD_ATOM(615, 9, "dup");
+        WORD_ATOM(631, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(615, 13, "has-args?");
+        WORD_ATOM(631, 13, "has-args?");
         mw_Token_2E_has_args_3F_();
-        WORD_ATOM(615, 23, "not");
+        WORD_ATOM(631, 23, "not");
         mw_Bool_2E_not();
     } else {
-        WORD_ATOM(616, 5, "dup");
+        WORD_ATOM(632, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(616, 9, "lsquare?");
+        WORD_ATOM(632, 9, "lsquare?");
         mw_Token_2E_lsquare_3F_();
-        WORD_ATOM(616, 18, ".if");
+        WORD_ATOM(632, 18, ".if");
         push_u64(0);
         push_fnptr(&mb_token_is_lambda_param_3F__3);
         mw_prim_pack_cons();
@@ -21213,135 +21337,135 @@ static void mw_token_is_lambda_param_3F_ (void){
     WORD_EXIT(mw_token_is_lambda_param_3F_);
 }
 static void mw_elab_lambda_params_21_ (void){
-    WORD_ENTER(mw_elab_lambda_params_21_, "elab-lambda-params!", "src/mirth/elab.mth", 625, 5);
-    WORD_ATOM(625, 5, "L0");
+    WORD_ENTER(mw_elab_lambda_params_21_, "elab-lambda-params!", "src/mirth/elab.mth", 641, 5);
+    WORD_ATOM(641, 5, "L0");
     mw_L0();
-    WORD_ATOM(625, 8, "over");
+    WORD_ATOM(641, 8, "over");
     mw_over();
-    WORD_ATOM(625, 13, "~params");
+    WORD_ATOM(641, 13, "~params");
     mw_Lambda_7E_params();
-    WORD_ATOM(625, 21, "!");
+    WORD_ATOM(641, 21, "!");
     mw_prim_mut_set();
-    WORD_ATOM(626, 5, "dup");
+    WORD_ATOM(642, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(626, 9, "outer-ctx");
+    WORD_ATOM(642, 9, "outer-ctx");
     mw_Lambda_2E_outer_ctx();
-    WORD_ATOM(626, 19, "over");
+    WORD_ATOM(642, 19, "over");
     mw_over();
-    WORD_ATOM(626, 24, "~inner-ctx");
+    WORD_ATOM(642, 24, "~inner-ctx");
     mw_Lambda_7E_inner_ctx();
-    WORD_ATOM(626, 35, "!");
+    WORD_ATOM(642, 35, "!");
     mw_prim_mut_set();
-    WORD_ATOM(627, 5, "dup");
+    WORD_ATOM(643, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(627, 9, "dom");
+    WORD_ATOM(643, 9, "dom");
     mw_Lambda_2E_dom();
-    WORD_ATOM(627, 13, "over");
+    WORD_ATOM(643, 13, "over");
     mw_over();
-    WORD_ATOM(627, 18, "~mid");
+    WORD_ATOM(643, 18, "~mid");
     mw_Lambda_7E_mid();
-    WORD_ATOM(627, 23, "!");
+    WORD_ATOM(643, 23, "!");
     mw_prim_mut_set();
-    WORD_ATOM(628, 5, "dup");
+    WORD_ATOM(644, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(628, 9, "token");
+    WORD_ATOM(644, 9, "token");
     mw_Lambda_2E_token();
-    WORD_ATOM(628, 15, "args-1");
+    WORD_ATOM(644, 15, "args-1");
     mw_Token_2E_args_1();
-    WORD_ATOM(629, 5, "while");
+    WORD_ATOM(645, 5, "while");
     while(1) {
-        WORD_ATOM(629, 11, "token-is-lambda-param?");
+        WORD_ATOM(645, 11, "token-is-lambda-param?");
         mw_token_is_lambda_param_3F_();
         if (! pop_u64()) break;
-        WORD_ATOM(629, 35, "next");
+        WORD_ATOM(645, 35, "next");
         mw_Token_2E_next();
     }
-    WORD_ATOM(630, 5, "expect-token-arrow");
+    WORD_ATOM(646, 5, "expect-token-arrow");
     mw_expect_token_arrow();
-    WORD_ATOM(630, 24, "prev");
+    WORD_ATOM(646, 24, "prev");
     mw_Token_2E_prev();
-    WORD_ATOM(631, 5, "while");
+    WORD_ATOM(647, 5, "while");
     while(1) {
-        WORD_ATOM(631, 11, "token-is-lambda-param?");
+        WORD_ATOM(647, 11, "token-is-lambda-param?");
         mw_token_is_lambda_param_3F_();
         if (! pop_u64()) break;
-        WORD_ATOM(632, 9, "elab-lambda-pop-from-mid!");
+        WORD_ATOM(648, 9, "elab-lambda-pop-from-mid!");
         mw_elab_lambda_pop_from_mid_21_();
-        WORD_ATOM(632, 35, "sip");
+        WORD_ATOM(648, 35, "sip");
         push_u64(0);
         push_fnptr(&mb_elab_lambda_params_21__5);
         mw_prim_pack_cons();
         mw_sip();
-        WORD_ATOM(645, 9, "prev");
+        WORD_ATOM(661, 9, "prev");
         mw_Token_2E_prev();
     }
-    WORD_ATOM(646, 5, "drop");
+    WORD_ATOM(662, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_lambda_params_21_);
 }
 static void mw_elab_lambda_body_21_ (void){
-    WORD_ENTER(mw_elab_lambda_body_21_, "elab-lambda-body!", "src/mirth/elab.mth", 649, 5);
-    WORD_ATOM(649, 5, "dup");
+    WORD_ENTER(mw_elab_lambda_body_21_, "elab-lambda-body!", "src/mirth/elab.mth", 665, 5);
+    WORD_ATOM(665, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(649, 9, "token");
+    WORD_ATOM(665, 9, "token");
     mw_Lambda_2E_token();
-    WORD_ATOM(649, 15, "args-1");
+    WORD_ATOM(665, 15, "args-1");
     mw_Token_2E_args_1();
-    WORD_ATOM(650, 5, "while");
+    WORD_ATOM(666, 5, "while");
     while(1) {
-        WORD_ATOM(650, 11, "token-is-lambda-param?");
+        WORD_ATOM(666, 11, "token-is-lambda-param?");
         mw_token_is_lambda_param_3F_();
         if (! pop_u64()) break;
-        WORD_ATOM(650, 35, "next");
+        WORD_ATOM(666, 35, "next");
         mw_Token_2E_next();
     }
-    WORD_ATOM(650, 41, "succ");
+    WORD_ATOM(666, 41, "succ");
     mw_Token_2E_succ();
-    WORD_ATOM(651, 5, "dip");
+    WORD_ATOM(667, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(651, 9, "dup");
+        WORD_ATOM(667, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(651, 13, "mid");
+        WORD_ATOM(667, 13, "mid");
         mw_Lambda_2E_mid();
-        WORD_ATOM(651, 17, "dip");
+        WORD_ATOM(667, 17, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(651, 21, "dup");
+            WORD_ATOM(667, 21, "dup");
             mw_prim_dup();
-            WORD_ATOM(651, 25, "inner-ctx");
+            WORD_ATOM(667, 25, "inner-ctx");
             mw_Lambda_2E_inner_ctx();
             push_value(d3);
         }
         push_value(d2);
     }
-    WORD_ATOM(652, 5, "elab-arrow-fwd!");
+    WORD_ATOM(668, 5, "elab-arrow-fwd!");
     mw_elab_arrow_fwd_21_();
-    WORD_ATOM(653, 5, "dup2");
+    WORD_ATOM(669, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(653, 10, "swap");
+    WORD_ATOM(669, 10, "swap");
     mw_prim_swap();
-    WORD_ATOM(653, 15, "~body");
+    WORD_ATOM(669, 15, "~body");
     mw_Lambda_7E_body();
-    WORD_ATOM(653, 21, "!");
+    WORD_ATOM(669, 21, "!");
     mw_prim_mut_set();
-    WORD_ATOM(654, 5, "cod");
+    WORD_ATOM(670, 5, "cod");
     mw_Arrow_2E_cod();
-    WORD_ATOM(654, 9, "over");
+    WORD_ATOM(670, 9, "over");
     mw_over();
-    WORD_ATOM(654, 14, "~cod");
+    WORD_ATOM(670, 14, "~cod");
     mw_Lambda_7E_cod();
-    WORD_ATOM(654, 19, "!");
+    WORD_ATOM(670, 19, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_elab_lambda_body_21_);
 }
 static void mw_elab_match_exhaustive_21_ (void){
-    WORD_ENTER(mw_elab_match_exhaustive_21_, "elab-match-exhaustive!", "src/mirth/elab.mth", 658, 5);
-    WORD_ATOM(658, 5, "dup");
+    WORD_ENTER(mw_elab_match_exhaustive_21_, "elab-match-exhaustive!", "src/mirth/elab.mth", 674, 5);
+    WORD_ATOM(674, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(658, 9, "is-exhaustive?");
+    WORD_ATOM(674, 9, "is-exhaustive?");
     mw_Match_2E_is_exhaustive_3F_();
-    WORD_ATOM(658, 24, "else");
+    WORD_ATOM(674, 24, "else");
     push_u64(0);
     push_fnptr(&mb_elab_match_exhaustive_21__1);
     mw_prim_pack_cons();
@@ -21349,80 +21473,80 @@ static void mw_elab_match_exhaustive_21_ (void){
     WORD_EXIT(mw_elab_match_exhaustive_21_);
 }
 static void mw_elab_match_cases_21_ (void){
-    WORD_ENTER(mw_elab_match_cases_21_, "elab-match-cases!", "src/mirth/elab.mth", 664, 5);
-    WORD_ATOM(664, 5, "L0");
+    WORD_ENTER(mw_elab_match_cases_21_, "elab-match-cases!", "src/mirth/elab.mth", 680, 5);
+    WORD_ATOM(680, 5, "L0");
     mw_L0();
-    WORD_ATOM(664, 8, "over");
+    WORD_ATOM(680, 8, "over");
     mw_over();
-    WORD_ATOM(664, 13, "~cases");
+    WORD_ATOM(680, 13, "~cases");
     mw_Match_7E_cases();
-    WORD_ATOM(664, 20, "!");
+    WORD_ATOM(680, 20, "!");
     mw_prim_mut_set();
-    WORD_ATOM(665, 5, "dup");
+    WORD_ATOM(681, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(665, 9, "body");
+    WORD_ATOM(681, 9, "body");
     mw_Match_2E_body();
-    WORD_ATOM(666, 5, "while");
+    WORD_ATOM(682, 5, "while");
     while(1) {
-        WORD_ATOM(666, 11, "dup");
+        WORD_ATOM(682, 11, "dup");
         mw_prim_dup();
-        WORD_ATOM(666, 15, "rparen?");
+        WORD_ATOM(682, 15, "rparen?");
         mw_Token_2E_rparen_3F_();
-        WORD_ATOM(666, 23, "not");
+        WORD_ATOM(682, 23, "not");
         mw_Maybe_2E_not();
         if (! pop_u64()) break;
-        WORD_ATOM(666, 28, "elab-match-case!");
+        WORD_ATOM(682, 28, "elab-match-case!");
         mw_elab_match_case_21_();
     }
-    WORD_ATOM(667, 5, "drop");
+    WORD_ATOM(683, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_match_cases_21_);
 }
 static void mw_elab_match_case_21_ (void){
-    WORD_ENTER(mw_elab_match_case_21_, "elab-match-case!", "src/mirth/elab.mth", 671, 5);
-    WORD_ATOM(671, 5, "Case.alloc!");
+    WORD_ENTER(mw_elab_match_case_21_, "elab-match-case!", "src/mirth/elab.mth", 687, 5);
+    WORD_ATOM(687, 5, "Case.alloc!");
     mw_Case_2E_alloc_21_();
-    WORD_ATOM(672, 5, "dup2");
+    WORD_ATOM(688, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(672, 10, "~token");
+    WORD_ATOM(688, 10, "~token");
     mw_Case_7E_token();
-    WORD_ATOM(672, 17, "!");
+    WORD_ATOM(688, 17, "!");
     mw_prim_mut_set();
-    WORD_ATOM(673, 5, "swap");
+    WORD_ATOM(689, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(673, 10, "dip");
+    WORD_ATOM(689, 10, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(673, 14, "dup2");
+        WORD_ATOM(689, 14, "dup2");
         mw_dup2();
-        WORD_ATOM(673, 19, "~match");
+        WORD_ATOM(689, 19, "~match");
         mw_Case_7E_match();
-        WORD_ATOM(673, 26, "!");
+        WORD_ATOM(689, 26, "!");
         mw_prim_mut_set();
         push_value(d2);
     }
-    WORD_ATOM(674, 5, "elab-case-pattern!");
+    WORD_ATOM(690, 5, "elab-case-pattern!");
     mw_elab_case_pattern_21_();
-    WORD_ATOM(675, 5, "expect-token-arrow");
+    WORD_ATOM(691, 5, "expect-token-arrow");
     mw_expect_token_arrow();
-    WORD_ATOM(675, 24, "succ");
+    WORD_ATOM(691, 24, "succ");
     mw_Token_2E_succ();
-    WORD_ATOM(676, 5, "elab-case-body!");
+    WORD_ATOM(692, 5, "elab-case-body!");
     mw_elab_case_body_21_();
-    WORD_ATOM(677, 5, "dip");
+    WORD_ATOM(693, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(677, 9, "over");
+        WORD_ATOM(693, 9, "over");
         mw_over();
-        WORD_ATOM(677, 14, "add-case!");
+        WORD_ATOM(693, 14, "add-case!");
         mw_Match_2E_add_case_21_();
         push_value(d2);
     }
-    WORD_ATOM(678, 5, "dup");
+    WORD_ATOM(694, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(678, 9, "comma?");
+    WORD_ATOM(694, 9, "comma?");
     mw_Token_2E_comma_3F_();
-    WORD_ATOM(678, 16, "then");
+    WORD_ATOM(694, 16, "then");
     push_u64(0);
     push_fnptr(&mb_elab_match_case_21__3);
     mw_prim_pack_cons();
@@ -21430,64 +21554,64 @@ static void mw_elab_match_case_21_ (void){
     WORD_EXIT(mw_elab_match_case_21_);
 }
 static void mw_elab_case_pattern_21_ (void){
-    WORD_ENTER(mw_elab_case_pattern_21_, "elab-case-pattern!", "src/mirth/elab.mth", 682, 5);
-    WORD_ATOM(682, 5, "dup");
+    WORD_ENTER(mw_elab_case_pattern_21_, "elab-case-pattern!", "src/mirth/elab.mth", 698, 5);
+    WORD_ATOM(698, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(682, 9, "pat-underscore?");
+    WORD_ATOM(698, 9, "pat-underscore?");
     mw_Token_2E_pat_underscore_3F_();
-    WORD_ATOM(682, 25, "if");
+    WORD_ATOM(698, 25, "if");
     if (pop_u64()) {
-        WORD_ATOM(684, 9, "dip");
+        WORD_ATOM(700, 9, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(684, 13, "PATTERN_UNDERSCORE");
+            WORD_ATOM(700, 13, "PATTERN_UNDERSCORE");
             mw_PATTERN_5F_UNDERSCORE();
-            WORD_ATOM(684, 32, "over");
+            WORD_ATOM(700, 32, "over");
             mw_over();
-            WORD_ATOM(684, 37, "~pattern");
+            WORD_ATOM(700, 37, "~pattern");
             mw_Case_7E_pattern();
-            WORD_ATOM(684, 46, "!");
+            WORD_ATOM(700, 46, "!");
             mw_prim_mut_set();
             push_value(d3);
         }
-        WORD_ATOM(687, 9, "dip");
+        WORD_ATOM(703, 9, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(687, 13, "dup");
+            WORD_ATOM(703, 13, "dup");
             mw_prim_dup();
-            WORD_ATOM(687, 17, ".match");
+            WORD_ATOM(703, 17, ".match");
             mw_Case_2E_match();
-            WORD_ATOM(687, 24, "dom");
+            WORD_ATOM(703, 24, "dom");
             mw_Match_2E_dom();
-            WORD_ATOM(687, 28, "STACK_TYPE_DONT_CARE");
+            WORD_ATOM(703, 28, "STACK_TYPE_DONT_CARE");
             mw_STACK_5F_TYPE_5F_DONT_5F_CARE();
-            WORD_ATOM(687, 49, "TYPE_DONT_CARE");
+            WORD_ATOM(703, 49, "TYPE_DONT_CARE");
             mw_TYPE_5F_DONT_5F_CARE();
-            WORD_ATOM(687, 64, "T*");
+            WORD_ATOM(703, 64, "T*");
             mw_T_2A_();
             push_value(d3);
         }
-        WORD_ATOM(688, 9, "elab-stack-type-unify!");
+        WORD_ATOM(704, 9, "elab-stack-type-unify!");
         mw_elab_stack_type_unify_21_();
-        WORD_ATOM(688, 32, "dip");
+        WORD_ATOM(704, 32, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(688, 36, "over");
+            WORD_ATOM(704, 36, "over");
             mw_over();
-            WORD_ATOM(688, 41, "~mid");
+            WORD_ATOM(704, 41, "~mid");
             mw_Case_7E_mid();
-            WORD_ATOM(688, 46, "!");
+            WORD_ATOM(704, 46, "!");
             mw_prim_mut_set();
             push_value(d3);
         }
-        WORD_ATOM(691, 9, "succ");
+        WORD_ATOM(707, 9, "succ");
         mw_Token_2E_succ();
     } else {
-        WORD_ATOM(693, 5, "dup");
+        WORD_ATOM(709, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(693, 9, "name?");
+        WORD_ATOM(709, 9, "name?");
         mw_Token_2E_name_3F_();
-        WORD_ATOM(693, 15, "if-some");
+        WORD_ATOM(709, 15, "if-some");
         push_u64(0);
         push_fnptr(&mb_elab_case_pattern_21__6);
         mw_prim_pack_cons();
@@ -21499,147 +21623,147 @@ static void mw_elab_case_pattern_21_ (void){
     WORD_EXIT(mw_elab_case_pattern_21_);
 }
 static void mw_elab_case_body_21_ (void){
-    WORD_ENTER(mw_elab_case_body_21_, "elab-case-body!", "src/mirth/elab.mth", 726, 5);
-    WORD_ATOM(726, 5, "dip");
+    WORD_ENTER(mw_elab_case_body_21_, "elab-case-body!", "src/mirth/elab.mth", 742, 5);
+    WORD_ATOM(742, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(726, 9, "dup");
+        WORD_ATOM(742, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(726, 13, "mid");
+        WORD_ATOM(742, 13, "mid");
         mw_Case_2E_mid();
-        WORD_ATOM(726, 17, "dip");
+        WORD_ATOM(742, 17, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(726, 21, "dup");
+            WORD_ATOM(742, 21, "dup");
             mw_prim_dup();
-            WORD_ATOM(726, 25, ".match");
+            WORD_ATOM(742, 25, ".match");
             mw_Case_2E_match();
-            WORD_ATOM(726, 32, "ctx");
+            WORD_ATOM(742, 32, "ctx");
             mw_Match_2E_ctx();
             push_value(d3);
         }
         push_value(d2);
     }
-    WORD_ATOM(726, 38, "elab-arrow-fwd!");
+    WORD_ATOM(742, 38, "elab-arrow-fwd!");
     mw_elab_arrow_fwd_21_();
-    WORD_ATOM(727, 5, "dup");
+    WORD_ATOM(743, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(727, 9, "token-end");
+    WORD_ATOM(743, 9, "token-end");
     mw_Arrow_2E_token_end();
-    WORD_ATOM(727, 19, "dip");
+    WORD_ATOM(743, 19, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(727, 23, "dup");
+        WORD_ATOM(743, 23, "dup");
         mw_prim_dup();
-        WORD_ATOM(727, 27, "cod");
+        WORD_ATOM(743, 27, "cod");
         mw_Arrow_2E_cod();
         push_value(d2);
     }
-    WORD_ATOM(728, 5, "dip2");
+    WORD_ATOM(744, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_elab_case_body_21__4);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(729, 5, "dip2");
+    WORD_ATOM(745, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_elab_case_body_21__5);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(729, 26, "elab-stack-type-unify!");
+    WORD_ATOM(745, 26, "elab-stack-type-unify!");
     mw_elab_stack_type_unify_21_();
-    WORD_ATOM(729, 49, "nip");
+    WORD_ATOM(745, 49, "nip");
     mw_nip();
     WORD_EXIT(mw_elab_case_body_21_);
 }
 static void mw_elab_module_21_ (void){
-    WORD_ENTER(mw_elab_module_21_, "elab-module!", "src/mirth/elab.mth", 737, 5);
-    WORD_ATOM(737, 5, "dup");
+    WORD_ENTER(mw_elab_module_21_, "elab-module!", "src/mirth/elab.mth", 753, 5);
+    WORD_ATOM(753, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(737, 9, "start");
+    WORD_ATOM(753, 9, "start");
     mw_Module_2E_start();
-    WORD_ATOM(738, 5, "elab-module-header!");
+    WORD_ATOM(754, 5, "elab-module-header!");
     mw_elab_module_header_21_();
-    WORD_ATOM(739, 5, "while");
+    WORD_ATOM(755, 5, "while");
     while(1) {
-        WORD_ATOM(739, 11, "dup");
+        WORD_ATOM(755, 11, "dup");
         mw_prim_dup();
-        WORD_ATOM(739, 15, "module-end?");
+        WORD_ATOM(755, 15, "module-end?");
         mw_Token_2E_module_end_3F_();
-        WORD_ATOM(739, 27, "not");
+        WORD_ATOM(755, 27, "not");
         mw_Bool_2E_not();
         if (! pop_u64()) break;
-        WORD_ATOM(739, 32, "elab-module-decl!");
+        WORD_ATOM(755, 32, "elab-module-decl!");
         mw_elab_module_decl_21_();
     }
-    WORD_ATOM(740, 5, "drop");
+    WORD_ATOM(756, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_module_21_);
 }
 static void mw_elab_module_header_21_ (void){
-    WORD_ENTER(mw_elab_module_header_21_, "elab-module-header!", "src/mirth/elab.mth", 745, 5);
-    WORD_ATOM(745, 5, "dup");
+    WORD_ENTER(mw_elab_module_header_21_, "elab-module-header!", "src/mirth/elab.mth", 761, 5);
+    WORD_ATOM(761, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(745, 9, "module-header?");
+    WORD_ATOM(761, 9, "module-header?");
     mw_Token_2E_module_header_3F_();
-    WORD_ATOM(745, 24, "if");
+    WORD_ATOM(761, 24, "if");
     if (pop_u64()) {
-        WORD_ATOM(746, 9, "sip");
+        WORD_ATOM(762, 9, "sip");
         push_u64(0);
         push_fnptr(&mb_elab_module_header_21__2);
         mw_prim_pack_cons();
         mw_sip();
-        WORD_ATOM(746, 19, "args-1");
+        WORD_ATOM(762, 19, "args-1");
         mw_Token_2E_args_1();
-        WORD_ATOM(747, 9, "dup");
+        WORD_ATOM(763, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(747, 13, "name?");
+        WORD_ATOM(763, 13, "name?");
         mw_Token_2E_name_3F_();
-        WORD_ATOM(747, 19, "unwrap-or");
+        WORD_ATOM(763, 19, "unwrap-or");
         push_u64(0);
         push_fnptr(&mb_elab_module_header_21__3);
         mw_prim_pack_cons();
         mw_Maybe_2E_unwrap_or();
-        WORD_ATOM(748, 9, "name-defined?");
+        WORD_ATOM(764, 9, "name-defined?");
         mw_name_defined_3F_();
-        WORD_ATOM(748, 23, "then");
+        WORD_ATOM(764, 23, "then");
         push_u64(0);
         push_fnptr(&mb_elab_module_header_21__4);
         mw_prim_pack_cons();
         mw_Bool_2E_then();
-        WORD_ATOM(749, 9, "over");
+        WORD_ATOM(765, 9, "over");
         mw_over();
-        WORD_ATOM(749, 14, ".module");
+        WORD_ATOM(765, 14, ".module");
         mw_Token_2E_module();
-        WORD_ATOM(750, 9, "dup2");
+        WORD_ATOM(766, 9, "dup2");
         mw_dup2();
-        WORD_ATOM(750, 14, "~name");
+        WORD_ATOM(766, 14, "~name");
         mw_Module_7E_name();
-        WORD_ATOM(750, 20, "!");
+        WORD_ATOM(766, 20, "!");
         mw_prim_mut_set();
-        WORD_ATOM(751, 9, "dup2");
+        WORD_ATOM(767, 9, "dup2");
         mw_dup2();
-        WORD_ATOM(751, 14, "DEF_MODULE");
+        WORD_ATOM(767, 14, "DEF_MODULE");
         mw_DEF_5F_MODULE();
-        WORD_ATOM(751, 25, "swap");
+        WORD_ATOM(767, 25, "swap");
         mw_prim_swap();
-        WORD_ATOM(751, 30, "~Def");
+        WORD_ATOM(767, 30, "~Def");
         mw_Name_7E_Def();
-        WORD_ATOM(751, 35, "!");
+        WORD_ATOM(767, 35, "!");
         mw_prim_mut_set();
-        WORD_ATOM(752, 9, "path");
+        WORD_ATOM(768, 9, "path");
         mw_Module_2E_path();
-        WORD_ATOM(752, 14, "swap");
+        WORD_ATOM(768, 14, "swap");
         mw_prim_swap();
-        WORD_ATOM(753, 9, "to-module-path");
+        WORD_ATOM(769, 9, "to-module-path");
         mw_Name_2E_to_module_path();
-        WORD_ATOM(753, 24, "=");
+        WORD_ATOM(769, 24, "=");
         mw_Path_3D_();
-        WORD_ATOM(753, 26, "if");
+        WORD_ATOM(769, 26, "if");
         if (pop_u64()) {
-            WORD_ATOM(753, 29, "drop");
+            WORD_ATOM(769, 29, "drop");
             mw_prim_drop();
         } else {
-            WORD_ATOM(754, 13, "");
+            WORD_ATOM(770, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -21650,13 +21774,13 @@ static void mw_elab_module_header_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(754, 46, "emit-error!");
+            WORD_ATOM(770, 46, "emit-error!");
             mw_emit_error_21_();
         }
     } else {
-        WORD_ATOM(755, 9, "dup");
+        WORD_ATOM(771, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(755, 13, "");
+        WORD_ATOM(771, 13, "");
         {
             static bool vready = false;
             static VAL v;
@@ -21667,107 +21791,107 @@ static void mw_elab_module_header_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(755, 39, "emit-error!");
+        WORD_ATOM(771, 39, "emit-error!");
         mw_emit_error_21_();
     }
     WORD_EXIT(mw_elab_module_header_21_);
 }
 static void mw_elab_module_decl_21_ (void){
-    WORD_ENTER(mw_elab_module_decl_21_, "elab-module-decl!", "src/mirth/elab.mth", 760, 5);
-    WORD_ATOM(760, 5, "dup");
+    WORD_ENTER(mw_elab_module_decl_21_, "elab-module-decl!", "src/mirth/elab.mth", 776, 5);
+    WORD_ATOM(776, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(761, 5, "name?");
+    WORD_ATOM(777, 5, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(761, 11, "unwrap-or");
+    WORD_ATOM(777, 11, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_module_decl_21__1);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(762, 5, ">Def");
+    WORD_ATOM(778, 5, ">Def");
     mw_Name_3E_Def();
-    WORD_ATOM(762, 10, "prim?");
+    WORD_ATOM(778, 10, "prim?");
     mw_Def_2E_prim_3F_();
-    WORD_ATOM(762, 16, "unwrap-or");
+    WORD_ATOM(778, 16, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_module_decl_21__2);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(763, 5, "decl");
+    WORD_ATOM(779, 5, "decl");
     mw_Prim_2E_decl();
-    WORD_ATOM(763, 10, "unwrap-or");
+    WORD_ATOM(779, 10, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_module_decl_21__3);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(764, 5, "run");
+    WORD_ATOM(780, 5, "run");
     mw_prim_run();
     WORD_EXIT(mw_elab_module_decl_21_);
 }
 static void mw_elab_module_import_21_ (void){
-    WORD_ENTER(mw_elab_module_import_21_, "elab-module-import!", "src/mirth/elab.mth", 768, 5);
-    WORD_ATOM(768, 5, "sip");
+    WORD_ENTER(mw_elab_module_import_21_, "elab-module-import!", "src/mirth/elab.mth", 784, 5);
+    WORD_ATOM(784, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_module_import_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(769, 5, "args-1");
+    WORD_ATOM(785, 5, "args-1");
     mw_Token_2E_args_1();
-    WORD_ATOM(769, 12, "dup");
+    WORD_ATOM(785, 12, "dup");
     mw_prim_dup();
-    WORD_ATOM(769, 16, "value");
+    WORD_ATOM(785, 16, "value");
     mw_Token_2E_value();
-    WORD_ATOM(769, 22, "match");
+    WORD_ATOM(785, 22, "match");
     switch (get_top_data_tag()) {
         case 13LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(771, 13, "dup");
+            WORD_ATOM(787, 13, "dup");
             mw_prim_dup();
-            WORD_ATOM(771, 17, ">Def");
+            WORD_ATOM(787, 17, ">Def");
             mw_Name_3E_Def();
-            WORD_ATOM(771, 22, "match");
+            WORD_ATOM(787, 22, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(773, 21, "dip");
+                    WORD_ATOM(789, 21, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(773, 25, "drop2");
+                        WORD_ATOM(789, 25, "drop2");
                         mw_drop2();
-                        WORD_ATOM(773, 31, "dup");
+                        WORD_ATOM(789, 31, "dup");
                         mw_prim_dup();
-                        WORD_ATOM(773, 35, ".module");
+                        WORD_ATOM(789, 35, ".module");
                         mw_Token_2E_module();
                         push_value(d6);
                     }
-                    WORD_ATOM(773, 44, "add-import!");
+                    WORD_ATOM(789, 44, "add-import!");
                     mw_Module_2E_add_import_21_();
                     break;
                 case 0LL:
                     mw_prim_drop();
-                    WORD_ATOM(777, 21, "to-module-path");
+                    WORD_ATOM(793, 21, "to-module-path");
                     mw_Name_2E_to_module_path();
-                    WORD_ATOM(777, 36, "run-lexer!");
+                    WORD_ATOM(793, 36, "run-lexer!");
                     mw_run_lexer_21_();
-                    WORD_ATOM(778, 21, "elab-module!");
+                    WORD_ATOM(794, 21, "elab-module!");
                     mw_elab_module_21_();
-                    WORD_ATOM(779, 21, "dip");
+                    WORD_ATOM(795, 21, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(779, 25, "drop");
+                        WORD_ATOM(795, 25, "drop");
                         mw_prim_drop();
-                        WORD_ATOM(779, 30, "dup");
+                        WORD_ATOM(795, 30, "dup");
                         mw_prim_dup();
-                        WORD_ATOM(779, 34, ".module");
+                        WORD_ATOM(795, 34, ".module");
                         mw_Token_2E_module();
                         push_value(d6);
                     }
-                    WORD_ATOM(779, 43, "add-import!");
+                    WORD_ATOM(795, 43, "add-import!");
                     mw_Module_2E_add_import_21_();
                     break;
                 default:
-                    WORD_ATOM(785, 21, "drop2");
+                    WORD_ATOM(801, 21, "drop2");
                     mw_drop2();
-                    WORD_ATOM(785, 27, "");
+                    WORD_ATOM(801, 27, "");
                     {
                         static bool vready = false;
                         static VAL v;
@@ -21778,15 +21902,15 @@ static void mw_elab_module_import_21_ (void){
                         push_value(v);
                         incref(v);
                     }
-                    WORD_ATOM(785, 55, "emit-fatal-error!");
+                    WORD_ATOM(801, 55, "emit-fatal-error!");
                     mw_emit_fatal_error_21_();
                     break;
             
 }            break;
         default:
-            WORD_ATOM(788, 13, "drop");
+            WORD_ATOM(804, 13, "drop");
             mw_prim_drop();
-            WORD_ATOM(788, 18, "");
+            WORD_ATOM(804, 18, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -21797,182 +21921,182 @@ static void mw_elab_module_import_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(788, 41, "emit-fatal-error!");
+            WORD_ATOM(804, 41, "emit-fatal-error!");
             mw_emit_fatal_error_21_();
             break;
     
 }    WORD_EXIT(mw_elab_module_import_21_);
 }
 static void mw_elab_data_21_ (void){
-    WORD_ENTER(mw_elab_data_21_, "elab-data!", "src/mirth/elab.mth", 793, 5);
-    WORD_ATOM(793, 5, "sip");
+    WORD_ENTER(mw_elab_data_21_, "elab-data!", "src/mirth/elab.mth", 809, 5);
+    WORD_ATOM(809, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_data_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(800, 7, "next");
+    WORD_ATOM(816, 7, "next");
     mw_Token_2E_next();
     WORD_EXIT(mw_elab_data_21_);
 }
 static void mw_elab_data_header_21_ (void){
-    WORD_ENTER(mw_elab_data_header_21_, "elab-data-header!", "src/mirth/elab.mth", 804, 5);
-    WORD_ATOM(804, 5, "dup2");
+    WORD_ENTER(mw_elab_data_header_21_, "elab-data-header!", "src/mirth/elab.mth", 820, 5);
+    WORD_ATOM(820, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(804, 10, "SOME");
+    WORD_ATOM(820, 10, "SOME");
     mw_SOME();
-    WORD_ATOM(804, 15, "swap");
+    WORD_ATOM(820, 15, "swap");
     mw_prim_swap();
-    WORD_ATOM(804, 20, "~head?");
+    WORD_ATOM(820, 20, "~head?");
     mw_Data_7E_head_3F_();
-    WORD_ATOM(804, 27, "!");
+    WORD_ATOM(820, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(805, 5, "dup");
+    WORD_ATOM(821, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(805, 9, "sig-type-con?");
+    WORD_ATOM(821, 9, "sig-type-con?");
     mw_Token_2E_sig_type_con_3F_();
-    WORD_ATOM(805, 23, "else");
+    WORD_ATOM(821, 23, "else");
     push_u64(0);
     push_fnptr(&mb_elab_data_header_21__1);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(806, 5, "dup2");
+    WORD_ATOM(822, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(806, 10, "name?");
+    WORD_ATOM(822, 10, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(806, 16, "unwrap");
+    WORD_ATOM(822, 16, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(806, 23, "name-undefined?");
+    WORD_ATOM(822, 23, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(806, 39, "else");
+    WORD_ATOM(822, 39, "else");
     push_u64(0);
     push_fnptr(&mb_elab_data_header_21__2);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(807, 5, "over");
+    WORD_ATOM(823, 5, "over");
     mw_over();
-    WORD_ATOM(807, 10, "TData");
+    WORD_ATOM(823, 10, "TData");
     mw_TData();
-    WORD_ATOM(807, 16, "DEF_TYPE");
+    WORD_ATOM(823, 16, "DEF_TYPE");
     mw_DEF_5F_TYPE();
-    WORD_ATOM(807, 25, "over");
+    WORD_ATOM(823, 25, "over");
     mw_over();
-    WORD_ATOM(807, 30, "~Def");
+    WORD_ATOM(823, 30, "~Def");
     mw_Name_7E_Def();
-    WORD_ATOM(807, 35, "!");
+    WORD_ATOM(823, 35, "!");
     mw_prim_mut_set();
-    WORD_ATOM(808, 5, "swap");
+    WORD_ATOM(824, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(808, 10, "~name");
+    WORD_ATOM(824, 10, "~name");
     mw_Data_7E_name();
-    WORD_ATOM(808, 16, "!");
+    WORD_ATOM(824, 16, "!");
     mw_prim_mut_set();
-    WORD_ATOM(810, 5, "num-args");
+    WORD_ATOM(826, 5, "num-args");
     mw_Token_2E_num_args();
-    WORD_ATOM(810, 14, "over");
+    WORD_ATOM(826, 14, "over");
     mw_over();
-    WORD_ATOM(810, 19, "~arity");
+    WORD_ATOM(826, 19, "~arity");
     mw_Data_7E_arity();
-    WORD_ATOM(810, 26, "!");
+    WORD_ATOM(826, 26, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_elab_data_header_21_);
 }
 static void mw_elab_data_tag_21_ (void){
-    WORD_ENTER(mw_elab_data_tag_21_, "elab-data-tag!", "src/mirth/elab.mth", 815, 5);
-    WORD_ATOM(815, 5, "dup");
+    WORD_ENTER(mw_elab_data_tag_21_, "elab-data-tag!", "src/mirth/elab.mth", 831, 5);
+    WORD_ATOM(831, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(815, 9, "name?");
+    WORD_ATOM(831, 9, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(815, 15, "unwrap-or");
+    WORD_ATOM(831, 15, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_data_tag_21__1);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(816, 5, "name-undefined?");
+    WORD_ATOM(832, 5, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(816, 21, "else");
+    WORD_ATOM(832, 21, "else");
     push_u64(0);
     push_fnptr(&mb_elab_data_tag_21__2);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(817, 5, "Tag.alloc!");
+    WORD_ATOM(833, 5, "Tag.alloc!");
     mw_Tag_2E_alloc_21_();
-    WORD_ATOM(818, 5, "dup2");
+    WORD_ATOM(834, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(818, 10, "DEF_TAG");
+    WORD_ATOM(834, 10, "DEF_TAG");
     mw_DEF_5F_TAG();
-    WORD_ATOM(818, 18, "swap");
+    WORD_ATOM(834, 18, "swap");
     mw_prim_swap();
-    WORD_ATOM(818, 23, "~Def");
+    WORD_ATOM(834, 23, "~Def");
     mw_Name_7E_Def();
-    WORD_ATOM(818, 28, "!");
+    WORD_ATOM(834, 28, "!");
     mw_prim_mut_set();
-    WORD_ATOM(819, 5, "tuck");
+    WORD_ATOM(835, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(819, 10, "~name");
+    WORD_ATOM(835, 10, "~name");
     mw_Tag_7E_name();
-    WORD_ATOM(819, 16, "!");
+    WORD_ATOM(835, 16, "!");
     mw_prim_mut_set();
-    WORD_ATOM(821, 5, "dip");
+    WORD_ATOM(837, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(821, 9, "over");
+        WORD_ATOM(837, 9, "over");
         mw_over();
         push_value(d2);
     }
-    WORD_ATOM(821, 15, "dup2");
+    WORD_ATOM(837, 15, "dup2");
     mw_dup2();
-    WORD_ATOM(821, 20, "~data");
+    WORD_ATOM(837, 20, "~data");
     mw_Tag_7E_data();
-    WORD_ATOM(821, 26, "!");
+    WORD_ATOM(837, 26, "!");
     mw_prim_mut_set();
-    WORD_ATOM(822, 5, "tuck");
+    WORD_ATOM(838, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(822, 10, "dip");
+    WORD_ATOM(838, 10, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(822, 14, "add-tag!");
+        WORD_ATOM(838, 14, "add-tag!");
         mw_Data_2E_add_tag_21_();
         push_value(d2);
     }
-    WORD_ATOM(824, 5, "swap");
+    WORD_ATOM(840, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(824, 10, "succ");
+    WORD_ATOM(840, 10, "succ");
     mw_Token_2E_succ();
-    WORD_ATOM(825, 5, "dup");
+    WORD_ATOM(841, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(825, 9, "pat-arrow?");
+    WORD_ATOM(841, 9, "pat-arrow?");
     mw_Token_2E_pat_arrow_3F_();
-    WORD_ATOM(825, 20, "if");
+    WORD_ATOM(841, 20, "if");
     if (pop_u64()) {
-        WORD_ATOM(826, 9, "succ");
+        WORD_ATOM(842, 9, "succ");
         mw_Token_2E_succ();
-        WORD_ATOM(826, 14, "SOME");
+        WORD_ATOM(842, 14, "SOME");
         mw_SOME();
-        WORD_ATOM(826, 19, "over");
+        WORD_ATOM(842, 19, "over");
         mw_over();
-        WORD_ATOM(826, 24, "~sig?");
+        WORD_ATOM(842, 24, "~sig?");
         mw_Tag_7E_sig_3F_();
-        WORD_ATOM(826, 30, "!");
+        WORD_ATOM(842, 30, "!");
         mw_prim_mut_set();
     } else {
-        WORD_ATOM(827, 5, "dup");
+        WORD_ATOM(843, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(827, 9, "run-end?");
+        WORD_ATOM(843, 9, "run-end?");
         mw_Token_2E_run_end_3F_();
-        WORD_ATOM(827, 18, "if");
+        WORD_ATOM(843, 18, "if");
         if (pop_u64()) {
-            WORD_ATOM(828, 9, "drop");
+            WORD_ATOM(844, 9, "drop");
             mw_prim_drop();
-            WORD_ATOM(828, 14, "NONE");
+            WORD_ATOM(844, 14, "NONE");
             mw_NONE();
-            WORD_ATOM(828, 19, "over");
+            WORD_ATOM(844, 19, "over");
             mw_over();
-            WORD_ATOM(828, 24, "~sig?");
+            WORD_ATOM(844, 24, "~sig?");
             mw_Tag_7E_sig_3F_();
-            WORD_ATOM(828, 30, "!");
+            WORD_ATOM(844, 30, "!");
             mw_prim_mut_set();
         } else {
-            WORD_ATOM(829, 9, "");
+            WORD_ATOM(845, 9, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -21983,41 +22107,41 @@ static void mw_elab_data_tag_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(829, 50, "emit-fatal-error!");
+            WORD_ATOM(845, 50, "emit-fatal-error!");
             mw_emit_fatal_error_21_();
         }
     }
-    WORD_ATOM(832, 5, "dup");
+    WORD_ATOM(848, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(832, 9, "delay");
+    WORD_ATOM(848, 9, "delay");
     push_u64(0);
     push_fnptr(&mb_elab_data_tag_21__9);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(841, 5, "over");
+    WORD_ATOM(857, 5, "over");
     mw_over();
-    WORD_ATOM(841, 10, "~ctx-type");
+    WORD_ATOM(857, 10, "~ctx-type");
     mw_Tag_7E_ctx_type();
-    WORD_ATOM(841, 20, "!");
+    WORD_ATOM(857, 20, "!");
     mw_prim_mut_set();
-    WORD_ATOM(842, 5, "sip");
+    WORD_ATOM(858, 5, "sip");
     push_u64(0);
-    push_fnptr(&mb_elab_data_tag_21__14);
+    push_fnptr(&mb_elab_data_tag_21__15);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(842, 30, "~num-inputs");
+    WORD_ATOM(858, 30, "~num-inputs");
     mw_Tag_7E_num_inputs();
-    WORD_ATOM(842, 42, "!");
+    WORD_ATOM(858, 42, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_elab_data_tag_21_);
 }
 static void mw_expect_token_arrow (void){
-    WORD_ENTER(mw_expect_token_arrow, "expect-token-arrow", "src/mirth/elab.mth", 845, 5);
-    WORD_ATOM(845, 5, "dup");
+    WORD_ENTER(mw_expect_token_arrow, "expect-token-arrow", "src/mirth/elab.mth", 861, 5);
+    WORD_ATOM(861, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(845, 9, "pat-arrow?");
+    WORD_ATOM(861, 9, "pat-arrow?");
     mw_Token_2E_pat_arrow_3F_();
-    WORD_ATOM(845, 20, "else");
+    WORD_ATOM(861, 20, "else");
     push_u64(0);
     push_fnptr(&mb_expect_token_arrow_1);
     mw_prim_pack_cons();
@@ -22025,27 +22149,27 @@ static void mw_expect_token_arrow (void){
     WORD_EXIT(mw_expect_token_arrow);
 }
 static void mw_token_def_args (void){
-    WORD_ENTER(mw_token_def_args, "token-def-args", "src/mirth/elab.mth", 852, 5);
-    WORD_ATOM(852, 5, "dup");
+    WORD_ENTER(mw_token_def_args, "token-def-args", "src/mirth/elab.mth", 868, 5);
+    WORD_ATOM(868, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(852, 9, "args");
+    WORD_ATOM(868, 9, "args");
     mw_Token_2E_args();
-    WORD_ATOM(852, 14, "dup");
+    WORD_ATOM(868, 14, "dup");
     mw_prim_dup();
-    WORD_ATOM(852, 18, "len");
+    WORD_ATOM(868, 18, "len");
     mw_List_2E_len();
-    WORD_ATOM(852, 22, "");
+    WORD_ATOM(868, 22, "");
     push_i64(2LL);
-    WORD_ATOM(852, 24, ">=");
+    WORD_ATOM(868, 24, ">=");
     mw_Int_3E__3D_();
-    WORD_ATOM(852, 27, "if");
+    WORD_ATOM(868, 27, "if");
     if (pop_u64()) {
-        WORD_ATOM(852, 30, "nip");
+        WORD_ATOM(868, 30, "nip");
         mw_nip();
     } else {
-        WORD_ATOM(853, 9, "drop");
+        WORD_ATOM(869, 9, "drop");
         mw_prim_drop();
-        WORD_ATOM(853, 14, "");
+        WORD_ATOM(869, 14, "");
         {
             static bool vready = false;
             static VAL v;
@@ -22056,24 +22180,24 @@ static void mw_token_def_args (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(853, 51, "emit-fatal-error!");
+        WORD_ATOM(869, 51, "emit-fatal-error!");
         mw_emit_fatal_error_21_();
     }
-    WORD_ATOM(854, 5, ">List+");
+    WORD_ATOM(870, 5, ">List+");
     mw_List_3E_List_2B_();
-    WORD_ATOM(854, 12, "unwrap");
+    WORD_ATOM(870, 12, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(854, 19, "uncons");
+    WORD_ATOM(870, 19, "uncons");
     mw_List_2B__2E_uncons();
-    WORD_ATOM(855, 5, ">List+");
+    WORD_ATOM(871, 5, ">List+");
     mw_List_3E_List_2B_();
-    WORD_ATOM(855, 12, "unwrap");
+    WORD_ATOM(871, 12, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(855, 19, "uncons");
+    WORD_ATOM(871, 19, "uncons");
     mw_List_2B__2E_uncons();
-    WORD_ATOM(856, 5, ">List+");
+    WORD_ATOM(872, 5, ">List+");
     mw_List_3E_List_2B_();
-    WORD_ATOM(856, 12, "if-some");
+    WORD_ATOM(872, 12, "if-some");
     push_u64(0);
     push_fnptr(&mb_token_def_args_3);
     mw_prim_pack_cons();
@@ -22084,126 +22208,126 @@ static void mw_token_def_args (void){
     WORD_EXIT(mw_token_def_args);
 }
 static void mw_elab_alias_21_ (void){
-    WORD_ENTER(mw_elab_alias_21_, "elab-alias!", "src/mirth/elab.mth", 866, 5);
-    WORD_ATOM(866, 5, "sip");
+    WORD_ENTER(mw_elab_alias_21_, "elab-alias!", "src/mirth/elab.mth", 882, 5);
+    WORD_ATOM(882, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_alias_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(866, 15, "args-2");
+    WORD_ATOM(882, 15, "args-2");
     mw_Token_2E_args_2();
-    WORD_ATOM(866, 22, "swap");
+    WORD_ATOM(882, 22, "swap");
     mw_prim_swap();
-    WORD_ATOM(867, 5, "dup");
+    WORD_ATOM(883, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(867, 9, "name?");
+    WORD_ATOM(883, 9, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(867, 15, "unwrap-or");
+    WORD_ATOM(883, 15, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_alias_21__2);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(867, 65, "dip");
+    WORD_ATOM(883, 65, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(867, 69, "dup");
+        WORD_ATOM(883, 69, "dup");
         mw_prim_dup();
-        WORD_ATOM(867, 73, "args-0");
+        WORD_ATOM(883, 73, "args-0");
         mw_Token_2E_args_0();
         push_value(d2);
     }
-    WORD_ATOM(868, 5, "name-undefined?");
+    WORD_ATOM(884, 5, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(868, 21, "else");
+    WORD_ATOM(884, 21, "else");
     push_u64(0);
     push_fnptr(&mb_elab_alias_21__4);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(868, 73, "rotl");
+    WORD_ATOM(884, 73, "rotl");
     mw_rotl();
-    WORD_ATOM(869, 5, "dup");
+    WORD_ATOM(885, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(869, 9, "name?");
+    WORD_ATOM(885, 9, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(869, 15, "unwrap-or");
+    WORD_ATOM(885, 15, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_alias_21__5);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(869, 65, "dip");
+    WORD_ATOM(885, 65, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(869, 69, "args-0");
+        WORD_ATOM(885, 69, "args-0");
         mw_Token_2E_args_0();
         push_value(d2);
     }
-    WORD_ATOM(870, 5, "Alias.new!");
+    WORD_ATOM(886, 5, "Alias.new!");
     mw_Alias_2E_new_21_();
-    WORD_ATOM(870, 16, "drop");
+    WORD_ATOM(886, 16, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_alias_21_);
 }
 static void mw_elab_def_missing_21_ (void){
-    WORD_ENTER(mw_elab_def_missing_21_, "elab-def-missing!", "src/mirth/elab.mth", 875, 5);
-    WORD_ATOM(875, 5, "dup");
+    WORD_ENTER(mw_elab_def_missing_21_, "elab-def-missing!", "src/mirth/elab.mth", 891, 5);
+    WORD_ATOM(891, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(875, 9, "succ");
+    WORD_ATOM(891, 9, "succ");
     mw_Token_2E_succ();
-    WORD_ATOM(875, 14, "succ");
+    WORD_ATOM(891, 14, "succ");
     mw_Token_2E_succ();
-    WORD_ATOM(875, 19, "dup");
+    WORD_ATOM(891, 19, "dup");
     mw_prim_dup();
-    WORD_ATOM(875, 23, "name?");
+    WORD_ATOM(891, 23, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(875, 29, "unwrap-or");
+    WORD_ATOM(891, 29, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_def_missing_21__1);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(875, 74, "nip");
+    WORD_ATOM(891, 74, "nip");
     mw_nip();
-    WORD_ATOM(875, 78, "name-defined?");
+    WORD_ATOM(891, 78, "name-defined?");
     mw_name_defined_3F_();
-    WORD_ATOM(875, 92, "nip");
+    WORD_ATOM(891, 92, "nip");
     mw_nip();
-    WORD_ATOM(875, 96, "if");
+    WORD_ATOM(891, 96, "if");
     if (pop_u64()) {
-        WORD_ATOM(876, 9, "next");
+        WORD_ATOM(892, 9, "next");
         mw_Token_2E_next();
     } else {
-        WORD_ATOM(877, 9, "elab-def!");
+        WORD_ATOM(893, 9, "elab-def!");
         mw_elab_def_21_();
     }
     WORD_EXIT(mw_elab_def_missing_21_);
 }
 static void mw_elab_def_21_ (void){
-    WORD_ENTER(mw_elab_def_21_, "elab-def!", "src/mirth/elab.mth", 882, 5);
-    WORD_ATOM(882, 5, "sip");
+    WORD_ENTER(mw_elab_def_21_, "elab-def!", "src/mirth/elab.mth", 898, 5);
+    WORD_ATOM(898, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_def_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(882, 15, "token-def-args");
+    WORD_ATOM(898, 15, "token-def-args");
     mw_token_def_args();
-    WORD_ATOM(883, 5, "uncons");
+    WORD_ATOM(899, 5, "uncons");
     mw_List_2B__2E_uncons();
-    WORD_ATOM(883, 12, "is-empty");
+    WORD_ATOM(899, 12, "is-empty");
     mw_List_2E_is_empty();
-    WORD_ATOM(883, 21, "if");
+    WORD_ATOM(899, 21, "if");
     if (pop_u64()) {
-        WORD_ATOM(883, 24, "id");
+        WORD_ATOM(899, 24, "id");
         mw_prim_id();
     } else {
-        WORD_ATOM(884, 9, "dup");
+        WORD_ATOM(900, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(884, 13, "run-has-arrow?");
+        WORD_ATOM(900, 13, "run-has-arrow?");
         mw_Token_2E_run_has_arrow_3F_();
-        WORD_ATOM(884, 28, "if");
+        WORD_ATOM(900, 28, "if");
         if (pop_u64()) {
-            WORD_ATOM(884, 31, "id");
+            WORD_ATOM(900, 31, "id");
             mw_prim_id();
         } else {
-            WORD_ATOM(885, 13, "");
+            WORD_ATOM(901, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -22214,31 +22338,31 @@ static void mw_elab_def_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(885, 35, "emit-fatal-error!");
+            WORD_ATOM(901, 35, "emit-fatal-error!");
             mw_emit_fatal_error_21_();
         }
     }
-    WORD_ATOM(886, 5, "rotl");
+    WORD_ATOM(902, 5, "rotl");
     mw_rotl();
-    WORD_ATOM(886, 10, "dup");
+    WORD_ATOM(902, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(886, 14, "name?");
+    WORD_ATOM(902, 14, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(886, 20, "unwrap-or");
+    WORD_ATOM(902, 20, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_def_21__6);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(887, 5, "name-undefined?");
+    WORD_ATOM(903, 5, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(887, 21, "if");
+    WORD_ATOM(903, 21, "if");
     if (pop_u64()) {
-        WORD_ATOM(887, 24, "id");
+        WORD_ATOM(903, 24, "id");
         mw_prim_id();
     } else {
-        WORD_ATOM(887, 28, "drop");
+        WORD_ATOM(903, 28, "drop");
         mw_prim_drop();
-        WORD_ATOM(887, 33, "");
+        WORD_ATOM(903, 33, "");
         {
             static bool vready = false;
             static VAL v;
@@ -22249,445 +22373,445 @@ static void mw_elab_def_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(887, 56, "emit-fatal-error!");
+        WORD_ATOM(903, 56, "emit-fatal-error!");
         mw_emit_fatal_error_21_();
     }
-    WORD_ATOM(889, 5, "Word.new!");
+    WORD_ATOM(905, 5, "Word.new!");
     mw_Word_2E_new_21_();
-    WORD_ATOM(890, 5, "tuck");
+    WORD_ATOM(906, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(890, 10, "~sig");
+    WORD_ATOM(906, 10, "~sig");
     mw_Word_7E_sig();
-    WORD_ATOM(890, 15, "!");
+    WORD_ATOM(906, 15, "!");
     mw_prim_mut_set();
-    WORD_ATOM(892, 5, "dup");
+    WORD_ATOM(908, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(892, 9, "delay");
+    WORD_ATOM(908, 9, "delay");
     push_u64(0);
     push_fnptr(&mb_elab_def_21__9);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(897, 7, "over");
+    WORD_ATOM(913, 7, "over");
     mw_over();
-    WORD_ATOM(897, 12, "~ctx-type");
+    WORD_ATOM(913, 12, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(897, 22, "!");
+    WORD_ATOM(913, 22, "!");
     mw_prim_mut_set();
-    WORD_ATOM(898, 5, "dup");
+    WORD_ATOM(914, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(898, 9, "delay");
+    WORD_ATOM(914, 9, "delay");
     push_u64(0);
     push_fnptr(&mb_elab_def_21__12);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(898, 33, "over");
+    WORD_ATOM(914, 33, "over");
     mw_over();
-    WORD_ATOM(898, 38, "~params");
+    WORD_ATOM(914, 38, "~params");
     mw_Word_7E_params();
-    WORD_ATOM(898, 46, "!");
+    WORD_ATOM(914, 46, "!");
     mw_prim_mut_set();
-    WORD_ATOM(899, 5, "dup");
+    WORD_ATOM(915, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(899, 9, "delay");
+    WORD_ATOM(915, 9, "delay");
     push_u64(0);
     push_fnptr(&mb_elab_def_21__13);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(906, 7, "swap");
+    WORD_ATOM(922, 7, "swap");
     mw_prim_swap();
-    WORD_ATOM(906, 12, "~arrow");
+    WORD_ATOM(922, 12, "~arrow");
     mw_Word_7E_arrow();
-    WORD_ATOM(906, 19, "!");
+    WORD_ATOM(922, 19, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_elab_def_21_);
 }
 static void mw_elab_def_params_21_ (void){
-    WORD_ENTER(mw_elab_def_params_21_, "elab-def-params!", "src/mirth/elab.mth", 910, 5);
-    WORD_ATOM(910, 5, "L0");
+    WORD_ENTER(mw_elab_def_params_21_, "elab-def-params!", "src/mirth/elab.mth", 926, 5);
+    WORD_ATOM(926, 5, "L0");
     mw_L0();
-    WORD_ATOM(910, 8, "over");
+    WORD_ATOM(926, 8, "over");
     mw_over();
-    WORD_ATOM(910, 13, "elab-word-ctx-type-weak!");
+    WORD_ATOM(926, 13, "elab-word-ctx-type-weak!");
     mw_elab_word_ctx_type_weak_21_();
-    WORD_ATOM(910, 38, "nip");
+    WORD_ATOM(926, 38, "nip");
     mw_nip();
-    WORD_ATOM(911, 5, "rotl");
+    WORD_ATOM(927, 5, "rotl");
     mw_rotl();
-    WORD_ATOM(911, 10, "head");
+    WORD_ATOM(927, 10, "head");
     mw_Word_2E_head();
-    WORD_ATOM(911, 15, "dip");
+    WORD_ATOM(927, 15, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(911, 19, "unpack");
+        WORD_ATOM(927, 19, "unpack");
         mw_ArrowType_2E_unpack();
         push_value(d2);
     }
-    WORD_ATOM(911, 27, "nip");
+    WORD_ATOM(927, 27, "nip");
     mw_nip();
-    WORD_ATOM(912, 5, "args");
+    WORD_ATOM(928, 5, "args");
     mw_Token_2E_args();
-    WORD_ATOM(912, 10, "reverse-for");
+    WORD_ATOM(928, 10, "reverse-for");
     push_u64(0);
     push_fnptr(&mb_elab_def_params_21__2);
     mw_prim_pack_cons();
     mw_List_2E_reverse_for();
-    WORD_ATOM(920, 7, "drop");
+    WORD_ATOM(936, 7, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_def_params_21_);
 }
 static void mw_elab_def_body_21_ (void){
-    WORD_ENTER(mw_elab_def_body_21_, "elab-def-body!", "src/mirth/elab.mth", 925, 5);
-    WORD_ATOM(925, 5, "ab-token");
+    WORD_ENTER(mw_elab_def_body_21_, "elab-def-body!", "src/mirth/elab.mth", 941, 5);
+    WORD_ATOM(941, 5, "ab-token");
     mw_ab_token();
-    WORD_ATOM(925, 14, "@");
+    WORD_ATOM(941, 14, "@");
     mw_prim_mut_get();
-    WORD_ATOM(925, 16, "run-has-arrow?");
+    WORD_ATOM(941, 16, "run-has-arrow?");
     mw_Token_2E_run_has_arrow_3F_();
-    WORD_ATOM(925, 31, "if");
+    WORD_ATOM(941, 31, "if");
     if (pop_u64()) {
-        WORD_ATOM(926, 9, "dup");
+        WORD_ATOM(942, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(926, 13, "ab-token");
+        WORD_ATOM(942, 13, "ab-token");
         mw_ab_token();
-        WORD_ATOM(926, 22, "@");
+        WORD_ATOM(942, 22, "@");
         mw_prim_mut_get();
-        WORD_ATOM(926, 24, "elab-match-at!");
+        WORD_ATOM(942, 24, "elab-match-at!");
         mw_elab_match_at_21_();
     } else {
-        WORD_ATOM(927, 9, "elab-atoms!");
+        WORD_ATOM(943, 9, "elab-atoms!");
         mw_elab_atoms_21_();
     }
     WORD_EXIT(mw_elab_def_body_21_);
 }
 static void mw_elab_def_external_21_ (void){
-    WORD_ENTER(mw_elab_def_external_21_, "elab-def-external!", "src/mirth/elab.mth", 932, 5);
-    WORD_ATOM(932, 5, "sip");
+    WORD_ENTER(mw_elab_def_external_21_, "elab-def-external!", "src/mirth/elab.mth", 948, 5);
+    WORD_ATOM(948, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_def_external_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(932, 15, "args-2");
+    WORD_ATOM(948, 15, "args-2");
     mw_Token_2E_args_2();
-    WORD_ATOM(933, 5, "swap");
+    WORD_ATOM(949, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(933, 10, "dup");
+    WORD_ATOM(949, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(933, 14, "name?");
+    WORD_ATOM(949, 14, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(933, 20, "unwrap-or");
+    WORD_ATOM(949, 20, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_def_external_21__2);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(934, 5, "name-undefined?");
+    WORD_ATOM(950, 5, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(934, 21, "else");
+    WORD_ATOM(950, 21, "else");
     push_u64(0);
     push_fnptr(&mb_elab_def_external_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(935, 5, "nip");
+    WORD_ATOM(951, 5, "nip");
     mw_nip();
-    WORD_ATOM(936, 5, "External.alloc!");
+    WORD_ATOM(952, 5, "External.alloc!");
     mw_External_2E_alloc_21_();
-    WORD_ATOM(937, 5, "dup2");
+    WORD_ATOM(953, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(937, 10, "DEF_EXTERNAL");
+    WORD_ATOM(953, 10, "DEF_EXTERNAL");
     mw_DEF_5F_EXTERNAL();
-    WORD_ATOM(937, 23, "swap");
+    WORD_ATOM(953, 23, "swap");
     mw_prim_swap();
-    WORD_ATOM(937, 28, "~Def");
+    WORD_ATOM(953, 28, "~Def");
     mw_Name_7E_Def();
-    WORD_ATOM(937, 33, "!");
+    WORD_ATOM(953, 33, "!");
     mw_prim_mut_set();
-    WORD_ATOM(938, 5, "tuck");
+    WORD_ATOM(954, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(938, 10, "~name");
+    WORD_ATOM(954, 10, "~name");
     mw_External_7E_name();
-    WORD_ATOM(938, 16, "!");
+    WORD_ATOM(954, 16, "!");
     mw_prim_mut_set();
-    WORD_ATOM(939, 5, "tuck");
+    WORD_ATOM(955, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(939, 10, "~sig");
+    WORD_ATOM(955, 10, "~sig");
     mw_External_7E_sig();
-    WORD_ATOM(939, 15, "!");
+    WORD_ATOM(955, 15, "!");
     mw_prim_mut_set();
-    WORD_ATOM(940, 5, "dup");
+    WORD_ATOM(956, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(940, 9, "delay");
+    WORD_ATOM(956, 9, "delay");
     push_u64(0);
     push_fnptr(&mb_elab_def_external_21__4);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(943, 7, "swap");
+    WORD_ATOM(959, 7, "swap");
     mw_prim_swap();
-    WORD_ATOM(943, 12, "~ctx-type");
+    WORD_ATOM(959, 12, "~ctx-type");
     mw_External_7E_ctx_type();
-    WORD_ATOM(943, 22, "!");
+    WORD_ATOM(959, 22, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_elab_def_external_21_);
 }
 static void mw_elab_def_type_21_ (void){
-    WORD_ENTER(mw_elab_def_type_21_, "elab-def-type!", "src/mirth/elab.mth", 947, 5);
-    WORD_ATOM(947, 5, "sip");
+    WORD_ENTER(mw_elab_def_type_21_, "elab-def-type!", "src/mirth/elab.mth", 963, 5);
+    WORD_ATOM(963, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_def_type_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(947, 15, "args-2");
+    WORD_ATOM(963, 15, "args-2");
     mw_Token_2E_args_2();
-    WORD_ATOM(948, 5, "swap");
+    WORD_ATOM(964, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(948, 10, "dup");
+    WORD_ATOM(964, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(948, 14, "sig-type-con?");
+    WORD_ATOM(964, 14, "sig-type-con?");
     mw_Token_2E_sig_type_con_3F_();
-    WORD_ATOM(948, 28, "else");
+    WORD_ATOM(964, 28, "else");
     push_u64(0);
     push_fnptr(&mb_elab_def_type_21__2);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(949, 5, "dup");
+    WORD_ATOM(965, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(949, 9, "name?");
+    WORD_ATOM(965, 9, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(949, 15, "unwrap");
+    WORD_ATOM(965, 15, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(949, 22, "name-undefined?");
+    WORD_ATOM(965, 22, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(949, 38, "else");
+    WORD_ATOM(965, 38, "else");
     push_u64(0);
     push_fnptr(&mb_elab_def_type_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(950, 5, "nip");
+    WORD_ATOM(966, 5, "nip");
     mw_nip();
-    WORD_ATOM(950, 9, "swap");
+    WORD_ATOM(966, 9, "swap");
     mw_prim_swap();
-    WORD_ATOM(950, 14, "elab-simple-type-arg!");
+    WORD_ATOM(966, 14, "elab-simple-type-arg!");
     mw_elab_simple_type_arg_21_();
-    WORD_ATOM(950, 36, "DEF_TYPE");
+    WORD_ATOM(966, 36, "DEF_TYPE");
     mw_DEF_5F_TYPE();
-    WORD_ATOM(950, 45, "swap");
+    WORD_ATOM(966, 45, "swap");
     mw_prim_swap();
-    WORD_ATOM(950, 50, "~Def");
+    WORD_ATOM(966, 50, "~Def");
     mw_Name_7E_Def();
-    WORD_ATOM(950, 55, "!");
+    WORD_ATOM(966, 55, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_elab_def_type_21_);
 }
 static void mw_elab_buffer_21_ (void){
-    WORD_ENTER(mw_elab_buffer_21_, "elab-buffer!", "src/mirth/elab.mth", 954, 5);
-    WORD_ATOM(954, 5, "sip");
+    WORD_ENTER(mw_elab_buffer_21_, "elab-buffer!", "src/mirth/elab.mth", 970, 5);
+    WORD_ATOM(970, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_buffer_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(954, 15, "args-2");
+    WORD_ATOM(970, 15, "args-2");
     mw_Token_2E_args_2();
-    WORD_ATOM(955, 5, "swap");
+    WORD_ATOM(971, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(955, 10, "dup");
+    WORD_ATOM(971, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(955, 14, "name?");
+    WORD_ATOM(971, 14, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(955, 20, "unwrap-or");
+    WORD_ATOM(971, 20, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_buffer_21__2);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(956, 5, "name-undefined?");
+    WORD_ATOM(972, 5, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(956, 21, "else");
+    WORD_ATOM(972, 21, "else");
     push_u64(0);
     push_fnptr(&mb_elab_buffer_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(957, 5, "rotl");
+    WORD_ATOM(973, 5, "rotl");
     mw_rotl();
-    WORD_ATOM(957, 10, "dup");
+    WORD_ATOM(973, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(957, 14, "int?");
+    WORD_ATOM(973, 14, "int?");
     mw_Token_2E_int_3F_();
-    WORD_ATOM(957, 19, "unwrap-or");
+    WORD_ATOM(973, 19, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_buffer_21__4);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(957, 71, "nip");
+    WORD_ATOM(973, 71, "nip");
     mw_nip();
-    WORD_ATOM(958, 5, "Buffer.new!");
+    WORD_ATOM(974, 5, "Buffer.new!");
     mw_Buffer_2E_new_21_();
-    WORD_ATOM(958, 17, "drop");
+    WORD_ATOM(974, 17, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_buffer_21_);
 }
 static void mw_elab_variable_21_ (void){
-    WORD_ENTER(mw_elab_variable_21_, "elab-variable!", "src/mirth/elab.mth", 962, 5);
-    WORD_ATOM(962, 5, "sip");
+    WORD_ENTER(mw_elab_variable_21_, "elab-variable!", "src/mirth/elab.mth", 978, 5);
+    WORD_ATOM(978, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_variable_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(962, 15, "args-2");
+    WORD_ATOM(978, 15, "args-2");
     mw_Token_2E_args_2();
-    WORD_ATOM(963, 5, "swap");
+    WORD_ATOM(979, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(963, 10, "dup");
+    WORD_ATOM(979, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(963, 14, "name?");
+    WORD_ATOM(979, 14, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(963, 20, "unwrap-or");
+    WORD_ATOM(979, 20, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_variable_21__2);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(964, 5, "name-undefined?");
+    WORD_ATOM(980, 5, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(964, 21, "else");
+    WORD_ATOM(980, 21, "else");
     push_u64(0);
     push_fnptr(&mb_elab_variable_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(965, 5, "rotl");
+    WORD_ATOM(981, 5, "rotl");
     mw_rotl();
-    WORD_ATOM(965, 10, "delay");
+    WORD_ATOM(981, 10, "delay");
     push_u64(0);
     push_fnptr(&mb_elab_variable_21__4);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(966, 5, "Variable.new!");
+    WORD_ATOM(982, 5, "Variable.new!");
     mw_Variable_2E_new_21_();
-    WORD_ATOM(966, 19, "drop");
+    WORD_ATOM(982, 19, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_variable_21_);
 }
 static void mw_elab_table_21_ (void){
-    WORD_ENTER(mw_elab_table_21_, "elab-table!", "src/mirth/elab.mth", 970, 5);
-    WORD_ATOM(970, 5, "sip");
+    WORD_ENTER(mw_elab_table_21_, "elab-table!", "src/mirth/elab.mth", 986, 5);
+    WORD_ATOM(986, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_table_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(970, 15, "args-1");
+    WORD_ATOM(986, 15, "args-1");
     mw_Token_2E_args_1();
-    WORD_ATOM(971, 5, "dup");
+    WORD_ATOM(987, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(971, 9, "sig-type-con?");
+    WORD_ATOM(987, 9, "sig-type-con?");
     mw_Token_2E_sig_type_con_3F_();
-    WORD_ATOM(971, 23, "else");
+    WORD_ATOM(987, 23, "else");
     push_u64(0);
     push_fnptr(&mb_elab_table_21__2);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(972, 5, "dup");
-    mw_prim_dup();
-    WORD_ATOM(972, 9, "name?");
-    mw_Token_2E_name_3F_();
-    WORD_ATOM(972, 15, "unwrap");
-    mw_Maybe_2E_unwrap();
-    WORD_ATOM(972, 22, "name-undefined?");
-    mw_name_undefined_3F_();
-    WORD_ATOM(972, 38, "else");
-    push_u64(0);
-    push_fnptr(&mb_elab_table_21__3);
-    mw_prim_pack_cons();
-    mw_Bool_2E_else();
-    WORD_ATOM(973, 5, "table-new!");
-    mw_table_new_21_();
-    WORD_ATOM(973, 16, "drop");
-    mw_prim_drop();
-    WORD_EXIT(mw_elab_table_21_);
-}
-static void mw_elab_target_c99_21_ (void){
-    WORD_ENTER(mw_elab_target_c99_21_, "elab-target-c99!", "src/mirth/elab.mth", 977, 5);
-    WORD_ATOM(977, 5, "typecheck-everything!");
-    mw_typecheck_everything_21_();
-    WORD_ATOM(978, 5, "sip");
-    push_u64(0);
-    push_fnptr(&mb_elab_target_c99_21__1);
-    mw_prim_pack_cons();
-    mw_sip();
-    WORD_ATOM(978, 15, "args-2");
-    mw_Token_2E_args_2();
-    WORD_ATOM(979, 5, "dip");
-    {
-        VAL d2 = pop_value();
-        WORD_ATOM(979, 9, "dup");
-        mw_prim_dup();
-        WORD_ATOM(979, 13, "str?");
-        mw_Token_2E_str_3F_();
-        WORD_ATOM(979, 18, "unwrap-or");
-        push_u64(0);
-        push_fnptr(&mb_elab_target_c99_21__3);
-        mw_prim_pack_cons();
-        mw_Maybe_2E_unwrap_or();
-        WORD_ATOM(979, 70, "nip");
-        mw_nip();
-        WORD_ATOM(979, 74, ">Path");
-        mw_Str_3E_Path();
-        push_value(d2);
-    }
-    WORD_ATOM(980, 5, "dip");
-    {
-        VAL d2 = pop_value();
-        WORD_ATOM(980, 9, "CTX0");
-        mw_CTX0();
-        WORD_ATOM(980, 14, "T0");
-        mw_T0();
-        WORD_ATOM(980, 17, "T0");
-        mw_T0();
-        WORD_ATOM(980, 20, "T->");
-        mw_T__3E_();
-        push_value(d2);
-    }
-    WORD_ATOM(981, 5, "elab-arrow!");
-    mw_elab_arrow_21_();
-    WORD_ATOM(982, 5, "swap");
-    mw_prim_swap();
-    WORD_ATOM(982, 10, "run-output-c99!");
-    mw_run_output_c99_21_();
-    WORD_EXIT(mw_elab_target_c99_21_);
-}
-static void mw_elab_embed_str_21_ (void){
-    WORD_ENTER(mw_elab_embed_str_21_, "elab-embed-str!", "src/mirth/elab.mth", 987, 5);
-    WORD_ATOM(987, 5, "sip");
-    push_u64(0);
-    push_fnptr(&mb_elab_embed_str_21__1);
-    mw_prim_pack_cons();
-    mw_sip();
-    WORD_ATOM(987, 15, "args-2");
-    mw_Token_2E_args_2();
-    WORD_ATOM(987, 22, "swap");
-    mw_prim_swap();
     WORD_ATOM(988, 5, "dup");
     mw_prim_dup();
     WORD_ATOM(988, 9, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(988, 15, "unwrap-or");
+    WORD_ATOM(988, 15, "unwrap");
+    mw_Maybe_2E_unwrap();
+    WORD_ATOM(988, 22, "name-undefined?");
+    mw_name_undefined_3F_();
+    WORD_ATOM(988, 38, "else");
+    push_u64(0);
+    push_fnptr(&mb_elab_table_21__3);
+    mw_prim_pack_cons();
+    mw_Bool_2E_else();
+    WORD_ATOM(989, 5, "table-new!");
+    mw_table_new_21_();
+    WORD_ATOM(989, 16, "drop");
+    mw_prim_drop();
+    WORD_EXIT(mw_elab_table_21_);
+}
+static void mw_elab_target_c99_21_ (void){
+    WORD_ENTER(mw_elab_target_c99_21_, "elab-target-c99!", "src/mirth/elab.mth", 993, 5);
+    WORD_ATOM(993, 5, "typecheck-everything!");
+    mw_typecheck_everything_21_();
+    WORD_ATOM(994, 5, "sip");
+    push_u64(0);
+    push_fnptr(&mb_elab_target_c99_21__1);
+    mw_prim_pack_cons();
+    mw_sip();
+    WORD_ATOM(994, 15, "args-2");
+    mw_Token_2E_args_2();
+    WORD_ATOM(995, 5, "dip");
+    {
+        VAL d2 = pop_value();
+        WORD_ATOM(995, 9, "dup");
+        mw_prim_dup();
+        WORD_ATOM(995, 13, "str?");
+        mw_Token_2E_str_3F_();
+        WORD_ATOM(995, 18, "unwrap-or");
+        push_u64(0);
+        push_fnptr(&mb_elab_target_c99_21__3);
+        mw_prim_pack_cons();
+        mw_Maybe_2E_unwrap_or();
+        WORD_ATOM(995, 70, "nip");
+        mw_nip();
+        WORD_ATOM(995, 74, ">Path");
+        mw_Str_3E_Path();
+        push_value(d2);
+    }
+    WORD_ATOM(996, 5, "dip");
+    {
+        VAL d2 = pop_value();
+        WORD_ATOM(996, 9, "CTX0");
+        mw_CTX0();
+        WORD_ATOM(996, 14, "T0");
+        mw_T0();
+        WORD_ATOM(996, 17, "T0");
+        mw_T0();
+        WORD_ATOM(996, 20, "T->");
+        mw_T__3E_();
+        push_value(d2);
+    }
+    WORD_ATOM(997, 5, "elab-arrow!");
+    mw_elab_arrow_21_();
+    WORD_ATOM(998, 5, "swap");
+    mw_prim_swap();
+    WORD_ATOM(998, 10, "run-output-c99!");
+    mw_run_output_c99_21_();
+    WORD_EXIT(mw_elab_target_c99_21_);
+}
+static void mw_elab_embed_str_21_ (void){
+    WORD_ENTER(mw_elab_embed_str_21_, "elab-embed-str!", "src/mirth/elab.mth", 1003, 5);
+    WORD_ATOM(1003, 5, "sip");
+    push_u64(0);
+    push_fnptr(&mb_elab_embed_str_21__1);
+    mw_prim_pack_cons();
+    mw_sip();
+    WORD_ATOM(1003, 15, "args-2");
+    mw_Token_2E_args_2();
+    WORD_ATOM(1003, 22, "swap");
+    mw_prim_swap();
+    WORD_ATOM(1004, 5, "dup");
+    mw_prim_dup();
+    WORD_ATOM(1004, 9, "name?");
+    mw_Token_2E_name_3F_();
+    WORD_ATOM(1004, 15, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_embed_str_21__2);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(989, 5, "name-undefined?");
+    WORD_ATOM(1005, 5, "name-undefined?");
     mw_name_undefined_3F_();
-    WORD_ATOM(989, 21, "else");
+    WORD_ATOM(1005, 21, "else");
     push_u64(0);
     push_fnptr(&mb_elab_embed_str_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(990, 5, "rotl");
+    WORD_ATOM(1006, 5, "rotl");
     mw_rotl();
-    WORD_ATOM(990, 10, "dup");
+    WORD_ATOM(1006, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(990, 14, "str?");
+    WORD_ATOM(1006, 14, "str?");
     mw_Token_2E_str_3F_();
-    WORD_ATOM(990, 19, "unwrap-or");
+    WORD_ATOM(1006, 19, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_embed_str_21__4);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(991, 5, "with-open-file!");
+    WORD_ATOM(1007, 5, "with-open-file!");
     push_u64(0);
     push_fnptr(&mb_elab_embed_str_21__5);
     mw_prim_pack_cons();
@@ -22695,22 +22819,22 @@ static void mw_elab_embed_str_21_ (void){
     push_fnptr(&mb_elab_embed_str_21__6);
     mw_prim_pack_cons();
     mw_with_open_file_21_();
-    WORD_ATOM(992, 5, "VALUE_STR");
+    WORD_ATOM(1008, 5, "VALUE_STR");
     mw_VALUE_5F_STR();
-    WORD_ATOM(992, 15, "Constant.new!");
+    WORD_ATOM(1008, 15, "Constant.new!");
     mw_Constant_2E_new_21_();
-    WORD_ATOM(992, 29, "drop");
+    WORD_ATOM(1008, 29, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_elab_embed_str_21_);
 }
 static void mw_typecheck_everything_21_ (void){
-    WORD_ENTER(mw_typecheck_everything_21_, "typecheck-everything!", "src/mirth/elab.mth", 996, 5);
-    WORD_ATOM(996, 5, "Name.for");
+    WORD_ENTER(mw_typecheck_everything_21_, "typecheck-everything!", "src/mirth/elab.mth", 1012, 5);
+    WORD_ATOM(1012, 5, "Name.for");
     push_u64(0);
     push_fnptr(&mb_typecheck_everything_21__1);
     mw_prim_pack_cons();
     mw_Name_2E_for();
-    WORD_ATOM(997, 5, "Block.for");
+    WORD_ATOM(1013, 5, "Block.for");
     push_u64(0);
     push_fnptr(&mb_typecheck_everything_21__2);
     mw_prim_pack_cons();
@@ -22718,75 +22842,75 @@ static void mw_typecheck_everything_21_ (void){
     WORD_EXIT(mw_typecheck_everything_21_);
 }
 static void mw_TABLE_5F_MAX_5F_SIZE (void){
-    WORD_ENTER(mw_TABLE_5F_MAX_5F_SIZE, "TABLE_MAX_SIZE", "src/mirth/elab.mth", 1003, 26);
-    WORD_ATOM(1003, 26, "");
+    WORD_ENTER(mw_TABLE_5F_MAX_5F_SIZE, "TABLE_MAX_SIZE", "src/mirth/elab.mth", 1019, 26);
+    WORD_ATOM(1019, 26, "");
     push_i64(65536LL);
     WORD_EXIT(mw_TABLE_5F_MAX_5F_SIZE);
 }
 static void mw_table_word_new_21_ (void){
-    WORD_ENTER(mw_table_word_new_21_, "table-word-new!", "src/mirth/elab.mth", 1006, 5);
-    WORD_ATOM(1006, 5, "dip");
+    WORD_ENTER(mw_table_word_new_21_, "table-word-new!", "src/mirth/elab.mth", 1022, 5);
+    WORD_ATOM(1022, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(1006, 9, "dup");
+        WORD_ATOM(1022, 9, "dup");
         mw_prim_dup();
-        WORD_ATOM(1006, 13, "head");
+        WORD_ATOM(1022, 13, "head");
         mw_Table_2E_head();
-        WORD_ATOM(1006, 18, "dup");
+        WORD_ATOM(1022, 18, "dup");
         mw_prim_dup();
-        WORD_ATOM(1006, 22, "rotl");
+        WORD_ATOM(1022, 22, "rotl");
         mw_rotl();
-        WORD_ATOM(1006, 27, "name");
+        WORD_ATOM(1022, 27, "name");
         mw_Table_2E_name();
         push_value(d2);
     }
-    WORD_ATOM(1006, 33, "Name.cat");
+    WORD_ATOM(1022, 33, "Name.cat");
     mw_Name_2E_cat();
-    WORD_ATOM(1006, 42, "Word.new!");
+    WORD_ATOM(1022, 42, "Word.new!");
     mw_Word_2E_new_21_();
     WORD_EXIT(mw_table_word_new_21_);
 }
 static void mw_table_new_21_ (void){
-    WORD_ENTER(mw_table_new_21_, "table-new!", "src/mirth/elab.mth", 1009, 5);
-    WORD_ATOM(1009, 5, "Table.alloc!");
+    WORD_ENTER(mw_table_new_21_, "table-new!", "src/mirth/elab.mth", 1025, 5);
+    WORD_ATOM(1025, 5, "Table.alloc!");
     mw_Table_2E_alloc_21_();
-    WORD_ATOM(1010, 5, "tuck");
+    WORD_ATOM(1026, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(1010, 10, "~name");
+    WORD_ATOM(1026, 10, "~name");
     mw_Table_7E_name();
-    WORD_ATOM(1010, 16, "!");
+    WORD_ATOM(1026, 16, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1011, 5, "tuck");
+    WORD_ATOM(1027, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(1011, 10, "~head");
+    WORD_ATOM(1027, 10, "~head");
     mw_Table_7E_head();
-    WORD_ATOM(1011, 16, "!");
+    WORD_ATOM(1027, 16, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1012, 5, "TABLE_MAX_SIZE");
+    WORD_ATOM(1028, 5, "TABLE_MAX_SIZE");
     mw_TABLE_5F_MAX_5F_SIZE();
-    WORD_ATOM(1012, 20, "over");
+    WORD_ATOM(1028, 20, "over");
     mw_over();
-    WORD_ATOM(1012, 25, "~max-count");
+    WORD_ATOM(1028, 25, "~max-count");
     mw_Table_7E_max_count();
-    WORD_ATOM(1012, 36, "!");
+    WORD_ATOM(1028, 36, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1013, 5, "dup");
+    WORD_ATOM(1029, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1013, 9, "TTable");
+    WORD_ATOM(1029, 9, "TTable");
     mw_TTable();
-    WORD_ATOM(1013, 16, "DEF_TYPE");
+    WORD_ATOM(1029, 16, "DEF_TYPE");
     mw_DEF_5F_TYPE();
-    WORD_ATOM(1013, 25, "over");
+    WORD_ATOM(1029, 25, "over");
     mw_over();
-    WORD_ATOM(1013, 30, "name");
+    WORD_ATOM(1029, 30, "name");
     mw_Table_2E_name();
-    WORD_ATOM(1013, 35, "~Def");
+    WORD_ATOM(1029, 35, "~Def");
     mw_Name_7E_Def();
-    WORD_ATOM(1013, 40, "!");
+    WORD_ATOM(1029, 40, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1017, 5, "dup");
+    WORD_ATOM(1033, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1017, 9, "");
+    WORD_ATOM(1033, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -22797,38 +22921,38 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1017, 16, "table-word-new!");
+    WORD_ATOM(1033, 16, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1019, 5, "L0");
+    WORD_ATOM(1035, 5, "L0");
     mw_L0();
-    WORD_ATOM(1019, 8, "CTX");
+    WORD_ATOM(1035, 8, "CTX");
     mw_CTX();
-    WORD_ATOM(1020, 5, "T0");
+    WORD_ATOM(1036, 5, "T0");
     mw_T0();
-    WORD_ATOM(1020, 8, "TYPE_INT");
+    WORD_ATOM(1036, 8, "TYPE_INT");
     mw_TYPE_5F_INT();
-    WORD_ATOM(1020, 17, "T1");
+    WORD_ATOM(1036, 17, "T1");
     mw_T1();
-    WORD_ATOM(1020, 20, "T->");
+    WORD_ATOM(1036, 20, "T->");
     mw_T__3E_();
-    WORD_ATOM(1021, 5, "ready2");
+    WORD_ATOM(1037, 5, "ready2");
     mw_ready2();
-    WORD_ATOM(1021, 12, "over");
+    WORD_ATOM(1037, 12, "over");
     mw_over();
-    WORD_ATOM(1021, 17, "~ctx-type");
+    WORD_ATOM(1037, 17, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(1021, 27, "!");
+    WORD_ATOM(1037, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1023, 5, "ab-build-word!");
+    WORD_ATOM(1039, 5, "ab-build-word!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__1);
     mw_prim_pack_cons();
     mw_ab_build_word_21_();
-    WORD_ATOM(1026, 7, "drop");
+    WORD_ATOM(1042, 7, "drop");
     mw_prim_drop();
-    WORD_ATOM(1029, 5, "dup");
+    WORD_ATOM(1045, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1029, 9, "");
+    WORD_ATOM(1045, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -22839,46 +22963,46 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1029, 16, "table-word-new!");
+    WORD_ATOM(1045, 16, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1031, 5, "L0");
+    WORD_ATOM(1047, 5, "L0");
     mw_L0();
-    WORD_ATOM(1031, 8, "CTX");
+    WORD_ATOM(1047, 8, "CTX");
     mw_CTX();
-    WORD_ATOM(1032, 5, "T0");
+    WORD_ATOM(1048, 5, "T0");
     mw_T0();
-    WORD_ATOM(1032, 8, "over3");
+    WORD_ATOM(1048, 8, "over3");
     mw_over3();
-    WORD_ATOM(1032, 14, "TTable");
+    WORD_ATOM(1048, 14, "TTable");
     mw_TTable();
-    WORD_ATOM(1032, 21, "T1");
+    WORD_ATOM(1048, 21, "T1");
     mw_T1();
-    WORD_ATOM(1032, 24, "T->");
+    WORD_ATOM(1048, 24, "T->");
     mw_T__3E_();
-    WORD_ATOM(1033, 5, "ready2");
+    WORD_ATOM(1049, 5, "ready2");
     mw_ready2();
-    WORD_ATOM(1033, 12, "over");
+    WORD_ATOM(1049, 12, "over");
     mw_over();
-    WORD_ATOM(1033, 17, "~ctx-type");
+    WORD_ATOM(1049, 17, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(1033, 27, "!");
+    WORD_ATOM(1049, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1035, 5, "ab-build-word!");
+    WORD_ATOM(1051, 5, "ab-build-word!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__2);
     mw_prim_pack_cons();
     mw_ab_build_word_21_();
-    WORD_ATOM(1039, 7, "drop");
+    WORD_ATOM(1055, 7, "drop");
     mw_prim_drop();
-    WORD_ATOM(1042, 5, "dup");
+    WORD_ATOM(1058, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1042, 9, "head");
+    WORD_ATOM(1058, 9, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1043, 5, "over");
+    WORD_ATOM(1059, 5, "over");
     mw_over();
-    WORD_ATOM(1043, 10, "name");
+    WORD_ATOM(1059, 10, "name");
     mw_Table_2E_name();
-    WORD_ATOM(1043, 15, "");
+    WORD_ATOM(1059, 15, "");
     {
         static bool vready = false;
         static VAL v;
@@ -22889,21 +23013,21 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1043, 22, "Name.cat");
+    WORD_ATOM(1059, 22, "Name.cat");
     mw_Name_2E_cat();
-    WORD_ATOM(1044, 5, "");
+    WORD_ATOM(1060, 5, "");
     push_i64(8LL);
-    WORD_ATOM(1044, 7, "Buffer.new!");
+    WORD_ATOM(1060, 7, "Buffer.new!");
     mw_Buffer_2E_new_21_();
-    WORD_ATOM(1045, 5, "over");
+    WORD_ATOM(1061, 5, "over");
     mw_over();
-    WORD_ATOM(1045, 10, "~num-buffer");
+    WORD_ATOM(1061, 10, "~num-buffer");
     mw_Table_7E_num_buffer();
-    WORD_ATOM(1045, 22, "!");
+    WORD_ATOM(1061, 22, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1048, 5, "dup");
+    WORD_ATOM(1064, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1048, 9, "");
+    WORD_ATOM(1064, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -22914,42 +23038,42 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1048, 15, "table-word-new!");
+    WORD_ATOM(1064, 15, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1050, 5, "L0");
+    WORD_ATOM(1066, 5, "L0");
     mw_L0();
-    WORD_ATOM(1050, 8, "CTX");
+    WORD_ATOM(1066, 8, "CTX");
     mw_CTX();
-    WORD_ATOM(1051, 5, "over2");
+    WORD_ATOM(1067, 5, "over2");
     mw_over2();
-    WORD_ATOM(1051, 11, "TTable");
+    WORD_ATOM(1067, 11, "TTable");
     mw_TTable();
-    WORD_ATOM(1051, 18, "T1");
+    WORD_ATOM(1067, 18, "T1");
     mw_T1();
-    WORD_ATOM(1051, 21, "TYPE_INT");
+    WORD_ATOM(1067, 21, "TYPE_INT");
     mw_TYPE_5F_INT();
-    WORD_ATOM(1051, 30, "T1");
+    WORD_ATOM(1067, 30, "T1");
     mw_T1();
-    WORD_ATOM(1051, 33, "T->");
+    WORD_ATOM(1067, 33, "T->");
     mw_T__3E_();
-    WORD_ATOM(1052, 5, "ready2");
+    WORD_ATOM(1068, 5, "ready2");
     mw_ready2();
-    WORD_ATOM(1052, 12, "over");
+    WORD_ATOM(1068, 12, "over");
     mw_over();
-    WORD_ATOM(1052, 17, "~ctx-type");
+    WORD_ATOM(1068, 17, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(1052, 27, "!");
+    WORD_ATOM(1068, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1054, 5, "ab-build-word!");
+    WORD_ATOM(1070, 5, "ab-build-word!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__3);
     mw_prim_pack_cons();
     mw_ab_build_word_21_();
-    WORD_ATOM(1057, 7, "drop");
+    WORD_ATOM(1073, 7, "drop");
     mw_prim_drop();
-    WORD_ATOM(1060, 5, "dup");
+    WORD_ATOM(1076, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1060, 9, "");
+    WORD_ATOM(1076, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -22960,44 +23084,44 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1060, 20, "table-word-new!");
+    WORD_ATOM(1076, 20, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1062, 5, "L0");
+    WORD_ATOM(1078, 5, "L0");
     mw_L0();
-    WORD_ATOM(1062, 8, "CTX");
+    WORD_ATOM(1078, 8, "CTX");
     mw_CTX();
-    WORD_ATOM(1063, 5, "over2");
+    WORD_ATOM(1079, 5, "over2");
     mw_over2();
-    WORD_ATOM(1063, 11, "TTable");
+    WORD_ATOM(1079, 11, "TTable");
     mw_TTable();
-    WORD_ATOM(1063, 18, "T1");
+    WORD_ATOM(1079, 18, "T1");
     mw_T1();
-    WORD_ATOM(1063, 21, "TYPE_INT");
+    WORD_ATOM(1079, 21, "TYPE_INT");
     mw_TYPE_5F_INT();
-    WORD_ATOM(1063, 30, "T1");
+    WORD_ATOM(1079, 30, "T1");
     mw_T1();
-    WORD_ATOM(1063, 33, "swap");
+    WORD_ATOM(1079, 33, "swap");
     mw_prim_swap();
-    WORD_ATOM(1063, 38, "T->");
+    WORD_ATOM(1079, 38, "T->");
     mw_T__3E_();
-    WORD_ATOM(1064, 5, "ready2");
+    WORD_ATOM(1080, 5, "ready2");
     mw_ready2();
-    WORD_ATOM(1064, 12, "over");
+    WORD_ATOM(1080, 12, "over");
     mw_over();
-    WORD_ATOM(1064, 17, "~ctx-type");
+    WORD_ATOM(1080, 17, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(1064, 27, "!");
+    WORD_ATOM(1080, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1066, 5, "ab-build-word!");
+    WORD_ATOM(1082, 5, "ab-build-word!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__4);
     mw_prim_pack_cons();
     mw_ab_build_word_21_();
-    WORD_ATOM(1069, 7, "drop");
+    WORD_ATOM(1085, 7, "drop");
     mw_prim_drop();
-    WORD_ATOM(1072, 5, "dup");
+    WORD_ATOM(1088, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1072, 9, "");
+    WORD_ATOM(1088, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23008,40 +23132,40 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1072, 17, "table-word-new!");
+    WORD_ATOM(1088, 17, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1074, 5, "L0");
+    WORD_ATOM(1090, 5, "L0");
     mw_L0();
-    WORD_ATOM(1074, 8, "CTX");
+    WORD_ATOM(1090, 8, "CTX");
     mw_CTX();
-    WORD_ATOM(1075, 5, "over2");
+    WORD_ATOM(1091, 5, "over2");
     mw_over2();
-    WORD_ATOM(1075, 11, "TTable");
+    WORD_ATOM(1091, 11, "TTable");
     mw_TTable();
-    WORD_ATOM(1075, 18, "T1");
+    WORD_ATOM(1091, 18, "T1");
     mw_T1();
-    WORD_ATOM(1075, 21, "dup");
+    WORD_ATOM(1091, 21, "dup");
     mw_prim_dup();
-    WORD_ATOM(1075, 25, "T->");
+    WORD_ATOM(1091, 25, "T->");
     mw_T__3E_();
-    WORD_ATOM(1076, 5, "ready2");
+    WORD_ATOM(1092, 5, "ready2");
     mw_ready2();
-    WORD_ATOM(1076, 12, "over");
+    WORD_ATOM(1092, 12, "over");
     mw_over();
-    WORD_ATOM(1076, 17, "~ctx-type");
+    WORD_ATOM(1092, 17, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(1076, 27, "!");
+    WORD_ATOM(1092, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1078, 5, "ab-build-word!");
+    WORD_ATOM(1094, 5, "ab-build-word!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__5);
     mw_prim_pack_cons();
     mw_ab_build_word_21_();
-    WORD_ATOM(1090, 7, "drop");
+    WORD_ATOM(1106, 7, "drop");
     mw_prim_drop();
-    WORD_ATOM(1093, 5, "dup");
+    WORD_ATOM(1109, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1093, 9, "");
+    WORD_ATOM(1109, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23052,40 +23176,40 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1093, 17, "table-word-new!");
+    WORD_ATOM(1109, 17, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1095, 5, "L0");
+    WORD_ATOM(1111, 5, "L0");
     mw_L0();
-    WORD_ATOM(1095, 8, "CTX");
+    WORD_ATOM(1111, 8, "CTX");
     mw_CTX();
-    WORD_ATOM(1096, 5, "over2");
+    WORD_ATOM(1112, 5, "over2");
     mw_over2();
-    WORD_ATOM(1096, 11, "TTable");
+    WORD_ATOM(1112, 11, "TTable");
     mw_TTable();
-    WORD_ATOM(1096, 18, "T1");
+    WORD_ATOM(1112, 18, "T1");
     mw_T1();
-    WORD_ATOM(1096, 21, "dup");
+    WORD_ATOM(1112, 21, "dup");
     mw_prim_dup();
-    WORD_ATOM(1096, 25, "T->");
+    WORD_ATOM(1112, 25, "T->");
     mw_T__3E_();
-    WORD_ATOM(1097, 5, "ready2");
+    WORD_ATOM(1113, 5, "ready2");
     mw_ready2();
-    WORD_ATOM(1097, 12, "over");
+    WORD_ATOM(1113, 12, "over");
     mw_over();
-    WORD_ATOM(1097, 17, "~ctx-type");
+    WORD_ATOM(1113, 17, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(1097, 27, "!");
+    WORD_ATOM(1113, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1099, 5, "ab-build-word!");
+    WORD_ATOM(1115, 5, "ab-build-word!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__6);
     mw_prim_pack_cons();
     mw_ab_build_word_21_();
-    WORD_ATOM(1111, 7, "drop");
+    WORD_ATOM(1127, 7, "drop");
     mw_prim_drop();
-    WORD_ATOM(1115, 5, "dup");
+    WORD_ATOM(1131, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1115, 9, "");
+    WORD_ATOM(1131, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23096,11 +23220,11 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1115, 16, "table-word-new!");
+    WORD_ATOM(1131, 16, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1116, 5, "TYPE_STACK");
+    WORD_ATOM(1132, 5, "TYPE_STACK");
     mw_TYPE_5F_STACK();
-    WORD_ATOM(1116, 16, "");
+    WORD_ATOM(1132, 16, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23111,38 +23235,38 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1116, 21, ">Name");
+    WORD_ATOM(1132, 21, ">Name");
     mw_Str_3E_Name();
-    WORD_ATOM(1116, 27, "Var.new!");
+    WORD_ATOM(1132, 27, "Var.new!");
     mw_Var_2E_new_21_();
-    WORD_ATOM(1116, 36, "dup");
+    WORD_ATOM(1132, 36, "dup");
     mw_prim_dup();
-    WORD_ATOM(1116, 40, "STVar");
+    WORD_ATOM(1132, 40, "STVar");
     mw_STVar();
-    WORD_ATOM(1117, 5, "\\");
+    WORD_ATOM(1133, 5, "\\");
     {
         VAL var_a = pop_value();
         VAL var_va = pop_value();
         VAL var_w = pop_value();
         VAL var_t = pop_value();
-        WORD_ATOM(1117, 19, "a");
+        WORD_ATOM(1133, 19, "a");
         incref(var_a);
         push_value(var_a);
-        WORD_ATOM(1117, 21, "t");
+        WORD_ATOM(1133, 21, "t");
         incref(var_t);
         push_value(var_t);
-        WORD_ATOM(1117, 23, "TTable");
+        WORD_ATOM(1133, 23, "TTable");
         mw_TTable();
-        WORD_ATOM(1117, 30, "T*");
+        WORD_ATOM(1133, 30, "T*");
         mw_T_2A_();
-        WORD_ATOM(1117, 33, "a");
+        WORD_ATOM(1133, 33, "a");
         incref(var_a);
         push_value(var_a);
-        WORD_ATOM(1117, 35, "T->");
+        WORD_ATOM(1133, 35, "T->");
         mw_T__3E_();
-        WORD_ATOM(1117, 39, ">Type");
+        WORD_ATOM(1133, 39, ">Type");
         mw_ArrowType_3E_Type();
-        WORD_ATOM(1117, 45, "");
+        WORD_ATOM(1133, 45, "");
         {
             static bool vready = false;
             static VAL v;
@@ -23153,58 +23277,58 @@ static void mw_table_new_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(1117, 49, ">Name");
+        WORD_ATOM(1133, 49, ">Name");
         mw_Str_3E_Name();
-        WORD_ATOM(1117, 55, "Var.new-auto-run!");
+        WORD_ATOM(1133, 55, "Var.new-auto-run!");
         mw_Var_2E_new_auto_run_21_();
-        WORD_ATOM(1118, 5, "\\");
+        WORD_ATOM(1134, 5, "\\");
         {
             VAL var_x = pop_value();
-            WORD_ATOM(1119, 9, "va");
+            WORD_ATOM(1135, 9, "va");
             incref(var_va);
             push_value(var_va);
-            WORD_ATOM(1119, 12, "CTX1");
+            WORD_ATOM(1135, 12, "CTX1");
             mw_CTX1();
-            WORD_ATOM(1120, 9, "a");
+            WORD_ATOM(1136, 9, "a");
             incref(var_a);
             push_value(var_a);
-            WORD_ATOM(1120, 11, "a");
+            WORD_ATOM(1136, 11, "a");
             incref(var_a);
             push_value(var_a);
-            WORD_ATOM(1120, 13, "t");
+            WORD_ATOM(1136, 13, "t");
             incref(var_t);
             push_value(var_t);
-            WORD_ATOM(1120, 15, "TTable");
+            WORD_ATOM(1136, 15, "TTable");
             mw_TTable();
-            WORD_ATOM(1120, 22, "T*");
+            WORD_ATOM(1136, 22, "T*");
             mw_T_2A_();
-            WORD_ATOM(1120, 25, "a");
+            WORD_ATOM(1136, 25, "a");
             incref(var_a);
             push_value(var_a);
-            WORD_ATOM(1120, 27, "T->");
+            WORD_ATOM(1136, 27, "T->");
             mw_T__3E_();
-            WORD_ATOM(1120, 31, ">Type");
+            WORD_ATOM(1136, 31, ">Type");
             mw_ArrowType_3E_Type();
-            WORD_ATOM(1120, 37, "T*");
+            WORD_ATOM(1136, 37, "T*");
             mw_T_2A_();
-            WORD_ATOM(1120, 40, "a");
+            WORD_ATOM(1136, 40, "a");
             incref(var_a);
             push_value(var_a);
-            WORD_ATOM(1120, 42, "T->");
+            WORD_ATOM(1136, 42, "T->");
             mw_T__3E_();
-            WORD_ATOM(1121, 9, "ready2");
+            WORD_ATOM(1137, 9, "ready2");
             mw_ready2();
-            WORD_ATOM(1121, 16, "w");
+            WORD_ATOM(1137, 16, "w");
             incref(var_w);
             push_value(var_w);
-            WORD_ATOM(1121, 18, "~ctx-type");
+            WORD_ATOM(1137, 18, "~ctx-type");
             mw_Word_7E_ctx_type();
-            WORD_ATOM(1121, 28, "!");
+            WORD_ATOM(1137, 28, "!");
             mw_prim_mut_set();
-            WORD_ATOM(1123, 9, "w");
+            WORD_ATOM(1139, 9, "w");
             incref(var_w);
             push_value(var_w);
-            WORD_ATOM(1123, 11, "ab-build-word!");
+            WORD_ATOM(1139, 11, "ab-build-word!");
             push_u64(0);
             incref(var_a);
             push_value(var_a);
@@ -23224,9 +23348,9 @@ static void mw_table_new_21_ (void){
             push_fnptr(&mb_table_new_21__11);
             mw_prim_pack_cons();
             mw_ab_build_word_21_();
-            WORD_ATOM(1146, 11, "drop");
+            WORD_ATOM(1162, 11, "drop");
             mw_prim_drop();
-            WORD_ATOM(1148, 5, "t");
+            WORD_ATOM(1164, 5, "t");
             incref(var_t);
             push_value(var_t);
             decref(var_x);
@@ -23236,9 +23360,9 @@ static void mw_table_new_21_ (void){
         decref(var_w);
         decref(var_t);
     }
-    WORD_ATOM(1151, 5, "dup");
+    WORD_ATOM(1167, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(1151, 9, "");
+    WORD_ATOM(1167, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -23249,68 +23373,68 @@ static void mw_table_new_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(1151, 19, "table-word-new!");
+    WORD_ATOM(1167, 19, "table-word-new!");
     mw_table_word_new_21_();
-    WORD_ATOM(1153, 5, "L0");
+    WORD_ATOM(1169, 5, "L0");
     mw_L0();
-    WORD_ATOM(1153, 8, "CTX");
+    WORD_ATOM(1169, 8, "CTX");
     mw_CTX();
-    WORD_ATOM(1154, 5, "T0");
+    WORD_ATOM(1170, 5, "T0");
     mw_T0();
-    WORD_ATOM(1154, 8, "over3");
+    WORD_ATOM(1170, 8, "over3");
     mw_over3();
-    WORD_ATOM(1154, 14, "TTable");
+    WORD_ATOM(1170, 14, "TTable");
     mw_TTable();
-    WORD_ATOM(1154, 21, "T1");
+    WORD_ATOM(1170, 21, "T1");
     mw_T1();
-    WORD_ATOM(1154, 24, "T->");
+    WORD_ATOM(1170, 24, "T->");
     mw_T__3E_();
-    WORD_ATOM(1155, 5, "ready2");
+    WORD_ATOM(1171, 5, "ready2");
     mw_ready2();
-    WORD_ATOM(1155, 12, "over");
+    WORD_ATOM(1171, 12, "over");
     mw_over();
-    WORD_ATOM(1155, 17, "~ctx-type");
+    WORD_ATOM(1171, 17, "~ctx-type");
     mw_Word_7E_ctx_type();
-    WORD_ATOM(1155, 27, "!");
+    WORD_ATOM(1171, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1157, 5, "ab-build-word!");
+    WORD_ATOM(1173, 5, "ab-build-word!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__16);
     mw_prim_pack_cons();
     mw_ab_build_word_21_();
-    WORD_ATOM(1170, 5, "drop");
+    WORD_ATOM(1186, 5, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_table_new_21_);
 }
 static void mw_elab_field_21_ (void){
-    WORD_ENTER(mw_elab_field_21_, "elab-field!", "src/mirth/elab.mth", 1179, 5);
-    WORD_ATOM(1179, 5, "sip");
+    WORD_ENTER(mw_elab_field_21_, "elab-field!", "src/mirth/elab.mth", 1195, 5);
+    WORD_ATOM(1195, 5, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_field_21__1);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(1179, 15, "args-3");
+    WORD_ATOM(1195, 15, "args-3");
     mw_Token_2E_args_3();
-    WORD_ATOM(1179, 22, "rotl");
+    WORD_ATOM(1195, 22, "rotl");
     mw_rotl();
-    WORD_ATOM(1179, 27, "dup");
+    WORD_ATOM(1195, 27, "dup");
     mw_prim_dup();
-    WORD_ATOM(1179, 31, "value");
+    WORD_ATOM(1195, 31, "value");
     mw_Token_2E_value();
-    WORD_ATOM(1179, 37, "match");
+    WORD_ATOM(1195, 37, "match");
     switch (get_top_data_tag()) {
         case 13LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(1181, 13, "name-undefined?");
+            WORD_ATOM(1197, 13, "name-undefined?");
             mw_name_undefined_3F_();
-            WORD_ATOM(1181, 29, "if");
+            WORD_ATOM(1197, 29, "if");
             if (pop_u64()) {
-                WORD_ATOM(1181, 32, "id");
+                WORD_ATOM(1197, 32, "id");
                 mw_prim_id();
             } else {
-                WORD_ATOM(1182, 17, "drop");
+                WORD_ATOM(1198, 17, "drop");
                 mw_prim_drop();
-                WORD_ATOM(1182, 22, "");
+                WORD_ATOM(1198, 22, "");
                 {
                     static bool vready = false;
                     static VAL v;
@@ -23321,18 +23445,18 @@ static void mw_elab_field_21_ (void){
                     push_value(v);
                     incref(v);
                 }
-                WORD_ATOM(1182, 45, "emit-fatal-error!");
+                WORD_ATOM(1198, 45, "emit-fatal-error!");
                 mw_emit_fatal_error_21_();
             }
-            WORD_ATOM(1183, 13, "field-new!");
+            WORD_ATOM(1199, 13, "field-new!");
             mw_field_new_21_();
-            WORD_ATOM(1183, 24, "drop");
+            WORD_ATOM(1199, 24, "drop");
             mw_prim_drop();
             break;
         default:
-            WORD_ATOM(1185, 13, "drop");
+            WORD_ATOM(1201, 13, "drop");
             mw_prim_drop();
-            WORD_ATOM(1185, 18, "");
+            WORD_ATOM(1201, 18, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -23343,63 +23467,63 @@ static void mw_elab_field_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(1185, 40, "emit-fatal-error!");
+            WORD_ATOM(1201, 40, "emit-fatal-error!");
             mw_emit_fatal_error_21_();
             break;
     
 }    WORD_EXIT(mw_elab_field_21_);
 }
 static void mw_field_new_21_ (void){
-    WORD_ENTER(mw_field_new_21_, "field-new!", "src/mirth/elab.mth", 1189, 5);
-    WORD_ATOM(1189, 5, "Field.alloc!");
+    WORD_ENTER(mw_field_new_21_, "field-new!", "src/mirth/elab.mth", 1205, 5);
+    WORD_ATOM(1205, 5, "Field.alloc!");
     mw_Field_2E_alloc_21_();
-    WORD_ATOM(1190, 5, "tuck");
+    WORD_ATOM(1206, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(1190, 10, "dup2");
+    WORD_ATOM(1206, 10, "dup2");
     mw_dup2();
-    WORD_ATOM(1190, 15, "~name");
+    WORD_ATOM(1206, 15, "~name");
     mw_Field_7E_name();
-    WORD_ATOM(1190, 21, "!");
+    WORD_ATOM(1206, 21, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1191, 5, "DEF_FIELD");
+    WORD_ATOM(1207, 5, "DEF_FIELD");
     mw_DEF_5F_FIELD();
-    WORD_ATOM(1191, 15, "swap");
+    WORD_ATOM(1207, 15, "swap");
     mw_prim_swap();
-    WORD_ATOM(1191, 20, "~Def");
+    WORD_ATOM(1207, 20, "~Def");
     mw_Name_7E_Def();
-    WORD_ATOM(1191, 25, "!");
+    WORD_ATOM(1207, 25, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1192, 5, "tuck");
+    WORD_ATOM(1208, 5, "tuck");
     mw_tuck();
-    WORD_ATOM(1192, 10, "~head");
+    WORD_ATOM(1208, 10, "~head");
     mw_Field_7E_head();
-    WORD_ATOM(1192, 16, "!");
+    WORD_ATOM(1208, 16, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1193, 5, "swap");
+    WORD_ATOM(1209, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(1193, 10, "delay");
+    WORD_ATOM(1209, 10, "delay");
     push_u64(0);
     push_fnptr(&mb_field_new_21__1);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(1193, 39, "over");
+    WORD_ATOM(1209, 39, "over");
     mw_over();
-    WORD_ATOM(1193, 44, "~value-type");
+    WORD_ATOM(1209, 44, "~value-type");
     mw_Field_7E_value_type();
-    WORD_ATOM(1193, 56, "!");
+    WORD_ATOM(1209, 56, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1194, 5, "swap");
+    WORD_ATOM(1210, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(1194, 10, "delay");
+    WORD_ATOM(1210, 10, "delay");
     push_u64(0);
     push_fnptr(&mb_field_new_21__2);
     mw_prim_pack_cons();
     mw_delay();
-    WORD_ATOM(1194, 39, "over");
+    WORD_ATOM(1210, 39, "over");
     mw_over();
-    WORD_ATOM(1194, 44, "~index-type");
+    WORD_ATOM(1210, 44, "~index-type");
     mw_Field_7E_index_type();
-    WORD_ATOM(1194, 56, "!");
+    WORD_ATOM(1210, 56, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_field_new_21_);
 }
@@ -24318,19 +24442,37 @@ static void mw_T_2A_ (void){
     mw_STCons();
     WORD_EXIT(mw_T_2A_);
 }
+static void mw_T_2A__2B_ (void){
+    WORD_ENTER(mw_T_2A__2B_, "T*+", "src/mirth/data/type.mth", 102, 57);
+    WORD_ATOM(102, 57, "match");
+    switch (get_top_data_tag()) {
+        case 0LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(102, 71, "T*");
+            mw_T_2A_();
+            break;
+        case 1LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(102, 84, "T+");
+            mw_T_2B_();
+            break;
+        default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
+    
+}    WORD_EXIT(mw_T_2A__2B_);
+}
 static void mw_T__3E_ (void){
-    WORD_ENTER(mw_T__3E_, "T->", "src/mirth/data/type.mth", 102, 44);
-    WORD_ATOM(102, 44, "ARROW_TYPE");
+    WORD_ENTER(mw_T__3E_, "T->", "src/mirth/data/type.mth", 103, 44);
+    WORD_ATOM(103, 44, "ARROW_TYPE");
     mw_ARROW_5F_TYPE();
     WORD_EXIT(mw_T__3E_);
 }
 static void mw_TT (void){
-    WORD_ENTER(mw_TT, "TT", "src/mirth/data/type.mth", 104, 34);
-    WORD_ATOM(104, 34, "T0");
+    WORD_ENTER(mw_TT, "TT", "src/mirth/data/type.mth", 105, 34);
+    WORD_ATOM(105, 34, "T0");
     mw_T0();
-    WORD_ATOM(104, 37, "swap");
+    WORD_ATOM(105, 37, "swap");
     mw_prim_swap();
-    WORD_ATOM(104, 42, "for");
+    WORD_ATOM(105, 42, "for");
     push_u64(0);
     push_fnptr(&mb_TT_1);
     mw_prim_pack_cons();
@@ -24338,174 +24480,174 @@ static void mw_TT (void){
     WORD_EXIT(mw_TT);
 }
 static void mw_T0 (void){
-    WORD_ENTER(mw_T0, "T0", "src/mirth/data/type.mth", 105, 20);
-    WORD_ATOM(105, 20, "STACK_TYPE_UNIT");
+    WORD_ENTER(mw_T0, "T0", "src/mirth/data/type.mth", 106, 20);
+    WORD_ATOM(106, 20, "STACK_TYPE_UNIT");
     mw_STACK_5F_TYPE_5F_UNIT();
     WORD_EXIT(mw_T0);
 }
 static void mw_T1 (void){
-    WORD_ENTER(mw_T1, "T1", "src/mirth/data/type.mth", 106, 28);
-    WORD_ATOM(106, 28, "dip");
+    WORD_ENTER(mw_T1, "T1", "src/mirth/data/type.mth", 107, 28);
+    WORD_ATOM(107, 28, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(106, 32, "T0");
+        WORD_ATOM(107, 32, "T0");
         mw_T0();
         push_value(d2);
     }
-    WORD_ATOM(106, 36, "T*");
+    WORD_ATOM(107, 36, "T*");
     mw_T_2A_();
     WORD_EXIT(mw_T1);
 }
 static void mw_T2 (void){
-    WORD_ENTER(mw_T2, "T2", "src/mirth/data/type.mth", 107, 33);
-    WORD_ATOM(107, 33, "dip");
+    WORD_ENTER(mw_T2, "T2", "src/mirth/data/type.mth", 108, 33);
+    WORD_ATOM(108, 33, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(107, 37, "T1");
+        WORD_ATOM(108, 37, "T1");
         mw_T1();
         push_value(d2);
     }
-    WORD_ATOM(107, 41, "T*");
+    WORD_ATOM(108, 41, "T*");
     mw_T_2A_();
     WORD_EXIT(mw_T2);
 }
 static void mw_T3 (void){
-    WORD_ENTER(mw_T3, "T3", "src/mirth/data/type.mth", 108, 38);
-    WORD_ATOM(108, 38, "dip");
+    WORD_ENTER(mw_T3, "T3", "src/mirth/data/type.mth", 109, 38);
+    WORD_ATOM(109, 38, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(108, 42, "T2");
+        WORD_ATOM(109, 42, "T2");
         mw_T2();
         push_value(d2);
     }
-    WORD_ATOM(108, 46, "T*");
+    WORD_ATOM(109, 46, "T*");
     mw_T_2A_();
     WORD_EXIT(mw_T3);
 }
 static void mw_T4 (void){
-    WORD_ENTER(mw_T4, "T4", "src/mirth/data/type.mth", 109, 43);
-    WORD_ATOM(109, 43, "dip");
+    WORD_ENTER(mw_T4, "T4", "src/mirth/data/type.mth", 110, 43);
+    WORD_ATOM(110, 43, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(109, 47, "T3");
+        WORD_ATOM(110, 47, "T3");
         mw_T3();
         push_value(d2);
     }
-    WORD_ATOM(109, 51, "T*");
+    WORD_ATOM(110, 51, "T*");
     mw_T_2A_();
     WORD_EXIT(mw_T4);
 }
 static void mw_T5 (void){
-    WORD_ENTER(mw_T5, "T5", "src/mirth/data/type.mth", 110, 48);
-    WORD_ATOM(110, 48, "dip");
+    WORD_ENTER(mw_T5, "T5", "src/mirth/data/type.mth", 111, 48);
+    WORD_ATOM(111, 48, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(110, 52, "T4");
+        WORD_ATOM(111, 52, "T4");
         mw_T4();
         push_value(d2);
     }
-    WORD_ATOM(110, 56, "T*");
+    WORD_ATOM(111, 56, "T*");
     mw_T_2A_();
     WORD_EXIT(mw_T5);
 }
 static void mw_T6 (void){
-    WORD_ENTER(mw_T6, "T6", "src/mirth/data/type.mth", 111, 53);
-    WORD_ATOM(111, 53, "dip");
+    WORD_ENTER(mw_T6, "T6", "src/mirth/data/type.mth", 112, 53);
+    WORD_ATOM(112, 53, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(111, 57, "T5");
+        WORD_ATOM(112, 57, "T5");
         mw_T5();
         push_value(d2);
     }
-    WORD_ATOM(111, 61, "T*");
+    WORD_ATOM(112, 61, "T*");
     mw_T_2A_();
     WORD_EXIT(mw_T6);
 }
 static void mw_Type_2E_morphism_3F_ (void){
-    WORD_ENTER(mw_Type_2E_morphism_3F_, "Type.morphism?", "src/mirth/data/type.mth", 125, 47);
-    WORD_ATOM(125, 47, "expand");
+    WORD_ENTER(mw_Type_2E_morphism_3F_, "Type.morphism?", "src/mirth/data/type.mth", 126, 47);
+    WORD_ATOM(126, 47, "expand");
     mw_Type_2E_expand();
-    WORD_ATOM(125, 54, "match");
+    WORD_ATOM(126, 54, "match");
     switch (get_top_data_tag()) {
         case 9LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(125, 73, "SOME");
+            WORD_ATOM(126, 73, "SOME");
             mw_SOME();
             break;
         default:
-            WORD_ATOM(125, 84, "drop");
+            WORD_ATOM(126, 84, "drop");
             mw_prim_drop();
-            WORD_ATOM(125, 89, "NONE");
+            WORD_ATOM(126, 89, "NONE");
             mw_NONE();
             break;
     
 }    WORD_EXIT(mw_Type_2E_morphism_3F_);
 }
 static void mw_Type_2E_prim_3F_ (void){
-    WORD_ENTER(mw_Type_2E_prim_3F_, "Type.prim?", "src/mirth/data/type.mth", 126, 42);
-    WORD_ATOM(126, 42, "expand");
+    WORD_ENTER(mw_Type_2E_prim_3F_, "Type.prim?", "src/mirth/data/type.mth", 127, 42);
+    WORD_ATOM(127, 42, "expand");
     mw_Type_2E_expand();
-    WORD_ATOM(126, 49, "match");
+    WORD_ATOM(127, 49, "match");
     switch (get_top_data_tag()) {
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(126, 64, "SOME");
+            WORD_ATOM(127, 64, "SOME");
             mw_SOME();
             break;
         default:
-            WORD_ATOM(126, 75, "drop");
+            WORD_ATOM(127, 75, "drop");
             mw_prim_drop();
-            WORD_ATOM(126, 80, "NONE");
+            WORD_ATOM(127, 80, "NONE");
             mw_NONE();
             break;
     
 }    WORD_EXIT(mw_Type_2E_prim_3F_);
 }
 static void mw_Type_2E_data_3F_ (void){
-    WORD_ENTER(mw_Type_2E_data_3F_, "Type.data?", "src/mirth/data/type.mth", 128, 5);
-    WORD_ATOM(128, 5, "type-head");
+    WORD_ENTER(mw_Type_2E_data_3F_, "Type.data?", "src/mirth/data/type.mth", 129, 5);
+    WORD_ATOM(129, 5, "type-head");
     mw_type_head();
-    WORD_ATOM(128, 15, "match");
+    WORD_ATOM(129, 15, "match");
     switch (get_top_data_tag()) {
         case 7LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(128, 30, "SOME");
+            WORD_ATOM(129, 30, "SOME");
             mw_SOME();
             break;
         default:
-            WORD_ATOM(128, 41, "drop");
+            WORD_ATOM(129, 41, "drop");
             mw_prim_drop();
-            WORD_ATOM(128, 46, "NONE");
+            WORD_ATOM(129, 46, "NONE");
             mw_NONE();
             break;
     
 }    WORD_EXIT(mw_Type_2E_data_3F_);
 }
 static void mw_Type_3D_meta (void){
-    WORD_ENTER(mw_Type_3D_meta, "Type=meta", "src/mirth/data/type.mth", 137, 5);
-    WORD_ATOM(137, 5, "TMeta");
+    WORD_ENTER(mw_Type_3D_meta, "Type=meta", "src/mirth/data/type.mth", 138, 5);
+    WORD_ATOM(138, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(137, 14, "=");
+            WORD_ATOM(138, 14, "=");
             mw_MetaVar_3D_();
             break;
         default:
-            WORD_ATOM(138, 10, "drop2");
+            WORD_ATOM(139, 10, "drop2");
             mw_drop2();
-            WORD_ATOM(138, 16, "F");
+            WORD_ATOM(139, 16, "F");
             mw_F();
             break;
     
 }    WORD_EXIT(mw_Type_3D_meta);
 }
 static void mw_Type_2E_is_physical_3F_ (void){
-    WORD_ENTER(mw_Type_2E_is_physical_3F_, "Type.is-physical?", "src/mirth/data/type.mth", 141, 5);
-    WORD_ATOM(141, 5, "TMeta");
+    WORD_ENTER(mw_Type_2E_is_physical_3F_, "Type.is-physical?", "src/mirth/data/type.mth", 142, 5);
+    WORD_ATOM(142, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(141, 14, "expand-if");
+            WORD_ATOM(142, 14, "expand-if");
             push_u64(0);
             push_fnptr(&mb_Type_2E_is_physical_3F__2);
             mw_prim_pack_cons();
@@ -24516,100 +24658,100 @@ static void mw_Type_2E_is_physical_3F_ (void){
             break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(142, 14, "is-physical?");
+            WORD_ATOM(143, 14, "is-physical?");
             mw_PrimType_2E_is_physical_3F_();
             break;
         default:
-            WORD_ATOM(143, 10, "drop");
+            WORD_ATOM(144, 10, "drop");
             mw_prim_drop();
-            WORD_ATOM(143, 15, "T");
+            WORD_ATOM(144, 15, "T");
             mw_T();
             break;
     
 }    WORD_EXIT(mw_Type_2E_is_physical_3F_);
 }
 static void mw_TYPE_5F_TYPE (void){
-    WORD_ENTER(mw_TYPE_5F_TYPE, "TYPE_TYPE", "src/mirth/data/type.mth", 146, 22);
-    WORD_ATOM(146, 22, "PRIM_TYPE_TYPE");
+    WORD_ENTER(mw_TYPE_5F_TYPE, "TYPE_TYPE", "src/mirth/data/type.mth", 147, 22);
+    WORD_ATOM(147, 22, "PRIM_TYPE_TYPE");
     mw_PRIM_5F_TYPE_5F_TYPE();
-    WORD_ATOM(146, 37, "TPrim");
+    WORD_ATOM(147, 37, "TPrim");
     mw_TPrim();
     WORD_EXIT(mw_TYPE_5F_TYPE);
 }
 static void mw_TYPE_5F_STACK (void){
-    WORD_ENTER(mw_TYPE_5F_STACK, "TYPE_STACK", "src/mirth/data/type.mth", 147, 23);
-    WORD_ATOM(147, 23, "PRIM_TYPE_STACK");
+    WORD_ENTER(mw_TYPE_5F_STACK, "TYPE_STACK", "src/mirth/data/type.mth", 148, 23);
+    WORD_ATOM(148, 23, "PRIM_TYPE_STACK");
     mw_PRIM_5F_TYPE_5F_STACK();
-    WORD_ATOM(147, 39, "TPrim");
+    WORD_ATOM(148, 39, "TPrim");
     mw_TPrim();
     WORD_EXIT(mw_TYPE_5F_STACK);
 }
 static void mw_TYPE_5F_RESOURCE (void){
-    WORD_ENTER(mw_TYPE_5F_RESOURCE, "TYPE_RESOURCE", "src/mirth/data/type.mth", 148, 26);
-    WORD_ATOM(148, 26, "PRIM_TYPE_RESOURCE");
+    WORD_ENTER(mw_TYPE_5F_RESOURCE, "TYPE_RESOURCE", "src/mirth/data/type.mth", 149, 26);
+    WORD_ATOM(149, 26, "PRIM_TYPE_RESOURCE");
     mw_PRIM_5F_TYPE_5F_RESOURCE();
-    WORD_ATOM(148, 45, "TPrim");
+    WORD_ATOM(149, 45, "TPrim");
     mw_TPrim();
     WORD_EXIT(mw_TYPE_5F_RESOURCE);
 }
 static void mw_TYPE_5F_INT (void){
-    WORD_ENTER(mw_TYPE_5F_INT, "TYPE_INT", "src/mirth/data/type.mth", 149, 21);
-    WORD_ATOM(149, 21, "PRIM_TYPE_INT");
+    WORD_ENTER(mw_TYPE_5F_INT, "TYPE_INT", "src/mirth/data/type.mth", 150, 21);
+    WORD_ATOM(150, 21, "PRIM_TYPE_INT");
     mw_PRIM_5F_TYPE_5F_INT();
-    WORD_ATOM(149, 35, "TPrim");
+    WORD_ATOM(150, 35, "TPrim");
     mw_TPrim();
     WORD_EXIT(mw_TYPE_5F_INT);
 }
 static void mw_TYPE_5F_PTR (void){
-    WORD_ENTER(mw_TYPE_5F_PTR, "TYPE_PTR", "src/mirth/data/type.mth", 150, 21);
-    WORD_ATOM(150, 21, "PRIM_TYPE_PTR");
+    WORD_ENTER(mw_TYPE_5F_PTR, "TYPE_PTR", "src/mirth/data/type.mth", 151, 21);
+    WORD_ATOM(151, 21, "PRIM_TYPE_PTR");
     mw_PRIM_5F_TYPE_5F_PTR();
-    WORD_ATOM(150, 35, "TPrim");
+    WORD_ATOM(151, 35, "TPrim");
     mw_TPrim();
     WORD_EXIT(mw_TYPE_5F_PTR);
 }
 static void mw_TYPE_5F_STR (void){
-    WORD_ENTER(mw_TYPE_5F_STR, "TYPE_STR", "src/mirth/data/type.mth", 151, 21);
-    WORD_ATOM(151, 21, "PRIM_TYPE_STR");
+    WORD_ENTER(mw_TYPE_5F_STR, "TYPE_STR", "src/mirth/data/type.mth", 152, 21);
+    WORD_ATOM(152, 21, "PRIM_TYPE_STR");
     mw_PRIM_5F_TYPE_5F_STR();
-    WORD_ATOM(151, 35, "TPrim");
+    WORD_ATOM(152, 35, "TPrim");
     mw_TPrim();
     WORD_EXIT(mw_TYPE_5F_STR);
 }
 static void mw_Type_2E_expand (void){
-    WORD_ENTER(mw_Type_2E_expand, "Type.expand", "src/mirth/data/type.mth", 162, 5);
-    WORD_ATOM(162, 5, "TMeta");
+    WORD_ENTER(mw_Type_2E_expand, "Type.expand", "src/mirth/data/type.mth", 163, 5);
+    WORD_ATOM(163, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(162, 14, "expand");
+            WORD_ATOM(163, 14, "expand");
             mw_MetaVar_2E_expand();
             break;
         default:
-            WORD_ATOM(163, 10, "id");
+            WORD_ATOM(164, 10, "id");
             mw_prim_id();
             break;
     
 }    WORD_EXIT(mw_Type_2E_expand);
 }
 static void mw_Gamma_2E_token (void){
-    WORD_ENTER(mw_Gamma_2E_token, "Gamma.token", "src/mirth/data/type.mth", 166, 34);
-    WORD_ATOM(166, 34, "GAMMA");
-    WORD_ATOM(166, 43, "id");
+    WORD_ENTER(mw_Gamma_2E_token, "Gamma.token", "src/mirth/data/type.mth", 167, 34);
+    WORD_ATOM(167, 34, "GAMMA");
+    WORD_ATOM(167, 43, "id");
     mw_prim_id();
     WORD_EXIT(mw_Gamma_2E_token);
 }
 static void mw_Type_2E_unify_failed_21_ (void){
-    WORD_ENTER(mw_Type_2E_unify_failed_21_, "Type.unify-failed!", "src/mirth/data/type.mth", 170, 5);
-    WORD_ATOM(170, 5, "over2");
+    WORD_ENTER(mw_Type_2E_unify_failed_21_, "Type.unify-failed!", "src/mirth/data/type.mth", 171, 5);
+    WORD_ATOM(171, 5, "over2");
     mw_over2();
-    WORD_ATOM(170, 11, "token");
+    WORD_ATOM(171, 11, "token");
     mw_Gamma_2E_token();
-    WORD_ATOM(170, 17, "location");
+    WORD_ATOM(171, 17, "location");
     mw_Token_2E_location();
-    WORD_ATOM(170, 26, "trace!");
+    WORD_ATOM(171, 26, "trace!");
     mw_Location_2E_trace_21_();
-    WORD_ATOM(171, 5, "");
+    WORD_ATOM(172, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -24620,16 +24762,16 @@ static void mw_Type_2E_unify_failed_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(171, 33, "trace!");
+    WORD_ATOM(172, 33, "trace!");
     mw_Str_2E_trace_21_();
-    WORD_ATOM(172, 5, "dip");
+    WORD_ATOM(173, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(172, 9, "trace!");
+        WORD_ATOM(173, 9, "trace!");
         mw_Type_2E_trace_21_();
         push_value(d2);
     }
-    WORD_ATOM(173, 5, "");
+    WORD_ATOM(174, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -24640,17 +24782,17 @@ static void mw_Type_2E_unify_failed_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(173, 14, "trace!");
+    WORD_ATOM(174, 14, "trace!");
     mw_Str_2E_trace_21_();
-    WORD_ATOM(174, 5, "trace!");
+    WORD_ATOM(175, 5, "trace!");
     mw_Type_2E_trace_21_();
-    WORD_ATOM(175, 5, "line-trace!");
+    WORD_ATOM(176, 5, "line-trace!");
     mw_line_trace_21_();
-    WORD_ATOM(176, 5, "TYPE_ERROR");
+    WORD_ATOM(177, 5, "TYPE_ERROR");
     mw_TYPE_5F_ERROR();
-    WORD_ATOM(177, 5, "num-errors");
+    WORD_ATOM(178, 5, "num-errors");
     mw_num_errors();
-    WORD_ATOM(177, 16, "modify");
+    WORD_ATOM(178, 16, "modify");
     push_u64(0);
     push_fnptr(&mb_Type_2E_unify_failed_21__2);
     mw_prim_pack_cons();
@@ -24658,74 +24800,50 @@ static void mw_Type_2E_unify_failed_21_ (void){
     WORD_EXIT(mw_Type_2E_unify_failed_21_);
 }
 static void mw_Type_2E_unify_simple_21_ (void){
-    WORD_ENTER(mw_Type_2E_unify_simple_21_, "Type.unify-simple!", "src/mirth/data/type.mth", 181, 5);
-    WORD_ATOM(181, 5, "TVar");
+    WORD_ENTER(mw_Type_2E_unify_simple_21_, "Type.unify-simple!", "src/mirth/data/type.mth", 182, 5);
+    WORD_ATOM(182, 5, "TVar");
     switch (get_top_data_tag()) {
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(181, 13, "swap");
+            WORD_ATOM(182, 13, "swap");
             mw_prim_swap();
-            WORD_ATOM(181, 18, "match");
+            WORD_ATOM(182, 18, "match");
             switch (get_top_data_tag()) {
                 case 5LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(181, 32, "unify!");
+                    WORD_ATOM(182, 32, "unify!");
                     mw_Var_2E_unify_21_();
                     break;
                 default:
-                    WORD_ATOM(181, 45, "dip");
+                    WORD_ATOM(182, 45, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(181, 49, "TVar");
+                        WORD_ATOM(182, 49, "TVar");
                         mw_TVar();
                         push_value(d6);
                     }
-                    WORD_ATOM(181, 55, "unify-failed!");
+                    WORD_ATOM(182, 55, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
             
 }            break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(182, 14, "swap");
-            mw_prim_swap();
-            WORD_ATOM(182, 19, "match");
-            switch (get_top_data_tag()) {
-                case 2LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(182, 34, "unify!");
-                    mw_PrimType_2E_unify_21_();
-                    break;
-                default:
-                    WORD_ATOM(182, 47, "dip");
-                    {
-                        VAL d6 = pop_value();
-                        WORD_ATOM(182, 51, "TPrim");
-                        mw_TPrim();
-                        push_value(d6);
-                    }
-                    WORD_ATOM(182, 58, "unify-failed!");
-                    mw_Type_2E_unify_failed_21_();
-                    break;
-            
-}            break;
-        case 7LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
             WORD_ATOM(183, 14, "swap");
             mw_prim_swap();
             WORD_ATOM(183, 19, "match");
             switch (get_top_data_tag()) {
-                case 7LL:
+                case 2LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
                     WORD_ATOM(183, 34, "unify!");
-                    mw_Data_2E_unify_21_();
+                    mw_PrimType_2E_unify_21_();
                     break;
                 default:
                     WORD_ATOM(183, 47, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(183, 51, "TData");
-                        mw_TData();
+                        WORD_ATOM(183, 51, "TPrim");
+                        mw_TPrim();
                         push_value(d6);
                     }
                     WORD_ATOM(183, 58, "unify-failed!");
@@ -24733,78 +24851,102 @@ static void mw_Type_2E_unify_simple_21_ (void){
                     break;
             
 }            break;
+        case 7LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(184, 14, "swap");
+            mw_prim_swap();
+            WORD_ATOM(184, 19, "match");
+            switch (get_top_data_tag()) {
+                case 7LL:
+                    mw_prim_pack_uncons(); mw_prim_drop();
+                    WORD_ATOM(184, 34, "unify!");
+                    mw_Data_2E_unify_21_();
+                    break;
+                default:
+                    WORD_ATOM(184, 47, "dip");
+                    {
+                        VAL d6 = pop_value();
+                        WORD_ATOM(184, 51, "TData");
+                        mw_TData();
+                        push_value(d6);
+                    }
+                    WORD_ATOM(184, 58, "unify-failed!");
+                    mw_Type_2E_unify_failed_21_();
+                    break;
+            
+}            break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(184, 15, "swap");
+            WORD_ATOM(185, 15, "swap");
             mw_prim_swap();
-            WORD_ATOM(184, 20, "match");
+            WORD_ATOM(185, 20, "match");
             switch (get_top_data_tag()) {
                 case 6LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(184, 36, "unify!");
+                    WORD_ATOM(185, 36, "unify!");
                     mw_Table_2E_unify_21_();
                     break;
                 default:
-                    WORD_ATOM(184, 49, "dip");
+                    WORD_ATOM(185, 49, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(184, 53, "TTable");
+                        WORD_ATOM(185, 53, "TTable");
                         mw_TTable();
                         push_value(d6);
                     }
-                    WORD_ATOM(184, 61, "unify-failed!");
+                    WORD_ATOM(185, 61, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
             
 }            break;
         case 8LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(185, 16, "swap");
+            WORD_ATOM(186, 16, "swap");
             mw_prim_swap();
-            WORD_ATOM(185, 21, "match");
+            WORD_ATOM(186, 21, "match");
             switch (get_top_data_tag()) {
                 case 8LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(185, 38, "unify!");
+                    WORD_ATOM(186, 38, "unify!");
                     mw_StackType_2E_unify_21_();
-                    WORD_ATOM(185, 45, ">Type");
+                    WORD_ATOM(186, 45, ">Type");
                     mw_StackType_3E_Type();
                     break;
                 default:
-                    WORD_ATOM(185, 57, "dip");
+                    WORD_ATOM(186, 57, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(185, 61, "TTensor");
+                        WORD_ATOM(186, 61, "TTensor");
                         mw_TTensor();
                         push_value(d6);
                     }
-                    WORD_ATOM(185, 70, "unify-failed!");
+                    WORD_ATOM(186, 70, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
             
 }            break;
         case 9LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(186, 18, "swap");
+            WORD_ATOM(187, 18, "swap");
             mw_prim_swap();
-            WORD_ATOM(186, 23, "match");
+            WORD_ATOM(187, 23, "match");
             switch (get_top_data_tag()) {
                 case 9LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(186, 42, "unify!");
+                    WORD_ATOM(187, 42, "unify!");
                     mw_ArrowType_2E_unify_21_();
-                    WORD_ATOM(186, 49, "TMorphism");
+                    WORD_ATOM(187, 49, "TMorphism");
                     mw_TMorphism();
                     break;
                 default:
-                    WORD_ATOM(186, 65, "dip");
+                    WORD_ATOM(187, 65, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(186, 69, "TMorphism");
+                        WORD_ATOM(187, 69, "TMorphism");
                         mw_TMorphism();
                         push_value(d6);
                     }
-                    WORD_ATOM(186, 80, "unify-failed!");
+                    WORD_ATOM(187, 80, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
             
@@ -24812,116 +24954,104 @@ static void mw_Type_2E_unify_simple_21_ (void){
         case 10LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(187, 13, "rotl");
+            WORD_ATOM(188, 13, "rotl");
             mw_rotl();
-            WORD_ATOM(187, 18, "match");
+            WORD_ATOM(188, 18, "match");
             switch (get_top_data_tag()) {
                 case 10LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
                     mw_prim_pack_uncons(); mw_prim_swap();
-                    WORD_ATOM(187, 32, "unify2!");
+                    WORD_ATOM(188, 32, "unify2!");
                     mw_Type_2E_unify2_21_();
-                    WORD_ATOM(187, 40, "TApp");
+                    WORD_ATOM(188, 40, "TApp");
                     mw_TApp();
                     break;
                 default:
-                    WORD_ATOM(187, 51, "dip");
+                    WORD_ATOM(188, 51, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(187, 55, "TApp");
+                        WORD_ATOM(188, 55, "TApp");
                         mw_TApp();
                         push_value(d6);
                     }
-                    WORD_ATOM(187, 61, "unify-failed!");
+                    WORD_ATOM(188, 61, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
             
 }            break;
         case 11LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(188, 13, "swap");
+            WORD_ATOM(189, 13, "swap");
             mw_prim_swap();
-            WORD_ATOM(188, 18, "match");
+            WORD_ATOM(189, 18, "match");
             switch (get_top_data_tag()) {
                 case 11LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(188, 32, "unify!");
+                    WORD_ATOM(189, 32, "unify!");
                     mw_Type_2E_unify_21_();
-                    WORD_ATOM(188, 39, "TMut");
+                    WORD_ATOM(189, 39, "TMut");
                     mw_TMut();
                     break;
                 default:
-                    WORD_ATOM(188, 50, "dip");
+                    WORD_ATOM(189, 50, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(188, 54, "TMut");
+                        WORD_ATOM(189, 54, "TMut");
                         mw_TMut();
                         push_value(d6);
                     }
-                    WORD_ATOM(188, 60, "unify-failed!");
+                    WORD_ATOM(189, 60, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                     break;
             
 }            break;
         default:
-            WORD_ATOM(189, 10, "unify-failed!");
+            WORD_ATOM(190, 10, "unify-failed!");
             mw_Type_2E_unify_failed_21_();
             break;
     
 }    WORD_EXIT(mw_Type_2E_unify_simple_21_);
 }
 static void mw_Type_2E_unify_aux_21_ (void){
-    WORD_ENTER(mw_Type_2E_unify_aux_21_, "Type.unify-aux!", "src/mirth/data/type.mth", 193, 5);
-    WORD_ATOM(193, 5, "TYPE_ERROR");
+    WORD_ENTER(mw_Type_2E_unify_aux_21_, "Type.unify-aux!", "src/mirth/data/type.mth", 194, 5);
+    WORD_ATOM(194, 5, "TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(193, 19, "drop");
+            WORD_ATOM(194, 19, "drop");
             mw_prim_drop();
-            WORD_ATOM(193, 24, "TYPE_ERROR");
+            WORD_ATOM(194, 24, "TYPE_ERROR");
             mw_TYPE_5F_ERROR();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(194, 23, "id");
+            WORD_ATOM(195, 23, "id");
             mw_prim_id();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(195, 14, "type-hole-unify!");
+            WORD_ATOM(196, 14, "type-hole-unify!");
             mw_type_hole_unify_21_();
             break;
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(197, 9, "swap");
+            WORD_ATOM(198, 9, "swap");
             mw_prim_swap();
-            WORD_ATOM(197, 14, "match");
+            WORD_ATOM(198, 14, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
                     mw_prim_drop();
-                    WORD_ATOM(198, 27, "drop");
+                    WORD_ATOM(199, 27, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(198, 32, "TYPE_ERROR");
+                    WORD_ATOM(199, 32, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 case 1LL:
                     mw_prim_drop();
-                    WORD_ATOM(199, 31, "TMeta");
+                    WORD_ATOM(200, 31, "TMeta");
                     mw_TMeta();
                     break;
                 case 4LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(200, 22, "dip");
-                    {
-                        VAL d6 = pop_value();
-                        WORD_ATOM(200, 26, "TMeta");
-                        mw_TMeta();
-                        push_value(d6);
-                    }
-                    WORD_ATOM(200, 33, "type-hole-unify!");
-                    mw_type_hole_unify_21_();
-                    break;
-                case 3LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
                     WORD_ATOM(201, 22, "dip");
                     {
@@ -24930,60 +25060,60 @@ static void mw_Type_2E_unify_aux_21_ (void){
                         mw_TMeta();
                         push_value(d6);
                     }
-                    WORD_ATOM(201, 33, "unify!");
+                    WORD_ATOM(201, 33, "type-hole-unify!");
+                    mw_type_hole_unify_21_();
+                    break;
+                case 3LL:
+                    mw_prim_pack_uncons(); mw_prim_drop();
+                    WORD_ATOM(202, 22, "dip");
+                    {
+                        VAL d6 = pop_value();
+                        WORD_ATOM(202, 26, "TMeta");
+                        mw_TMeta();
+                        push_value(d6);
+                    }
+                    WORD_ATOM(202, 33, "unify!");
                     mw_MetaVar_2E_unify_21_();
                     break;
                 case 12LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(202, 23, "dip");
+                    WORD_ATOM(203, 23, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(202, 27, "TMeta");
+                        WORD_ATOM(203, 27, "TMeta");
                         mw_TMeta();
                         push_value(d6);
                     }
-                    WORD_ATOM(202, 34, "unify-type!");
+                    WORD_ATOM(203, 34, "unify-type!");
                     mw_Value_2E_unify_type_21_();
                     break;
                 default:
-                    WORD_ATOM(203, 18, "swap");
+                    WORD_ATOM(204, 18, "swap");
                     mw_prim_swap();
-                    WORD_ATOM(203, 23, "unify!");
+                    WORD_ATOM(204, 23, "unify!");
                     mw_MetaVar_2E_unify_21_();
                     break;
             
 }            break;
         case 12LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(206, 9, "swap");
+            WORD_ATOM(207, 9, "swap");
             mw_prim_swap();
-            WORD_ATOM(206, 14, "match");
+            WORD_ATOM(207, 14, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
                     mw_prim_drop();
-                    WORD_ATOM(207, 27, "drop");
+                    WORD_ATOM(208, 27, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(207, 32, "TYPE_ERROR");
+                    WORD_ATOM(208, 32, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 case 1LL:
                     mw_prim_drop();
-                    WORD_ATOM(208, 31, "TValue");
+                    WORD_ATOM(209, 31, "TValue");
                     mw_TValue();
                     break;
                 case 4LL:
-                    mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(209, 22, "dip");
-                    {
-                        VAL d6 = pop_value();
-                        WORD_ATOM(209, 26, "TValue");
-                        mw_TValue();
-                        push_value(d6);
-                    }
-                    WORD_ATOM(209, 34, "type-hole-unify!");
-                    mw_type_hole_unify_21_();
-                    break;
-                case 3LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
                     WORD_ATOM(210, 22, "dip");
                     {
@@ -24992,56 +25122,68 @@ static void mw_Type_2E_unify_aux_21_ (void){
                         mw_TValue();
                         push_value(d6);
                     }
-                    WORD_ATOM(210, 34, "unify!");
+                    WORD_ATOM(210, 34, "type-hole-unify!");
+                    mw_type_hole_unify_21_();
+                    break;
+                case 3LL:
+                    mw_prim_pack_uncons(); mw_prim_drop();
+                    WORD_ATOM(211, 22, "dip");
+                    {
+                        VAL d6 = pop_value();
+                        WORD_ATOM(211, 26, "TValue");
+                        mw_TValue();
+                        push_value(d6);
+                    }
+                    WORD_ATOM(211, 34, "unify!");
                     mw_MetaVar_2E_unify_21_();
                     break;
                 case 12LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(211, 23, "unify!");
+                    WORD_ATOM(212, 23, "unify!");
                     mw_Value_2E_unify_21_();
                     break;
                 default:
-                    WORD_ATOM(212, 18, "swap");
+                    WORD_ATOM(213, 18, "swap");
                     mw_prim_swap();
-                    WORD_ATOM(212, 23, "unify-type!");
+                    WORD_ATOM(213, 23, "unify-type!");
                     mw_Value_2E_unify_type_21_();
                     break;
             
 }            break;
         default:
-            WORD_ATOM(215, 9, "swap");
+            WORD_ATOM(216, 9, "swap");
             mw_prim_swap();
-            WORD_ATOM(215, 14, "match");
+            WORD_ATOM(216, 14, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
                     mw_prim_drop();
-                    WORD_ATOM(216, 27, "drop");
+                    WORD_ATOM(217, 27, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(216, 32, "TYPE_ERROR");
+                    WORD_ATOM(217, 32, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 case 1LL:
                     mw_prim_drop();
-                    WORD_ATOM(217, 31, "id");
+                    WORD_ATOM(218, 31, "id");
                     mw_prim_id();
                     break;
                 case 4LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(218, 22, "type-hole-unify!");
+                    WORD_ATOM(219, 22, "type-hole-unify!");
                     mw_type_hole_unify_21_();
                     break;
                 case 3LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(219, 22, "unify!");
+                    WORD_ATOM(220, 22, "unify!");
                     mw_MetaVar_2E_unify_21_();
                     break;
                 case 12LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(220, 23, "unify-type!");
+                    WORD_ATOM(221, 23, "unify-type!");
                     mw_Value_2E_unify_type_21_();
                     break;
                 default:
-                    WORD_ATOM(221, 18, "unify-simple!");
+                    WORD_ATOM(222, 18, "unify-simple!");
                     mw_Type_2E_unify_simple_21_();
                     break;
             
@@ -25050,58 +25192,58 @@ static void mw_Type_2E_unify_aux_21_ (void){
 }    WORD_EXIT(mw_Type_2E_unify_aux_21_);
 }
 static void mw_Type_2E_unify_21_ (void){
-    WORD_ENTER(mw_Type_2E_unify_21_, "Type.unify!", "src/mirth/data/type.mth", 227, 5);
-    WORD_ATOM(227, 5, "both");
+    WORD_ENTER(mw_Type_2E_unify_21_, "Type.unify!", "src/mirth/data/type.mth", 228, 5);
+    WORD_ATOM(228, 5, "both");
     push_u64(0);
     push_fnptr(&mb_Type_2E_unify_21__1);
     mw_prim_pack_cons();
     mw_both();
-    WORD_ATOM(227, 18, "unify-aux!");
+    WORD_ATOM(228, 18, "unify-aux!");
     mw_Type_2E_unify_aux_21_();
     WORD_EXIT(mw_Type_2E_unify_21_);
 }
 static void mw_Value_2E_unify_21_ (void){
-    WORD_ENTER(mw_Value_2E_unify_21_, "Value.unify!", "src/mirth/data/type.mth", 230, 5);
-    WORD_ATOM(230, 5, "swap");
+    WORD_ENTER(mw_Value_2E_unify_21_, "Value.unify!", "src/mirth/data/type.mth", 231, 5);
+    WORD_ATOM(231, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(230, 10, "match");
+    WORD_ATOM(231, 10, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(231, 22, "swap");
+            WORD_ATOM(232, 22, "swap");
             mw_prim_swap();
-            WORD_ATOM(231, 27, "match");
+            WORD_ATOM(232, 27, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(232, 26, "dup2");
+                    WORD_ATOM(233, 26, "dup2");
                     mw_dup2();
-                    WORD_ATOM(232, 31, "=");
+                    WORD_ATOM(233, 31, "=");
                     mw_prim_int_eq();
-                    WORD_ATOM(232, 33, "if");
+                    WORD_ATOM(233, 33, "if");
                     if (pop_u64()) {
-                        WORD_ATOM(232, 36, "drop");
+                        WORD_ATOM(233, 36, "drop");
                         mw_prim_drop();
-                        WORD_ATOM(232, 41, "VALUE_INT");
+                        WORD_ATOM(233, 41, "VALUE_INT");
                         mw_VALUE_5F_INT();
-                        WORD_ATOM(232, 51, "TValue");
+                        WORD_ATOM(233, 51, "TValue");
                         mw_TValue();
                     } else {
-                        WORD_ATOM(232, 59, "drop2");
+                        WORD_ATOM(233, 59, "drop2");
                         mw_drop2();
-                        WORD_ATOM(232, 65, "TYPE_INT");
+                        WORD_ATOM(233, 65, "TYPE_INT");
                         mw_TYPE_5F_INT();
                     }
                     break;
                 case 1LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(234, 17, "drop2");
+                    WORD_ATOM(235, 17, "drop2");
                     mw_drop2();
-                    WORD_ATOM(234, 23, "dup");
+                    WORD_ATOM(235, 23, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(234, 27, "token");
+                    WORD_ATOM(235, 27, "token");
                     mw_Gamma_2E_token();
-                    WORD_ATOM(235, 17, "");
+                    WORD_ATOM(236, 17, "");
                     {
                         static bool vready = false;
                         static VAL v;
@@ -25112,20 +25254,20 @@ static void mw_Value_2E_unify_21_ (void){
                         push_value(v);
                         incref(v);
                     }
-                    WORD_ATOM(236, 17, "emit-error!");
+                    WORD_ATOM(237, 17, "emit-error!");
                     mw_emit_error_21_();
-                    WORD_ATOM(236, 29, "TYPE_ERROR");
+                    WORD_ATOM(237, 29, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 case 2LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(238, 17, "drop2");
+                    WORD_ATOM(239, 17, "drop2");
                     mw_drop2();
-                    WORD_ATOM(238, 23, "dup");
+                    WORD_ATOM(239, 23, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(238, 27, "token");
+                    WORD_ATOM(239, 27, "token");
                     mw_Gamma_2E_token();
-                    WORD_ATOM(239, 17, "");
+                    WORD_ATOM(240, 17, "");
                     {
                         static bool vready = false;
                         static VAL v;
@@ -25136,9 +25278,9 @@ static void mw_Value_2E_unify_21_ (void){
                         push_value(v);
                         incref(v);
                     }
-                    WORD_ATOM(240, 17, "emit-error!");
+                    WORD_ATOM(241, 17, "emit-error!");
                     mw_emit_error_21_();
-                    WORD_ATOM(240, 29, "TYPE_ERROR");
+                    WORD_ATOM(241, 29, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -25146,40 +25288,40 @@ static void mw_Value_2E_unify_21_ (void){
 }            break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(243, 22, "swap");
+            WORD_ATOM(244, 22, "swap");
             mw_prim_swap();
-            WORD_ATOM(243, 27, "match");
+            WORD_ATOM(244, 27, "match");
             switch (get_top_data_tag()) {
                 case 1LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(244, 26, "dup2");
+                    WORD_ATOM(245, 26, "dup2");
                     mw_dup2();
-                    WORD_ATOM(244, 31, "=");
+                    WORD_ATOM(245, 31, "=");
                     mw_Str_3D_();
-                    WORD_ATOM(244, 33, "if");
+                    WORD_ATOM(245, 33, "if");
                     if (pop_u64()) {
-                        WORD_ATOM(244, 36, "drop");
+                        WORD_ATOM(245, 36, "drop");
                         mw_prim_drop();
-                        WORD_ATOM(244, 41, "VALUE_STR");
+                        WORD_ATOM(245, 41, "VALUE_STR");
                         mw_VALUE_5F_STR();
-                        WORD_ATOM(244, 51, "TValue");
+                        WORD_ATOM(245, 51, "TValue");
                         mw_TValue();
                     } else {
-                        WORD_ATOM(244, 59, "drop2");
+                        WORD_ATOM(245, 59, "drop2");
                         mw_drop2();
-                        WORD_ATOM(244, 65, "TYPE_STR");
+                        WORD_ATOM(245, 65, "TYPE_STR");
                         mw_TYPE_5F_STR();
                     }
                     break;
                 case 0LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(246, 17, "drop2");
+                    WORD_ATOM(247, 17, "drop2");
                     mw_drop2();
-                    WORD_ATOM(246, 23, "dup");
+                    WORD_ATOM(247, 23, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(246, 27, "token");
+                    WORD_ATOM(247, 27, "token");
                     mw_Gamma_2E_token();
-                    WORD_ATOM(247, 17, "");
+                    WORD_ATOM(248, 17, "");
                     {
                         static bool vready = false;
                         static VAL v;
@@ -25190,20 +25332,20 @@ static void mw_Value_2E_unify_21_ (void){
                         push_value(v);
                         incref(v);
                     }
-                    WORD_ATOM(248, 17, "emit-error!");
+                    WORD_ATOM(249, 17, "emit-error!");
                     mw_emit_error_21_();
-                    WORD_ATOM(248, 29, "TYPE_ERROR");
+                    WORD_ATOM(249, 29, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 case 2LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(250, 17, "drop2");
+                    WORD_ATOM(251, 17, "drop2");
                     mw_drop2();
-                    WORD_ATOM(250, 23, "dup");
+                    WORD_ATOM(251, 23, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(250, 27, "token");
+                    WORD_ATOM(251, 27, "token");
                     mw_Gamma_2E_token();
-                    WORD_ATOM(251, 17, "");
+                    WORD_ATOM(252, 17, "");
                     {
                         static bool vready = false;
                         static VAL v;
@@ -25214,9 +25356,9 @@ static void mw_Value_2E_unify_21_ (void){
                         push_value(v);
                         incref(v);
                     }
-                    WORD_ATOM(252, 17, "emit-error!");
+                    WORD_ATOM(253, 17, "emit-error!");
                     mw_emit_error_21_();
-                    WORD_ATOM(252, 29, "TYPE_ERROR");
+                    WORD_ATOM(253, 29, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -25224,44 +25366,44 @@ static void mw_Value_2E_unify_21_ (void){
 }            break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(255, 24, "swap");
+            WORD_ATOM(256, 24, "swap");
             mw_prim_swap();
-            WORD_ATOM(255, 29, "match");
+            WORD_ATOM(256, 29, "match");
             switch (get_top_data_tag()) {
                 case 2LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(257, 17, "dup2");
+                    WORD_ATOM(258, 17, "dup2");
                     mw_dup2();
-                    WORD_ATOM(257, 22, "=");
+                    WORD_ATOM(258, 22, "=");
                     mw_Block_3D_();
-                    WORD_ATOM(257, 24, "if");
+                    WORD_ATOM(258, 24, "if");
                     if (pop_u64()) {
-                        WORD_ATOM(258, 21, "drop");
+                        WORD_ATOM(259, 21, "drop");
                         mw_prim_drop();
-                        WORD_ATOM(258, 26, "VALUE_BLOCK");
+                        WORD_ATOM(259, 26, "VALUE_BLOCK");
                         mw_VALUE_5F_BLOCK();
-                        WORD_ATOM(258, 38, "TValue");
+                        WORD_ATOM(259, 38, "TValue");
                         mw_TValue();
                     } else {
-                        WORD_ATOM(259, 21, "arrow");
+                        WORD_ATOM(260, 21, "arrow");
                         mw_Block_2E_arrow();
-                        WORD_ATOM(259, 27, "type");
+                        WORD_ATOM(260, 27, "type");
                         mw_Arrow_2E_type();
-                        WORD_ATOM(259, 32, "block-unify-type!");
+                        WORD_ATOM(260, 32, "block-unify-type!");
                         mw_block_unify_type_21_();
-                        WORD_ATOM(259, 50, ">Type");
+                        WORD_ATOM(260, 50, ">Type");
                         mw_ArrowType_3E_Type();
                     }
                     break;
                 case 0LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(262, 17, "drop2");
+                    WORD_ATOM(263, 17, "drop2");
                     mw_drop2();
-                    WORD_ATOM(262, 23, "dup");
+                    WORD_ATOM(263, 23, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(262, 27, "token");
+                    WORD_ATOM(263, 27, "token");
                     mw_Gamma_2E_token();
-                    WORD_ATOM(263, 17, "");
+                    WORD_ATOM(264, 17, "");
                     {
                         static bool vready = false;
                         static VAL v;
@@ -25272,20 +25414,20 @@ static void mw_Value_2E_unify_21_ (void){
                         push_value(v);
                         incref(v);
                     }
-                    WORD_ATOM(264, 17, "emit-error!");
+                    WORD_ATOM(265, 17, "emit-error!");
                     mw_emit_error_21_();
-                    WORD_ATOM(264, 29, "TYPE_ERROR");
+                    WORD_ATOM(265, 29, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 case 1LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(266, 17, "drop2");
+                    WORD_ATOM(267, 17, "drop2");
                     mw_drop2();
-                    WORD_ATOM(266, 23, "dup");
+                    WORD_ATOM(267, 23, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(266, 27, "token");
+                    WORD_ATOM(267, 27, "token");
                     mw_Gamma_2E_token();
-                    WORD_ATOM(267, 17, "");
+                    WORD_ATOM(268, 17, "");
                     {
                         static bool vready = false;
                         static VAL v;
@@ -25296,9 +25438,9 @@ static void mw_Value_2E_unify_21_ (void){
                         push_value(v);
                         incref(v);
                     }
-                    WORD_ATOM(268, 17, "emit-error!");
+                    WORD_ATOM(269, 17, "emit-error!");
                     mw_emit_error_21_();
-                    WORD_ATOM(268, 29, "TYPE_ERROR");
+                    WORD_ATOM(269, 29, "TYPE_ERROR");
                     mw_TYPE_5F_ERROR();
                     break;
                 default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -25309,32 +25451,32 @@ static void mw_Value_2E_unify_21_ (void){
 }    WORD_EXIT(mw_Value_2E_unify_21_);
 }
 static void mw_Value_2E_unify_type_21_ (void){
-    WORD_ENTER(mw_Value_2E_unify_type_21_, "Value.unify-type!", "src/mirth/data/type.mth", 273, 5);
-    WORD_ATOM(273, 5, "VALUE_INT");
+    WORD_ENTER(mw_Value_2E_unify_type_21_, "Value.unify-type!", "src/mirth/data/type.mth", 274, 5);
+    WORD_ATOM(274, 5, "VALUE_INT");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(273, 18, "drop");
+            WORD_ATOM(274, 18, "drop");
             mw_prim_drop();
-            WORD_ATOM(273, 23, "TYPE_INT");
+            WORD_ATOM(274, 23, "TYPE_INT");
             mw_TYPE_5F_INT();
-            WORD_ATOM(273, 32, "unify!");
+            WORD_ATOM(274, 32, "unify!");
             mw_Type_2E_unify_21_();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(274, 18, "drop");
+            WORD_ATOM(275, 18, "drop");
             mw_prim_drop();
-            WORD_ATOM(274, 23, "TYPE_STR");
+            WORD_ATOM(275, 23, "TYPE_STR");
             mw_TYPE_5F_STR();
-            WORD_ATOM(274, 32, "unify!");
+            WORD_ATOM(275, 32, "unify!");
             mw_Type_2E_unify_21_();
             break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(275, 20, "swap");
+            WORD_ATOM(276, 20, "swap");
             mw_prim_swap();
-            WORD_ATOM(275, 25, "unify-block!");
+            WORD_ATOM(276, 25, "unify-block!");
             mw_Type_2E_unify_block_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -25342,266 +25484,266 @@ static void mw_Value_2E_unify_type_21_ (void){
 }    WORD_EXIT(mw_Value_2E_unify_type_21_);
 }
 static void mw_Type_2E_unify_block_21_ (void){
-    WORD_ENTER(mw_Type_2E_unify_block_21_, "Type.unify-block!", "src/mirth/data/type.mth", 278, 5);
-    WORD_ATOM(278, 5, "expand");
+    WORD_ENTER(mw_Type_2E_unify_block_21_, "Type.unify-block!", "src/mirth/data/type.mth", 279, 5);
+    WORD_ATOM(279, 5, "expand");
     mw_Type_2E_expand();
-    WORD_ATOM(278, 12, "match");
+    WORD_ATOM(279, 12, "match");
     switch (get_top_data_tag()) {
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(279, 18, "over");
+            WORD_ATOM(280, 18, "over");
             mw_over();
-            WORD_ATOM(279, 23, "dip");
+            WORD_ATOM(280, 23, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(279, 27, "dip");
+                WORD_ATOM(280, 27, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(279, 31, "type");
+                    WORD_ATOM(280, 31, "type");
                     mw_Block_2E_type();
-                    WORD_ATOM(279, 36, ">Type");
+                    WORD_ATOM(280, 36, ">Type");
                     mw_ArrowType_3E_Type();
                     push_value(d5);
                 }
-                WORD_ATOM(279, 43, "unify!");
+                WORD_ATOM(280, 43, "unify!");
                 mw_MetaVar_2E_unify_21_();
-                WORD_ATOM(279, 50, "drop");
+                WORD_ATOM(280, 50, "drop");
                 mw_prim_drop();
                 push_value(d4);
             }
-            WORD_ATOM(279, 56, "arrow");
+            WORD_ATOM(280, 56, "arrow");
             mw_Block_2E_arrow();
-            WORD_ATOM(279, 62, "type");
+            WORD_ATOM(280, 62, "type");
             mw_Arrow_2E_type();
-            WORD_ATOM(279, 67, ">Type");
+            WORD_ATOM(280, 67, ">Type");
             mw_ArrowType_3E_Type();
             break;
         case 9LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(280, 22, "block-unify-type!");
+            WORD_ATOM(281, 22, "block-unify-type!");
             mw_block_unify_type_21_();
-            WORD_ATOM(280, 40, ">Type");
+            WORD_ATOM(281, 40, ">Type");
             mw_ArrowType_3E_Type();
             break;
         default:
-            WORD_ATOM(281, 14, "dip");
+            WORD_ATOM(282, 14, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(281, 18, "type");
+                WORD_ATOM(282, 18, "type");
                 mw_Block_2E_type();
-                WORD_ATOM(281, 23, ">Type");
+                WORD_ATOM(282, 23, ">Type");
                 mw_ArrowType_3E_Type();
                 push_value(d4);
             }
-            WORD_ATOM(281, 30, "unify!");
+            WORD_ATOM(282, 30, "unify!");
             mw_Type_2E_unify_21_();
             break;
     
 }    WORD_EXIT(mw_Type_2E_unify_block_21_);
 }
 static void mw_Type_2E_unify2_21_ (void){
-    WORD_ENTER(mw_Type_2E_unify2_21_, "Type.unify2!", "src/mirth/data/type.mth", 285, 5);
-    WORD_ATOM(285, 5, "dip");
+    WORD_ENTER(mw_Type_2E_unify2_21_, "Type.unify2!", "src/mirth/data/type.mth", 286, 5);
+    WORD_ATOM(286, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(285, 9, "swap");
+        WORD_ATOM(286, 9, "swap");
         mw_prim_swap();
-        WORD_ATOM(285, 14, "dip");
+        WORD_ATOM(286, 14, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(285, 18, "unify!");
+            WORD_ATOM(286, 18, "unify!");
             mw_Type_2E_unify_21_();
-            WORD_ATOM(285, 25, "swap");
+            WORD_ATOM(286, 25, "swap");
             mw_prim_swap();
             push_value(d3);
         }
         push_value(d2);
     }
-    WORD_ATOM(285, 32, "unify!");
+    WORD_ATOM(286, 32, "unify!");
     mw_Type_2E_unify_21_();
-    WORD_ATOM(285, 39, "dip");
+    WORD_ATOM(286, 39, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(285, 43, "swap");
+        WORD_ATOM(286, 43, "swap");
         mw_prim_swap();
         push_value(d2);
     }
     WORD_EXIT(mw_Type_2E_unify2_21_);
 }
 static void mw_PrimType_2E_unify_21_ (void){
-    WORD_ENTER(mw_PrimType_2E_unify_21_, "PrimType.unify!", "src/mirth/data/type.mth", 288, 5);
-    WORD_ATOM(288, 5, "dup2");
+    WORD_ENTER(mw_PrimType_2E_unify_21_, "PrimType.unify!", "src/mirth/data/type.mth", 289, 5);
+    WORD_ATOM(289, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(288, 10, "=");
+    WORD_ATOM(289, 10, "=");
     mw_PrimType_3D_();
-    WORD_ATOM(288, 12, "if");
+    WORD_ATOM(289, 12, "if");
     if (pop_u64()) {
-        WORD_ATOM(288, 15, "drop");
+        WORD_ATOM(289, 15, "drop");
         mw_prim_drop();
-        WORD_ATOM(288, 20, "TPrim");
+        WORD_ATOM(289, 20, "TPrim");
         mw_TPrim();
     } else {
-        WORD_ATOM(288, 27, "both");
+        WORD_ATOM(289, 27, "both");
         push_u64(0);
         push_fnptr(&mb_PrimType_2E_unify_21__3);
         mw_prim_pack_cons();
         mw_both();
-        WORD_ATOM(288, 39, "unify-failed!");
+        WORD_ATOM(289, 39, "unify-failed!");
         mw_Type_2E_unify_failed_21_();
     }
     WORD_EXIT(mw_PrimType_2E_unify_21_);
 }
 static void mw_Data_2E_unify_21_ (void){
-    WORD_ENTER(mw_Data_2E_unify_21_, "Data.unify!", "src/mirth/data/type.mth", 290, 5);
-    WORD_ATOM(290, 5, "dup2");
+    WORD_ENTER(mw_Data_2E_unify_21_, "Data.unify!", "src/mirth/data/type.mth", 291, 5);
+    WORD_ATOM(291, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(290, 10, "=");
+    WORD_ATOM(291, 10, "=");
     mw_Data_3D_();
-    WORD_ATOM(290, 12, "if");
+    WORD_ATOM(291, 12, "if");
     if (pop_u64()) {
-        WORD_ATOM(290, 15, "drop");
+        WORD_ATOM(291, 15, "drop");
         mw_prim_drop();
-        WORD_ATOM(290, 20, "TData");
+        WORD_ATOM(291, 20, "TData");
         mw_TData();
     } else {
-        WORD_ATOM(290, 27, "both");
+        WORD_ATOM(291, 27, "both");
         push_u64(0);
         push_fnptr(&mb_Data_2E_unify_21__3);
         mw_prim_pack_cons();
         mw_both();
-        WORD_ATOM(290, 39, "unify-failed!");
+        WORD_ATOM(291, 39, "unify-failed!");
         mw_Type_2E_unify_failed_21_();
     }
     WORD_EXIT(mw_Data_2E_unify_21_);
 }
 static void mw_Table_2E_unify_21_ (void){
-    WORD_ENTER(mw_Table_2E_unify_21_, "Table.unify!", "src/mirth/data/type.mth", 292, 5);
-    WORD_ATOM(292, 5, "dup2");
+    WORD_ENTER(mw_Table_2E_unify_21_, "Table.unify!", "src/mirth/data/type.mth", 293, 5);
+    WORD_ATOM(293, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(292, 10, "=");
+    WORD_ATOM(293, 10, "=");
     mw_Table_3D_();
-    WORD_ATOM(292, 12, "if");
+    WORD_ATOM(293, 12, "if");
     if (pop_u64()) {
-        WORD_ATOM(292, 15, "drop");
+        WORD_ATOM(293, 15, "drop");
         mw_prim_drop();
-        WORD_ATOM(292, 20, "TTable");
+        WORD_ATOM(293, 20, "TTable");
         mw_TTable();
     } else {
-        WORD_ATOM(292, 28, "both");
+        WORD_ATOM(293, 28, "both");
         push_u64(0);
         push_fnptr(&mb_Table_2E_unify_21__3);
         mw_prim_pack_cons();
         mw_both();
-        WORD_ATOM(292, 41, "unify-failed!");
+        WORD_ATOM(293, 41, "unify-failed!");
         mw_Type_2E_unify_failed_21_();
     }
     WORD_EXIT(mw_Table_2E_unify_21_);
 }
 static void mw_Var_2E_unify_21_ (void){
-    WORD_ENTER(mw_Var_2E_unify_21_, "Var.unify!", "src/mirth/data/type.mth", 294, 5);
-    WORD_ATOM(294, 5, "dup2");
+    WORD_ENTER(mw_Var_2E_unify_21_, "Var.unify!", "src/mirth/data/type.mth", 295, 5);
+    WORD_ATOM(295, 5, "dup2");
     mw_dup2();
-    WORD_ATOM(294, 10, "=");
+    WORD_ATOM(295, 10, "=");
     mw_Var_3D_();
-    WORD_ATOM(294, 12, "if");
+    WORD_ATOM(295, 12, "if");
     if (pop_u64()) {
-        WORD_ATOM(294, 15, "drop");
+        WORD_ATOM(295, 15, "drop");
         mw_prim_drop();
-        WORD_ATOM(294, 20, "TVar");
+        WORD_ATOM(295, 20, "TVar");
         mw_TVar();
     } else {
-        WORD_ATOM(294, 26, "both");
+        WORD_ATOM(295, 26, "both");
         push_u64(0);
         push_fnptr(&mb_Var_2E_unify_21__3);
         mw_prim_pack_cons();
         mw_both();
-        WORD_ATOM(294, 37, "unify-failed!");
+        WORD_ATOM(295, 37, "unify-failed!");
         mw_Type_2E_unify_failed_21_();
     }
     WORD_EXIT(mw_Var_2E_unify_21_);
 }
 static void mw_Type_2E_has_meta_3F_ (void){
-    WORD_ENTER(mw_Type_2E_has_meta_3F_, "Type.has-meta?", "src/mirth/data/type.mth", 297, 5);
-    WORD_ATOM(297, 5, "TMeta");
+    WORD_ENTER(mw_Type_2E_has_meta_3F_, "Type.has-meta?", "src/mirth/data/type.mth", 298, 5);
+    WORD_ATOM(298, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(297, 14, "has-meta?");
+            WORD_ATOM(298, 14, "has-meta?");
             mw_MetaVar_2E_has_meta_3F_();
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(298, 19, "drop");
+            WORD_ATOM(299, 19, "drop");
             mw_prim_drop();
-            WORD_ATOM(298, 24, "F");
+            WORD_ATOM(299, 24, "F");
             mw_F();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(299, 23, "drop");
+            WORD_ATOM(300, 23, "drop");
             mw_prim_drop();
-            WORD_ATOM(299, 28, "F");
+            WORD_ATOM(300, 28, "F");
             mw_F();
             break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(300, 14, "drop2");
+            WORD_ATOM(301, 14, "drop2");
             mw_drop2();
-            WORD_ATOM(300, 20, "F");
+            WORD_ATOM(301, 20, "F");
             mw_F();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(301, 13, "drop2");
+            WORD_ATOM(302, 13, "drop2");
             mw_drop2();
-            WORD_ATOM(301, 19, "F");
+            WORD_ATOM(302, 19, "F");
             mw_F();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(302, 14, "drop2");
+            WORD_ATOM(303, 14, "drop2");
             mw_drop2();
-            WORD_ATOM(302, 20, "F");
+            WORD_ATOM(303, 20, "F");
             mw_F();
             break;
         case 8LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(303, 16, "has-meta?");
+            WORD_ATOM(304, 16, "has-meta?");
             mw_StackType_2E_has_meta_3F_();
             break;
         case 9LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(304, 18, "has-meta?");
+            WORD_ATOM(305, 18, "has-meta?");
             mw_ArrowType_2E_has_meta_3F_();
             break;
         case 10LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(305, 13, "has-meta2?");
+            WORD_ATOM(306, 13, "has-meta2?");
             mw_Type_2E_has_meta2_3F_();
             break;
         case 7LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(306, 14, "drop2");
+            WORD_ATOM(307, 14, "drop2");
             mw_drop2();
-            WORD_ATOM(306, 20, "F");
+            WORD_ATOM(307, 20, "F");
             mw_F();
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(307, 15, "drop2");
+            WORD_ATOM(308, 15, "drop2");
             mw_drop2();
-            WORD_ATOM(307, 21, "F");
+            WORD_ATOM(308, 21, "F");
             mw_F();
             break;
         case 12LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(308, 15, "has-meta?");
+            WORD_ATOM(309, 15, "has-meta?");
             mw_Value_2E_has_meta_3F_();
             break;
         case 11LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(309, 13, "has-meta?");
+            WORD_ATOM(310, 13, "has-meta?");
             mw_Type_2E_has_meta_3F_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -25609,43 +25751,43 @@ static void mw_Type_2E_has_meta_3F_ (void){
 }    WORD_EXIT(mw_Type_2E_has_meta_3F_);
 }
 static void mw_Type_2E_has_meta2_3F_ (void){
-    WORD_ENTER(mw_Type_2E_has_meta2_3F_, "Type.has-meta2?", "src/mirth/data/type.mth", 312, 5);
-    WORD_ATOM(312, 5, "dip");
+    WORD_ENTER(mw_Type_2E_has_meta2_3F_, "Type.has-meta2?", "src/mirth/data/type.mth", 313, 5);
+    WORD_ATOM(313, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(312, 9, "over");
+        WORD_ATOM(313, 9, "over");
         mw_over();
         push_value(d2);
     }
-    WORD_ATOM(312, 15, "has-meta?");
+    WORD_ATOM(313, 15, "has-meta?");
     mw_Type_2E_has_meta_3F_();
-    WORD_ATOM(312, 25, "if");
+    WORD_ATOM(313, 25, "if");
     if (pop_u64()) {
-        WORD_ATOM(312, 28, "drop2");
+        WORD_ATOM(313, 28, "drop2");
         mw_drop2();
-        WORD_ATOM(312, 34, "T");
+        WORD_ATOM(313, 34, "T");
         mw_T();
     } else {
-        WORD_ATOM(312, 37, "has-meta?");
+        WORD_ATOM(313, 37, "has-meta?");
         mw_Type_2E_has_meta_3F_();
     }
     WORD_EXIT(mw_Type_2E_has_meta2_3F_);
 }
 static void mw_Value_2E_has_meta_3F_ (void){
-    WORD_ENTER(mw_Value_2E_has_meta_3F_, "Value.has-meta?", "src/mirth/data/type.mth", 315, 5);
-    WORD_ATOM(315, 5, "type");
+    WORD_ENTER(mw_Value_2E_has_meta_3F_, "Value.has-meta?", "src/mirth/data/type.mth", 316, 5);
+    WORD_ATOM(316, 5, "type");
     mw_Value_2E_type();
-    WORD_ATOM(315, 10, "has-meta?");
+    WORD_ATOM(316, 10, "has-meta?");
     mw_Type_2E_has_meta_3F_();
     WORD_EXIT(mw_Value_2E_has_meta_3F_);
 }
 static void mw_Type_2E_trace_sig_21_ (void){
-    WORD_ENTER(mw_Type_2E_trace_sig_21_, "Type.trace-sig!", "src/mirth/data/type.mth", 318, 5);
-    WORD_ATOM(318, 5, "TMeta");
+    WORD_ENTER(mw_Type_2E_trace_sig_21_, "Type.trace-sig!", "src/mirth/data/type.mth", 319, 5);
+    WORD_ATOM(319, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(318, 14, "expand-if");
+            WORD_ATOM(319, 14, "expand-if");
             push_u64(0);
             push_fnptr(&mb_Type_2E_trace_sig_21__2);
             mw_prim_pack_cons();
@@ -25656,7 +25798,7 @@ static void mw_Type_2E_trace_sig_21_ (void){
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(319, 19, "");
+            WORD_ATOM(320, 19, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -25667,28 +25809,28 @@ static void mw_Type_2E_trace_sig_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(319, 29, "trace!");
+            WORD_ATOM(320, 29, "trace!");
             mw_Str_2E_trace_21_();
             break;
         case 9LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(320, 18, "trace!");
+            WORD_ATOM(321, 18, "trace!");
             mw_ArrowType_2E_trace_21_();
             break;
         default:
-            WORD_ATOM(321, 10, "trace!");
+            WORD_ATOM(322, 10, "trace!");
             mw_Type_2E_trace_21_();
             break;
     
 }    WORD_EXIT(mw_Type_2E_trace_sig_21_);
 }
 static void mw_Type_2E_trace_21_ (void){
-    WORD_ENTER(mw_Type_2E_trace_21_, "Type.trace!", "src/mirth/data/type.mth", 324, 5);
-    WORD_ATOM(324, 5, "TYPE_ERROR");
+    WORD_ENTER(mw_Type_2E_trace_21_, "Type.trace!", "src/mirth/data/type.mth", 325, 5);
+    WORD_ATOM(325, 5, "TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(324, 19, "");
+            WORD_ATOM(325, 19, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -25699,12 +25841,12 @@ static void mw_Type_2E_trace_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(324, 29, "trace!");
+            WORD_ATOM(325, 29, "trace!");
             mw_Str_2E_trace_21_();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(325, 23, "");
+            WORD_ATOM(326, 23, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -25715,27 +25857,27 @@ static void mw_Type_2E_trace_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(325, 27, "trace!");
+            WORD_ATOM(326, 27, "trace!");
             mw_Str_2E_trace_21_();
             break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(326, 14, "trace!");
+            WORD_ATOM(327, 14, "trace!");
             mw_PrimType_2E_trace_21_();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(327, 13, "trace!");
+            WORD_ATOM(328, 13, "trace!");
             mw_Var_2E_trace_21_();
             break;
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(328, 14, "trace!");
+            WORD_ATOM(329, 14, "trace!");
             mw_MetaVar_2E_trace_21_();
             break;
         case 8LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(329, 16, "");
+            WORD_ATOM(330, 16, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -25746,11 +25888,11 @@ static void mw_Type_2E_trace_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(329, 20, "trace!");
+            WORD_ATOM(330, 20, "trace!");
             mw_Str_2E_trace_21_();
-            WORD_ATOM(329, 27, "trace!");
+            WORD_ATOM(330, 27, "trace!");
             mw_StackType_2E_trace_21_();
-            WORD_ATOM(329, 34, "");
+            WORD_ATOM(330, 34, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -25761,12 +25903,12 @@ static void mw_Type_2E_trace_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(329, 38, "trace!");
+            WORD_ATOM(330, 38, "trace!");
             mw_Str_2E_trace_21_();
             break;
         case 9LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(330, 18, "");
+            WORD_ATOM(331, 18, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -25777,13 +25919,13 @@ static void mw_Type_2E_trace_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(330, 22, "trace!");
+            WORD_ATOM(331, 22, "trace!");
             mw_Str_2E_trace_21_();
-            WORD_ATOM(330, 29, "TMorphism");
+            WORD_ATOM(331, 29, "TMorphism");
             mw_TMorphism();
-            WORD_ATOM(330, 39, "trace-sig!");
+            WORD_ATOM(331, 39, "trace-sig!");
             mw_Type_2E_trace_sig_21_();
-            WORD_ATOM(330, 50, "");
+            WORD_ATOM(331, 50, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -25794,44 +25936,44 @@ static void mw_Type_2E_trace_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(330, 54, "trace!");
+            WORD_ATOM(331, 54, "trace!");
             mw_Str_2E_trace_21_();
             break;
         case 7LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(331, 14, "name");
+            WORD_ATOM(332, 14, "name");
             mw_Data_2E_name();
-            WORD_ATOM(331, 19, "trace!");
+            WORD_ATOM(332, 19, "trace!");
             mw_Name_2E_trace_21_();
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(332, 15, "name");
+            WORD_ATOM(333, 15, "name");
             mw_Table_2E_name();
-            WORD_ATOM(332, 20, "trace!");
+            WORD_ATOM(333, 20, "trace!");
             mw_Name_2E_trace_21_();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(333, 14, "trace!");
+            WORD_ATOM(334, 14, "trace!");
             mw_Name_2E_trace_21_();
             break;
         case 10LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(334, 13, "trace-app!");
+            WORD_ATOM(335, 13, "trace-app!");
             mw_Type_2E_trace_app_21_();
             break;
         case 12LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(335, 15, "type");
+            WORD_ATOM(336, 15, "type");
             mw_Value_2E_type();
-            WORD_ATOM(335, 20, "trace!");
+            WORD_ATOM(336, 20, "trace!");
             mw_Type_2E_trace_21_();
             break;
         case 11LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(336, 13, "");
+            WORD_ATOM(337, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -25842,11 +25984,11 @@ static void mw_Type_2E_trace_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(336, 20, "trace!");
+            WORD_ATOM(337, 20, "trace!");
             mw_Str_2E_trace_21_();
-            WORD_ATOM(336, 27, "trace!");
+            WORD_ATOM(337, 27, "trace!");
             mw_Type_2E_trace_21_();
-            WORD_ATOM(336, 34, "");
+            WORD_ATOM(337, 34, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -25857,7 +25999,7 @@ static void mw_Type_2E_trace_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(336, 38, "trace!");
+            WORD_ATOM(337, 38, "trace!");
             mw_Str_2E_trace_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -25865,32 +26007,32 @@ static void mw_Type_2E_trace_21_ (void){
 }    WORD_EXIT(mw_Type_2E_trace_21_);
 }
 static void mw_Value_2E_type (void){
-    WORD_ENTER(mw_Value_2E_type, "Value.type", "src/mirth/data/type.mth", 339, 5);
-    WORD_ATOM(339, 5, "VALUE_INT");
+    WORD_ENTER(mw_Value_2E_type, "Value.type", "src/mirth/data/type.mth", 340, 5);
+    WORD_ATOM(340, 5, "VALUE_INT");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(339, 18, "drop");
+            WORD_ATOM(340, 18, "drop");
             mw_prim_drop();
-            WORD_ATOM(339, 23, "PRIM_TYPE_INT");
+            WORD_ATOM(340, 23, "PRIM_TYPE_INT");
             mw_PRIM_5F_TYPE_5F_INT();
-            WORD_ATOM(339, 37, "TPrim");
+            WORD_ATOM(340, 37, "TPrim");
             mw_TPrim();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(340, 18, "drop");
+            WORD_ATOM(341, 18, "drop");
             mw_prim_drop();
-            WORD_ATOM(340, 23, "PRIM_TYPE_STR");
+            WORD_ATOM(341, 23, "PRIM_TYPE_STR");
             mw_PRIM_5F_TYPE_5F_STR();
-            WORD_ATOM(340, 37, "TPrim");
+            WORD_ATOM(341, 37, "TPrim");
             mw_TPrim();
             break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(341, 20, "type");
+            WORD_ATOM(342, 20, "type");
             mw_Block_2E_type();
-            WORD_ATOM(341, 25, ">Type");
+            WORD_ATOM(342, 25, ">Type");
             mw_ArrowType_3E_Type();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -25898,12 +26040,12 @@ static void mw_Value_2E_type (void){
 }    WORD_EXIT(mw_Value_2E_type);
 }
 static void mw_PrimType_2E_trace_21_ (void){
-    WORD_ENTER(mw_PrimType_2E_trace_21_, "PrimType.trace!", "src/mirth/data/type.mth", 344, 5);
-    WORD_ATOM(344, 5, "match");
+    WORD_ENTER(mw_PrimType_2E_trace_21_, "PrimType.trace!", "src/mirth/data/type.mth", 345, 5);
+    WORD_ATOM(345, 5, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(345, 27, "");
+            WORD_ATOM(346, 27, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -25917,7 +26059,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(346, 28, "");
+            WORD_ATOM(347, 28, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -25931,7 +26073,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             break;
         case 2LL:
             mw_prim_drop();
-            WORD_ATOM(347, 31, "");
+            WORD_ATOM(348, 31, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -25945,7 +26087,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             break;
         case 3LL:
             mw_prim_drop();
-            WORD_ATOM(348, 26, "");
+            WORD_ATOM(349, 26, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -25959,7 +26101,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             break;
         case 4LL:
             mw_prim_drop();
-            WORD_ATOM(349, 26, "");
+            WORD_ATOM(350, 26, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -25973,7 +26115,7 @@ static void mw_PrimType_2E_trace_21_ (void){
             break;
         case 5LL:
             mw_prim_drop();
-            WORD_ATOM(350, 26, "");
+            WORD_ATOM(351, 26, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -25987,86 +26129,86 @@ static void mw_PrimType_2E_trace_21_ (void){
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
     
-}    WORD_ATOM(351, 7, "trace!");
+}    WORD_ATOM(352, 7, "trace!");
     mw_Str_2E_trace_21_();
     WORD_EXIT(mw_PrimType_2E_trace_21_);
 }
 static void mw_Type_2E_freshen (void){
-    WORD_ENTER(mw_Type_2E_freshen, "Type.freshen", "src/mirth/data/type.mth", 372, 5);
-    WORD_ATOM(372, 5, "TYPE_ERROR");
+    WORD_ENTER(mw_Type_2E_freshen, "Type.freshen", "src/mirth/data/type.mth", 373, 5);
+    WORD_ATOM(373, 5, "TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(372, 19, "TYPE_ERROR");
+            WORD_ATOM(373, 19, "TYPE_ERROR");
             mw_TYPE_5F_ERROR();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(373, 23, "TYPE_DONT_CARE");
+            WORD_ATOM(374, 23, "TYPE_DONT_CARE");
             mw_TYPE_5F_DONT_5F_CARE();
             break;
         case 2LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(374, 14, "TPrim");
+            WORD_ATOM(375, 14, "TPrim");
             mw_TPrim();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(375, 14, "THole");
+            WORD_ATOM(376, 14, "THole");
             mw_THole();
             break;
         case 7LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(376, 14, "TData");
+            WORD_ATOM(377, 14, "TData");
             mw_TData();
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(377, 15, "TTable");
+            WORD_ATOM(378, 15, "TTable");
             mw_TTable();
             break;
         case 12LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(378, 15, "TValue");
+            WORD_ATOM(379, 15, "TValue");
             mw_TValue();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(379, 13, "freshen");
+            WORD_ATOM(380, 13, "freshen");
             mw_Var_2E_freshen();
             break;
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(380, 14, "freshen");
+            WORD_ATOM(381, 14, "freshen");
             mw_MetaVar_2E_freshen();
             break;
         case 8LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(381, 16, "freshen");
+            WORD_ATOM(382, 16, "freshen");
             mw_StackType_2E_freshen();
-            WORD_ATOM(381, 24, "TTensor");
+            WORD_ATOM(382, 24, "TTensor");
             mw_TTensor();
             break;
         case 9LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(382, 18, "freshen");
+            WORD_ATOM(383, 18, "freshen");
             mw_ArrowType_2E_freshen();
-            WORD_ATOM(382, 26, "TMorphism");
+            WORD_ATOM(383, 26, "TMorphism");
             mw_TMorphism();
             break;
         case 10LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(383, 13, "freshen2");
+            WORD_ATOM(384, 13, "freshen2");
             mw_Type_2E_freshen2();
-            WORD_ATOM(383, 22, "TApp");
+            WORD_ATOM(384, 22, "TApp");
             mw_TApp();
             break;
         case 11LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(384, 13, "freshen");
+            WORD_ATOM(385, 13, "freshen");
             mw_Type_2E_freshen();
-            WORD_ATOM(384, 21, "TMut");
+            WORD_ATOM(385, 21, "TMut");
             mw_TMut();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -26074,30 +26216,30 @@ static void mw_Type_2E_freshen (void){
 }    WORD_EXIT(mw_Type_2E_freshen);
 }
 static void mw_Type_2E_freshen2 (void){
-    WORD_ENTER(mw_Type_2E_freshen2, "Type.freshen2", "src/mirth/data/type.mth", 388, 5);
-    WORD_ATOM(388, 5, "dip");
+    WORD_ENTER(mw_Type_2E_freshen2, "Type.freshen2", "src/mirth/data/type.mth", 389, 5);
+    WORD_ATOM(389, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(388, 9, "freshen");
+        WORD_ATOM(389, 9, "freshen");
         mw_Type_2E_freshen();
-        WORD_ATOM(388, 17, "swap");
+        WORD_ATOM(389, 17, "swap");
         mw_prim_swap();
         push_value(d2);
     }
-    WORD_ATOM(388, 23, "freshen");
+    WORD_ATOM(389, 23, "freshen");
     mw_Type_2E_freshen();
-    WORD_ATOM(388, 31, "dip");
+    WORD_ATOM(389, 31, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(388, 35, "swap");
+        WORD_ATOM(389, 35, "swap");
         mw_prim_swap();
         push_value(d2);
     }
     WORD_EXIT(mw_Type_2E_freshen2);
 }
 static void mw_MetaVar_2E_freshen (void){
-    WORD_ENTER(mw_MetaVar_2E_freshen, "MetaVar.freshen", "src/mirth/data/type.mth", 391, 5);
-    WORD_ATOM(391, 5, "expand-if");
+    WORD_ENTER(mw_MetaVar_2E_freshen, "MetaVar.freshen", "src/mirth/data/type.mth", 392, 5);
+    WORD_ATOM(392, 5, "expand-if");
     push_u64(0);
     push_fnptr(&mb_MetaVar_2E_freshen_1);
     mw_prim_pack_cons();
@@ -26108,32 +26250,32 @@ static void mw_MetaVar_2E_freshen (void){
     WORD_EXIT(mw_MetaVar_2E_freshen);
 }
 static void mw_Var_2E_freshen (void){
-    WORD_ENTER(mw_Var_2E_freshen, "Var.freshen", "src/mirth/data/type.mth", 394, 5);
-    WORD_ATOM(394, 5, "swap");
+    WORD_ENTER(mw_Var_2E_freshen, "Var.freshen", "src/mirth/data/type.mth", 395, 5);
+    WORD_ATOM(395, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(394, 10, "dup2");
+    WORD_ATOM(395, 10, "dup2");
     mw_dup2();
-    WORD_ATOM(394, 15, "has-var?");
+    WORD_ATOM(395, 15, "has-var?");
     mw_Subst_2E_has_var_3F_();
-    WORD_ATOM(394, 24, "if");
+    WORD_ATOM(395, 24, "if");
     if (pop_u64()) {
-        WORD_ATOM(395, 9, "tuck");
+        WORD_ATOM(396, 9, "tuck");
         mw_tuck();
-        WORD_ATOM(395, 14, "get-var");
+        WORD_ATOM(396, 14, "get-var");
         mw_Subst_2E_get_var();
     } else {
-        WORD_ATOM(396, 9, "MetaVar.new!");
+        WORD_ATOM(397, 9, "MetaVar.new!");
         mw_MetaVar_2E_new_21_();
-        WORD_ATOM(396, 22, "TMeta");
+        WORD_ATOM(397, 22, "TMeta");
         mw_TMeta();
-        WORD_ATOM(396, 28, "dup");
+        WORD_ATOM(397, 28, "dup");
         mw_prim_dup();
-        WORD_ATOM(397, 9, "dip");
+        WORD_ATOM(398, 9, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(397, 13, "rotr");
+            WORD_ATOM(398, 13, "rotr");
             mw_rotr();
-            WORD_ATOM(397, 18, "cons");
+            WORD_ATOM(398, 18, "cons");
             mw_Subst_2E_cons();
             push_value(d3);
         }
@@ -26141,12 +26283,12 @@ static void mw_Var_2E_freshen (void){
     WORD_EXIT(mw_Var_2E_freshen);
 }
 static void mw_Type_2E_arity (void){
-    WORD_ENTER(mw_Type_2E_arity, "Type.arity", "src/mirth/data/type.mth", 437, 5);
-    WORD_ATOM(437, 5, "TMeta");
+    WORD_ENTER(mw_Type_2E_arity, "Type.arity", "src/mirth/data/type.mth", 438, 5);
+    WORD_ATOM(438, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(437, 14, "expand-if");
+            WORD_ATOM(438, 14, "expand-if");
             push_u64(0);
             push_fnptr(&mb_Type_2E_arity_2);
             mw_prim_pack_cons();
@@ -26157,35 +26299,35 @@ static void mw_Type_2E_arity (void){
             break;
         case 7LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(438, 14, "arity");
+            WORD_ATOM(439, 14, "arity");
             mw_Data_2E_arity();
             break;
         case 10LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(439, 13, "drop");
+            WORD_ATOM(440, 13, "drop");
             mw_prim_drop();
-            WORD_ATOM(439, 18, "arity");
+            WORD_ATOM(440, 18, "arity");
             mw_Type_2E_arity();
-            WORD_ATOM(439, 24, "1-");
+            WORD_ATOM(440, 24, "1-");
             mw_prim_int_pred();
             break;
         default:
-            WORD_ATOM(440, 10, "drop");
+            WORD_ATOM(441, 10, "drop");
             mw_prim_drop();
-            WORD_ATOM(440, 15, "");
+            WORD_ATOM(441, 15, "");
             push_i64(0LL);
             break;
     
 }    WORD_EXIT(mw_Type_2E_arity);
 }
 static void mw_type_head (void){
-    WORD_ENTER(mw_type_head, "type-head", "src/mirth/data/type.mth", 444, 5);
-    WORD_ATOM(444, 5, "TMeta");
+    WORD_ENTER(mw_type_head, "type-head", "src/mirth/data/type.mth", 445, 5);
+    WORD_ATOM(445, 5, "TMeta");
     switch (get_top_data_tag()) {
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(444, 14, "expand-if");
+            WORD_ATOM(445, 14, "expand-if");
             push_u64(0);
             push_fnptr(&mb_type_head_2);
             mw_prim_pack_cons();
@@ -26197,74 +26339,74 @@ static void mw_type_head (void){
         case 10LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(445, 13, "drop");
+            WORD_ATOM(446, 13, "drop");
             mw_prim_drop();
-            WORD_ATOM(445, 18, "type-head");
+            WORD_ATOM(446, 18, "type-head");
             mw_type_head();
             break;
         default:
-            WORD_ATOM(446, 10, "id");
+            WORD_ATOM(447, 10, "id");
             mw_prim_id();
             break;
     
 }    WORD_EXIT(mw_type_head);
 }
 static void mw_MetaVar_2E_id (void){
-    WORD_ENTER(mw_MetaVar_2E_id, "MetaVar.id", "src/mirth/data/type.mth", 468, 7);
-    WORD_ATOM(468, 7, "MetaVar");
+    WORD_ENTER(mw_MetaVar_2E_id, "MetaVar.id", "src/mirth/data/type.mth", 469, 7);
+    WORD_ATOM(469, 7, "MetaVar");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_MetaVar_2E_id);
 }
 static void mw_MetaVar_2E_alloc_21_ (void){
-    WORD_ENTER(mw_MetaVar_2E_alloc_21_, "MetaVar.alloc!", "src/mirth/data/type.mth", 468, 7);
-    WORD_ATOM(468, 7, "MetaVar");
+    WORD_ENTER(mw_MetaVar_2E_alloc_21_, "MetaVar.alloc!", "src/mirth/data/type.mth", 469, 7);
+    WORD_ATOM(469, 7, "MetaVar");
     mw_MetaVar_2E_NUM();
-    WORD_ATOM(468, 7, "MetaVar");
+    WORD_ATOM(469, 7, "MetaVar");
     mw_prim_u64_get();
-    WORD_ATOM(468, 7, "MetaVar");
+    WORD_ATOM(469, 7, "MetaVar");
     mw_prim_unsafe_cast();
-    WORD_ATOM(468, 7, "MetaVar");
+    WORD_ATOM(469, 7, "MetaVar");
     push_i64(1LL);
-    WORD_ATOM(468, 7, "MetaVar");
+    WORD_ATOM(469, 7, "MetaVar");
     mw_prim_int_add();
-    WORD_ATOM(468, 7, "MetaVar");
+    WORD_ATOM(469, 7, "MetaVar");
     mw_prim_dup();
-    WORD_ATOM(468, 7, "MetaVar");
+    WORD_ATOM(469, 7, "MetaVar");
     mw_prim_unsafe_cast();
-    WORD_ATOM(468, 7, "MetaVar");
+    WORD_ATOM(469, 7, "MetaVar");
     mw_MetaVar_2E_NUM();
-    WORD_ATOM(468, 7, "MetaVar");
+    WORD_ATOM(469, 7, "MetaVar");
     mw_prim_u64_set();
-    WORD_ATOM(468, 7, "MetaVar");
+    WORD_ATOM(469, 7, "MetaVar");
     mw_prim_unsafe_cast();
     WORD_EXIT(mw_MetaVar_2E_alloc_21_);
 }
 static void mw_MetaVar_2E_type_3F_ (void){
-    WORD_ENTER(mw_MetaVar_2E_type_3F_, "MetaVar.type?", "src/mirth/data/type.mth", 470, 44);
-    WORD_ATOM(470, 44, "~type?");
+    WORD_ENTER(mw_MetaVar_2E_type_3F_, "MetaVar.type?", "src/mirth/data/type.mth", 471, 44);
+    WORD_ATOM(471, 44, "~type?");
     mw_MetaVar_7E_type_3F_();
-    WORD_ATOM(470, 51, "@");
+    WORD_ATOM(471, 51, "@");
     mw_prim_mut_get();
     WORD_EXIT(mw_MetaVar_2E_type_3F_);
 }
 static void mw_MetaVar_2E_has_meta_3F_ (void){
-    WORD_ENTER(mw_MetaVar_2E_has_meta_3F_, "MetaVar.has-meta?", "src/mirth/data/type.mth", 473, 5);
-    WORD_ATOM(473, 5, "dup");
+    WORD_ENTER(mw_MetaVar_2E_has_meta_3F_, "MetaVar.has-meta?", "src/mirth/data/type.mth", 474, 5);
+    WORD_ATOM(474, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(473, 9, "type?");
+    WORD_ATOM(474, 9, "type?");
     mw_MetaVar_2E_type_3F_();
-    WORD_ATOM(473, 15, "match");
+    WORD_ATOM(474, 15, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(474, 17, "=");
+            WORD_ATOM(475, 17, "=");
             mw_MetaVar_3D_();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(475, 17, "nip");
+            WORD_ATOM(476, 17, "nip");
             mw_nip();
-            WORD_ATOM(475, 21, "has-meta?");
+            WORD_ATOM(476, 21, "has-meta?");
             mw_Type_2E_has_meta_3F_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -26272,16 +26414,16 @@ static void mw_MetaVar_2E_has_meta_3F_ (void){
 }    WORD_EXIT(mw_MetaVar_2E_has_meta_3F_);
 }
 static void mw_MetaVar_2E_trace_21_ (void){
-    WORD_ENTER(mw_MetaVar_2E_trace_21_, "MetaVar.trace!", "src/mirth/data/type.mth", 479, 5);
-    WORD_ATOM(479, 5, "dup");
+    WORD_ENTER(mw_MetaVar_2E_trace_21_, "MetaVar.trace!", "src/mirth/data/type.mth", 480, 5);
+    WORD_ATOM(480, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(479, 9, "type?");
+    WORD_ATOM(480, 9, "type?");
     mw_MetaVar_2E_type_3F_();
-    WORD_ATOM(479, 15, "match");
+    WORD_ATOM(480, 15, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(480, 17, "");
+            WORD_ATOM(481, 17, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -26292,18 +26434,18 @@ static void mw_MetaVar_2E_trace_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(480, 21, "trace!");
+            WORD_ATOM(481, 21, "trace!");
             mw_Str_2E_trace_21_();
-            WORD_ATOM(480, 28, "MetaVar.id");
+            WORD_ATOM(481, 28, "MetaVar.id");
             mw_MetaVar_2E_id();
-            WORD_ATOM(480, 39, "trace!");
+            WORD_ATOM(481, 39, "trace!");
             mw_Int_2E_trace_21_();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(481, 17, "nip");
+            WORD_ATOM(482, 17, "nip");
             mw_nip();
-            WORD_ATOM(481, 21, "trace!");
+            WORD_ATOM(482, 21, "trace!");
             mw_Type_2E_trace_21_();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -26311,52 +26453,52 @@ static void mw_MetaVar_2E_trace_21_ (void){
 }    WORD_EXIT(mw_MetaVar_2E_trace_21_);
 }
 static void mw_MetaVar_2E_new_21_ (void){
-    WORD_ENTER(mw_MetaVar_2E_new_21_, "MetaVar.new!", "src/mirth/data/type.mth", 484, 5);
-    WORD_ATOM(484, 5, "MetaVar.alloc!");
+    WORD_ENTER(mw_MetaVar_2E_new_21_, "MetaVar.new!", "src/mirth/data/type.mth", 485, 5);
+    WORD_ATOM(485, 5, "MetaVar.alloc!");
     mw_MetaVar_2E_alloc_21_();
-    WORD_ATOM(485, 5, "NONE");
+    WORD_ATOM(486, 5, "NONE");
     mw_NONE();
-    WORD_ATOM(485, 10, "over");
+    WORD_ATOM(486, 10, "over");
     mw_over();
-    WORD_ATOM(485, 15, "~type?");
+    WORD_ATOM(486, 15, "~type?");
     mw_MetaVar_7E_type_3F_();
-    WORD_ATOM(485, 22, "!");
+    WORD_ATOM(486, 22, "!");
     mw_prim_mut_set();
     WORD_EXIT(mw_MetaVar_2E_new_21_);
 }
 static void mw_MetaVar_2E_expand_if (void){
-    WORD_ENTER(mw_MetaVar_2E_expand_if, "MetaVar.expand-if", "src/mirth/data/type.mth", 488, 5);
-    WORD_ATOM(488, 5, "dup");
+    WORD_ENTER(mw_MetaVar_2E_expand_if, "MetaVar.expand-if", "src/mirth/data/type.mth", 489, 5);
+    WORD_ATOM(489, 5, "dup");
     {
         VAL var_g = pop_value();
         VAL var_f = pop_value();
-        WORD_ATOM(488, 5, "dup");
+        WORD_ATOM(489, 5, "dup");
         mw_prim_dup();
-        WORD_ATOM(488, 9, "type?");
+        WORD_ATOM(489, 9, "type?");
         mw_MetaVar_2E_type_3F_();
-        WORD_ATOM(488, 15, "match");
+        WORD_ATOM(489, 15, "match");
         switch (get_top_data_tag()) {
             case 0LL:
                 mw_prim_drop();
-                WORD_ATOM(489, 17, "g");
+                WORD_ATOM(490, 17, "g");
                 incref(var_g);
                 run_value(var_g);
                 break;
             case 1LL:
                 mw_prim_pack_uncons(); mw_prim_drop();
-                WORD_ATOM(490, 17, "expand");
+                WORD_ATOM(491, 17, "expand");
                 mw_Type_2E_expand();
-                WORD_ATOM(490, 24, "tuck");
+                WORD_ATOM(491, 24, "tuck");
                 mw_tuck();
-                WORD_ATOM(490, 29, "SOME");
+                WORD_ATOM(491, 29, "SOME");
                 mw_SOME();
-                WORD_ATOM(490, 34, "swap");
+                WORD_ATOM(491, 34, "swap");
                 mw_prim_swap();
-                WORD_ATOM(490, 39, "~type?");
+                WORD_ATOM(491, 39, "~type?");
                 mw_MetaVar_7E_type_3F_();
-                WORD_ATOM(490, 46, "!");
+                WORD_ATOM(491, 46, "!");
                 mw_prim_mut_set();
-                WORD_ATOM(490, 48, "f");
+                WORD_ATOM(491, 48, "f");
                 incref(var_f);
                 run_value(var_f);
                 break;
@@ -26368,8 +26510,8 @@ static void mw_MetaVar_2E_expand_if (void){
     WORD_EXIT(mw_MetaVar_2E_expand_if);
 }
 static void mw_MetaVar_2E_expand (void){
-    WORD_ENTER(mw_MetaVar_2E_expand, "MetaVar.expand", "src/mirth/data/type.mth", 493, 5);
-    WORD_ATOM(493, 5, "expand-if");
+    WORD_ENTER(mw_MetaVar_2E_expand, "MetaVar.expand", "src/mirth/data/type.mth", 494, 5);
+    WORD_ATOM(494, 5, "expand-if");
     push_u64(0);
     push_fnptr(&mb_MetaVar_2E_expand_1);
     mw_prim_pack_cons();
@@ -26380,57 +26522,57 @@ static void mw_MetaVar_2E_expand (void){
     WORD_EXIT(mw_MetaVar_2E_expand);
 }
 static void mw_MetaVar_2E_unify_21_ (void){
-    WORD_ENTER(mw_MetaVar_2E_unify_21_, "MetaVar.unify!", "src/mirth/data/type.mth", 495, 5);
-    WORD_ATOM(495, 5, "dup");
+    WORD_ENTER(mw_MetaVar_2E_unify_21_, "MetaVar.unify!", "src/mirth/data/type.mth", 496, 5);
+    WORD_ATOM(496, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(495, 9, "type?");
+    WORD_ATOM(496, 9, "type?");
     mw_MetaVar_2E_type_3F_();
-    WORD_ATOM(495, 15, "match");
+    WORD_ATOM(496, 15, "match");
     switch (get_top_data_tag()) {
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(496, 17, "nip");
+            WORD_ATOM(497, 17, "nip");
             mw_nip();
-            WORD_ATOM(496, 21, "unify!");
+            WORD_ATOM(497, 21, "unify!");
             mw_Type_2E_unify_21_();
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(497, 17, "dup2");
+            WORD_ATOM(498, 17, "dup2");
             mw_dup2();
-            WORD_ATOM(497, 22, "swap");
+            WORD_ATOM(498, 22, "swap");
             mw_prim_swap();
-            WORD_ATOM(497, 27, "=meta");
+            WORD_ATOM(498, 27, "=meta");
             mw_Type_3D_meta();
-            WORD_ATOM(497, 33, "if");
+            WORD_ATOM(498, 33, "if");
             if (pop_u64()) {
-                WORD_ATOM(498, 13, "drop");
+                WORD_ATOM(499, 13, "drop");
                 mw_prim_drop();
             } else {
-                WORD_ATOM(499, 13, "swap");
+                WORD_ATOM(500, 13, "swap");
                 mw_prim_swap();
-                WORD_ATOM(499, 18, "dup2");
+                WORD_ATOM(500, 18, "dup2");
                 mw_dup2();
-                WORD_ATOM(499, 23, "has-meta?");
+                WORD_ATOM(500, 23, "has-meta?");
                 mw_Type_2E_has_meta_3F_();
-                WORD_ATOM(499, 33, "if");
+                WORD_ATOM(500, 33, "if");
                 if (pop_u64()) {
-                    WORD_ATOM(500, 17, "swap");
+                    WORD_ATOM(501, 17, "swap");
                     mw_prim_swap();
-                    WORD_ATOM(500, 22, "TMeta");
+                    WORD_ATOM(501, 22, "TMeta");
                     mw_TMeta();
-                    WORD_ATOM(500, 28, "unify-failed!");
+                    WORD_ATOM(501, 28, "unify-failed!");
                     mw_Type_2E_unify_failed_21_();
                 } else {
-                    WORD_ATOM(501, 17, "tuck");
+                    WORD_ATOM(502, 17, "tuck");
                     mw_tuck();
-                    WORD_ATOM(501, 22, "SOME");
+                    WORD_ATOM(502, 22, "SOME");
                     mw_SOME();
-                    WORD_ATOM(501, 27, "swap");
+                    WORD_ATOM(502, 27, "swap");
                     mw_prim_swap();
-                    WORD_ATOM(501, 32, "~type?");
+                    WORD_ATOM(502, 32, "~type?");
                     mw_MetaVar_7E_type_3F_();
-                    WORD_ATOM(501, 39, "!");
+                    WORD_ATOM(502, 39, "!");
                     mw_prim_mut_set();
                 }
             }
@@ -26440,23 +26582,23 @@ static void mw_MetaVar_2E_unify_21_ (void){
 }    WORD_EXIT(mw_MetaVar_2E_unify_21_);
 }
 static void mw_MetaVar_3D_ (void){
-    WORD_ENTER(mw_MetaVar_3D_, "MetaVar=", "src/mirth/data/type.mth", 511, 40);
-    WORD_ATOM(511, 40, "both");
+    WORD_ENTER(mw_MetaVar_3D_, "MetaVar=", "src/mirth/data/type.mth", 512, 40);
+    WORD_ATOM(512, 40, "both");
     push_u64(0);
     push_fnptr(&mb_MetaVar_3D__1);
     mw_prim_pack_cons();
     mw_both();
-    WORD_ATOM(511, 50, "=");
+    WORD_ATOM(512, 50, "=");
     mw_prim_int_eq();
     WORD_EXIT(mw_MetaVar_3D_);
 }
 static void mw_type_hole_unify_21_ (void){
-    WORD_ENTER(mw_type_hole_unify_21_, "type-hole-unify!", "src/mirth/data/type.mth", 518, 5);
-    WORD_ATOM(518, 5, "THole");
+    WORD_ENTER(mw_type_hole_unify_21_, "type-hole-unify!", "src/mirth/data/type.mth", 519, 5);
+    WORD_ATOM(519, 5, "THole");
     mw_THole();
-    WORD_ATOM(518, 11, "trace!");
+    WORD_ATOM(519, 11, "trace!");
     mw_Type_2E_trace_21_();
-    WORD_ATOM(519, 5, "");
+    WORD_ATOM(520, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -26467,21 +26609,21 @@ static void mw_type_hole_unify_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(519, 11, "trace!");
+    WORD_ATOM(520, 11, "trace!");
     mw_Str_2E_trace_21_();
-    WORD_ATOM(520, 5, "dup");
+    WORD_ATOM(521, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(520, 9, "trace!");
+    WORD_ATOM(521, 9, "trace!");
     mw_Type_2E_trace_21_();
-    WORD_ATOM(521, 5, "line-trace!");
+    WORD_ATOM(522, 5, "line-trace!");
     mw_line_trace_21_();
     WORD_EXIT(mw_type_hole_unify_21_);
 }
 static void mw_Type_2E_trace_app_21_ (void){
-    WORD_ENTER(mw_Type_2E_trace_app_21_, "Type.trace-app!", "src/mirth/data/type.mth", 528, 5);
-    WORD_ATOM(528, 5, "trace-app-open!");
+    WORD_ENTER(mw_Type_2E_trace_app_21_, "Type.trace-app!", "src/mirth/data/type.mth", 529, 5);
+    WORD_ATOM(529, 5, "trace-app-open!");
     mw_Type_2E_trace_app_open_21_();
-    WORD_ATOM(528, 21, "");
+    WORD_ATOM(529, 21, "");
     {
         static bool vready = false;
         static VAL v;
@@ -26492,24 +26634,24 @@ static void mw_Type_2E_trace_app_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(528, 25, "trace!");
+    WORD_ATOM(529, 25, "trace!");
     mw_Str_2E_trace_21_();
     WORD_EXIT(mw_Type_2E_trace_app_21_);
 }
 static void mw_Type_2E_trace_app_open_21_ (void){
-    WORD_ENTER(mw_Type_2E_trace_app_open_21_, "Type.trace-app-open!", "src/mirth/data/type.mth", 531, 5);
-    WORD_ATOM(531, 5, "swap");
+    WORD_ENTER(mw_Type_2E_trace_app_open_21_, "Type.trace-app-open!", "src/mirth/data/type.mth", 532, 5);
+    WORD_ATOM(532, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(531, 10, "expand");
+    WORD_ATOM(532, 10, "expand");
     mw_Type_2E_expand();
-    WORD_ATOM(531, 17, "match");
+    WORD_ATOM(532, 17, "match");
     switch (get_top_data_tag()) {
         case 10LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(533, 13, "trace-app-open!");
+            WORD_ATOM(534, 13, "trace-app-open!");
             mw_Type_2E_trace_app_open_21_();
-            WORD_ATOM(534, 13, "");
+            WORD_ATOM(535, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -26520,15 +26662,15 @@ static void mw_Type_2E_trace_app_open_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(534, 18, "trace!");
+            WORD_ATOM(535, 18, "trace!");
             mw_Str_2E_trace_21_();
-            WORD_ATOM(535, 13, "trace!");
+            WORD_ATOM(536, 13, "trace!");
             mw_Type_2E_trace_21_();
             break;
         default:
-            WORD_ATOM(537, 13, "trace!");
+            WORD_ATOM(538, 13, "trace!");
             mw_Type_2E_trace_21_();
-            WORD_ATOM(538, 13, "");
+            WORD_ATOM(539, 13, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -26539,51 +26681,51 @@ static void mw_Type_2E_trace_app_open_21_ (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(538, 17, "trace!");
+            WORD_ATOM(539, 17, "trace!");
             mw_Str_2E_trace_21_();
-            WORD_ATOM(539, 13, "trace!");
+            WORD_ATOM(540, 13, "trace!");
             mw_Type_2E_trace_21_();
             break;
     
 }    WORD_EXIT(mw_Type_2E_trace_app_open_21_);
 }
 static void mw_Resource_3E_Type (void){
-    WORD_ENTER(mw_Resource_3E_Type, "Resource>Type", "src/mirth/data/type.mth", 547, 38);
-    WORD_ATOM(547, 38, "RESOURCE");
-    WORD_ATOM(547, 50, "id");
+    WORD_ENTER(mw_Resource_3E_Type, "Resource>Type", "src/mirth/data/type.mth", 548, 38);
+    WORD_ATOM(548, 38, "RESOURCE");
+    WORD_ATOM(548, 50, "id");
     mw_prim_id();
     WORD_EXIT(mw_Resource_3E_Type);
 }
 static void mw_Type_3E_Resource (void){
-    WORD_ENTER(mw_Type_3E_Resource, "Type>Resource", "src/mirth/data/type.mth", 548, 38);
-    WORD_ATOM(548, 38, "RESOURCE");
+    WORD_ENTER(mw_Type_3E_Resource, "Type>Resource", "src/mirth/data/type.mth", 549, 38);
+    WORD_ATOM(549, 38, "RESOURCE");
     mw_RESOURCE();
     WORD_EXIT(mw_Type_3E_Resource);
 }
 static void mw_Resource_2E_has_meta_3F_ (void){
-    WORD_ENTER(mw_Resource_2E_has_meta_3F_, "Resource.has-meta?", "src/mirth/data/type.mth", 549, 51);
-    WORD_ATOM(549, 51, ">Type");
+    WORD_ENTER(mw_Resource_2E_has_meta_3F_, "Resource.has-meta?", "src/mirth/data/type.mth", 550, 51);
+    WORD_ATOM(550, 51, ">Type");
     mw_Resource_3E_Type();
-    WORD_ATOM(549, 57, "has-meta?");
+    WORD_ATOM(550, 57, "has-meta?");
     mw_Type_2E_has_meta_3F_();
     WORD_EXIT(mw_Resource_2E_has_meta_3F_);
 }
 static void mw_Resource_2E_unify_21_ (void){
-    WORD_ENTER(mw_Resource_2E_unify_21_, "Resource.unify!", "src/mirth/data/type.mth", 551, 5);
-    WORD_ATOM(551, 5, "both");
+    WORD_ENTER(mw_Resource_2E_unify_21_, "Resource.unify!", "src/mirth/data/type.mth", 552, 5);
+    WORD_ATOM(552, 5, "both");
     push_u64(0);
     push_fnptr(&mb_Resource_2E_unify_21__1);
     mw_prim_pack_cons();
     mw_both();
-    WORD_ATOM(551, 17, "unify!");
+    WORD_ATOM(552, 17, "unify!");
     mw_Type_2E_unify_21_();
-    WORD_ATOM(551, 24, ">Resource");
+    WORD_ATOM(552, 24, ">Resource");
     mw_Type_3E_Resource();
     WORD_EXIT(mw_Resource_2E_unify_21_);
 }
 static void mw_Resource_2E_trace_21_ (void){
-    WORD_ENTER(mw_Resource_2E_trace_21_, "Resource.trace!", "src/mirth/data/type.mth", 553, 5);
-    WORD_ATOM(553, 5, "");
+    WORD_ENTER(mw_Resource_2E_trace_21_, "Resource.trace!", "src/mirth/data/type.mth", 554, 5);
+    WORD_ATOM(554, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -26594,55 +26736,55 @@ static void mw_Resource_2E_trace_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(553, 9, "trace!");
+    WORD_ATOM(554, 9, "trace!");
     mw_Str_2E_trace_21_();
-    WORD_ATOM(554, 5, ">Type");
+    WORD_ATOM(555, 5, ">Type");
     mw_Resource_3E_Type();
-    WORD_ATOM(554, 11, "trace!");
+    WORD_ATOM(555, 11, "trace!");
     mw_Type_2E_trace_21_();
     WORD_EXIT(mw_Resource_2E_trace_21_);
 }
 static void mw_Resource_2E_freshen (void){
-    WORD_ENTER(mw_Resource_2E_freshen, "Resource.freshen", "src/mirth/data/type.mth", 556, 5);
-    WORD_ATOM(556, 5, ">Type");
+    WORD_ENTER(mw_Resource_2E_freshen, "Resource.freshen", "src/mirth/data/type.mth", 557, 5);
+    WORD_ATOM(557, 5, ">Type");
     mw_Resource_3E_Type();
-    WORD_ATOM(556, 11, "freshen");
+    WORD_ATOM(557, 11, "freshen");
     mw_Type_2E_freshen();
-    WORD_ATOM(556, 19, ">Resource");
+    WORD_ATOM(557, 19, ">Resource");
     mw_Type_3E_Resource();
     WORD_EXIT(mw_Resource_2E_freshen);
 }
 static void mw_Type_3E_StackType (void){
-    WORD_ENTER(mw_Type_3E_StackType, "Type>StackType", "src/mirth/data/type.mth", 574, 5);
-    WORD_ATOM(574, 5, "TYPE_ERROR");
+    WORD_ENTER(mw_Type_3E_StackType, "Type>StackType", "src/mirth/data/type.mth", 575, 5);
+    WORD_ATOM(575, 5, "TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(574, 19, "STACK_TYPE_ERROR");
+            WORD_ATOM(575, 19, "STACK_TYPE_ERROR");
             mw_STACK_5F_TYPE_5F_ERROR();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(575, 23, "STACK_TYPE_DONT_CARE");
+            WORD_ATOM(576, 23, "STACK_TYPE_DONT_CARE");
             mw_STACK_5F_TYPE_5F_DONT_5F_CARE();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(576, 13, "STVar");
+            WORD_ATOM(577, 13, "STVar");
             mw_STVar();
             break;
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(577, 14, "STMeta");
+            WORD_ATOM(578, 14, "STMeta");
             mw_STMeta();
             break;
         case 8LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(578, 16, "id");
+            WORD_ATOM(579, 16, "id");
             mw_prim_id();
             break;
         default:
-            WORD_ATOM(579, 10, "");
+            WORD_ATOM(580, 10, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -26653,108 +26795,88 @@ static void mw_Type_3E_StackType (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(579, 63, "panic!");
+            WORD_ATOM(580, 63, "panic!");
             mw_prim_panic();
             break;
     
 }    WORD_EXIT(mw_Type_3E_StackType);
 }
 static void mw_StackType_3E_Type (void){
-    WORD_ENTER(mw_StackType_3E_Type, "StackType>Type", "src/mirth/data/type.mth", 582, 5);
-    WORD_ATOM(582, 5, "STACK_TYPE_ERROR");
+    WORD_ENTER(mw_StackType_3E_Type, "StackType>Type", "src/mirth/data/type.mth", 583, 5);
+    WORD_ATOM(583, 5, "STACK_TYPE_ERROR");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(582, 25, "TYPE_ERROR");
+            WORD_ATOM(583, 25, "TYPE_ERROR");
             mw_TYPE_5F_ERROR();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(583, 29, "TYPE_DONT_CARE");
+            WORD_ATOM(584, 29, "TYPE_DONT_CARE");
             mw_TYPE_5F_DONT_5F_CARE();
             break;
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(584, 14, "TVar");
+            WORD_ATOM(585, 14, "TVar");
             mw_TVar();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(585, 15, "TMeta");
+            WORD_ATOM(586, 15, "TMeta");
             mw_TMeta();
             break;
         default:
-            WORD_ATOM(586, 10, "TTensor");
+            WORD_ATOM(587, 10, "TTensor");
             mw_TTensor();
             break;
     
 }    WORD_EXIT(mw_StackType_3E_Type);
 }
 static void mw_StackType_2E_expand (void){
-    WORD_ENTER(mw_StackType_2E_expand, "StackType.expand", "src/mirth/data/type.mth", 589, 5);
-    WORD_ATOM(589, 5, "STMeta");
+    WORD_ENTER(mw_StackType_2E_expand, "StackType.expand", "src/mirth/data/type.mth", 590, 5);
+    WORD_ATOM(590, 5, "STMeta");
     switch (get_top_data_tag()) {
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(589, 15, "expand");
+            WORD_ATOM(590, 15, "expand");
             mw_MetaVar_2E_expand();
-            WORD_ATOM(589, 22, ">StackType");
+            WORD_ATOM(590, 22, ">StackType");
             mw_Type_3E_StackType();
             break;
         default:
-            WORD_ATOM(590, 10, "id");
+            WORD_ATOM(591, 10, "id");
             mw_prim_id();
             break;
     
 }    WORD_EXIT(mw_StackType_2E_expand);
 }
 static void mw_StackType_2E_unit_3F_ (void){
-    WORD_ENTER(mw_StackType_2E_unit_3F_, "StackType.unit?", "src/mirth/data/type.mth", 593, 5);
-    WORD_ATOM(593, 5, "expand");
+    WORD_ENTER(mw_StackType_2E_unit_3F_, "StackType.unit?", "src/mirth/data/type.mth", 594, 5);
+    WORD_ATOM(594, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(593, 12, "match");
+    WORD_ATOM(594, 12, "match");
     switch (get_top_data_tag()) {
         case 2LL:
             mw_prim_drop();
-            WORD_ATOM(594, 28, "T");
+            WORD_ATOM(595, 28, "T");
             mw_T();
             break;
         default:
-            WORD_ATOM(595, 14, "drop");
+            WORD_ATOM(596, 14, "drop");
             mw_prim_drop();
-            WORD_ATOM(595, 19, "F");
+            WORD_ATOM(596, 19, "F");
             mw_F();
             break;
     
 }    WORD_EXIT(mw_StackType_2E_unit_3F_);
 }
 static void mw_StackType_2E_split3 (void){
-    WORD_ENTER(mw_StackType_2E_split3, "StackType.split3", "src/mirth/data/type.mth", 600, 5);
-    WORD_ATOM(600, 5, "expand");
+    WORD_ENTER(mw_StackType_2E_split3, "StackType.split3", "src/mirth/data/type.mth", 601, 5);
+    WORD_ATOM(601, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(600, 12, "match");
+    WORD_ATOM(601, 12, "match");
     switch (get_top_data_tag()) {
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(601, 19, "dip");
-            {
-                VAL d4 = pop_value();
-                WORD_ATOM(601, 23, "split3");
-                mw_StackType_2E_split3();
-                push_value(d4);
-            }
-            WORD_ATOM(601, 31, "swap");
-            mw_prim_swap();
-            WORD_ATOM(601, 36, "dip");
-            {
-                VAL d4 = pop_value();
-                WORD_ATOM(601, 40, "snoc");
-                mw_snoc();
-                push_value(d4);
-            }
-            break;
-        case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
             WORD_ATOM(602, 19, "dip");
@@ -26764,54 +26886,74 @@ static void mw_StackType_2E_split3 (void){
                 mw_StackType_2E_split3();
                 push_value(d4);
             }
-            WORD_ATOM(602, 31, "snoc");
+            WORD_ATOM(602, 31, "swap");
+            mw_prim_swap();
+            WORD_ATOM(602, 36, "dip");
+            {
+                VAL d4 = pop_value();
+                WORD_ATOM(602, 40, "snoc");
+                mw_snoc();
+                push_value(d4);
+            }
+            break;
+        case 6LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            mw_prim_pack_uncons(); mw_prim_swap();
+            WORD_ATOM(603, 19, "dip");
+            {
+                VAL d4 = pop_value();
+                WORD_ATOM(603, 23, "split3");
+                mw_StackType_2E_split3();
+                push_value(d4);
+            }
+            WORD_ATOM(603, 31, "snoc");
             mw_snoc();
             break;
         default:
-            WORD_ATOM(603, 14, "L0");
+            WORD_ATOM(604, 14, "L0");
             mw_L0();
-            WORD_ATOM(603, 17, "L0");
+            WORD_ATOM(604, 17, "L0");
             mw_L0();
             break;
     
 }    WORD_EXIT(mw_StackType_2E_split3);
 }
 static void mw_StackType_2E_base (void){
-    WORD_ENTER(mw_StackType_2E_base, "StackType.base", "src/mirth/data/type.mth", 607, 45);
-    WORD_ATOM(607, 45, "split3");
+    WORD_ENTER(mw_StackType_2E_base, "StackType.base", "src/mirth/data/type.mth", 608, 45);
+    WORD_ATOM(608, 45, "split3");
     mw_StackType_2E_split3();
-    WORD_ATOM(607, 52, "drop2");
+    WORD_ATOM(608, 52, "drop2");
     mw_drop2();
     WORD_EXIT(mw_StackType_2E_base);
 }
 static void mw_StackType_2E_top_type (void){
-    WORD_ENTER(mw_StackType_2E_top_type, "StackType.top-type", "src/mirth/data/type.mth", 617, 5);
-    WORD_ATOM(617, 5, "expand");
+    WORD_ENTER(mw_StackType_2E_top_type, "StackType.top-type", "src/mirth/data/type.mth", 618, 5);
+    WORD_ATOM(618, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(617, 12, "match");
+    WORD_ATOM(618, 12, "match");
     switch (get_top_data_tag()) {
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(618, 19, "nip");
+            WORD_ATOM(619, 19, "nip");
             mw_nip();
-            WORD_ATOM(618, 23, "SOME");
+            WORD_ATOM(619, 23, "SOME");
             mw_SOME();
             break;
         default:
-            WORD_ATOM(619, 14, "drop");
+            WORD_ATOM(620, 14, "drop");
             mw_prim_drop();
-            WORD_ATOM(619, 19, "NONE");
+            WORD_ATOM(620, 19, "NONE");
             mw_NONE();
             break;
     
 }    WORD_EXIT(mw_StackType_2E_top_type);
 }
 static void mw_StackType_2E_top_tycon_name (void){
-    WORD_ENTER(mw_StackType_2E_top_tycon_name, "StackType.top-tycon-name", "src/mirth/data/type.mth", 624, 5);
-    WORD_ATOM(624, 5, "top-type");
+    WORD_ENTER(mw_StackType_2E_top_tycon_name, "StackType.top-tycon-name", "src/mirth/data/type.mth", 625, 5);
+    WORD_ATOM(625, 5, "top-type");
     mw_StackType_2E_top_type();
-    WORD_ATOM(624, 14, "bind");
+    WORD_ATOM(625, 14, "bind");
     push_u64(0);
     push_fnptr(&mb_StackType_2E_top_tycon_name_1);
     mw_prim_pack_cons();
@@ -26819,68 +26961,45 @@ static void mw_StackType_2E_top_tycon_name (void){
     WORD_EXIT(mw_StackType_2E_top_tycon_name);
 }
 static void mw_StackType_2E_has_meta_3F_ (void){
-    WORD_ENTER(mw_StackType_2E_has_meta_3F_, "StackType.has-meta?", "src/mirth/data/type.mth", 627, 5);
-    WORD_ATOM(627, 5, "expand");
+    WORD_ENTER(mw_StackType_2E_has_meta_3F_, "StackType.has-meta?", "src/mirth/data/type.mth", 628, 5);
+    WORD_ATOM(628, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(627, 12, "match");
+    WORD_ATOM(628, 12, "match");
     switch (get_top_data_tag()) {
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(628, 19, "=");
+            WORD_ATOM(629, 19, "=");
             mw_MetaVar_3D_();
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(629, 29, "drop");
+            WORD_ATOM(630, 29, "drop");
             mw_prim_drop();
-            WORD_ATOM(629, 34, "F");
+            WORD_ATOM(630, 34, "F");
             mw_F();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(630, 33, "drop");
+            WORD_ATOM(631, 33, "drop");
             mw_prim_drop();
-            WORD_ATOM(630, 38, "F");
+            WORD_ATOM(631, 38, "F");
             mw_F();
             break;
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(631, 18, "drop2");
+            WORD_ATOM(632, 18, "drop2");
             mw_drop2();
-            WORD_ATOM(631, 24, "F");
+            WORD_ATOM(632, 24, "F");
             mw_F();
             break;
         case 2LL:
             mw_prim_drop();
-            WORD_ATOM(632, 28, "drop");
+            WORD_ATOM(633, 28, "drop");
             mw_prim_drop();
-            WORD_ATOM(632, 33, "F");
+            WORD_ATOM(633, 33, "F");
             mw_F();
             break;
         case 5LL:
-            mw_prim_pack_uncons(); mw_prim_drop();
-            mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(633, 19, "dip");
-            {
-                VAL d4 = pop_value();
-                WORD_ATOM(633, 23, "over");
-                mw_over();
-                push_value(d4);
-            }
-            WORD_ATOM(633, 29, "has-meta?");
-            mw_Type_2E_has_meta_3F_();
-            WORD_ATOM(633, 39, "if");
-            if (pop_u64()) {
-                WORD_ATOM(633, 42, "drop2");
-                mw_drop2();
-                WORD_ATOM(633, 48, "T");
-                mw_T();
-            } else {
-                WORD_ATOM(633, 51, "has-meta?");
-                mw_StackType_2E_has_meta_3F_();
-            }
-            break;
-        case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
             WORD_ATOM(634, 19, "dip");
@@ -26891,7 +27010,7 @@ static void mw_StackType_2E_has_meta_3F_ (void){
                 push_value(d4);
             }
             WORD_ATOM(634, 29, "has-meta?");
-            mw_Resource_2E_has_meta_3F_();
+            mw_Type_2E_has_meta_3F_();
             WORD_ATOM(634, 39, "if");
             if (pop_u64()) {
                 WORD_ATOM(634, 42, "drop2");
@@ -26903,184 +27022,207 @@ static void mw_StackType_2E_has_meta_3F_ (void){
                 mw_StackType_2E_has_meta_3F_();
             }
             break;
+        case 6LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            mw_prim_pack_uncons(); mw_prim_swap();
+            WORD_ATOM(635, 19, "dip");
+            {
+                VAL d4 = pop_value();
+                WORD_ATOM(635, 23, "over");
+                mw_over();
+                push_value(d4);
+            }
+            WORD_ATOM(635, 29, "has-meta?");
+            mw_Resource_2E_has_meta_3F_();
+            WORD_ATOM(635, 39, "if");
+            if (pop_u64()) {
+                WORD_ATOM(635, 42, "drop2");
+                mw_drop2();
+                WORD_ATOM(635, 48, "T");
+                mw_T();
+            } else {
+                WORD_ATOM(635, 51, "has-meta?");
+                mw_StackType_2E_has_meta_3F_();
+            }
+            break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
     
 }    WORD_EXIT(mw_StackType_2E_has_meta_3F_);
 }
 static void mw_StackType_2E_unify_failed_21_ (void){
-    WORD_ENTER(mw_StackType_2E_unify_failed_21_, "StackType.unify-failed!", "src/mirth/data/type.mth", 639, 4);
-    WORD_ATOM(639, 4, "both");
+    WORD_ENTER(mw_StackType_2E_unify_failed_21_, "StackType.unify-failed!", "src/mirth/data/type.mth", 640, 4);
+    WORD_ATOM(640, 4, "both");
     push_u64(0);
     push_fnptr(&mb_StackType_2E_unify_failed_21__1);
     mw_prim_pack_cons();
     mw_both();
-    WORD_ATOM(639, 16, "unify-failed!");
+    WORD_ATOM(640, 16, "unify-failed!");
     mw_Type_2E_unify_failed_21_();
-    WORD_ATOM(639, 30, ">StackType");
+    WORD_ATOM(640, 30, ">StackType");
     mw_Type_3E_StackType();
     WORD_EXIT(mw_StackType_2E_unify_failed_21_);
 }
 static void mw_StackType_2E_unify_21_ (void){
-    WORD_ENTER(mw_StackType_2E_unify_21_, "StackType.unify!", "src/mirth/data/type.mth", 642, 5);
-    WORD_ATOM(642, 5, "swap");
+    WORD_ENTER(mw_StackType_2E_unify_21_, "StackType.unify!", "src/mirth/data/type.mth", 643, 5);
+    WORD_ATOM(643, 5, "swap");
     mw_prim_swap();
-    WORD_ATOM(642, 10, "expand");
+    WORD_ATOM(643, 10, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(642, 17, "match");
+    WORD_ATOM(643, 17, "match");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(643, 29, "drop");
+            WORD_ATOM(644, 29, "drop");
             mw_prim_drop();
-            WORD_ATOM(643, 34, "STACK_TYPE_ERROR");
+            WORD_ATOM(644, 34, "STACK_TYPE_ERROR");
             mw_STACK_5F_TYPE_5F_ERROR();
             break;
         case 1LL:
             mw_prim_drop();
-            WORD_ATOM(644, 33, "id");
+            WORD_ATOM(645, 33, "id");
             mw_prim_id();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(645, 19, "swap");
+            WORD_ATOM(646, 19, "swap");
             mw_prim_swap();
-            WORD_ATOM(645, 24, "expand");
+            WORD_ATOM(646, 24, "expand");
             mw_StackType_2E_expand();
-            WORD_ATOM(645, 31, "match");
+            WORD_ATOM(646, 31, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
                     mw_prim_drop();
-                    WORD_ATOM(646, 33, "drop");
+                    WORD_ATOM(647, 33, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(646, 38, "STACK_TYPE_ERROR");
+                    WORD_ATOM(647, 38, "STACK_TYPE_ERROR");
                     mw_STACK_5F_TYPE_5F_ERROR();
                     break;
                 case 1LL:
                     mw_prim_drop();
-                    WORD_ATOM(647, 37, "STMeta");
+                    WORD_ATOM(648, 37, "STMeta");
                     mw_STMeta();
                     break;
                 case 4LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(648, 23, "dip");
+                    WORD_ATOM(649, 23, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(648, 27, "TMeta");
+                        WORD_ATOM(649, 27, "TMeta");
                         mw_TMeta();
                         push_value(d6);
                     }
-                    WORD_ATOM(648, 34, "unify!");
+                    WORD_ATOM(649, 34, "unify!");
                     mw_MetaVar_2E_unify_21_();
-                    WORD_ATOM(648, 41, ">StackType");
+                    WORD_ATOM(649, 41, ">StackType");
                     mw_Type_3E_StackType();
                     break;
                 default:
-                    WORD_ATOM(649, 18, ">Type");
+                    WORD_ATOM(650, 18, ">Type");
                     mw_StackType_3E_Type();
-                    WORD_ATOM(649, 24, "swap");
+                    WORD_ATOM(650, 24, "swap");
                     mw_prim_swap();
-                    WORD_ATOM(649, 29, "unify!");
+                    WORD_ATOM(650, 29, "unify!");
                     mw_MetaVar_2E_unify_21_();
-                    WORD_ATOM(649, 36, ">StackType");
+                    WORD_ATOM(650, 36, ">StackType");
                     mw_Type_3E_StackType();
                     break;
             
 }            break;
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(651, 18, "swap");
+            WORD_ATOM(652, 18, "swap");
             mw_prim_swap();
-            WORD_ATOM(651, 23, "expand");
+            WORD_ATOM(652, 23, "expand");
             mw_StackType_2E_expand();
-            WORD_ATOM(651, 30, "match");
+            WORD_ATOM(652, 30, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
                     mw_prim_drop();
-                    WORD_ATOM(652, 33, "drop");
+                    WORD_ATOM(653, 33, "drop");
                     mw_prim_drop();
-                    WORD_ATOM(652, 38, "STACK_TYPE_ERROR");
+                    WORD_ATOM(653, 38, "STACK_TYPE_ERROR");
                     mw_STACK_5F_TYPE_5F_ERROR();
                     break;
                 case 1LL:
                     mw_prim_drop();
-                    WORD_ATOM(653, 37, "STVar");
+                    WORD_ATOM(654, 37, "STVar");
                     mw_STVar();
                     break;
                 case 4LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(654, 23, "dip");
+                    WORD_ATOM(655, 23, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(654, 27, "TVar");
+                        WORD_ATOM(655, 27, "TVar");
                         mw_TVar();
                         push_value(d6);
                     }
-                    WORD_ATOM(654, 33, "unify!");
+                    WORD_ATOM(655, 33, "unify!");
                     mw_MetaVar_2E_unify_21_();
-                    WORD_ATOM(654, 40, ">StackType");
+                    WORD_ATOM(655, 40, ">StackType");
                     mw_Type_3E_StackType();
                     break;
                 case 3LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(655, 22, "unify!");
+                    WORD_ATOM(656, 22, "unify!");
                     mw_Var_2E_unify_21_();
-                    WORD_ATOM(655, 29, ">StackType");
+                    WORD_ATOM(656, 29, ">StackType");
                     mw_Type_3E_StackType();
                     break;
                 default:
-                    WORD_ATOM(656, 18, "dip");
+                    WORD_ATOM(657, 18, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(656, 22, "STVar");
+                        WORD_ATOM(657, 22, "STVar");
                         mw_STVar();
                         push_value(d6);
                     }
-                    WORD_ATOM(656, 29, "unify-failed!");
+                    WORD_ATOM(657, 29, "unify-failed!");
                     mw_StackType_2E_unify_failed_21_();
                     break;
             
 }            break;
         case 2LL:
             mw_prim_drop();
-            WORD_ATOM(658, 28, "expand");
+            WORD_ATOM(659, 28, "expand");
             mw_StackType_2E_expand();
-            WORD_ATOM(658, 35, "match");
+            WORD_ATOM(659, 35, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
                     mw_prim_drop();
-                    WORD_ATOM(659, 33, "STACK_TYPE_ERROR");
+                    WORD_ATOM(660, 33, "STACK_TYPE_ERROR");
                     mw_STACK_5F_TYPE_5F_ERROR();
                     break;
                 case 4LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(660, 23, "dip");
+                    WORD_ATOM(661, 23, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(660, 27, "STACK_TYPE_UNIT");
+                        WORD_ATOM(661, 27, "STACK_TYPE_UNIT");
                         mw_STACK_5F_TYPE_5F_UNIT();
-                        WORD_ATOM(660, 43, ">Type");
+                        WORD_ATOM(661, 43, ">Type");
                         mw_StackType_3E_Type();
                         push_value(d6);
                     }
-                    WORD_ATOM(660, 50, "unify!");
+                    WORD_ATOM(661, 50, "unify!");
                     mw_MetaVar_2E_unify_21_();
-                    WORD_ATOM(660, 57, ">StackType");
+                    WORD_ATOM(661, 57, ">StackType");
                     mw_Type_3E_StackType();
                     break;
                 case 1LL:
                     mw_prim_drop();
-                    WORD_ATOM(661, 37, "STACK_TYPE_UNIT");
+                    WORD_ATOM(662, 37, "STACK_TYPE_UNIT");
                     mw_STACK_5F_TYPE_5F_UNIT();
                     break;
                 case 2LL:
                     mw_prim_drop();
-                    WORD_ATOM(662, 32, "STACK_TYPE_UNIT");
+                    WORD_ATOM(663, 32, "STACK_TYPE_UNIT");
                     mw_STACK_5F_TYPE_5F_UNIT();
                     break;
                 default:
-                    WORD_ATOM(663, 18, "STACK_TYPE_UNIT");
+                    WORD_ATOM(664, 18, "STACK_TYPE_UNIT");
                     mw_STACK_5F_TYPE_5F_UNIT();
-                    WORD_ATOM(663, 34, "unify-failed!");
+                    WORD_ATOM(664, 34, "unify-failed!");
                     mw_StackType_2E_unify_failed_21_();
                     break;
             
@@ -27088,46 +27230,46 @@ static void mw_StackType_2E_unify_21_ (void){
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(665, 19, "rotl");
+            WORD_ATOM(666, 19, "rotl");
             mw_rotl();
-            WORD_ATOM(665, 24, "expand");
+            WORD_ATOM(666, 24, "expand");
             mw_StackType_2E_expand();
-            WORD_ATOM(665, 31, "match");
+            WORD_ATOM(666, 31, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
                     mw_prim_drop();
-                    WORD_ATOM(666, 33, "drop2");
+                    WORD_ATOM(667, 33, "drop2");
                     mw_drop2();
-                    WORD_ATOM(666, 39, "STACK_TYPE_ERROR");
+                    WORD_ATOM(667, 39, "STACK_TYPE_ERROR");
                     mw_STACK_5F_TYPE_5F_ERROR();
                     break;
                 case 4LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(667, 23, "dip");
+                    WORD_ATOM(668, 23, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(667, 27, "STCons");
+                        WORD_ATOM(668, 27, "STCons");
                         mw_STCons();
-                        WORD_ATOM(667, 34, ">Type");
+                        WORD_ATOM(668, 34, ">Type");
                         mw_StackType_3E_Type();
                         push_value(d6);
                     }
-                    WORD_ATOM(667, 41, "unify!");
+                    WORD_ATOM(668, 41, "unify!");
                     mw_MetaVar_2E_unify_21_();
-                    WORD_ATOM(667, 48, ">StackType");
+                    WORD_ATOM(668, 48, ">StackType");
                     mw_Type_3E_StackType();
                     break;
                 case 1LL:
                     mw_prim_drop();
-                    WORD_ATOM(668, 37, "STCons");
+                    WORD_ATOM(669, 37, "STCons");
                     mw_STCons();
                     break;
                 default:
-                    WORD_ATOM(669, 18, "dup");
+                    WORD_ATOM(670, 18, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(669, 22, "force-cons?!");
+                    WORD_ATOM(670, 22, "force-cons?!");
                     mw_StackType_2E_force_cons_3F__21_();
-                    WORD_ATOM(669, 35, "if-some");
+                    WORD_ATOM(670, 35, "if-some");
                     push_u64(0);
                     push_fnptr(&mb_StackType_2E_unify_21__30);
                     mw_prim_pack_cons();
@@ -27141,46 +27283,46 @@ static void mw_StackType_2E_unify_21_ (void){
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(674, 19, "rotl");
+            WORD_ATOM(675, 19, "rotl");
             mw_rotl();
-            WORD_ATOM(674, 24, "expand");
+            WORD_ATOM(675, 24, "expand");
             mw_StackType_2E_expand();
-            WORD_ATOM(674, 31, "match");
+            WORD_ATOM(675, 31, "match");
             switch (get_top_data_tag()) {
                 case 0LL:
                     mw_prim_drop();
-                    WORD_ATOM(675, 33, "drop2");
+                    WORD_ATOM(676, 33, "drop2");
                     mw_drop2();
-                    WORD_ATOM(675, 39, "STACK_TYPE_ERROR");
+                    WORD_ATOM(676, 39, "STACK_TYPE_ERROR");
                     mw_STACK_5F_TYPE_5F_ERROR();
                     break;
                 case 4LL:
                     mw_prim_pack_uncons(); mw_prim_drop();
-                    WORD_ATOM(676, 23, "dip");
+                    WORD_ATOM(677, 23, "dip");
                     {
                         VAL d6 = pop_value();
-                        WORD_ATOM(676, 27, "STWith");
+                        WORD_ATOM(677, 27, "STWith");
                         mw_STWith();
-                        WORD_ATOM(676, 34, ">Type");
+                        WORD_ATOM(677, 34, ">Type");
                         mw_StackType_3E_Type();
                         push_value(d6);
                     }
-                    WORD_ATOM(676, 41, "unify!");
+                    WORD_ATOM(677, 41, "unify!");
                     mw_MetaVar_2E_unify_21_();
-                    WORD_ATOM(676, 48, ">StackType");
+                    WORD_ATOM(677, 48, ">StackType");
                     mw_Type_3E_StackType();
                     break;
                 case 1LL:
                     mw_prim_drop();
-                    WORD_ATOM(677, 37, "STWith");
+                    WORD_ATOM(678, 37, "STWith");
                     mw_STWith();
                     break;
                 default:
-                    WORD_ATOM(678, 18, "dup");
+                    WORD_ATOM(679, 18, "dup");
                     mw_prim_dup();
-                    WORD_ATOM(678, 22, "force-with?!");
+                    WORD_ATOM(679, 22, "force-with?!");
                     mw_StackType_2E_force_with_3F__21_();
-                    WORD_ATOM(678, 35, "if-some");
+                    WORD_ATOM(679, 35, "if-some");
                     push_u64(0);
                     push_fnptr(&mb_StackType_2E_unify_21__42);
                     mw_prim_pack_cons();
@@ -27196,163 +27338,163 @@ static void mw_StackType_2E_unify_21_ (void){
 }    WORD_EXIT(mw_StackType_2E_unify_21_);
 }
 static void mw_StackType_2E_force_cons_3F__21_ (void){
-    WORD_ENTER(mw_StackType_2E_force_cons_3F__21_, "StackType.force-cons?!", "src/mirth/data/type.mth", 686, 5);
-    WORD_ATOM(686, 5, "expand");
+    WORD_ENTER(mw_StackType_2E_force_cons_3F__21_, "StackType.force-cons?!", "src/mirth/data/type.mth", 687, 5);
+    WORD_ATOM(687, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(686, 12, "match");
+    WORD_ATOM(687, 12, "match");
     switch (get_top_data_tag()) {
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(687, 19, "pack2");
+            WORD_ATOM(688, 19, "pack2");
             mw_pack2();
-            WORD_ATOM(687, 25, "SOME");
+            WORD_ATOM(688, 25, "SOME");
             mw_SOME();
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(688, 19, "swap");
+            WORD_ATOM(689, 19, "swap");
             mw_prim_swap();
-            WORD_ATOM(688, 24, "force-cons?!");
+            WORD_ATOM(689, 24, "force-cons?!");
             mw_StackType_2E_force_cons_3F__21_();
-            WORD_ATOM(688, 37, "map");
+            WORD_ATOM(689, 37, "map");
             push_u64(0);
             push_fnptr(&mb_StackType_2E_force_cons_3F__21__3);
             mw_prim_pack_cons();
             mw_Maybe_2E_map();
-            WORD_ATOM(688, 73, "nip");
+            WORD_ATOM(689, 73, "nip");
             mw_nip();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(690, 13, "dip");
+            WORD_ATOM(691, 13, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(690, 17, "MetaVar.alloc!");
-                mw_MetaVar_2E_alloc_21_();
-                WORD_ATOM(690, 32, "STMeta");
+                WORD_ATOM(691, 17, "MetaVar.new!");
+                mw_MetaVar_2E_new_21_();
+                WORD_ATOM(691, 30, "STMeta");
                 mw_STMeta();
-                WORD_ATOM(691, 17, "MetaVar.alloc!");
-                mw_MetaVar_2E_alloc_21_();
-                WORD_ATOM(691, 32, "TMeta");
+                WORD_ATOM(692, 17, "MetaVar.new!");
+                mw_MetaVar_2E_new_21_();
+                WORD_ATOM(692, 30, "TMeta");
                 mw_TMeta();
-                WORD_ATOM(692, 17, "dup2");
+                WORD_ATOM(693, 17, "dup2");
                 mw_dup2();
-                WORD_ATOM(692, 22, "STCons");
+                WORD_ATOM(693, 22, "STCons");
                 mw_STCons();
-                WORD_ATOM(692, 29, ">Type");
+                WORD_ATOM(693, 29, ">Type");
                 mw_StackType_3E_Type();
-                WORD_ATOM(692, 35, "SOME");
+                WORD_ATOM(693, 35, "SOME");
                 mw_SOME();
                 push_value(d4);
             }
-            WORD_ATOM(692, 41, "~type?");
+            WORD_ATOM(693, 41, "~type?");
             mw_MetaVar_7E_type_3F_();
-            WORD_ATOM(692, 48, "!");
+            WORD_ATOM(693, 48, "!");
             mw_prim_mut_set();
-            WORD_ATOM(693, 13, "pack2");
+            WORD_ATOM(694, 13, "pack2");
             mw_pack2();
-            WORD_ATOM(693, 19, "SOME");
+            WORD_ATOM(694, 19, "SOME");
             mw_SOME();
             break;
         default:
-            WORD_ATOM(694, 14, "drop");
+            WORD_ATOM(695, 14, "drop");
             mw_prim_drop();
-            WORD_ATOM(694, 19, "NONE");
+            WORD_ATOM(695, 19, "NONE");
             mw_NONE();
             break;
     
 }    WORD_EXIT(mw_StackType_2E_force_cons_3F__21_);
 }
 static void mw_StackType_2E_force_with_3F__21_ (void){
-    WORD_ENTER(mw_StackType_2E_force_with_3F__21_, "StackType.force-with?!", "src/mirth/data/type.mth", 698, 5);
-    WORD_ATOM(698, 5, "expand");
+    WORD_ENTER(mw_StackType_2E_force_with_3F__21_, "StackType.force-with?!", "src/mirth/data/type.mth", 699, 5);
+    WORD_ATOM(699, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(698, 12, "match");
+    WORD_ATOM(699, 12, "match");
     switch (get_top_data_tag()) {
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(699, 19, "pack2");
+            WORD_ATOM(700, 19, "pack2");
             mw_pack2();
-            WORD_ATOM(699, 25, "SOME");
+            WORD_ATOM(700, 25, "SOME");
             mw_SOME();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(700, 19, "swap");
+            WORD_ATOM(701, 19, "swap");
             mw_prim_swap();
-            WORD_ATOM(700, 24, "force-with?!");
+            WORD_ATOM(701, 24, "force-with?!");
             mw_StackType_2E_force_with_3F__21_();
-            WORD_ATOM(700, 37, "map");
+            WORD_ATOM(701, 37, "map");
             push_u64(0);
             push_fnptr(&mb_StackType_2E_force_with_3F__21__3);
             mw_prim_pack_cons();
             mw_Maybe_2E_map();
-            WORD_ATOM(700, 73, "nip");
+            WORD_ATOM(701, 73, "nip");
             mw_nip();
             break;
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(702, 13, "dip");
+            WORD_ATOM(703, 13, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(702, 17, "MetaVar.alloc!");
-                mw_MetaVar_2E_alloc_21_();
-                WORD_ATOM(702, 32, "STMeta");
+                WORD_ATOM(703, 17, "MetaVar.new!");
+                mw_MetaVar_2E_new_21_();
+                WORD_ATOM(703, 30, "STMeta");
                 mw_STMeta();
-                WORD_ATOM(703, 17, "MetaVar.alloc!");
-                mw_MetaVar_2E_alloc_21_();
-                WORD_ATOM(703, 32, "TMeta");
+                WORD_ATOM(704, 17, "MetaVar.new!");
+                mw_MetaVar_2E_new_21_();
+                WORD_ATOM(704, 30, "TMeta");
                 mw_TMeta();
-                WORD_ATOM(703, 38, "RESOURCE");
+                WORD_ATOM(704, 36, "RESOURCE");
                 mw_RESOURCE();
-                WORD_ATOM(704, 17, "dup2");
+                WORD_ATOM(705, 17, "dup2");
                 mw_dup2();
-                WORD_ATOM(704, 22, "STWith");
+                WORD_ATOM(705, 22, "STWith");
                 mw_STWith();
-                WORD_ATOM(704, 29, ">Type");
+                WORD_ATOM(705, 29, ">Type");
                 mw_StackType_3E_Type();
-                WORD_ATOM(704, 35, "SOME");
+                WORD_ATOM(705, 35, "SOME");
                 mw_SOME();
                 push_value(d4);
             }
-            WORD_ATOM(704, 41, "~type?");
+            WORD_ATOM(705, 41, "~type?");
             mw_MetaVar_7E_type_3F_();
-            WORD_ATOM(704, 48, "!");
+            WORD_ATOM(705, 48, "!");
             mw_prim_mut_set();
-            WORD_ATOM(705, 13, "pack2");
+            WORD_ATOM(706, 13, "pack2");
             mw_pack2();
-            WORD_ATOM(705, 19, "SOME");
+            WORD_ATOM(706, 19, "SOME");
             mw_SOME();
             break;
         default:
-            WORD_ATOM(706, 14, "drop");
+            WORD_ATOM(707, 14, "drop");
             mw_prim_drop();
-            WORD_ATOM(706, 19, "NONE");
+            WORD_ATOM(707, 19, "NONE");
             mw_NONE();
             break;
     
 }    WORD_EXIT(mw_StackType_2E_force_with_3F__21_);
 }
 static void mw_StackType_2E_trace_dom_21_ (void){
-    WORD_ENTER(mw_StackType_2E_trace_dom_21_, "StackType.trace-dom!", "src/mirth/data/type.mth", 710, 5);
-    WORD_ATOM(710, 5, "expand");
+    WORD_ENTER(mw_StackType_2E_trace_dom_21_, "StackType.trace-dom!", "src/mirth/data/type.mth", 711, 5);
+    WORD_ATOM(711, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(710, 12, "dup");
+    WORD_ATOM(711, 12, "dup");
     mw_prim_dup();
-    WORD_ATOM(710, 16, "unit?");
+    WORD_ATOM(711, 16, "unit?");
     mw_StackType_2E_unit_3F_();
-    WORD_ATOM(710, 22, "if");
+    WORD_ATOM(711, 22, "if");
     if (pop_u64()) {
-        WORD_ATOM(711, 9, "drop");
+        WORD_ATOM(712, 9, "drop");
         mw_prim_drop();
     } else {
-        WORD_ATOM(712, 9, "trace!");
+        WORD_ATOM(713, 9, "trace!");
         mw_StackType_2E_trace_21_();
-        WORD_ATOM(713, 9, "");
+        WORD_ATOM(714, 9, "");
         {
             static bool vready = false;
             static VAL v;
@@ -27363,25 +27505,25 @@ static void mw_StackType_2E_trace_dom_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(713, 13, "trace!");
+        WORD_ATOM(714, 13, "trace!");
         mw_Str_2E_trace_21_();
     }
     WORD_EXIT(mw_StackType_2E_trace_dom_21_);
 }
 static void mw_StackType_2E_trace_cod_21_ (void){
-    WORD_ENTER(mw_StackType_2E_trace_cod_21_, "StackType.trace-cod!", "src/mirth/data/type.mth", 717, 5);
-    WORD_ATOM(717, 5, "expand");
+    WORD_ENTER(mw_StackType_2E_trace_cod_21_, "StackType.trace-cod!", "src/mirth/data/type.mth", 718, 5);
+    WORD_ATOM(718, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(717, 12, "dup");
+    WORD_ATOM(718, 12, "dup");
     mw_prim_dup();
-    WORD_ATOM(717, 16, "unit?");
+    WORD_ATOM(718, 16, "unit?");
     mw_StackType_2E_unit_3F_();
-    WORD_ATOM(717, 22, "if");
+    WORD_ATOM(718, 22, "if");
     if (pop_u64()) {
-        WORD_ATOM(718, 9, "drop");
+        WORD_ATOM(719, 9, "drop");
         mw_prim_drop();
     } else {
-        WORD_ATOM(719, 9, "");
+        WORD_ATOM(720, 9, "");
         {
             static bool vready = false;
             static VAL v;
@@ -27392,105 +27534,138 @@ static void mw_StackType_2E_trace_cod_21_ (void){
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(719, 13, "trace!");
+        WORD_ATOM(720, 13, "trace!");
         mw_Str_2E_trace_21_();
-        WORD_ATOM(720, 9, "trace!");
+        WORD_ATOM(721, 9, "trace!");
         mw_StackType_2E_trace_21_();
     }
     WORD_EXIT(mw_StackType_2E_trace_cod_21_);
 }
 static void mw_StackType_2E_trace_base_21_ (void){
-    WORD_ENTER(mw_StackType_2E_trace_base_21_, "StackType.trace-base!", "src/mirth/data/type.mth", 724, 5);
-    WORD_ATOM(724, 5, "match");
+    WORD_ENTER(mw_StackType_2E_trace_base_21_, "StackType.trace-base!", "src/mirth/data/type.mth", 725, 5);
+    WORD_ATOM(725, 5, "match");
     switch (get_top_data_tag()) {
+        case 2LL:
+            mw_prim_drop();
+            WORD_ATOM(726, 28, "id");
+            mw_prim_id();
+            WORD_ATOM(726, 31, "F");
+            mw_F();
+            break;
+        case 4LL:
+            mw_prim_pack_uncons(); mw_prim_drop();
+            WORD_ATOM(727, 19, "trace!");
+            mw_MetaVar_2E_trace_21_();
+            WORD_ATOM(727, 26, "");
+            {
+                static bool vready = false;
+                static VAL v;
+                if (! vready) {
+                    v = mkstr(" .", 2);
+                    vready = true;
+                }
+                push_value(v);
+                incref(v);
+            }
+            WORD_ATOM(727, 31, "trace!");
+            mw_Str_2E_trace_21_();
+            WORD_ATOM(727, 38, "T");
+            mw_T();
+            break;
         case 3LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(725, 18, "dup");
+            WORD_ATOM(728, 18, "dup");
             mw_prim_dup();
-            WORD_ATOM(725, 22, "Var.trace!");
+            WORD_ATOM(728, 22, "trace!");
             mw_Var_2E_trace_21_();
-            WORD_ATOM(725, 33, "is-stack?");
+            WORD_ATOM(728, 29, "is-stack?");
             mw_Var_2E_is_stack_3F_();
-            WORD_ATOM(725, 43, "else");
+            WORD_ATOM(728, 39, "else");
             push_u64(0);
-            push_fnptr(&mb_StackType_2E_trace_base_21__2);
+            push_fnptr(&mb_StackType_2E_trace_base_21__4);
             mw_prim_pack_cons();
             mw_Bool_2E_else();
+            WORD_ATOM(728, 57, "T");
+            mw_T();
             break;
         default:
-            WORD_ATOM(726, 14, ">Type");
+            WORD_ATOM(729, 14, ">Type");
             mw_StackType_3E_Type();
-            WORD_ATOM(726, 20, "trace!");
+            WORD_ATOM(729, 20, "trace!");
             mw_Type_2E_trace_21_();
+            WORD_ATOM(729, 27, "T");
+            mw_T();
             break;
     
 }    WORD_EXIT(mw_StackType_2E_trace_base_21_);
 }
 static void mw_StackType_2E_trace_21_ (void){
-    WORD_ENTER(mw_StackType_2E_trace_21_, "StackType.trace!", "src/mirth/data/type.mth", 730, 5);
-    WORD_ATOM(730, 5, "split3");
+    WORD_ENTER(mw_StackType_2E_trace_21_, "StackType.trace!", "src/mirth/data/type.mth", 733, 5);
+    WORD_ATOM(733, 5, "split3");
     mw_StackType_2E_split3();
-    WORD_ATOM(731, 5, "dip2");
+    WORD_ATOM(734, 5, "dip2");
     push_u64(0);
     push_fnptr(&mb_StackType_2E_trace_21__1);
     mw_prim_pack_cons();
     mw_dip2();
-    WORD_ATOM(732, 5, "dip");
+    WORD_ATOM(735, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(732, 9, "for");
+        WORD_ATOM(735, 9, "for");
         push_u64(0);
         push_fnptr(&mb_StackType_2E_trace_21__3);
         mw_prim_pack_cons();
         mw_List_2E_for();
         push_value(d2);
     }
-    WORD_ATOM(733, 5, "reverse-for");
+    WORD_ATOM(736, 5, "reverse-for");
     push_u64(0);
-    push_fnptr(&mb_StackType_2E_trace_21__4);
+    push_fnptr(&mb_StackType_2E_trace_21__5);
     mw_prim_pack_cons();
     mw_List_2E_reverse_for();
+    WORD_ATOM(736, 49, "drop");
+    mw_prim_drop();
     WORD_EXIT(mw_StackType_2E_trace_21_);
 }
 static void mw_StackType_2E_semifreshen (void){
-    WORD_ENTER(mw_StackType_2E_semifreshen, "StackType.semifreshen", "src/mirth/data/type.mth", 754, 5);
-    WORD_ATOM(754, 5, "expand");
+    WORD_ENTER(mw_StackType_2E_semifreshen, "StackType.semifreshen", "src/mirth/data/type.mth", 757, 5);
+    WORD_ATOM(757, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(754, 12, "match");
+    WORD_ATOM(757, 12, "match");
     switch (get_top_data_tag()) {
         case 2LL:
             mw_prim_drop();
-            WORD_ATOM(755, 28, "dup");
+            WORD_ATOM(758, 28, "dup");
             mw_prim_dup();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(756, 19, "dip");
+            WORD_ATOM(759, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(756, 23, "semifreshen");
+                WORD_ATOM(759, 23, "semifreshen");
                 mw_StackType_2E_semifreshen();
                 push_value(d4);
             }
-            WORD_ATOM(756, 36, "STCons");
+            WORD_ATOM(759, 36, "STCons");
             mw_STCons();
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(757, 19, "dip");
+            WORD_ATOM(760, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(757, 23, "semifreshen");
+                WORD_ATOM(760, 23, "semifreshen");
                 mw_StackType_2E_semifreshen();
                 push_value(d4);
             }
-            WORD_ATOM(757, 36, "STWith");
+            WORD_ATOM(760, 36, "STWith");
             mw_STWith();
             break;
         default:
-            WORD_ATOM(758, 14, "");
+            WORD_ATOM(761, 14, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -27501,159 +27676,159 @@ static void mw_StackType_2E_semifreshen (void){
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(758, 58, "panic!");
+            WORD_ATOM(761, 58, "panic!");
             mw_prim_panic();
             break;
     
 }    WORD_EXIT(mw_StackType_2E_semifreshen);
 }
 static void mw_StackType_2E_freshen (void){
-    WORD_ENTER(mw_StackType_2E_freshen, "StackType.freshen", "src/mirth/data/type.mth", 762, 5);
-    WORD_ATOM(762, 5, "expand");
+    WORD_ENTER(mw_StackType_2E_freshen, "StackType.freshen", "src/mirth/data/type.mth", 765, 5);
+    WORD_ATOM(765, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(762, 12, "match");
+    WORD_ATOM(765, 12, "match");
     switch (get_top_data_tag()) {
         case 2LL:
             mw_prim_drop();
-            WORD_ATOM(763, 28, "STACK_TYPE_UNIT");
+            WORD_ATOM(766, 28, "STACK_TYPE_UNIT");
             mw_STACK_5F_TYPE_5F_UNIT();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(764, 19, "dip");
+            WORD_ATOM(767, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(764, 23, "freshen");
+                WORD_ATOM(767, 23, "freshen");
                 mw_StackType_2E_freshen();
                 push_value(d4);
             }
-            WORD_ATOM(764, 32, "swap");
+            WORD_ATOM(767, 32, "swap");
             mw_prim_swap();
-            WORD_ATOM(764, 37, "dip");
+            WORD_ATOM(767, 37, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(764, 41, "freshen");
+                WORD_ATOM(767, 41, "freshen");
                 mw_Type_2E_freshen();
                 push_value(d4);
             }
-            WORD_ATOM(764, 50, "swap");
+            WORD_ATOM(767, 50, "swap");
             mw_prim_swap();
-            WORD_ATOM(764, 55, "STCons");
+            WORD_ATOM(767, 55, "STCons");
             mw_STCons();
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(765, 19, "dip");
+            WORD_ATOM(768, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(765, 23, "freshen");
+                WORD_ATOM(768, 23, "freshen");
                 mw_StackType_2E_freshen();
                 push_value(d4);
             }
-            WORD_ATOM(765, 32, "swap");
+            WORD_ATOM(768, 32, "swap");
             mw_prim_swap();
-            WORD_ATOM(765, 37, "dip");
+            WORD_ATOM(768, 37, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(765, 41, "freshen");
+                WORD_ATOM(768, 41, "freshen");
                 mw_Resource_2E_freshen();
                 push_value(d4);
             }
-            WORD_ATOM(765, 50, "swap");
+            WORD_ATOM(768, 50, "swap");
             mw_prim_swap();
-            WORD_ATOM(765, 55, "STWith");
+            WORD_ATOM(768, 55, "STWith");
             mw_STWith();
             break;
         default:
-            WORD_ATOM(766, 14, ">Type");
+            WORD_ATOM(769, 14, ">Type");
             mw_StackType_3E_Type();
-            WORD_ATOM(766, 20, "freshen");
+            WORD_ATOM(769, 20, "freshen");
             mw_Type_2E_freshen();
-            WORD_ATOM(766, 28, ">StackType");
+            WORD_ATOM(769, 28, ">StackType");
             mw_Type_3E_StackType();
             break;
     
 }    WORD_EXIT(mw_StackType_2E_freshen);
 }
 static void mw_StackType_2E_freshen_aux (void){
-    WORD_ENTER(mw_StackType_2E_freshen_aux, "StackType.freshen-aux", "src/mirth/data/type.mth", 770, 5);
-    WORD_ATOM(770, 5, "expand");
+    WORD_ENTER(mw_StackType_2E_freshen_aux, "StackType.freshen-aux", "src/mirth/data/type.mth", 773, 5);
+    WORD_ATOM(773, 5, "expand");
     mw_StackType_2E_expand();
-    WORD_ATOM(770, 12, "match");
+    WORD_ATOM(773, 12, "match");
     switch (get_top_data_tag()) {
         case 2LL:
             mw_prim_drop();
-            WORD_ATOM(771, 28, "over");
+            WORD_ATOM(774, 28, "over");
             mw_over();
             break;
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(772, 19, "dip");
+            WORD_ATOM(775, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(772, 23, "freshen-aux");
+                WORD_ATOM(775, 23, "freshen-aux");
                 mw_StackType_2E_freshen_aux();
                 push_value(d4);
             }
-            WORD_ATOM(772, 36, "swap");
+            WORD_ATOM(775, 36, "swap");
             mw_prim_swap();
-            WORD_ATOM(772, 41, "dip");
+            WORD_ATOM(775, 41, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(772, 45, "freshen");
+                WORD_ATOM(775, 45, "freshen");
                 mw_Type_2E_freshen();
                 push_value(d4);
             }
-            WORD_ATOM(772, 54, "swap");
+            WORD_ATOM(775, 54, "swap");
             mw_prim_swap();
-            WORD_ATOM(772, 59, "STCons");
+            WORD_ATOM(775, 59, "STCons");
             mw_STCons();
             break;
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(773, 19, "dip");
+            WORD_ATOM(776, 19, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(773, 23, "freshen-aux");
+                WORD_ATOM(776, 23, "freshen-aux");
                 mw_StackType_2E_freshen_aux();
                 push_value(d4);
             }
-            WORD_ATOM(773, 36, "swap");
+            WORD_ATOM(776, 36, "swap");
             mw_prim_swap();
-            WORD_ATOM(773, 41, "dip");
+            WORD_ATOM(776, 41, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(773, 45, "freshen");
+                WORD_ATOM(776, 45, "freshen");
                 mw_Resource_2E_freshen();
                 push_value(d4);
             }
-            WORD_ATOM(773, 54, "swap");
+            WORD_ATOM(776, 54, "swap");
             mw_prim_swap();
-            WORD_ATOM(773, 59, "STWith");
+            WORD_ATOM(776, 59, "STWith");
             mw_STWith();
             break;
         default:
-            WORD_ATOM(774, 14, ">Type");
+            WORD_ATOM(777, 14, ">Type");
             mw_StackType_3E_Type();
-            WORD_ATOM(774, 20, "freshen");
+            WORD_ATOM(777, 20, "freshen");
             mw_Type_2E_freshen();
-            WORD_ATOM(774, 28, ">StackType");
+            WORD_ATOM(777, 28, ">StackType");
             mw_Type_3E_StackType();
             break;
     
 }    WORD_EXIT(mw_StackType_2E_freshen_aux);
 }
 static void mw_StackType_2E_num_morphisms_on_top (void){
-    WORD_ENTER(mw_StackType_2E_num_morphisms_on_top, "StackType.num-morphisms-on-top", "src/mirth/data/type.mth", 787, 5);
-    WORD_ATOM(787, 5, "STMeta");
+    WORD_ENTER(mw_StackType_2E_num_morphisms_on_top, "StackType.num-morphisms-on-top", "src/mirth/data/type.mth", 790, 5);
+    WORD_ATOM(790, 5, "STMeta");
     switch (get_top_data_tag()) {
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(787, 15, "expand-if");
+            WORD_ATOM(790, 15, "expand-if");
             push_u64(0);
             push_fnptr(&mb_StackType_2E_num_morphisms_on_top_2);
             mw_prim_pack_cons();
@@ -27665,9 +27840,9 @@ static void mw_StackType_2E_num_morphisms_on_top (void){
         case 5LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(788, 15, "morphism?");
+            WORD_ATOM(791, 15, "morphism?");
             mw_Type_2E_morphism_3F_();
-            WORD_ATOM(788, 25, ".if");
+            WORD_ATOM(791, 25, ".if");
             push_u64(0);
             push_fnptr(&mb_StackType_2E_num_morphisms_on_top_5);
             mw_prim_pack_cons();
@@ -27679,34 +27854,34 @@ static void mw_StackType_2E_num_morphisms_on_top (void){
         case 6LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(789, 15, "drop");
+            WORD_ATOM(792, 15, "drop");
             mw_prim_drop();
-            WORD_ATOM(789, 20, "num-morphisms-on-top");
+            WORD_ATOM(792, 20, "num-morphisms-on-top");
             mw_StackType_2E_num_morphisms_on_top();
             break;
         default:
-            WORD_ATOM(790, 10, "drop");
+            WORD_ATOM(793, 10, "drop");
             mw_prim_drop();
-            WORD_ATOM(790, 15, "");
+            WORD_ATOM(793, 15, "");
             push_i64(0LL);
             break;
     
 }    WORD_EXIT(mw_StackType_2E_num_morphisms_on_top);
 }
 static void mw_ArrowType_3E_Type (void){
-    WORD_ENTER(mw_ArrowType_3E_Type, "ArrowType>Type", "src/mirth/data/type.mth", 797, 40);
-    WORD_ATOM(797, 40, "TMorphism");
+    WORD_ENTER(mw_ArrowType_3E_Type, "ArrowType>Type", "src/mirth/data/type.mth", 800, 40);
+    WORD_ATOM(800, 40, "TMorphism");
     mw_TMorphism();
     WORD_EXIT(mw_ArrowType_3E_Type);
 }
 static void mw_ArrowType_2E_unpack (void){
-    WORD_ENTER(mw_ArrowType_2E_unpack, "ArrowType.unpack", "src/mirth/data/type.mth", 799, 57);
-    WORD_ATOM(799, 57, "ARROW_TYPE");
+    WORD_ENTER(mw_ArrowType_2E_unpack, "ArrowType.unpack", "src/mirth/data/type.mth", 802, 57);
+    WORD_ATOM(802, 57, "ARROW_TYPE");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(799, 71, "id");
+            WORD_ATOM(802, 71, "id");
             mw_prim_id();
             break;
         default: write(2, "unexpected fallthrough in match\n", 32); mw_prim_debug(); exit(99);
@@ -27714,87 +27889,87 @@ static void mw_ArrowType_2E_unpack (void){
 }    WORD_EXIT(mw_ArrowType_2E_unpack);
 }
 static void mw_ArrowType_2E_dom (void){
-    WORD_ENTER(mw_ArrowType_2E_dom, "ArrowType.dom", "src/mirth/data/type.mth", 800, 44);
-    WORD_ATOM(800, 44, "unpack");
+    WORD_ENTER(mw_ArrowType_2E_dom, "ArrowType.dom", "src/mirth/data/type.mth", 803, 44);
+    WORD_ATOM(803, 44, "unpack");
     mw_ArrowType_2E_unpack();
-    WORD_ATOM(800, 51, "drop");
+    WORD_ATOM(803, 51, "drop");
     mw_prim_drop();
     WORD_EXIT(mw_ArrowType_2E_dom);
 }
 static void mw_ArrowType_2E_unify_21_ (void){
-    WORD_ENTER(mw_ArrowType_2E_unify_21_, "ArrowType.unify!", "src/mirth/data/type.mth", 803, 5);
-    WORD_ATOM(803, 5, "dip");
+    WORD_ENTER(mw_ArrowType_2E_unify_21_, "ArrowType.unify!", "src/mirth/data/type.mth", 806, 5);
+    WORD_ATOM(806, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(803, 9, "unpack");
+        WORD_ATOM(806, 9, "unpack");
         mw_ArrowType_2E_unpack();
         push_value(d2);
     }
-    WORD_ATOM(803, 17, "unpack");
+    WORD_ATOM(806, 17, "unpack");
     mw_ArrowType_2E_unpack();
-    WORD_ATOM(804, 5, "dip");
+    WORD_ATOM(807, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(804, 9, "swap");
+        WORD_ATOM(807, 9, "swap");
         mw_prim_swap();
-        WORD_ATOM(804, 14, "dip");
+        WORD_ATOM(807, 14, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(804, 18, "unify!");
+            WORD_ATOM(807, 18, "unify!");
             mw_StackType_2E_unify_21_();
             push_value(d3);
         }
         push_value(d2);
     }
-    WORD_ATOM(804, 27, "rotl");
+    WORD_ATOM(807, 27, "rotl");
     mw_rotl();
-    WORD_ATOM(805, 5, "dip");
+    WORD_ATOM(808, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(805, 9, "unify!");
+        WORD_ATOM(808, 9, "unify!");
         mw_StackType_2E_unify_21_();
         push_value(d2);
     }
-    WORD_ATOM(805, 17, "swap");
+    WORD_ATOM(808, 17, "swap");
     mw_prim_swap();
-    WORD_ATOM(806, 5, "ARROW_TYPE");
+    WORD_ATOM(809, 5, "ARROW_TYPE");
     mw_ARROW_5F_TYPE();
     WORD_EXIT(mw_ArrowType_2E_unify_21_);
 }
 static void mw_ArrowType_2E_has_meta_3F_ (void){
-    WORD_ENTER(mw_ArrowType_2E_has_meta_3F_, "ArrowType.has-meta?", "src/mirth/data/type.mth", 808, 5);
-    WORD_ATOM(808, 5, "unpack");
+    WORD_ENTER(mw_ArrowType_2E_has_meta_3F_, "ArrowType.has-meta?", "src/mirth/data/type.mth", 811, 5);
+    WORD_ATOM(811, 5, "unpack");
     mw_ArrowType_2E_unpack();
-    WORD_ATOM(808, 12, "dip");
+    WORD_ATOM(811, 12, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(808, 16, "over");
+        WORD_ATOM(811, 16, "over");
         mw_over();
         push_value(d2);
     }
-    WORD_ATOM(808, 22, "has-meta?");
+    WORD_ATOM(811, 22, "has-meta?");
     mw_StackType_2E_has_meta_3F_();
-    WORD_ATOM(808, 32, "if");
+    WORD_ATOM(811, 32, "if");
     if (pop_u64()) {
-        WORD_ATOM(808, 35, "drop2");
+        WORD_ATOM(811, 35, "drop2");
         mw_drop2();
-        WORD_ATOM(808, 41, "T");
+        WORD_ATOM(811, 41, "T");
         mw_T();
     } else {
-        WORD_ATOM(808, 44, "has-meta?");
+        WORD_ATOM(811, 44, "has-meta?");
         mw_StackType_2E_has_meta_3F_();
     }
     WORD_EXIT(mw_ArrowType_2E_has_meta_3F_);
 }
 static void mw_ArrowType_2E_trace_21_ (void){
-    WORD_ENTER(mw_ArrowType_2E_trace_21_, "ArrowType.trace!", "src/mirth/data/type.mth", 811, 5);
-    WORD_ATOM(811, 5, "unpack");
+    WORD_ENTER(mw_ArrowType_2E_trace_21_, "ArrowType.trace!", "src/mirth/data/type.mth", 814, 5);
+    WORD_ATOM(814, 5, "unpack");
     mw_ArrowType_2E_unpack();
-    WORD_ATOM(811, 12, "swap");
+    WORD_ATOM(814, 12, "swap");
     mw_prim_swap();
-    WORD_ATOM(812, 5, "trace-dom!");
+    WORD_ATOM(815, 5, "trace-dom!");
     mw_StackType_2E_trace_dom_21_();
-    WORD_ATOM(813, 5, "");
+    WORD_ATOM(816, 5, "");
     {
         static bool vready = false;
         static VAL v;
@@ -27805,19 +27980,19 @@ static void mw_ArrowType_2E_trace_21_ (void){
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(813, 10, "trace!");
+    WORD_ATOM(816, 10, "trace!");
     mw_Str_2E_trace_21_();
-    WORD_ATOM(814, 5, "trace-cod!");
+    WORD_ATOM(817, 5, "trace-cod!");
     mw_StackType_2E_trace_cod_21_();
     WORD_EXIT(mw_ArrowType_2E_trace_21_);
 }
 static void mw_ArrowType_2E_semifreshen_sig (void){
-    WORD_ENTER(mw_ArrowType_2E_semifreshen_sig, "ArrowType.semifreshen-sig", "src/mirth/data/type.mth", 818, 5);
-    WORD_ATOM(818, 5, "dup");
+    WORD_ENTER(mw_ArrowType_2E_semifreshen_sig, "ArrowType.semifreshen-sig", "src/mirth/data/type.mth", 821, 5);
+    WORD_ATOM(821, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(818, 9, "needs-fresh-stack-rest?");
+    WORD_ATOM(821, 9, "needs-fresh-stack-rest?");
     mw_ArrowType_2E_needs_fresh_stack_rest_3F_();
-    WORD_ATOM(818, 33, "then");
+    WORD_ATOM(821, 33, "then");
     push_u64(0);
     push_fnptr(&mb_ArrowType_2E_semifreshen_sig_1);
     mw_prim_pack_cons();
@@ -27825,193 +28000,193 @@ static void mw_ArrowType_2E_semifreshen_sig (void){
     WORD_EXIT(mw_ArrowType_2E_semifreshen_sig);
 }
 static void mw_ArrowType_2E_semifreshen_aux (void){
-    WORD_ENTER(mw_ArrowType_2E_semifreshen_aux, "ArrowType.semifreshen-aux", "src/mirth/data/type.mth", 821, 5);
-    WORD_ATOM(821, 5, "MetaVar.new!");
+    WORD_ENTER(mw_ArrowType_2E_semifreshen_aux, "ArrowType.semifreshen-aux", "src/mirth/data/type.mth", 824, 5);
+    WORD_ATOM(824, 5, "MetaVar.new!");
     mw_MetaVar_2E_new_21_();
-    WORD_ATOM(821, 18, "STMeta");
+    WORD_ATOM(824, 18, "STMeta");
     mw_STMeta();
-    WORD_ATOM(821, 25, "swap");
+    WORD_ATOM(824, 25, "swap");
     mw_prim_swap();
-    WORD_ATOM(821, 30, "unpack");
+    WORD_ATOM(824, 30, "unpack");
     mw_ArrowType_2E_unpack();
-    WORD_ATOM(822, 5, "dip");
+    WORD_ATOM(825, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(822, 9, "semifreshen");
+        WORD_ATOM(825, 9, "semifreshen");
         mw_StackType_2E_semifreshen();
         push_value(d2);
     }
-    WORD_ATOM(822, 22, "swap");
+    WORD_ATOM(825, 22, "swap");
     mw_prim_swap();
-    WORD_ATOM(823, 5, "dip");
+    WORD_ATOM(826, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(823, 9, "semifreshen");
+        WORD_ATOM(826, 9, "semifreshen");
         mw_StackType_2E_semifreshen();
         push_value(d2);
     }
-    WORD_ATOM(823, 22, "swap");
+    WORD_ATOM(826, 22, "swap");
     mw_prim_swap();
-    WORD_ATOM(824, 5, "ARROW_TYPE");
+    WORD_ATOM(827, 5, "ARROW_TYPE");
     mw_ARROW_5F_TYPE();
-    WORD_ATOM(824, 16, "nip");
+    WORD_ATOM(827, 16, "nip");
     mw_nip();
     WORD_EXIT(mw_ArrowType_2E_semifreshen_aux);
 }
 static void mw_ArrowType_2E_needs_fresh_stack_rest_3F_ (void){
-    WORD_ENTER(mw_ArrowType_2E_needs_fresh_stack_rest_3F_, "ArrowType.needs-fresh-stack-rest?", "src/mirth/data/type.mth", 827, 5);
-    WORD_ATOM(827, 5, "unpack");
+    WORD_ENTER(mw_ArrowType_2E_needs_fresh_stack_rest_3F_, "ArrowType.needs-fresh-stack-rest?", "src/mirth/data/type.mth", 830, 5);
+    WORD_ATOM(830, 5, "unpack");
     mw_ArrowType_2E_unpack();
-    WORD_ATOM(827, 12, "base");
+    WORD_ATOM(830, 12, "base");
     mw_StackType_2E_base();
-    WORD_ATOM(827, 17, "unit?");
+    WORD_ATOM(830, 17, "unit?");
     mw_StackType_2E_unit_3F_();
-    WORD_ATOM(827, 23, "if");
+    WORD_ATOM(830, 23, "if");
     if (pop_u64()) {
-        WORD_ATOM(828, 9, "base");
+        WORD_ATOM(831, 9, "base");
         mw_StackType_2E_base();
-        WORD_ATOM(828, 14, "unit?");
+        WORD_ATOM(831, 14, "unit?");
         mw_StackType_2E_unit_3F_();
     } else {
-        WORD_ATOM(829, 9, "drop");
+        WORD_ATOM(832, 9, "drop");
         mw_prim_drop();
-        WORD_ATOM(829, 14, "F");
+        WORD_ATOM(832, 14, "F");
         mw_F();
     }
     WORD_EXIT(mw_ArrowType_2E_needs_fresh_stack_rest_3F_);
 }
 static void mw_ArrowType_2E_freshen_sig (void){
-    WORD_ENTER(mw_ArrowType_2E_freshen_sig, "ArrowType.freshen-sig", "src/mirth/data/type.mth", 833, 5);
-    WORD_ATOM(833, 5, "dup");
+    WORD_ENTER(mw_ArrowType_2E_freshen_sig, "ArrowType.freshen-sig", "src/mirth/data/type.mth", 836, 5);
+    WORD_ATOM(836, 5, "dup");
     mw_prim_dup();
-    WORD_ATOM(833, 9, "needs-fresh-stack-rest?");
+    WORD_ATOM(836, 9, "needs-fresh-stack-rest?");
     mw_ArrowType_2E_needs_fresh_stack_rest_3F_();
-    WORD_ATOM(833, 33, "if");
+    WORD_ATOM(836, 33, "if");
     if (pop_u64()) {
-        WORD_ATOM(834, 9, "freshen-sig-aux");
+        WORD_ATOM(837, 9, "freshen-sig-aux");
         mw_ArrowType_2E_freshen_sig_aux();
     } else {
-        WORD_ATOM(835, 9, "freshen");
+        WORD_ATOM(838, 9, "freshen");
         mw_ArrowType_2E_freshen();
     }
     WORD_EXIT(mw_ArrowType_2E_freshen_sig);
 }
 static void mw_ArrowType_2E_freshen_sig_aux (void){
-    WORD_ENTER(mw_ArrowType_2E_freshen_sig_aux, "ArrowType.freshen-sig-aux", "src/mirth/data/type.mth", 839, 5);
-    WORD_ATOM(839, 5, "MetaVar.new!");
+    WORD_ENTER(mw_ArrowType_2E_freshen_sig_aux, "ArrowType.freshen-sig-aux", "src/mirth/data/type.mth", 842, 5);
+    WORD_ATOM(842, 5, "MetaVar.new!");
     mw_MetaVar_2E_new_21_();
-    WORD_ATOM(839, 18, "STMeta");
+    WORD_ATOM(842, 18, "STMeta");
     mw_STMeta();
-    WORD_ATOM(839, 25, "rotr");
+    WORD_ATOM(842, 25, "rotr");
     mw_rotr();
-    WORD_ATOM(839, 30, "unpack");
+    WORD_ATOM(842, 30, "unpack");
     mw_ArrowType_2E_unpack();
-    WORD_ATOM(840, 5, "dip");
+    WORD_ATOM(843, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(840, 9, "freshen-aux");
+        WORD_ATOM(843, 9, "freshen-aux");
         mw_StackType_2E_freshen_aux();
         push_value(d2);
     }
-    WORD_ATOM(840, 22, "swap");
+    WORD_ATOM(843, 22, "swap");
     mw_prim_swap();
-    WORD_ATOM(841, 5, "dip");
+    WORD_ATOM(844, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(841, 9, "freshen-aux");
+        WORD_ATOM(844, 9, "freshen-aux");
         mw_StackType_2E_freshen_aux();
         push_value(d2);
     }
-    WORD_ATOM(841, 22, "swap");
+    WORD_ATOM(844, 22, "swap");
     mw_prim_swap();
-    WORD_ATOM(842, 5, "ARROW_TYPE");
+    WORD_ATOM(845, 5, "ARROW_TYPE");
     mw_ARROW_5F_TYPE();
-    WORD_ATOM(842, 16, "dip");
+    WORD_ATOM(845, 16, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(842, 20, "nip");
+        WORD_ATOM(845, 20, "nip");
         mw_nip();
         push_value(d2);
     }
     WORD_EXIT(mw_ArrowType_2E_freshen_sig_aux);
 }
 static void mw_ArrowType_2E_freshen (void){
-    WORD_ENTER(mw_ArrowType_2E_freshen, "ArrowType.freshen", "src/mirth/data/type.mth", 845, 5);
-    WORD_ATOM(845, 5, "unpack");
+    WORD_ENTER(mw_ArrowType_2E_freshen, "ArrowType.freshen", "src/mirth/data/type.mth", 848, 5);
+    WORD_ATOM(848, 5, "unpack");
     mw_ArrowType_2E_unpack();
-    WORD_ATOM(846, 5, "dip");
+    WORD_ATOM(849, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(846, 9, "freshen");
+        WORD_ATOM(849, 9, "freshen");
         mw_StackType_2E_freshen();
         push_value(d2);
     }
-    WORD_ATOM(846, 18, "swap");
+    WORD_ATOM(849, 18, "swap");
     mw_prim_swap();
-    WORD_ATOM(847, 5, "dip");
+    WORD_ATOM(850, 5, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(847, 9, "freshen");
+        WORD_ATOM(850, 9, "freshen");
         mw_StackType_2E_freshen();
         push_value(d2);
     }
-    WORD_ATOM(847, 18, "swap");
+    WORD_ATOM(850, 18, "swap");
     mw_prim_swap();
-    WORD_ATOM(848, 5, "ARROW_TYPE");
+    WORD_ATOM(851, 5, "ARROW_TYPE");
     mw_ARROW_5F_TYPE();
     WORD_EXIT(mw_ArrowType_2E_freshen);
 }
 static void mw_ArrowType_2E_max_num_params (void){
-    WORD_ENTER(mw_ArrowType_2E_max_num_params, "ArrowType.max-num-params", "src/mirth/data/type.mth", 857, 5);
-    WORD_ATOM(857, 5, "dom");
+    WORD_ENTER(mw_ArrowType_2E_max_num_params, "ArrowType.max-num-params", "src/mirth/data/type.mth", 860, 5);
+    WORD_ATOM(860, 5, "dom");
     mw_ArrowType_2E_dom();
-    WORD_ATOM(857, 9, "num-morphisms-on-top");
+    WORD_ATOM(860, 9, "num-morphisms-on-top");
     mw_StackType_2E_num_morphisms_on_top();
     WORD_EXIT(mw_ArrowType_2E_max_num_params);
 }
 static void mw_Subst_2E_nil (void){
-    WORD_ENTER(mw_Subst_2E_nil, "Subst.nil", "src/mirth/data/type.mth", 873, 23);
-    WORD_ATOM(873, 23, "SUBST_NIL");
+    WORD_ENTER(mw_Subst_2E_nil, "Subst.nil", "src/mirth/data/type.mth", 876, 23);
+    WORD_ATOM(876, 23, "SUBST_NIL");
     mw_SUBST_5F_NIL();
     WORD_EXIT(mw_Subst_2E_nil);
 }
 static void mw_Subst_2E_cons (void){
-    WORD_ENTER(mw_Subst_2E_cons, "Subst.cons", "src/mirth/data/type.mth", 874, 42);
-    WORD_ATOM(874, 42, "rotr");
+    WORD_ENTER(mw_Subst_2E_cons, "Subst.cons", "src/mirth/data/type.mth", 877, 42);
+    WORD_ATOM(877, 42, "rotr");
     mw_rotr();
-    WORD_ATOM(874, 47, "SUBST_CON");
+    WORD_ATOM(877, 47, "SUBST_CON");
     mw_SUBST_5F_CON();
     WORD_EXIT(mw_Subst_2E_cons);
 }
 static void mw_Subst_2E_has_var_3F_ (void){
-    WORD_ENTER(mw_Subst_2E_has_var_3F_, "Subst.has-var?", "src/mirth/data/type.mth", 876, 5);
-    WORD_ATOM(876, 5, "SUBST_NIL");
+    WORD_ENTER(mw_Subst_2E_has_var_3F_, "Subst.has-var?", "src/mirth/data/type.mth", 879, 5);
+    WORD_ATOM(879, 5, "SUBST_NIL");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(876, 18, "drop");
+            WORD_ATOM(879, 18, "drop");
             mw_prim_drop();
-            WORD_ATOM(876, 23, "F");
+            WORD_ATOM(879, 23, "F");
             mw_F();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(877, 18, "nip");
+            WORD_ATOM(880, 18, "nip");
             mw_nip();
-            WORD_ATOM(877, 22, "over2");
+            WORD_ATOM(880, 22, "over2");
             mw_over2();
-            WORD_ATOM(877, 28, "=");
+            WORD_ATOM(880, 28, "=");
             mw_Var_3D_();
-            WORD_ATOM(877, 30, "if");
+            WORD_ATOM(880, 30, "if");
             if (pop_u64()) {
-                WORD_ATOM(877, 33, "drop2");
+                WORD_ATOM(880, 33, "drop2");
                 mw_drop2();
-                WORD_ATOM(877, 39, "T");
+                WORD_ATOM(880, 39, "T");
                 mw_T();
             } else {
-                WORD_ATOM(877, 42, "has-var?");
+                WORD_ATOM(880, 42, "has-var?");
                 mw_Subst_2E_has_var_3F_();
             }
             break;
@@ -28020,37 +28195,37 @@ static void mw_Subst_2E_has_var_3F_ (void){
 }    WORD_EXIT(mw_Subst_2E_has_var_3F_);
 }
 static void mw_Subst_2E_get_var (void){
-    WORD_ENTER(mw_Subst_2E_get_var, "Subst.get-var", "src/mirth/data/type.mth", 879, 5);
-    WORD_ATOM(879, 5, "SUBST_NIL");
+    WORD_ENTER(mw_Subst_2E_get_var, "Subst.get-var", "src/mirth/data/type.mth", 882, 5);
+    WORD_ATOM(882, 5, "SUBST_NIL");
     switch (get_top_data_tag()) {
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(879, 18, "drop");
+            WORD_ATOM(882, 18, "drop");
             mw_prim_drop();
-            WORD_ATOM(879, 23, "TYPE_ERROR");
+            WORD_ATOM(882, 23, "TYPE_ERROR");
             mw_TYPE_5F_ERROR();
             break;
         case 1LL:
             mw_prim_pack_uncons(); mw_prim_drop();
             mw_prim_pack_uncons(); mw_prim_swap();
             mw_prim_pack_uncons(); mw_prim_swap();
-            WORD_ATOM(880, 18, "over3");
+            WORD_ATOM(883, 18, "over3");
             mw_over3();
-            WORD_ATOM(880, 24, "=");
+            WORD_ATOM(883, 24, "=");
             mw_Var_3D_();
-            WORD_ATOM(880, 26, "if");
+            WORD_ATOM(883, 26, "if");
             if (pop_u64()) {
-                WORD_ATOM(880, 29, "dip");
+                WORD_ATOM(883, 29, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(880, 33, "drop2");
+                    WORD_ATOM(883, 33, "drop2");
                     mw_drop2();
                     push_value(d5);
                 }
             } else {
-                WORD_ATOM(880, 41, "drop");
+                WORD_ATOM(883, 41, "drop");
                 mw_prim_drop();
-                WORD_ATOM(880, 46, "get-var");
+                WORD_ATOM(883, 46, "get-var");
                 mw_Subst_2E_get_var();
             }
             break;
@@ -31703,6 +31878,28 @@ static void mw_TokenValue_2E_sig_stack_var_3F_ (void){
     mw_Maybe_2E_and_some();
     WORD_EXIT(mw_TokenValue_2E_sig_stack_var_3F_);
 }
+static void mw_TokenValue_2E_sig_resource_var_3F_ (void){
+    WORD_ENTER(mw_TokenValue_2E_sig_resource_var_3F_, "TokenValue.sig-resource-var?", "src/mirth/data/token.mth", 69, 55);
+    WORD_ATOM(69, 55, "name?");
+    mw_TokenValue_2E_name_3F_();
+    WORD_ATOM(69, 61, "and-some");
+    push_u64(0);
+    push_fnptr(&mb_TokenValue_2E_sig_resource_var_3F__1);
+    mw_prim_pack_cons();
+    mw_Maybe_2E_and_some();
+    WORD_EXIT(mw_TokenValue_2E_sig_resource_var_3F_);
+}
+static void mw_TokenValue_2E_sig_resource_con_3F_ (void){
+    WORD_ENTER(mw_TokenValue_2E_sig_resource_con_3F_, "TokenValue.sig-resource-con?", "src/mirth/data/token.mth", 70, 55);
+    WORD_ATOM(70, 55, "name?");
+    mw_TokenValue_2E_name_3F_();
+    WORD_ATOM(70, 61, "and-some");
+    push_u64(0);
+    push_fnptr(&mb_TokenValue_2E_sig_resource_con_3F__1);
+    mw_prim_pack_cons();
+    mw_Maybe_2E_and_some();
+    WORD_EXIT(mw_TokenValue_2E_sig_resource_con_3F_);
+}
 static void mw_TokenValue_2E_sig_dashes_3F_ (void){
     WORD_ENTER(mw_TokenValue_2E_sig_dashes_3F_, "TokenValue.sig-dashes?", "src/mirth/data/token.mth", 71, 49);
     WORD_ATOM(71, 49, "name?");
@@ -32016,6 +32213,22 @@ static void mw_Token_2E_sig_stack_var_3F_ (void){
     WORD_ATOM(109, 48, "sig-stack-var?");
     mw_TokenValue_2E_sig_stack_var_3F_();
     WORD_EXIT(mw_Token_2E_sig_stack_var_3F_);
+}
+static void mw_Token_2E_sig_resource_var_3F_ (void){
+    WORD_ENTER(mw_Token_2E_sig_resource_var_3F_, "Token.sig-resource-var?", "src/mirth/data/token.mth", 110, 45);
+    WORD_ATOM(110, 45, "value");
+    mw_Token_2E_value();
+    WORD_ATOM(110, 51, "sig-resource-var?");
+    mw_TokenValue_2E_sig_resource_var_3F_();
+    WORD_EXIT(mw_Token_2E_sig_resource_var_3F_);
+}
+static void mw_Token_2E_sig_resource_con_3F_ (void){
+    WORD_ENTER(mw_Token_2E_sig_resource_con_3F_, "Token.sig-resource-con?", "src/mirth/data/token.mth", 111, 45);
+    WORD_ATOM(111, 45, "value");
+    mw_Token_2E_value();
+    WORD_ATOM(111, 51, "sig-resource-con?");
+    mw_TokenValue_2E_sig_resource_con_3F_();
+    WORD_EXIT(mw_Token_2E_sig_resource_con_3F_);
 }
 static void mw_Token_2E_sig_dashes_3F_ (void){
     WORD_ENTER(mw_Token_2E_sig_dashes_3F_, "Token.sig-dashes?", "src/mirth/data/token.mth", 112, 39);
@@ -33576,6 +33789,46 @@ static void mw_Name_2E_could_be_stack_var (void){
     mw_Bool_26__26_();
     WORD_EXIT(mw_Name_2E_could_be_stack_var);
 }
+static void mw_Name_2E_could_be_resource_var (void){
+    WORD_ENTER(mw_Name_2E_could_be_resource_var, "Name.could-be-resource-var", "src/mirth/data/name.mth", 96, 47);
+    WORD_ATOM(96, 47, "dup");
+    mw_prim_dup();
+    WORD_ATOM(96, 51, "head");
+    mw_Name_2E_head();
+    WORD_ATOM(96, 56, "B'+'");
+    mw_B_27__2B__27_();
+    WORD_ATOM(96, 61, "=");
+    mw_Byte_3D_();
+    WORD_ATOM(96, 63, "swap");
+    mw_prim_swap();
+    WORD_ATOM(96, 68, "tail-head");
+    mw_Name_2E_tail_head();
+    WORD_ATOM(96, 78, "is-lower");
+    mw_Byte_2E_is_lower();
+    WORD_ATOM(96, 87, "&&");
+    mw_Bool_26__26_();
+    WORD_EXIT(mw_Name_2E_could_be_resource_var);
+}
+static void mw_Name_2E_could_be_resource_con (void){
+    WORD_ENTER(mw_Name_2E_could_be_resource_con, "Name.could-be-resource-con", "src/mirth/data/name.mth", 97, 47);
+    WORD_ATOM(97, 47, "dup");
+    mw_prim_dup();
+    WORD_ATOM(97, 51, "head");
+    mw_Name_2E_head();
+    WORD_ATOM(97, 56, "B'+'");
+    mw_B_27__2B__27_();
+    WORD_ATOM(97, 61, "=");
+    mw_Byte_3D_();
+    WORD_ATOM(97, 63, "swap");
+    mw_prim_swap();
+    WORD_ATOM(97, 68, "tail-head");
+    mw_Name_2E_tail_head();
+    WORD_ATOM(97, 78, "is-upper");
+    mw_Byte_2E_is_upper();
+    WORD_ATOM(97, 87, "&&");
+    mw_Bool_26__26_();
+    WORD_EXIT(mw_Name_2E_could_be_resource_con);
+}
 static void mw_Name_2E_mangle_compute_21_ (void){
     WORD_ENTER(mw_Name_2E_mangle_compute_21_, "Name.mangle-compute!", "src/mirth/data/name.mth", 100, 5);
     WORD_ATOM(100, 5, "build-str!");
@@ -34273,19 +34526,19 @@ static void mb_init_prims_21__16 (void) {
 }
 
 static void mb_typecheck_everything_21__1 (void) {
-    WORD_ENTER(mb_typecheck_everything_21__1, "typecheck-everything! block", "src/mirth/elab.mth", 996, 14);
+    WORD_ENTER(mb_typecheck_everything_21__1, "typecheck-everything! block", "src/mirth/elab.mth", 1012, 14);
     mw_prim_drop();
-    WORD_ATOM(996, 14, ">Def");
+    WORD_ATOM(1012, 14, ">Def");
     mw_Name_3E_Def();
-    WORD_ATOM(996, 19, "typecheck!");
+    WORD_ATOM(1012, 19, "typecheck!");
     mw_Def_2E_typecheck_21_();
     WORD_EXIT(mb_typecheck_everything_21__1);
 }
 
 static void mb_typecheck_everything_21__2 (void) {
-    WORD_ENTER(mb_typecheck_everything_21__2, "typecheck-everything! block", "src/mirth/elab.mth", 997, 15);
+    WORD_ENTER(mb_typecheck_everything_21__2, "typecheck-everything! block", "src/mirth/elab.mth", 1013, 15);
     mw_prim_drop();
-    WORD_ATOM(997, 15, "typecheck!");
+    WORD_ATOM(1013, 15, "typecheck!");
     mw_Block_2E_typecheck_21_();
     WORD_EXIT(mb_typecheck_everything_21__2);
 }
@@ -34320,83 +34573,83 @@ static void mb_main_2 (void) {
 }
 
 static void mb_count_2 (void) {
-    WORD_ENTER(mb_count_2, "count block", "src/prelude.mth", 164, 19);
+    WORD_ENTER(mb_count_2, "count block", "src/prelude.mth", 169, 19);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(164, 19, "dup");
+    WORD_ATOM(169, 19, "dup");
     mw_prim_dup();
-    WORD_ATOM(164, 23, "dip");
+    WORD_ATOM(169, 23, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(164, 27, "f");
+        WORD_ATOM(169, 27, "f");
         incref(var_f);
         run_value(var_f);
         push_value(d2);
     }
-    WORD_ATOM(164, 30, "1+");
+    WORD_ATOM(169, 30, "1+");
     mw_prim_int_succ();
     decref(var_f);
     WORD_EXIT(mb_count_2);
 }
 
 static void mb_countdown_2 (void) {
-    WORD_ENTER(mb_countdown_2, "countdown block", "src/prelude.mth", 166, 24);
+    WORD_ENTER(mb_countdown_2, "countdown block", "src/prelude.mth", 171, 24);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(166, 24, "dup");
+    WORD_ATOM(171, 24, "dup");
     mw_prim_dup();
-    WORD_ATOM(166, 28, "dip");
+    WORD_ATOM(171, 28, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(166, 32, "f");
+        WORD_ATOM(171, 32, "f");
         incref(var_f);
         run_value(var_f);
         push_value(d2);
     }
-    WORD_ATOM(166, 35, "1-");
+    WORD_ATOM(171, 35, "1-");
     mw_prim_int_pred();
     decref(var_f);
     WORD_EXIT(mb_countdown_2);
 }
 
 static void mb_Ptr_40__40_Ptr_2 (void) {
-    WORD_ENTER(mb_Ptr_40__40_Ptr_2, "Ptr@@Ptr block", "src/prelude.mth", 235, 59);
+    WORD_ENTER(mb_Ptr_40__40_Ptr_2, "Ptr@@Ptr block", "src/prelude.mth", 240, 59);
     mw_prim_drop();
-    WORD_ATOM(235, 59, "@Ptr");
+    WORD_ATOM(240, 59, "@Ptr");
     mw_prim_ptr_get();
     WORD_EXIT(mb_Ptr_40__40_Ptr_2);
 }
 
 static void mb_Ptr_40__40_I64_2 (void) {
-    WORD_ENTER(mb_Ptr_40__40_I64_2, "Ptr@@I64 block", "src/prelude.mth", 245, 50);
+    WORD_ENTER(mb_Ptr_40__40_I64_2, "Ptr@@I64 block", "src/prelude.mth", 250, 50);
     mw_prim_drop();
-    WORD_ATOM(245, 50, "@I64");
+    WORD_ATOM(250, 50, "@I64");
     mw_prim_i64_get();
     WORD_EXIT(mb_Ptr_40__40_I64_2);
 }
 
 static void mb_Ptr_21__21_U8_1 (void) {
-    WORD_ENTER(mb_Ptr_21__21_U8_1, "Ptr!!U8 block", "src/prelude.mth", 247, 50);
+    WORD_ENTER(mb_Ptr_21__21_U8_1, "Ptr!!U8 block", "src/prelude.mth", 252, 50);
     mw_prim_drop();
-    WORD_ATOM(247, 50, "!U8");
+    WORD_ATOM(252, 50, "!U8");
     mw_prim_u8_set();
     WORD_EXIT(mb_Ptr_21__21_U8_1);
 }
 
 static void mb_Ptr_21__21_I64_2 (void) {
-    WORD_ENTER(mb_Ptr_21__21_I64_2, "Ptr!!I64 block", "src/prelude.mth", 254, 50);
+    WORD_ENTER(mb_Ptr_21__21_I64_2, "Ptr!!I64 block", "src/prelude.mth", 259, 50);
     mw_prim_drop();
-    WORD_ATOM(254, 50, "!I64");
+    WORD_ATOM(259, 50, "!I64");
     mw_prim_i64_set();
     WORD_EXIT(mb_Ptr_21__21_I64_2);
 }
 
 static void mb_Int_3E_U8_1 (void) {
-    WORD_ENTER(mb_Int_3E_U8_1, "Int>U8 block", "src/prelude.mth", 285, 46);
+    WORD_ENTER(mb_Int_3E_U8_1, "Int>U8 block", "src/prelude.mth", 290, 46);
     mw_prim_drop();
-    WORD_ATOM(285, 46, "");
+    WORD_ATOM(290, 46, "");
     {
         static bool vready = false;
         static VAL v;
@@ -34407,22 +34660,22 @@ static void mb_Int_3E_U8_1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(285, 65, "panic!");
+    WORD_ATOM(290, 65, "panic!");
     mw_prim_panic();
     WORD_EXIT(mb_Int_3E_U8_1);
 }
 
 static void mb_assert_21__3 (void) {
-    WORD_ENTER(mb_assert_21__3, "assert! block", "src/prelude.mth", 331, 15);
+    WORD_ENTER(mb_assert_21__3, "assert! block", "src/prelude.mth", 336, 15);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_pack_uncons();
     VAL var_g = pop_value();
     mw_prim_drop();
-    WORD_ATOM(331, 15, "g");
+    WORD_ATOM(336, 15, "g");
     incref(var_g);
     run_value(var_g);
-    WORD_ATOM(331, 17, "");
+    WORD_ATOM(336, 17, "");
     {
         static bool vready = false;
         static VAL v;
@@ -34433,9 +34686,9 @@ static void mb_assert_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(331, 38, "swap");
+    WORD_ATOM(336, 38, "swap");
     mw_prim_swap();
-    WORD_ATOM(331, 43, "prim-str-cat");
+    WORD_ATOM(336, 43, "prim-str-cat");
     mw_prim_str_cat();
     decref(var_f);
     decref(var_g);
@@ -35171,6 +35424,22 @@ static void mb_TokenValue_2E_sig_stack_var_3F__1 (void) {
     WORD_EXIT(mb_TokenValue_2E_sig_stack_var_3F__1);
 }
 
+static void mb_TokenValue_2E_sig_resource_var_3F__1 (void) {
+    WORD_ENTER(mb_TokenValue_2E_sig_resource_var_3F__1, "TokenValue.sig-resource-var? block", "src/mirth/data/token.mth", 69, 70);
+    mw_prim_drop();
+    WORD_ATOM(69, 70, "could-be-resource-var");
+    mw_Name_2E_could_be_resource_var();
+    WORD_EXIT(mb_TokenValue_2E_sig_resource_var_3F__1);
+}
+
+static void mb_TokenValue_2E_sig_resource_con_3F__1 (void) {
+    WORD_ENTER(mb_TokenValue_2E_sig_resource_con_3F__1, "TokenValue.sig-resource-con? block", "src/mirth/data/token.mth", 70, 70);
+    mw_prim_drop();
+    WORD_ATOM(70, 70, "could-be-resource-con");
+    mw_Name_2E_could_be_resource_con();
+    WORD_EXIT(mb_TokenValue_2E_sig_resource_con_3F__1);
+}
+
 static void mb_TokenValue_2E_sig_dashes_3F__1 (void) {
     WORD_ENTER(mb_TokenValue_2E_sig_dashes_3F__1, "TokenValue.sig-dashes? block", "src/mirth/data/token.mth", 71, 64);
     mw_prim_drop();
@@ -35429,25 +35698,25 @@ static void mb_Token_2E_sig_stack_end_3F__1 (void) {
 }
 
 static void mb_elab_module_import_21__1 (void) {
-    WORD_ENTER(mb_elab_module_import_21__1, "elab-module-import! block", "src/mirth/elab.mth", 768, 9);
+    WORD_ENTER(mb_elab_module_import_21__1, "elab-module-import! block", "src/mirth/elab.mth", 784, 9);
     mw_prim_drop();
-    WORD_ATOM(768, 9, "next");
+    WORD_ATOM(784, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_module_import_21__1);
 }
 
 static void mb_elab_alias_21__1 (void) {
-    WORD_ENTER(mb_elab_alias_21__1, "elab-alias! block", "src/mirth/elab.mth", 866, 9);
+    WORD_ENTER(mb_elab_alias_21__1, "elab-alias! block", "src/mirth/elab.mth", 882, 9);
     mw_prim_drop();
-    WORD_ATOM(866, 9, "next");
+    WORD_ATOM(882, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_alias_21__1);
 }
 
 static void mb_elab_alias_21__2 (void) {
-    WORD_ENTER(mb_elab_alias_21__2, "elab-alias! block", "src/mirth/elab.mth", 867, 25);
+    WORD_ENTER(mb_elab_alias_21__2, "elab-alias! block", "src/mirth/elab.mth", 883, 25);
     mw_prim_drop();
-    WORD_ATOM(867, 25, "");
+    WORD_ATOM(883, 25, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35458,17 +35727,17 @@ static void mb_elab_alias_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(867, 46, "emit-fatal-error!");
+    WORD_ATOM(883, 46, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_alias_21__2);
 }
 
 static void mb_elab_alias_21__4 (void) {
-    WORD_ENTER(mb_elab_alias_21__4, "elab-alias! block", "src/mirth/elab.mth", 868, 26);
+    WORD_ENTER(mb_elab_alias_21__4, "elab-alias! block", "src/mirth/elab.mth", 884, 26);
     mw_prim_drop();
-    WORD_ATOM(868, 26, "drop");
+    WORD_ATOM(884, 26, "drop");
     mw_prim_drop();
-    WORD_ATOM(868, 31, "");
+    WORD_ATOM(884, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35479,15 +35748,15 @@ static void mb_elab_alias_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(868, 54, "emit-fatal-error!");
+    WORD_ATOM(884, 54, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_alias_21__4);
 }
 
 static void mb_elab_alias_21__5 (void) {
-    WORD_ENTER(mb_elab_alias_21__5, "elab-alias! block", "src/mirth/elab.mth", 869, 25);
+    WORD_ENTER(mb_elab_alias_21__5, "elab-alias! block", "src/mirth/elab.mth", 885, 25);
     mw_prim_drop();
-    WORD_ATOM(869, 25, "");
+    WORD_ATOM(885, 25, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35498,23 +35767,23 @@ static void mb_elab_alias_21__5 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(869, 46, "emit-fatal-error!");
+    WORD_ATOM(885, 46, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_alias_21__5);
 }
 
 static void mb_elab_def_21__1 (void) {
-    WORD_ENTER(mb_elab_def_21__1, "elab-def! block", "src/mirth/elab.mth", 882, 9);
+    WORD_ENTER(mb_elab_def_21__1, "elab-def! block", "src/mirth/elab.mth", 898, 9);
     mw_prim_drop();
-    WORD_ATOM(882, 9, "next");
+    WORD_ATOM(898, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_def_21__1);
 }
 
 static void mb_elab_def_21__6 (void) {
-    WORD_ENTER(mb_elab_def_21__6, "elab-def! block", "src/mirth/elab.mth", 886, 30);
+    WORD_ENTER(mb_elab_def_21__6, "elab-def! block", "src/mirth/elab.mth", 902, 30);
     mw_prim_drop();
-    WORD_ATOM(886, 30, "");
+    WORD_ATOM(902, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35525,51 +35794,51 @@ static void mb_elab_def_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(886, 51, "emit-fatal-error!");
+    WORD_ATOM(902, 51, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_21__6);
 }
 
 static void mb_elab_def_21__9 (void) {
-    WORD_ENTER(mb_elab_def_21__9, "elab-def! block", "src/mirth/elab.mth", 893, 9);
+    WORD_ENTER(mb_elab_def_21__9, "elab-def! block", "src/mirth/elab.mth", 909, 9);
     mw_prim_drop();
-    WORD_ATOM(893, 9, "type-elab-default");
+    WORD_ATOM(909, 9, "type-elab-default");
     mw_type_elab_default();
-    WORD_ATOM(894, 9, "over");
+    WORD_ATOM(910, 9, "over");
     mw_over();
-    WORD_ATOM(894, 14, "sig");
+    WORD_ATOM(910, 14, "sig");
     mw_Word_2E_sig();
-    WORD_ATOM(894, 18, "unwrap-or");
+    WORD_ATOM(910, 18, "unwrap-or");
     push_u64(0);
     push_fnptr(&mb_elab_def_21__10);
     mw_prim_pack_cons();
     mw_Maybe_2E_unwrap_or();
-    WORD_ATOM(895, 9, "elab-type-sig!");
+    WORD_ATOM(911, 9, "elab-type-sig!");
     mw_elab_type_sig_21_();
-    WORD_ATOM(895, 24, "drop");
+    WORD_ATOM(911, 24, "drop");
     mw_prim_drop();
-    WORD_ATOM(895, 29, "dip");
+    WORD_ATOM(911, 29, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(895, 33, "type-elab-ctx");
+        WORD_ATOM(911, 33, "type-elab-ctx");
         mw_type_elab_ctx();
         push_value(d2);
     }
-    WORD_ATOM(896, 9, "pack2");
+    WORD_ATOM(912, 9, "pack2");
     mw_pack2();
-    WORD_ATOM(896, 15, "nip");
+    WORD_ATOM(912, 15, "nip");
     mw_nip();
     WORD_EXIT(mb_elab_def_21__9);
 }
 
 static void mb_elab_def_21__10 (void) {
-    WORD_ENTER(mb_elab_def_21__10, "elab-def! block", "src/mirth/elab.mth", 894, 28);
+    WORD_ENTER(mb_elab_def_21__10, "elab-def! block", "src/mirth/elab.mth", 910, 28);
     mw_prim_drop();
-    WORD_ATOM(894, 28, "over");
+    WORD_ATOM(910, 28, "over");
     mw_over();
-    WORD_ATOM(894, 33, "head");
+    WORD_ATOM(910, 33, "head");
     mw_Word_2E_head();
-    WORD_ATOM(894, 38, "");
+    WORD_ATOM(910, 38, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35580,25 +35849,25 @@ static void mb_elab_def_21__10 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(894, 60, "emit-fatal-error!");
+    WORD_ATOM(910, 60, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_21__10);
 }
 
 static void mb_elab_def_21__12 (void) {
-    WORD_ENTER(mb_elab_def_21__12, "elab-def! block", "src/mirth/elab.mth", 898, 15);
+    WORD_ENTER(mb_elab_def_21__12, "elab-def! block", "src/mirth/elab.mth", 914, 15);
     mw_prim_drop();
-    WORD_ATOM(898, 15, "elab-def-params!");
+    WORD_ATOM(914, 15, "elab-def-params!");
     mw_elab_def_params_21_();
     WORD_EXIT(mb_elab_def_21__12);
 }
 
 static void mb_elab_def_21__13 (void) {
-    WORD_ENTER(mb_elab_def_21__13, "elab-def! block", "src/mirth/elab.mth", 900, 9);
+    WORD_ENTER(mb_elab_def_21__13, "elab-def! block", "src/mirth/elab.mth", 916, 9);
     mw_prim_drop();
-    WORD_ATOM(900, 9, "dup");
+    WORD_ATOM(916, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(900, 13, "ab-build-word-arrow!");
+    WORD_ATOM(916, 13, "ab-build-word-arrow!");
     push_u64(0);
     push_fnptr(&mb_elab_def_21__14);
     mw_prim_pack_cons();
@@ -35607,24 +35876,24 @@ static void mb_elab_def_21__13 (void) {
 }
 
 static void mb_elab_def_21__14 (void) {
-    WORD_ENTER(mb_elab_def_21__14, "elab-def! block", "src/mirth/elab.mth", 901, 13);
+    WORD_ENTER(mb_elab_def_21__14, "elab-def! block", "src/mirth/elab.mth", 917, 13);
     mw_prim_drop();
-    WORD_ATOM(901, 13, "swap");
+    WORD_ATOM(917, 13, "swap");
     mw_prim_swap();
-    WORD_ATOM(901, 18, "params");
+    WORD_ATOM(917, 18, "params");
     mw_Word_2E_params();
-    WORD_ATOM(901, 25, "dup");
+    WORD_ATOM(917, 25, "dup");
     mw_prim_dup();
-    WORD_ATOM(901, 29, "is-empty");
+    WORD_ATOM(917, 29, "is-empty");
     mw_List_2E_is_empty();
-    WORD_ATOM(901, 38, "if");
+    WORD_ATOM(917, 38, "if");
     if (pop_u64()) {
-        WORD_ATOM(902, 17, "drop");
+        WORD_ATOM(918, 17, "drop");
         mw_prim_drop();
-        WORD_ATOM(902, 22, "elab-def-body!");
+        WORD_ATOM(918, 22, "elab-def-body!");
         mw_elab_def_body_21_();
     } else {
-        WORD_ATOM(903, 17, "ab-lambda!");
+        WORD_ATOM(919, 17, "ab-lambda!");
         push_u64(0);
         push_fnptr(&mb_elab_def_21__17);
         mw_prim_pack_cons();
@@ -35634,17 +35903,17 @@ static void mb_elab_def_21__14 (void) {
 }
 
 static void mb_elab_def_21__17 (void) {
-    WORD_ENTER(mb_elab_def_21__17, "elab-def! block", "src/mirth/elab.mth", 903, 28);
+    WORD_ENTER(mb_elab_def_21__17, "elab-def! block", "src/mirth/elab.mth", 919, 28);
     mw_prim_drop();
-    WORD_ATOM(903, 28, "elab-def-body!");
+    WORD_ATOM(919, 28, "elab-def-body!");
     mw_elab_def_body_21_();
     WORD_EXIT(mb_elab_def_21__17);
 }
 
 static void mb_elab_def_missing_21__1 (void) {
-    WORD_ENTER(mb_elab_def_missing_21__1, "elab-def-missing! block", "src/mirth/elab.mth", 875, 39);
+    WORD_ENTER(mb_elab_def_missing_21__1, "elab-def-missing! block", "src/mirth/elab.mth", 891, 39);
     mw_prim_drop();
-    WORD_ATOM(875, 39, "");
+    WORD_ATOM(891, 39, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35655,23 +35924,23 @@ static void mb_elab_def_missing_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(875, 55, "emit-fatal-error!");
+    WORD_ATOM(891, 55, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_missing_21__1);
 }
 
 static void mb_elab_def_external_21__1 (void) {
-    WORD_ENTER(mb_elab_def_external_21__1, "elab-def-external! block", "src/mirth/elab.mth", 932, 9);
+    WORD_ENTER(mb_elab_def_external_21__1, "elab-def-external! block", "src/mirth/elab.mth", 948, 9);
     mw_prim_drop();
-    WORD_ATOM(932, 9, "next");
+    WORD_ATOM(948, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_def_external_21__1);
 }
 
 static void mb_elab_def_external_21__2 (void) {
-    WORD_ENTER(mb_elab_def_external_21__2, "elab-def-external! block", "src/mirth/elab.mth", 933, 30);
+    WORD_ENTER(mb_elab_def_external_21__2, "elab-def-external! block", "src/mirth/elab.mth", 949, 30);
     mw_prim_drop();
-    WORD_ATOM(933, 30, "");
+    WORD_ATOM(949, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35682,17 +35951,17 @@ static void mb_elab_def_external_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(933, 51, "emit-fatal-error!");
+    WORD_ATOM(949, 51, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_external_21__2);
 }
 
 static void mb_elab_def_external_21__3 (void) {
-    WORD_ENTER(mb_elab_def_external_21__3, "elab-def-external! block", "src/mirth/elab.mth", 934, 26);
+    WORD_ENTER(mb_elab_def_external_21__3, "elab-def-external! block", "src/mirth/elab.mth", 950, 26);
     mw_prim_drop();
-    WORD_ATOM(934, 26, "drop");
+    WORD_ATOM(950, 26, "drop");
     mw_prim_drop();
-    WORD_ATOM(934, 31, "");
+    WORD_ATOM(950, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35703,48 +35972,48 @@ static void mb_elab_def_external_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(934, 54, "emit-fatal-error!");
+    WORD_ATOM(950, 54, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_external_21__3);
 }
 
 static void mb_elab_def_external_21__4 (void) {
-    WORD_ENTER(mb_elab_def_external_21__4, "elab-def-external! block", "src/mirth/elab.mth", 941, 9);
+    WORD_ENTER(mb_elab_def_external_21__4, "elab-def-external! block", "src/mirth/elab.mth", 957, 9);
     mw_prim_drop();
-    WORD_ATOM(941, 9, "type-elab-default");
+    WORD_ATOM(957, 9, "type-elab-default");
     mw_type_elab_default();
-    WORD_ATOM(941, 27, "swap");
+    WORD_ATOM(957, 27, "swap");
     mw_prim_swap();
-    WORD_ATOM(941, 32, "sig");
+    WORD_ATOM(957, 32, "sig");
     mw_External_2E_sig();
-    WORD_ATOM(942, 9, "elab-type-sig!");
+    WORD_ATOM(958, 9, "elab-type-sig!");
     mw_elab_type_sig_21_();
-    WORD_ATOM(942, 24, "drop");
+    WORD_ATOM(958, 24, "drop");
     mw_prim_drop();
-    WORD_ATOM(942, 29, "dip");
+    WORD_ATOM(958, 29, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(942, 33, "type-elab-ctx");
+        WORD_ATOM(958, 33, "type-elab-ctx");
         mw_type_elab_ctx();
         push_value(d2);
     }
-    WORD_ATOM(942, 48, "pack2");
+    WORD_ATOM(958, 48, "pack2");
     mw_pack2();
     WORD_EXIT(mb_elab_def_external_21__4);
 }
 
 static void mb_elab_def_type_21__1 (void) {
-    WORD_ENTER(mb_elab_def_type_21__1, "elab-def-type! block", "src/mirth/elab.mth", 947, 9);
+    WORD_ENTER(mb_elab_def_type_21__1, "elab-def-type! block", "src/mirth/elab.mth", 963, 9);
     mw_prim_drop();
-    WORD_ATOM(947, 9, "next");
+    WORD_ATOM(963, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_def_type_21__1);
 }
 
 static void mb_elab_def_type_21__2 (void) {
-    WORD_ENTER(mb_elab_def_type_21__2, "elab-def-type! block", "src/mirth/elab.mth", 948, 33);
+    WORD_ENTER(mb_elab_def_type_21__2, "elab-def-type! block", "src/mirth/elab.mth", 964, 33);
     mw_prim_drop();
-    WORD_ATOM(948, 33, "");
+    WORD_ATOM(964, 33, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35755,17 +36024,17 @@ static void mb_elab_def_type_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(948, 61, "emit-fatal-error!");
+    WORD_ATOM(964, 61, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_type_21__2);
 }
 
 static void mb_elab_def_type_21__3 (void) {
-    WORD_ENTER(mb_elab_def_type_21__3, "elab-def-type! block", "src/mirth/elab.mth", 949, 43);
+    WORD_ENTER(mb_elab_def_type_21__3, "elab-def-type! block", "src/mirth/elab.mth", 965, 43);
     mw_prim_drop();
-    WORD_ATOM(949, 43, "drop");
+    WORD_ATOM(965, 43, "drop");
     mw_prim_drop();
-    WORD_ATOM(949, 48, "");
+    WORD_ATOM(965, 48, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35776,23 +36045,23 @@ static void mb_elab_def_type_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(949, 76, "emit-fatal-error!");
+    WORD_ATOM(965, 76, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_type_21__3);
 }
 
 static void mb_elab_buffer_21__1 (void) {
-    WORD_ENTER(mb_elab_buffer_21__1, "elab-buffer! block", "src/mirth/elab.mth", 954, 9);
+    WORD_ENTER(mb_elab_buffer_21__1, "elab-buffer! block", "src/mirth/elab.mth", 970, 9);
     mw_prim_drop();
-    WORD_ATOM(954, 9, "next");
+    WORD_ATOM(970, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_buffer_21__1);
 }
 
 static void mb_elab_buffer_21__2 (void) {
-    WORD_ENTER(mb_elab_buffer_21__2, "elab-buffer! block", "src/mirth/elab.mth", 955, 30);
+    WORD_ENTER(mb_elab_buffer_21__2, "elab-buffer! block", "src/mirth/elab.mth", 971, 30);
     mw_prim_drop();
-    WORD_ATOM(955, 30, "");
+    WORD_ATOM(971, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35803,17 +36072,17 @@ static void mb_elab_buffer_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(955, 53, "emit-fatal-error!");
+    WORD_ATOM(971, 53, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_buffer_21__2);
 }
 
 static void mb_elab_buffer_21__3 (void) {
-    WORD_ENTER(mb_elab_buffer_21__3, "elab-buffer! block", "src/mirth/elab.mth", 956, 26);
+    WORD_ENTER(mb_elab_buffer_21__3, "elab-buffer! block", "src/mirth/elab.mth", 972, 26);
     mw_prim_drop();
-    WORD_ATOM(956, 26, "drop");
+    WORD_ATOM(972, 26, "drop");
     mw_prim_drop();
-    WORD_ATOM(956, 31, "");
+    WORD_ATOM(972, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35824,15 +36093,15 @@ static void mb_elab_buffer_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(956, 61, "emit-fatal-error!");
+    WORD_ATOM(972, 61, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_buffer_21__3);
 }
 
 static void mb_elab_buffer_21__4 (void) {
-    WORD_ENTER(mb_elab_buffer_21__4, "elab-buffer! block", "src/mirth/elab.mth", 957, 29);
+    WORD_ENTER(mb_elab_buffer_21__4, "elab-buffer! block", "src/mirth/elab.mth", 973, 29);
     mw_prim_drop();
-    WORD_ATOM(957, 29, "");
+    WORD_ATOM(973, 29, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35843,23 +36112,23 @@ static void mb_elab_buffer_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(957, 52, "emit-fatal-error!");
+    WORD_ATOM(973, 52, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_buffer_21__4);
 }
 
 static void mb_elab_variable_21__1 (void) {
-    WORD_ENTER(mb_elab_variable_21__1, "elab-variable! block", "src/mirth/elab.mth", 962, 9);
+    WORD_ENTER(mb_elab_variable_21__1, "elab-variable! block", "src/mirth/elab.mth", 978, 9);
     mw_prim_drop();
-    WORD_ATOM(962, 9, "next");
+    WORD_ATOM(978, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_variable_21__1);
 }
 
 static void mb_elab_variable_21__2 (void) {
-    WORD_ENTER(mb_elab_variable_21__2, "elab-variable! block", "src/mirth/elab.mth", 963, 30);
+    WORD_ENTER(mb_elab_variable_21__2, "elab-variable! block", "src/mirth/elab.mth", 979, 30);
     mw_prim_drop();
-    WORD_ATOM(963, 30, "");
+    WORD_ATOM(979, 30, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35870,17 +36139,17 @@ static void mb_elab_variable_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(963, 55, "emit-fatal-error!");
+    WORD_ATOM(979, 55, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_variable_21__2);
 }
 
 static void mb_elab_variable_21__3 (void) {
-    WORD_ENTER(mb_elab_variable_21__3, "elab-variable! block", "src/mirth/elab.mth", 964, 26);
+    WORD_ENTER(mb_elab_variable_21__3, "elab-variable! block", "src/mirth/elab.mth", 980, 26);
     mw_prim_drop();
-    WORD_ATOM(964, 26, "drop");
+    WORD_ATOM(980, 26, "drop");
     mw_prim_drop();
-    WORD_ATOM(964, 31, "");
+    WORD_ATOM(980, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35891,31 +36160,31 @@ static void mb_elab_variable_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(964, 63, "emit-fatal-error!");
+    WORD_ATOM(980, 63, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_variable_21__3);
 }
 
 static void mb_elab_variable_21__4 (void) {
-    WORD_ENTER(mb_elab_variable_21__4, "elab-variable! block", "src/mirth/elab.mth", 965, 16);
+    WORD_ENTER(mb_elab_variable_21__4, "elab-variable! block", "src/mirth/elab.mth", 981, 16);
     mw_prim_drop();
-    WORD_ATOM(965, 16, "elab-simple-type-arg!");
+    WORD_ATOM(981, 16, "elab-simple-type-arg!");
     mw_elab_simple_type_arg_21_();
     WORD_EXIT(mb_elab_variable_21__4);
 }
 
 static void mb_elab_table_21__1 (void) {
-    WORD_ENTER(mb_elab_table_21__1, "elab-table! block", "src/mirth/elab.mth", 970, 9);
+    WORD_ENTER(mb_elab_table_21__1, "elab-table! block", "src/mirth/elab.mth", 986, 9);
     mw_prim_drop();
-    WORD_ATOM(970, 9, "next");
+    WORD_ATOM(986, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_table_21__1);
 }
 
 static void mb_elab_table_21__2 (void) {
-    WORD_ENTER(mb_elab_table_21__2, "elab-table! block", "src/mirth/elab.mth", 971, 28);
+    WORD_ENTER(mb_elab_table_21__2, "elab-table! block", "src/mirth/elab.mth", 987, 28);
     mw_prim_drop();
-    WORD_ATOM(971, 28, "");
+    WORD_ATOM(987, 28, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35926,17 +36195,17 @@ static void mb_elab_table_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(971, 49, "emit-fatal-error!");
+    WORD_ATOM(987, 49, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_table_21__2);
 }
 
 static void mb_elab_table_21__3 (void) {
-    WORD_ENTER(mb_elab_table_21__3, "elab-table! block", "src/mirth/elab.mth", 972, 43);
+    WORD_ENTER(mb_elab_table_21__3, "elab-table! block", "src/mirth/elab.mth", 988, 43);
     mw_prim_drop();
-    WORD_ATOM(972, 43, "drop");
+    WORD_ATOM(988, 43, "drop");
     mw_prim_drop();
-    WORD_ATOM(972, 48, "");
+    WORD_ATOM(988, 48, "");
     {
         static bool vready = false;
         static VAL v;
@@ -35947,75 +36216,75 @@ static void mb_elab_table_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(972, 77, "emit-fatal-error!");
+    WORD_ATOM(988, 77, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_table_21__3);
 }
 
 static void mb_elab_field_21__1 (void) {
-    WORD_ENTER(mb_elab_field_21__1, "elab-field! block", "src/mirth/elab.mth", 1179, 9);
+    WORD_ENTER(mb_elab_field_21__1, "elab-field! block", "src/mirth/elab.mth", 1195, 9);
     mw_prim_drop();
-    WORD_ATOM(1179, 9, "next");
+    WORD_ATOM(1195, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_field_21__1);
 }
 
 static void mb_elab_data_21__1 (void) {
-    WORD_ENTER(mb_elab_data_21__1, "elab-data! block", "src/mirth/elab.mth", 794, 9);
+    WORD_ENTER(mb_elab_data_21__1, "elab-data! block", "src/mirth/elab.mth", 810, 9);
     mw_prim_drop();
-    WORD_ATOM(794, 9, "Data.alloc!");
+    WORD_ATOM(810, 9, "Data.alloc!");
     mw_Data_2E_alloc_21_();
-    WORD_ATOM(795, 9, "L0");
+    WORD_ATOM(811, 9, "L0");
     mw_L0();
-    WORD_ATOM(795, 12, "over");
+    WORD_ATOM(811, 12, "over");
     mw_over();
-    WORD_ATOM(795, 17, "~tags");
+    WORD_ATOM(811, 17, "~tags");
     mw_Data_7E_tags();
-    WORD_ATOM(795, 23, "!");
+    WORD_ATOM(811, 23, "!");
     mw_prim_mut_set();
-    WORD_ATOM(796, 9, "swap");
+    WORD_ATOM(812, 9, "swap");
     mw_prim_swap();
-    WORD_ATOM(796, 14, "args+");
+    WORD_ATOM(812, 14, "args+");
     mw_Token_2E_args_2B_();
-    WORD_ATOM(797, 9, "uncons");
+    WORD_ATOM(813, 9, "uncons");
     mw_List_2B__2E_uncons();
-    WORD_ATOM(797, 16, "dip");
+    WORD_ATOM(813, 16, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(797, 20, "elab-data-header!");
+        WORD_ATOM(813, 20, "elab-data-header!");
         mw_elab_data_header_21_();
         push_value(d2);
     }
-    WORD_ATOM(798, 9, "for");
+    WORD_ATOM(814, 9, "for");
     push_u64(0);
     push_fnptr(&mb_elab_data_21__3);
     mw_prim_pack_cons();
     mw_List_2E_for();
-    WORD_ATOM(799, 9, "drop");
+    WORD_ATOM(815, 9, "drop");
     mw_prim_drop();
     WORD_EXIT(mb_elab_data_21__1);
 }
 
 static void mb_elab_data_21__3 (void) {
-    WORD_ENTER(mb_elab_data_21__3, "elab-data! block", "src/mirth/elab.mth", 798, 13);
+    WORD_ENTER(mb_elab_data_21__3, "elab-data! block", "src/mirth/elab.mth", 814, 13);
     mw_prim_drop();
-    WORD_ATOM(798, 13, "elab-data-tag!");
+    WORD_ATOM(814, 13, "elab-data-tag!");
     mw_elab_data_tag_21_();
     WORD_EXIT(mb_elab_data_21__3);
 }
 
 static void mb_elab_target_c99_21__1 (void) {
-    WORD_ENTER(mb_elab_target_c99_21__1, "elab-target-c99! block", "src/mirth/elab.mth", 978, 9);
+    WORD_ENTER(mb_elab_target_c99_21__1, "elab-target-c99! block", "src/mirth/elab.mth", 994, 9);
     mw_prim_drop();
-    WORD_ATOM(978, 9, "next");
+    WORD_ATOM(994, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_target_c99_21__1);
 }
 
 static void mb_elab_target_c99_21__3 (void) {
-    WORD_ENTER(mb_elab_target_c99_21__3, "elab-target-c99! block", "src/mirth/elab.mth", 979, 28);
+    WORD_ENTER(mb_elab_target_c99_21__3, "elab-target-c99! block", "src/mirth/elab.mth", 995, 28);
     mw_prim_drop();
-    WORD_ATOM(979, 28, "");
+    WORD_ATOM(995, 28, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36026,23 +36295,23 @@ static void mb_elab_target_c99_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(979, 51, "emit-fatal-error!");
+    WORD_ATOM(995, 51, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_target_c99_21__3);
 }
 
 static void mb_elab_embed_str_21__1 (void) {
-    WORD_ENTER(mb_elab_embed_str_21__1, "elab-embed-str! block", "src/mirth/elab.mth", 987, 9);
+    WORD_ENTER(mb_elab_embed_str_21__1, "elab-embed-str! block", "src/mirth/elab.mth", 1003, 9);
     mw_prim_drop();
-    WORD_ATOM(987, 9, "next");
+    WORD_ATOM(1003, 9, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_embed_str_21__1);
 }
 
 static void mb_elab_embed_str_21__2 (void) {
-    WORD_ENTER(mb_elab_embed_str_21__2, "elab-embed-str! block", "src/mirth/elab.mth", 988, 25);
+    WORD_ENTER(mb_elab_embed_str_21__2, "elab-embed-str! block", "src/mirth/elab.mth", 1004, 25);
     mw_prim_drop();
-    WORD_ATOM(988, 25, "");
+    WORD_ATOM(1004, 25, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36053,17 +36322,17 @@ static void mb_elab_embed_str_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(988, 59, "emit-fatal-error!");
+    WORD_ATOM(1004, 59, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_embed_str_21__2);
 }
 
 static void mb_elab_embed_str_21__3 (void) {
-    WORD_ENTER(mb_elab_embed_str_21__3, "elab-embed-str! block", "src/mirth/elab.mth", 989, 26);
+    WORD_ENTER(mb_elab_embed_str_21__3, "elab-embed-str! block", "src/mirth/elab.mth", 1005, 26);
     mw_prim_drop();
-    WORD_ATOM(989, 26, "drop");
+    WORD_ATOM(1005, 26, "drop");
     mw_prim_drop();
-    WORD_ATOM(989, 31, "");
+    WORD_ATOM(1005, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36074,15 +36343,15 @@ static void mb_elab_embed_str_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(989, 72, "emit-fatal-error!");
+    WORD_ATOM(1005, 72, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_embed_str_21__3);
 }
 
 static void mb_elab_embed_str_21__4 (void) {
-    WORD_ENTER(mb_elab_embed_str_21__4, "elab-embed-str! block", "src/mirth/elab.mth", 990, 29);
+    WORD_ENTER(mb_elab_embed_str_21__4, "elab-embed-str! block", "src/mirth/elab.mth", 1006, 29);
     mw_prim_drop();
-    WORD_ATOM(990, 29, "");
+    WORD_ATOM(1006, 29, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36093,25 +36362,25 @@ static void mb_elab_embed_str_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(990, 52, "emit-fatal-error!");
+    WORD_ATOM(1006, 52, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_embed_str_21__4);
 }
 
 static void mb_elab_embed_str_21__5 (void) {
-    WORD_ENTER(mb_elab_embed_str_21__5, "elab-embed-str! block", "src/mirth/elab.mth", 991, 21);
+    WORD_ENTER(mb_elab_embed_str_21__5, "elab-embed-str! block", "src/mirth/elab.mth", 1007, 21);
     mw_prim_drop();
-    WORD_ATOM(991, 21, "read-file!");
+    WORD_ATOM(1007, 21, "read-file!");
     mw_read_file_21_();
-    WORD_ATOM(991, 32, "nip");
+    WORD_ATOM(1007, 32, "nip");
     mw_nip();
     WORD_EXIT(mb_elab_embed_str_21__5);
 }
 
 static void mb_elab_embed_str_21__6 (void) {
-    WORD_ENTER(mb_elab_embed_str_21__6, "elab-embed-str! block", "src/mirth/elab.mth", 991, 37);
+    WORD_ENTER(mb_elab_embed_str_21__6, "elab-embed-str! block", "src/mirth/elab.mth", 1007, 37);
     mw_prim_drop();
-    WORD_ATOM(991, 37, "");
+    WORD_ATOM(1007, 37, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36122,7 +36391,7 @@ static void mb_elab_embed_str_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(991, 66, "emit-fatal-error!");
+    WORD_ATOM(1007, 66, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_embed_str_21__6);
 }
@@ -36154,41 +36423,41 @@ static void mb_PrimType_3D__1 (void) {
 }
 
 static void mb_TT_1 (void) {
-    WORD_ENTER(mb_TT_1, "TT block", "src/mirth/data/type.mth", 104, 46);
+    WORD_ENTER(mb_TT_1, "TT block", "src/mirth/data/type.mth", 105, 46);
     mw_prim_drop();
-    WORD_ATOM(104, 46, "T*");
+    WORD_ATOM(105, 46, "T*");
     mw_T_2A_();
     WORD_EXIT(mb_TT_1);
 }
 
 static void mb_type_head_2 (void) {
-    WORD_ENTER(mb_type_head_2, "type-head block", "src/mirth/data/type.mth", 444, 24);
+    WORD_ENTER(mb_type_head_2, "type-head block", "src/mirth/data/type.mth", 445, 24);
     mw_prim_drop();
-    WORD_ATOM(444, 24, "type-head");
+    WORD_ATOM(445, 24, "type-head");
     mw_type_head();
     WORD_EXIT(mb_type_head_2);
 }
 
 static void mb_type_head_3 (void) {
-    WORD_ENTER(mb_type_head_3, "type-head block", "src/mirth/data/type.mth", 444, 35);
+    WORD_ENTER(mb_type_head_3, "type-head block", "src/mirth/data/type.mth", 445, 35);
     mw_prim_drop();
-    WORD_ATOM(444, 35, "TMeta");
+    WORD_ATOM(445, 35, "TMeta");
     mw_TMeta();
     WORD_EXIT(mb_type_head_3);
 }
 
 static void mb_Type_2E_is_physical_3F__2 (void) {
-    WORD_ENTER(mb_Type_2E_is_physical_3F__2, "Type.is-physical? block", "src/mirth/data/type.mth", 141, 24);
+    WORD_ENTER(mb_Type_2E_is_physical_3F__2, "Type.is-physical? block", "src/mirth/data/type.mth", 142, 24);
     mw_prim_drop();
-    WORD_ATOM(141, 24, "is-physical?");
+    WORD_ATOM(142, 24, "is-physical?");
     mw_Type_2E_is_physical_3F_();
     WORD_EXIT(mb_Type_2E_is_physical_3F__2);
 }
 
 static void mb_Type_2E_is_physical_3F__3 (void) {
-    WORD_ENTER(mb_Type_2E_is_physical_3F__3, "Type.is-physical? block", "src/mirth/data/type.mth", 141, 38);
+    WORD_ENTER(mb_Type_2E_is_physical_3F__3, "Type.is-physical? block", "src/mirth/data/type.mth", 142, 38);
     mw_prim_drop();
-    WORD_ATOM(141, 38, "");
+    WORD_ATOM(142, 38, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36199,307 +36468,307 @@ static void mb_Type_2E_is_physical_3F__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(141, 74, "panic!");
+    WORD_ATOM(142, 74, "panic!");
     mw_prim_panic();
     WORD_EXIT(mb_Type_2E_is_physical_3F__3);
 }
 
 static void mb_Type_2E_unify_failed_21__2 (void) {
-    WORD_ENTER(mb_Type_2E_unify_failed_21__2, "Type.unify-failed! block", "src/mirth/data/type.mth", 177, 23);
+    WORD_ENTER(mb_Type_2E_unify_failed_21__2, "Type.unify-failed! block", "src/mirth/data/type.mth", 178, 23);
     mw_prim_drop();
-    WORD_ATOM(177, 23, "1+");
+    WORD_ATOM(178, 23, "1+");
     mw_prim_int_succ();
     WORD_EXIT(mb_Type_2E_unify_failed_21__2);
 }
 
 static void mb_Type_2E_unify_21__1 (void) {
-    WORD_ENTER(mb_Type_2E_unify_21__1, "Type.unify! block", "src/mirth/data/type.mth", 227, 10);
+    WORD_ENTER(mb_Type_2E_unify_21__1, "Type.unify! block", "src/mirth/data/type.mth", 228, 10);
     mw_prim_drop();
-    WORD_ATOM(227, 10, "expand");
+    WORD_ATOM(228, 10, "expand");
     mw_Type_2E_expand();
     WORD_EXIT(mb_Type_2E_unify_21__1);
 }
 
 static void mb_PrimType_2E_unify_21__3 (void) {
-    WORD_ENTER(mb_PrimType_2E_unify_21__3, "PrimType.unify! block", "src/mirth/data/type.mth", 288, 32);
+    WORD_ENTER(mb_PrimType_2E_unify_21__3, "PrimType.unify! block", "src/mirth/data/type.mth", 289, 32);
     mw_prim_drop();
-    WORD_ATOM(288, 32, "TPrim");
+    WORD_ATOM(289, 32, "TPrim");
     mw_TPrim();
     WORD_EXIT(mb_PrimType_2E_unify_21__3);
 }
 
 static void mb_Data_2E_unify_21__3 (void) {
-    WORD_ENTER(mb_Data_2E_unify_21__3, "Data.unify! block", "src/mirth/data/type.mth", 290, 32);
+    WORD_ENTER(mb_Data_2E_unify_21__3, "Data.unify! block", "src/mirth/data/type.mth", 291, 32);
     mw_prim_drop();
-    WORD_ATOM(290, 32, "TData");
+    WORD_ATOM(291, 32, "TData");
     mw_TData();
     WORD_EXIT(mb_Data_2E_unify_21__3);
 }
 
 static void mb_Table_2E_unify_21__3 (void) {
-    WORD_ENTER(mb_Table_2E_unify_21__3, "Table.unify! block", "src/mirth/data/type.mth", 292, 33);
+    WORD_ENTER(mb_Table_2E_unify_21__3, "Table.unify! block", "src/mirth/data/type.mth", 293, 33);
     mw_prim_drop();
-    WORD_ATOM(292, 33, "TTable");
+    WORD_ATOM(293, 33, "TTable");
     mw_TTable();
     WORD_EXIT(mb_Table_2E_unify_21__3);
 }
 
 static void mb_Var_2E_unify_21__3 (void) {
-    WORD_ENTER(mb_Var_2E_unify_21__3, "Var.unify! block", "src/mirth/data/type.mth", 294, 31);
+    WORD_ENTER(mb_Var_2E_unify_21__3, "Var.unify! block", "src/mirth/data/type.mth", 295, 31);
     mw_prim_drop();
-    WORD_ATOM(294, 31, "TVar");
+    WORD_ATOM(295, 31, "TVar");
     mw_TVar();
     WORD_EXIT(mb_Var_2E_unify_21__3);
 }
 
 static void mb_Type_2E_trace_sig_21__2 (void) {
-    WORD_ENTER(mb_Type_2E_trace_sig_21__2, "Type.trace-sig! block", "src/mirth/data/type.mth", 318, 24);
+    WORD_ENTER(mb_Type_2E_trace_sig_21__2, "Type.trace-sig! block", "src/mirth/data/type.mth", 319, 24);
     mw_prim_drop();
-    WORD_ATOM(318, 24, "trace-sig!");
+    WORD_ATOM(319, 24, "trace-sig!");
     mw_Type_2E_trace_sig_21_();
     WORD_EXIT(mb_Type_2E_trace_sig_21__2);
 }
 
 static void mb_Type_2E_trace_sig_21__3 (void) {
-    WORD_ENTER(mb_Type_2E_trace_sig_21__3, "Type.trace-sig! block", "src/mirth/data/type.mth", 318, 36);
+    WORD_ENTER(mb_Type_2E_trace_sig_21__3, "Type.trace-sig! block", "src/mirth/data/type.mth", 319, 36);
     mw_prim_drop();
-    WORD_ATOM(318, 36, "trace!");
+    WORD_ATOM(319, 36, "trace!");
     mw_MetaVar_2E_trace_21_();
     WORD_EXIT(mb_Type_2E_trace_sig_21__3);
 }
 
 static void mb_MetaVar_2E_freshen_1 (void) {
-    WORD_ENTER(mb_MetaVar_2E_freshen_1, "MetaVar.freshen block", "src/mirth/data/type.mth", 391, 15);
+    WORD_ENTER(mb_MetaVar_2E_freshen_1, "MetaVar.freshen block", "src/mirth/data/type.mth", 392, 15);
     mw_prim_drop();
-    WORD_ATOM(391, 15, "freshen");
+    WORD_ATOM(392, 15, "freshen");
     mw_Type_2E_freshen();
     WORD_EXIT(mb_MetaVar_2E_freshen_1);
 }
 
 static void mb_MetaVar_2E_freshen_2 (void) {
-    WORD_ENTER(mb_MetaVar_2E_freshen_2, "MetaVar.freshen block", "src/mirth/data/type.mth", 391, 24);
+    WORD_ENTER(mb_MetaVar_2E_freshen_2, "MetaVar.freshen block", "src/mirth/data/type.mth", 392, 24);
     mw_prim_drop();
-    WORD_ATOM(391, 24, "drop");
+    WORD_ATOM(392, 24, "drop");
     mw_prim_drop();
-    WORD_ATOM(391, 29, "MetaVar.new!");
+    WORD_ATOM(392, 29, "MetaVar.new!");
     mw_MetaVar_2E_new_21_();
-    WORD_ATOM(391, 42, "TMeta");
+    WORD_ATOM(392, 42, "TMeta");
     mw_TMeta();
     WORD_EXIT(mb_MetaVar_2E_freshen_2);
 }
 
 static void mb_Type_2E_arity_2 (void) {
-    WORD_ENTER(mb_Type_2E_arity_2, "Type.arity block", "src/mirth/data/type.mth", 437, 24);
+    WORD_ENTER(mb_Type_2E_arity_2, "Type.arity block", "src/mirth/data/type.mth", 438, 24);
     mw_prim_drop();
-    WORD_ATOM(437, 24, "arity");
+    WORD_ATOM(438, 24, "arity");
     mw_Type_2E_arity();
     WORD_EXIT(mb_Type_2E_arity_2);
 }
 
 static void mb_Type_2E_arity_3 (void) {
-    WORD_ENTER(mb_Type_2E_arity_3, "Type.arity block", "src/mirth/data/type.mth", 437, 31);
+    WORD_ENTER(mb_Type_2E_arity_3, "Type.arity block", "src/mirth/data/type.mth", 438, 31);
     mw_prim_drop();
-    WORD_ATOM(437, 31, "drop");
+    WORD_ATOM(438, 31, "drop");
     mw_prim_drop();
-    WORD_ATOM(437, 36, "");
+    WORD_ATOM(438, 36, "");
     push_i64(0LL);
     WORD_EXIT(mb_Type_2E_arity_3);
 }
 
 static void mb_MetaVar_2E_expand_1 (void) {
-    WORD_ENTER(mb_MetaVar_2E_expand_1, "MetaVar.expand block", "src/mirth/data/type.mth", 493, 15);
+    WORD_ENTER(mb_MetaVar_2E_expand_1, "MetaVar.expand block", "src/mirth/data/type.mth", 494, 15);
     mw_prim_drop();
-    WORD_ATOM(493, 15, "id");
+    WORD_ATOM(494, 15, "id");
     mw_prim_id();
     WORD_EXIT(mb_MetaVar_2E_expand_1);
 }
 
 static void mb_MetaVar_2E_expand_2 (void) {
-    WORD_ENTER(mb_MetaVar_2E_expand_2, "MetaVar.expand block", "src/mirth/data/type.mth", 493, 19);
+    WORD_ENTER(mb_MetaVar_2E_expand_2, "MetaVar.expand block", "src/mirth/data/type.mth", 494, 19);
     mw_prim_drop();
-    WORD_ATOM(493, 19, "TMeta");
+    WORD_ATOM(494, 19, "TMeta");
     mw_TMeta();
     WORD_EXIT(mb_MetaVar_2E_expand_2);
 }
 
 static void mb_MetaVar_3D__1 (void) {
-    WORD_ENTER(mb_MetaVar_3D__1, "MetaVar= block", "src/mirth/data/type.mth", 511, 45);
+    WORD_ENTER(mb_MetaVar_3D__1, "MetaVar= block", "src/mirth/data/type.mth", 512, 45);
     mw_prim_drop();
-    WORD_ATOM(511, 45, ".id");
+    WORD_ATOM(512, 45, ".id");
     mw_MetaVar_2E_id();
     WORD_EXIT(mb_MetaVar_3D__1);
 }
 
 static void mb_Resource_2E_unify_21__1 (void) {
-    WORD_ENTER(mb_Resource_2E_unify_21__1, "Resource.unify! block", "src/mirth/data/type.mth", 551, 10);
+    WORD_ENTER(mb_Resource_2E_unify_21__1, "Resource.unify! block", "src/mirth/data/type.mth", 552, 10);
     mw_prim_drop();
-    WORD_ATOM(551, 10, ">Type");
+    WORD_ATOM(552, 10, ">Type");
     mw_Resource_3E_Type();
     WORD_EXIT(mb_Resource_2E_unify_21__1);
 }
 
 static void mb_StackType_2E_top_tycon_name_1 (void) {
-    WORD_ENTER(mb_StackType_2E_top_tycon_name_1, "StackType.top-tycon-name block", "src/mirth/data/type.mth", 624, 19);
+    WORD_ENTER(mb_StackType_2E_top_tycon_name_1, "StackType.top-tycon-name block", "src/mirth/data/type.mth", 625, 19);
     mw_prim_drop();
-    WORD_ATOM(624, 19, "tycon-name");
+    WORD_ATOM(625, 19, "tycon-name");
     mw_Type_2E_tycon_name();
     WORD_EXIT(mb_StackType_2E_top_tycon_name_1);
 }
 
 static void mb_StackType_2E_unify_failed_21__1 (void) {
-    WORD_ENTER(mb_StackType_2E_unify_failed_21__1, "StackType.unify-failed! block", "src/mirth/data/type.mth", 639, 9);
+    WORD_ENTER(mb_StackType_2E_unify_failed_21__1, "StackType.unify-failed! block", "src/mirth/data/type.mth", 640, 9);
     mw_prim_drop();
-    WORD_ATOM(639, 9, ">Type");
+    WORD_ATOM(640, 9, ">Type");
     mw_StackType_3E_Type();
     WORD_EXIT(mb_StackType_2E_unify_failed_21__1);
 }
 
 static void mb_StackType_2E_unify_21__30 (void) {
-    WORD_ENTER(mb_StackType_2E_unify_21__30, "StackType.unify! block", "src/mirth/data/type.mth", 670, 17);
+    WORD_ENTER(mb_StackType_2E_unify_21__30, "StackType.unify! block", "src/mirth/data/type.mth", 671, 17);
     mw_prim_drop();
-    WORD_ATOM(670, 17, "nip");
+    WORD_ATOM(671, 17, "nip");
     mw_nip();
-    WORD_ATOM(670, 21, "unpack2");
+    WORD_ATOM(671, 21, "unpack2");
     mw_unpack2();
-    WORD_ATOM(670, 29, "dip");
+    WORD_ATOM(671, 29, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(670, 33, "swap");
+        WORD_ATOM(671, 33, "swap");
         mw_prim_swap();
-        WORD_ATOM(670, 38, "dip");
+        WORD_ATOM(671, 38, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(670, 42, "unify!");
+            WORD_ATOM(671, 42, "unify!");
             mw_StackType_2E_unify_21_();
-            WORD_ATOM(670, 49, "swap");
+            WORD_ATOM(671, 49, "swap");
             mw_prim_swap();
             push_value(d3);
         }
         push_value(d2);
     }
-    WORD_ATOM(670, 56, "unify!");
+    WORD_ATOM(671, 56, "unify!");
     mw_Type_2E_unify_21_();
-    WORD_ATOM(670, 63, "dip");
+    WORD_ATOM(671, 63, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(670, 67, "swap");
+        WORD_ATOM(671, 67, "swap");
         mw_prim_swap();
         push_value(d2);
     }
-    WORD_ATOM(670, 73, "STCons");
+    WORD_ATOM(671, 73, "STCons");
     mw_STCons();
     WORD_EXIT(mb_StackType_2E_unify_21__30);
 }
 
 static void mb_StackType_2E_unify_21__34 (void) {
-    WORD_ENTER(mb_StackType_2E_unify_21__34, "StackType.unify! block", "src/mirth/data/type.mth", 671, 17);
+    WORD_ENTER(mb_StackType_2E_unify_21__34, "StackType.unify! block", "src/mirth/data/type.mth", 672, 17);
     mw_prim_drop();
-    WORD_ATOM(671, 17, "dip");
+    WORD_ATOM(672, 17, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(671, 21, "STCons");
+        WORD_ATOM(672, 21, "STCons");
         mw_STCons();
         push_value(d2);
     }
-    WORD_ATOM(671, 29, "unify-failed!");
+    WORD_ATOM(672, 29, "unify-failed!");
     mw_StackType_2E_unify_failed_21_();
     WORD_EXIT(mb_StackType_2E_unify_21__34);
 }
 
 static void mb_StackType_2E_unify_21__42 (void) {
-    WORD_ENTER(mb_StackType_2E_unify_21__42, "StackType.unify! block", "src/mirth/data/type.mth", 679, 17);
+    WORD_ENTER(mb_StackType_2E_unify_21__42, "StackType.unify! block", "src/mirth/data/type.mth", 680, 17);
     mw_prim_drop();
-    WORD_ATOM(679, 17, "nip");
+    WORD_ATOM(680, 17, "nip");
     mw_nip();
-    WORD_ATOM(679, 21, "unpack2");
+    WORD_ATOM(680, 21, "unpack2");
     mw_unpack2();
-    WORD_ATOM(679, 29, "dip");
+    WORD_ATOM(680, 29, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(679, 33, "swap");
+        WORD_ATOM(680, 33, "swap");
         mw_prim_swap();
-        WORD_ATOM(679, 38, "dip");
+        WORD_ATOM(680, 38, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(679, 42, "unify!");
+            WORD_ATOM(680, 42, "unify!");
             mw_StackType_2E_unify_21_();
-            WORD_ATOM(679, 49, "swap");
+            WORD_ATOM(680, 49, "swap");
             mw_prim_swap();
             push_value(d3);
         }
         push_value(d2);
     }
-    WORD_ATOM(679, 56, "unify!");
+    WORD_ATOM(680, 56, "unify!");
     mw_Resource_2E_unify_21_();
-    WORD_ATOM(679, 63, "dip");
+    WORD_ATOM(680, 63, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(679, 67, "swap");
+        WORD_ATOM(680, 67, "swap");
         mw_prim_swap();
         push_value(d2);
     }
-    WORD_ATOM(679, 73, "STWith");
+    WORD_ATOM(680, 73, "STWith");
     mw_STWith();
     WORD_EXIT(mb_StackType_2E_unify_21__42);
 }
 
 static void mb_StackType_2E_unify_21__46 (void) {
-    WORD_ENTER(mb_StackType_2E_unify_21__46, "StackType.unify! block", "src/mirth/data/type.mth", 680, 17);
+    WORD_ENTER(mb_StackType_2E_unify_21__46, "StackType.unify! block", "src/mirth/data/type.mth", 681, 17);
     mw_prim_drop();
-    WORD_ATOM(680, 17, "dip");
+    WORD_ATOM(681, 17, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(680, 21, "STWith");
+        WORD_ATOM(681, 21, "STWith");
         mw_STWith();
         push_value(d2);
     }
-    WORD_ATOM(680, 29, "unify-failed!");
+    WORD_ATOM(681, 29, "unify-failed!");
     mw_StackType_2E_unify_failed_21_();
     WORD_EXIT(mb_StackType_2E_unify_21__46);
 }
 
 static void mb_StackType_2E_force_cons_3F__21__3 (void) {
-    WORD_ENTER(mb_StackType_2E_force_cons_3F__21__3, "StackType.force-cons?! block", "src/mirth/data/type.mth", 688, 41);
+    WORD_ENTER(mb_StackType_2E_force_cons_3F__21__3, "StackType.force-cons?! block", "src/mirth/data/type.mth", 689, 41);
     mw_prim_drop();
-    WORD_ATOM(688, 41, "unpack2");
+    WORD_ATOM(689, 41, "unpack2");
     mw_unpack2();
-    WORD_ATOM(688, 49, "dip");
+    WORD_ATOM(689, 49, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(688, 53, "over");
+        WORD_ATOM(689, 53, "over");
         mw_over();
-        WORD_ATOM(688, 58, "STWith");
+        WORD_ATOM(689, 58, "STWith");
         mw_STWith();
         push_value(d2);
     }
-    WORD_ATOM(688, 66, "pack2");
+    WORD_ATOM(689, 66, "pack2");
     mw_pack2();
     WORD_EXIT(mb_StackType_2E_force_cons_3F__21__3);
 }
 
 static void mb_StackType_2E_force_with_3F__21__3 (void) {
-    WORD_ENTER(mb_StackType_2E_force_with_3F__21__3, "StackType.force-with?! block", "src/mirth/data/type.mth", 700, 41);
+    WORD_ENTER(mb_StackType_2E_force_with_3F__21__3, "StackType.force-with?! block", "src/mirth/data/type.mth", 701, 41);
     mw_prim_drop();
-    WORD_ATOM(700, 41, "unpack2");
+    WORD_ATOM(701, 41, "unpack2");
     mw_unpack2();
-    WORD_ATOM(700, 49, "dip");
+    WORD_ATOM(701, 49, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(700, 53, "over");
+        WORD_ATOM(701, 53, "over");
         mw_over();
-        WORD_ATOM(700, 58, "STCons");
+        WORD_ATOM(701, 58, "STCons");
         mw_STCons();
         push_value(d2);
     }
-    WORD_ATOM(700, 66, "pack2");
+    WORD_ATOM(701, 66, "pack2");
     mw_pack2();
     WORD_EXIT(mb_StackType_2E_force_with_3F__21__3);
 }
 
-static void mb_StackType_2E_trace_base_21__2 (void) {
-    WORD_ENTER(mb_StackType_2E_trace_base_21__2, "StackType.trace-base! block", "src/mirth/data/type.mth", 725, 48);
+static void mb_StackType_2E_trace_base_21__4 (void) {
+    WORD_ENTER(mb_StackType_2E_trace_base_21__4, "StackType.trace-base! block", "src/mirth/data/type.mth", 728, 44);
     mw_prim_drop();
-    WORD_ATOM(725, 48, "");
+    WORD_ATOM(728, 44, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36510,44 +36779,40 @@ static void mb_StackType_2E_trace_base_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(725, 53, "trace!");
+    WORD_ATOM(728, 49, "trace!");
     mw_Str_2E_trace_21_();
-    WORD_EXIT(mb_StackType_2E_trace_base_21__2);
+    WORD_EXIT(mb_StackType_2E_trace_base_21__4);
 }
 
 static void mb_StackType_2E_trace_21__1 (void) {
-    WORD_ENTER(mb_StackType_2E_trace_21__1, "StackType.trace! block", "src/mirth/data/type.mth", 731, 10);
+    WORD_ENTER(mb_StackType_2E_trace_21__1, "StackType.trace! block", "src/mirth/data/type.mth", 734, 10);
     mw_prim_drop();
-    WORD_ATOM(731, 10, "trace-base!");
+    WORD_ATOM(734, 10, "trace-base!");
     mw_StackType_2E_trace_base_21_();
     WORD_EXIT(mb_StackType_2E_trace_21__1);
 }
 
 static void mb_StackType_2E_trace_21__3 (void) {
-    WORD_ENTER(mb_StackType_2E_trace_21__3, "StackType.trace! block", "src/mirth/data/type.mth", 732, 13);
+    WORD_ENTER(mb_StackType_2E_trace_21__3, "StackType.trace! block", "src/mirth/data/type.mth", 735, 13);
     mw_prim_drop();
-    WORD_ATOM(732, 13, "");
-    {
-        static bool vready = false;
-        static VAL v;
-        if (! vready) {
-            v = mkstr(" ", 1);
-            vready = true;
-        }
-        push_value(v);
-        incref(v);
-    }
-    WORD_ATOM(732, 17, "trace!");
-    mw_Str_2E_trace_21_();
-    WORD_ATOM(732, 24, "trace!");
+    WORD_ATOM(735, 13, "swap");
+    mw_prim_swap();
+    WORD_ATOM(735, 18, "then");
+    push_u64(0);
+    push_fnptr(&mb_StackType_2E_trace_21__4);
+    mw_prim_pack_cons();
+    mw_Bool_2E_then();
+    WORD_ATOM(735, 35, "trace!");
     mw_Type_2E_trace_21_();
+    WORD_ATOM(735, 42, "T");
+    mw_T();
     WORD_EXIT(mb_StackType_2E_trace_21__3);
 }
 
 static void mb_StackType_2E_trace_21__4 (void) {
-    WORD_ENTER(mb_StackType_2E_trace_21__4, "StackType.trace! block", "src/mirth/data/type.mth", 733, 17);
+    WORD_ENTER(mb_StackType_2E_trace_21__4, "StackType.trace! block", "src/mirth/data/type.mth", 735, 23);
     mw_prim_drop();
-    WORD_ATOM(733, 17, "");
+    WORD_ATOM(735, 23, "");
     {
         static bool vready = false;
         static VAL v;
@@ -36558,57 +36823,91 @@ static void mb_StackType_2E_trace_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(733, 21, "trace!");
+    WORD_ATOM(735, 27, "trace!");
     mw_Str_2E_trace_21_();
-    WORD_ATOM(733, 28, "trace!");
-    mw_Resource_2E_trace_21_();
     WORD_EXIT(mb_StackType_2E_trace_21__4);
 }
 
-static void mb_StackType_2E_num_morphisms_on_top_2 (void) {
-    WORD_ENTER(mb_StackType_2E_num_morphisms_on_top_2, "StackType.num-morphisms-on-top block", "src/mirth/data/type.mth", 787, 25);
+static void mb_StackType_2E_trace_21__5 (void) {
+    WORD_ENTER(mb_StackType_2E_trace_21__5, "StackType.trace! block", "src/mirth/data/type.mth", 736, 17);
     mw_prim_drop();
-    WORD_ATOM(787, 25, ">StackType");
+    WORD_ATOM(736, 17, "swap");
+    mw_prim_swap();
+    WORD_ATOM(736, 22, "then");
+    push_u64(0);
+    push_fnptr(&mb_StackType_2E_trace_21__6);
+    mw_prim_pack_cons();
+    mw_Bool_2E_then();
+    WORD_ATOM(736, 39, "trace!");
+    mw_Resource_2E_trace_21_();
+    WORD_ATOM(736, 46, "T");
+    mw_T();
+    WORD_EXIT(mb_StackType_2E_trace_21__5);
+}
+
+static void mb_StackType_2E_trace_21__6 (void) {
+    WORD_ENTER(mb_StackType_2E_trace_21__6, "StackType.trace! block", "src/mirth/data/type.mth", 736, 27);
+    mw_prim_drop();
+    WORD_ATOM(736, 27, "");
+    {
+        static bool vready = false;
+        static VAL v;
+        if (! vready) {
+            v = mkstr(" ", 1);
+            vready = true;
+        }
+        push_value(v);
+        incref(v);
+    }
+    WORD_ATOM(736, 31, "trace!");
+    mw_Str_2E_trace_21_();
+    WORD_EXIT(mb_StackType_2E_trace_21__6);
+}
+
+static void mb_StackType_2E_num_morphisms_on_top_2 (void) {
+    WORD_ENTER(mb_StackType_2E_num_morphisms_on_top_2, "StackType.num-morphisms-on-top block", "src/mirth/data/type.mth", 790, 25);
+    mw_prim_drop();
+    WORD_ATOM(790, 25, ">StackType");
     mw_Type_3E_StackType();
-    WORD_ATOM(787, 36, "num-morphisms-on-top");
+    WORD_ATOM(790, 36, "num-morphisms-on-top");
     mw_StackType_2E_num_morphisms_on_top();
     WORD_EXIT(mb_StackType_2E_num_morphisms_on_top_2);
 }
 
 static void mb_StackType_2E_num_morphisms_on_top_3 (void) {
-    WORD_ENTER(mb_StackType_2E_num_morphisms_on_top_3, "StackType.num-morphisms-on-top block", "src/mirth/data/type.mth", 787, 58);
+    WORD_ENTER(mb_StackType_2E_num_morphisms_on_top_3, "StackType.num-morphisms-on-top block", "src/mirth/data/type.mth", 790, 58);
     mw_prim_drop();
-    WORD_ATOM(787, 58, "drop");
+    WORD_ATOM(790, 58, "drop");
     mw_prim_drop();
-    WORD_ATOM(787, 63, "");
+    WORD_ATOM(790, 63, "");
     push_i64(0LL);
     WORD_EXIT(mb_StackType_2E_num_morphisms_on_top_3);
 }
 
 static void mb_StackType_2E_num_morphisms_on_top_5 (void) {
-    WORD_ENTER(mb_StackType_2E_num_morphisms_on_top_5, "StackType.num-morphisms-on-top block", "src/mirth/data/type.mth", 788, 29);
+    WORD_ENTER(mb_StackType_2E_num_morphisms_on_top_5, "StackType.num-morphisms-on-top block", "src/mirth/data/type.mth", 791, 29);
     mw_prim_drop();
-    WORD_ATOM(788, 29, "num-morphisms-on-top");
+    WORD_ATOM(791, 29, "num-morphisms-on-top");
     mw_StackType_2E_num_morphisms_on_top();
-    WORD_ATOM(788, 50, "1+");
+    WORD_ATOM(791, 50, "1+");
     mw_prim_int_succ();
     WORD_EXIT(mb_StackType_2E_num_morphisms_on_top_5);
 }
 
 static void mb_StackType_2E_num_morphisms_on_top_6 (void) {
-    WORD_ENTER(mb_StackType_2E_num_morphisms_on_top_6, "StackType.num-morphisms-on-top block", "src/mirth/data/type.mth", 788, 54);
+    WORD_ENTER(mb_StackType_2E_num_morphisms_on_top_6, "StackType.num-morphisms-on-top block", "src/mirth/data/type.mth", 791, 54);
     mw_prim_drop();
-    WORD_ATOM(788, 54, "drop");
+    WORD_ATOM(791, 54, "drop");
     mw_prim_drop();
-    WORD_ATOM(788, 59, "");
+    WORD_ATOM(791, 59, "");
     push_i64(0LL);
     WORD_EXIT(mb_StackType_2E_num_morphisms_on_top_6);
 }
 
 static void mb_ArrowType_2E_semifreshen_sig_1 (void) {
-    WORD_ENTER(mb_ArrowType_2E_semifreshen_sig_1, "ArrowType.semifreshen-sig block", "src/mirth/data/type.mth", 818, 38);
+    WORD_ENTER(mb_ArrowType_2E_semifreshen_sig_1, "ArrowType.semifreshen-sig block", "src/mirth/data/type.mth", 821, 38);
     mw_prim_drop();
-    WORD_ATOM(818, 38, "semifreshen-aux");
+    WORD_ATOM(821, 38, "semifreshen-aux");
     mw_ArrowType_2E_semifreshen_aux();
     WORD_EXIT(mb_ArrowType_2E_semifreshen_sig_1);
 }
@@ -37062,20 +37361,27 @@ static void mb_elab_type_sig_params_21__3 (void) {
     WORD_EXIT(mb_elab_type_sig_params_21__3);
 }
 
-static void mb_elab_type_atom_21__10 (void) {
-    WORD_ENTER(mb_elab_type_atom_21__10, "elab-type-atom! block", "src/mirth/elab.mth", 102, 9);
+static void mb_elab_type_atom_21__19 (void) {
+    WORD_ENTER(mb_elab_type_atom_21__19, "elab-type-atom! block", "src/mirth/elab.mth", 112, 9);
     mw_prim_drop();
-    WORD_ATOM(102, 9, "elab-type-quote!");
+    WORD_ATOM(112, 9, "elab-type-quote!");
     mw_elab_type_quote_21_();
-    WORD_EXIT(mb_elab_type_atom_21__10);
+    WORD_ATOM(112, 26, "dip");
+    {
+        VAL d2 = pop_value();
+        WORD_ATOM(112, 30, "LEFT");
+        mw_LEFT();
+        push_value(d2);
+    }
+    WORD_EXIT(mb_elab_type_atom_21__19);
 }
 
-static void mb_elab_type_atom_21__11 (void) {
-    WORD_ENTER(mb_elab_type_atom_21__11, "elab-type-atom! block", "src/mirth/elab.mth", 104, 9);
+static void mb_elab_type_atom_21__21 (void) {
+    WORD_ENTER(mb_elab_type_atom_21__21, "elab-type-atom! block", "src/mirth/elab.mth", 114, 9);
     mw_prim_drop();
-    WORD_ATOM(104, 9, "dup");
+    WORD_ATOM(114, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(104, 13, "");
+    WORD_ATOM(114, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -37086,130 +37392,132 @@ static void mb_elab_type_atom_21__11 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(104, 49, "emit-error!");
+    WORD_ATOM(114, 49, "emit-error!");
     mw_emit_error_21_();
-    WORD_ATOM(105, 9, "dip");
+    WORD_ATOM(115, 9, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(105, 13, "TYPE_ERROR");
+        WORD_ATOM(115, 13, "TYPE_ERROR");
         mw_TYPE_5F_ERROR();
+        WORD_ATOM(115, 24, "LEFT");
+        mw_LEFT();
         push_value(d2);
     }
-    WORD_ATOM(105, 25, "next");
+    WORD_ATOM(115, 30, "next");
     mw_Token_2E_next();
-    WORD_EXIT(mb_elab_type_atom_21__11);
+    WORD_EXIT(mb_elab_type_atom_21__21);
 }
 
 static void mb_elab_implicit_var_21__1 (void) {
-    WORD_ENTER(mb_elab_implicit_var_21__1, "elab-implicit-var! block", "src/mirth/elab.mth", 115, 10);
+    WORD_ENTER(mb_elab_implicit_var_21__1, "elab-implicit-var! block", "src/mirth/elab.mth", 128, 10);
     mw_prim_drop();
-    WORD_ATOM(115, 10, "type-elab-ctx?");
+    WORD_ATOM(128, 10, "type-elab-ctx?");
     mw_type_elab_ctx_3F_();
     WORD_EXIT(mb_elab_implicit_var_21__1);
 }
 
 static void mb_elab_implicit_var_21__2 (void) {
-    WORD_ENTER(mb_elab_implicit_var_21__2, "elab-implicit-var! block", "src/mirth/elab.mth", 116, 10);
+    WORD_ENTER(mb_elab_implicit_var_21__2, "elab-implicit-var! block", "src/mirth/elab.mth", 129, 10);
     mw_prim_drop();
-    WORD_ATOM(116, 10, "name?");
+    WORD_ATOM(129, 10, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(116, 16, "unwrap");
+    WORD_ATOM(129, 16, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(116, 23, "dup2");
+    WORD_ATOM(129, 23, "dup2");
     mw_dup2();
-    WORD_ATOM(116, 28, "swap");
+    WORD_ATOM(129, 28, "swap");
     mw_prim_swap();
-    WORD_ATOM(116, 33, "lookup");
+    WORD_ATOM(129, 33, "lookup");
     mw_Ctx_2E_lookup();
     WORD_EXIT(mb_elab_implicit_var_21__2);
 }
 
 static void mb_elab_implicit_var_21__4 (void) {
-    WORD_ENTER(mb_elab_implicit_var_21__4, "elab-implicit-var! block", "src/mirth/elab.mth", 119, 23);
+    WORD_ENTER(mb_elab_implicit_var_21__4, "elab-implicit-var! block", "src/mirth/elab.mth", 132, 23);
     mw_prim_drop();
-    WORD_ATOM(119, 23, "nip");
+    WORD_ATOM(132, 23, "nip");
     mw_nip();
-    WORD_ATOM(119, 27, "dup");
+    WORD_ATOM(132, 27, "dup");
     mw_prim_dup();
-    WORD_ATOM(119, 31, "type");
+    WORD_ATOM(132, 31, "type");
     mw_Var_2E_type();
     WORD_EXIT(mb_elab_implicit_var_21__4);
 }
 
 static void mb_elab_implicit_var_21__7 (void) {
-    WORD_ENTER(mb_elab_implicit_var_21__7, "elab-implicit-var! block", "src/mirth/elab.mth", 124, 21);
+    WORD_ENTER(mb_elab_implicit_var_21__7, "elab-implicit-var! block", "src/mirth/elab.mth", 137, 21);
     mw_prim_drop();
-    WORD_ATOM(124, 21, "Ctx.new");
+    WORD_ATOM(137, 21, "Ctx.new");
     mw_Ctx_2E_new();
     WORD_EXIT(mb_elab_implicit_var_21__7);
 }
 
 static void mb_elab_implicit_var_21__8 (void) {
-    WORD_ENTER(mb_elab_implicit_var_21__8, "elab-implicit-var! block", "src/mirth/elab.mth", 128, 10);
+    WORD_ENTER(mb_elab_implicit_var_21__8, "elab-implicit-var! block", "src/mirth/elab.mth", 141, 10);
     mw_prim_drop();
-    WORD_ATOM(128, 10, "type-elab-ctx-replace");
+    WORD_ATOM(141, 10, "type-elab-ctx-replace");
     mw_type_elab_ctx_replace();
     WORD_EXIT(mb_elab_implicit_var_21__8);
 }
 
 static void mb_elab_type_unify_21__1 (void) {
-    WORD_ENTER(mb_elab_type_unify_21__1, "elab-type-unify! block", "src/mirth/elab.mth", 188, 9);
+    WORD_ENTER(mb_elab_type_unify_21__1, "elab-type-unify! block", "src/mirth/elab.mth", 204, 9);
     mw_prim_drop();
-    WORD_ATOM(188, 9, "GAMMA");
+    WORD_ATOM(204, 9, "GAMMA");
     mw_GAMMA();
-    WORD_ATOM(188, 15, "rotr");
+    WORD_ATOM(204, 15, "rotr");
     mw_rotr();
-    WORD_ATOM(188, 20, "unify!");
+    WORD_ATOM(204, 20, "unify!");
     mw_Type_2E_unify_21_();
-    WORD_ATOM(188, 27, "nip");
+    WORD_ATOM(204, 27, "nip");
     mw_nip();
     WORD_EXIT(mb_elab_type_unify_21__1);
 }
 
 static void mb_elab_stack_type_unify_21__1 (void) {
-    WORD_ENTER(mb_elab_stack_type_unify_21__1, "elab-stack-type-unify! block", "src/mirth/elab.mth", 190, 9);
+    WORD_ENTER(mb_elab_stack_type_unify_21__1, "elab-stack-type-unify! block", "src/mirth/elab.mth", 206, 9);
     mw_prim_drop();
-    WORD_ATOM(190, 9, "GAMMA");
+    WORD_ATOM(206, 9, "GAMMA");
     mw_GAMMA();
-    WORD_ATOM(190, 15, "rotr");
+    WORD_ATOM(206, 15, "rotr");
     mw_rotr();
-    WORD_ATOM(190, 20, "unify!");
+    WORD_ATOM(206, 20, "unify!");
     mw_StackType_2E_unify_21_();
-    WORD_ATOM(190, 27, "nip");
+    WORD_ATOM(206, 27, "nip");
     mw_nip();
     WORD_EXIT(mb_elab_stack_type_unify_21__1);
 }
 
 static void mb_ab_build_21__2 (void) {
-    WORD_ENTER(mb_ab_build_21__2, "ab-build! block", "src/mirth/elab.mth", 215, 9);
+    WORD_ENTER(mb_ab_build_21__2, "ab-build! block", "src/mirth/elab.mth", 231, 9);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(215, 9, "Arrow.alloc!");
+    WORD_ATOM(231, 9, "Arrow.alloc!");
     mw_Arrow_2E_alloc_21_();
-    WORD_ATOM(216, 9, "ab-home");
+    WORD_ATOM(232, 9, "ab-home");
     mw_ab_home();
-    WORD_ATOM(216, 17, "@");
+    WORD_ATOM(232, 17, "@");
     mw_prim_mut_get();
-    WORD_ATOM(216, 19, "over");
+    WORD_ATOM(232, 19, "over");
     mw_over();
-    WORD_ATOM(216, 24, "~home");
+    WORD_ATOM(232, 24, "~home");
     mw_Arrow_7E_home();
-    WORD_ATOM(216, 30, "!");
+    WORD_ATOM(232, 30, "!");
     mw_prim_mut_set();
-    WORD_ATOM(217, 9, "ab-homeidx");
+    WORD_ATOM(233, 9, "ab-homeidx");
     mw_ab_homeidx();
-    WORD_ATOM(217, 20, "@");
+    WORD_ATOM(233, 20, "@");
     mw_prim_mut_get();
-    WORD_ATOM(217, 22, "over");
+    WORD_ATOM(233, 22, "over");
     mw_over();
-    WORD_ATOM(217, 27, "~homeidx");
+    WORD_ATOM(233, 27, "~homeidx");
     mw_Arrow_7E_homeidx();
-    WORD_ATOM(217, 36, "!");
+    WORD_ATOM(233, 36, "!");
     mw_prim_mut_set();
-    WORD_ATOM(218, 9, "ab-homeidx");
+    WORD_ATOM(234, 9, "ab-homeidx");
     mw_ab_homeidx();
-    WORD_ATOM(218, 20, "modify");
+    WORD_ATOM(234, 20, "modify");
     push_u64(0);
     incref(var_f);
     push_value(var_f);
@@ -37217,101 +37525,101 @@ static void mb_ab_build_21__2 (void) {
     push_fnptr(&mb_ab_build_21__3);
     mw_prim_pack_cons();
     mw_modify();
-    WORD_ATOM(219, 9, "tuck");
+    WORD_ATOM(235, 9, "tuck");
     mw_tuck();
-    WORD_ATOM(219, 14, "dup2");
+    WORD_ATOM(235, 14, "dup2");
     mw_dup2();
-    WORD_ATOM(219, 19, "~token-start");
+    WORD_ATOM(235, 19, "~token-start");
     mw_Arrow_7E_token_start();
-    WORD_ATOM(219, 32, "!");
+    WORD_ATOM(235, 32, "!");
     mw_prim_mut_set();
-    WORD_ATOM(219, 34, "~token-end");
+    WORD_ATOM(235, 34, "~token-end");
     mw_Arrow_7E_token_end();
-    WORD_ATOM(219, 45, "!");
+    WORD_ATOM(235, 45, "!");
     mw_prim_mut_set();
-    WORD_ATOM(220, 9, "tuck");
+    WORD_ATOM(236, 9, "tuck");
     mw_tuck();
-    WORD_ATOM(220, 14, "dup2");
+    WORD_ATOM(236, 14, "dup2");
     mw_dup2();
-    WORD_ATOM(220, 19, "~dom");
+    WORD_ATOM(236, 19, "~dom");
     mw_Arrow_7E_dom();
-    WORD_ATOM(220, 24, "!");
+    WORD_ATOM(236, 24, "!");
     mw_prim_mut_set();
-    WORD_ATOM(220, 26, "~cod");
+    WORD_ATOM(236, 26, "~cod");
     mw_Arrow_7E_cod();
-    WORD_ATOM(220, 31, "!");
+    WORD_ATOM(236, 31, "!");
     mw_prim_mut_set();
-    WORD_ATOM(221, 9, "tuck");
+    WORD_ATOM(237, 9, "tuck");
     mw_tuck();
-    WORD_ATOM(221, 14, "~ctx");
+    WORD_ATOM(237, 14, "~ctx");
     mw_Arrow_7E_ctx();
-    WORD_ATOM(221, 19, "!");
+    WORD_ATOM(237, 19, "!");
     mw_prim_mut_set();
-    WORD_ATOM(222, 9, "L0");
+    WORD_ATOM(238, 9, "L0");
     mw_L0();
-    WORD_ATOM(222, 12, "over");
+    WORD_ATOM(238, 12, "over");
     mw_over();
-    WORD_ATOM(222, 17, "~atoms");
+    WORD_ATOM(238, 17, "~atoms");
     mw_Arrow_7E_atoms();
-    WORD_ATOM(222, 24, "!");
+    WORD_ATOM(238, 24, "!");
     mw_prim_mut_set();
-    WORD_ATOM(223, 9, "ab-arrow");
+    WORD_ATOM(239, 9, "ab-arrow");
     mw_ab_arrow();
-    WORD_ATOM(223, 18, "!");
+    WORD_ATOM(239, 18, "!");
     mw_prim_mut_set();
-    WORD_ATOM(224, 9, "f");
+    WORD_ATOM(240, 9, "f");
     incref(var_f);
     run_value(var_f);
-    WORD_ATOM(225, 9, "ab-arrow");
+    WORD_ATOM(241, 9, "ab-arrow");
     mw_ab_arrow();
-    WORD_ATOM(225, 18, "@");
+    WORD_ATOM(241, 18, "@");
     mw_prim_mut_get();
     decref(var_f);
     WORD_EXIT(mb_ab_build_21__2);
 }
 
 static void mb_ab_build_21__3 (void) {
-    WORD_ENTER(mb_ab_build_21__3, "ab-build! block", "src/mirth/elab.mth", 218, 27);
+    WORD_ENTER(mb_ab_build_21__3, "ab-build! block", "src/mirth/elab.mth", 234, 27);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(218, 27, "1+");
+    WORD_ATOM(234, 27, "1+");
     mw_prim_int_succ();
     decref(var_f);
     WORD_EXIT(mb_ab_build_21__3);
 }
 
 static void mb_ab_build_hom_21__3 (void) {
-    WORD_ENTER(mb_ab_build_hom_21__3, "ab-build-hom! block", "src/mirth/elab.mth", 233, 15);
+    WORD_ENTER(mb_ab_build_hom_21__3, "ab-build-hom! block", "src/mirth/elab.mth", 249, 15);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(233, 15, "f");
+    WORD_ATOM(249, 15, "f");
     incref(var_f);
     run_value(var_f);
-    WORD_ATOM(233, 17, "ab-unify-type!");
+    WORD_ATOM(249, 17, "ab-unify-type!");
     mw_ab_unify_type_21_();
     decref(var_f);
     WORD_EXIT(mb_ab_build_hom_21__3);
 }
 
 static void mb_ab_build_word_arrow_21__2 (void) {
-    WORD_ENTER(mb_ab_build_word_arrow_21__2, "ab-build-word-arrow! block", "src/mirth/elab.mth", 236, 9);
+    WORD_ENTER(mb_ab_build_word_arrow_21__2, "ab-build-word-arrow! block", "src/mirth/elab.mth", 252, 9);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(236, 9, "elab-word-ctx-type-weak!");
+    WORD_ATOM(252, 9, "elab-word-ctx-type-weak!");
     mw_elab_word_ctx_type_weak_21_();
     decref(var_f);
     WORD_EXIT(mb_ab_build_word_arrow_21__2);
 }
 
 static void mb_ab_build_word_21__2 (void) {
-    WORD_ENTER(mb_ab_build_word_21__2, "ab-build-word! block", "src/mirth/elab.mth", 240, 9);
+    WORD_ENTER(mb_ab_build_word_21__2, "ab-build-word! block", "src/mirth/elab.mth", 256, 9);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(240, 9, "ab-build-word-arrow!");
+    WORD_ATOM(256, 9, "ab-build-word-arrow!");
     push_u64(0);
     incref(var_f);
     push_value(var_f);
@@ -37319,21 +37627,21 @@ static void mb_ab_build_word_21__2 (void) {
     push_fnptr(&mb_ab_build_word_21__3);
     mw_prim_pack_cons();
     mw_ab_build_word_arrow_21_();
-    WORD_ATOM(240, 38, "ready");
+    WORD_ATOM(256, 38, "ready");
     mw_ready();
     decref(var_f);
     WORD_EXIT(mb_ab_build_word_21__2);
 }
 
 static void mb_ab_build_word_21__3 (void) {
-    WORD_ENTER(mb_ab_build_word_21__3, "ab-build-word! block", "src/mirth/elab.mth", 240, 30);
+    WORD_ENTER(mb_ab_build_word_21__3, "ab-build-word! block", "src/mirth/elab.mth", 256, 30);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(240, 30, "dip");
+    WORD_ATOM(256, 30, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(240, 34, "f");
+        WORD_ATOM(256, 34, "f");
         incref(var_f);
         run_value(var_f);
         push_value(d2);
@@ -37343,158 +37651,158 @@ static void mb_ab_build_word_21__3 (void) {
 }
 
 static void mb_ab_optimized_snoc_21__2 (void) {
-    WORD_ENTER(mb_ab_optimized_snoc_21__2, "ab-optimized-snoc! block", "src/mirth/elab.mth", 258, 16);
+    WORD_ENTER(mb_ab_optimized_snoc_21__2, "ab-optimized-snoc! block", "src/mirth/elab.mth", 274, 16);
     mw_prim_drop();
-    WORD_ATOM(258, 16, "atoms-has-last-block?");
+    WORD_ATOM(274, 16, "atoms-has-last-block?");
     mw_atoms_has_last_block_3F_();
     WORD_EXIT(mb_ab_optimized_snoc_21__2);
 }
 
 static void mb_ab_optimized_snoc_21__3 (void) {
-    WORD_ENTER(mb_ab_optimized_snoc_21__3, "ab-optimized-snoc! block", "src/mirth/elab.mth", 258, 43);
+    WORD_ENTER(mb_ab_optimized_snoc_21__3, "ab-optimized-snoc! block", "src/mirth/elab.mth", 274, 43);
     mw_prim_drop();
-    WORD_ATOM(258, 43, "atom-accepts-args?");
+    WORD_ATOM(274, 43, "atom-accepts-args?");
     mw_atom_accepts_args_3F_();
     WORD_EXIT(mb_ab_optimized_snoc_21__3);
 }
 
 static void mb_ab_lambda_21__3 (void) {
-    WORD_ENTER(mb_ab_lambda_21__3, "ab-lambda! block", "src/mirth/elab.mth", 374, 9);
+    WORD_ENTER(mb_ab_lambda_21__3, "ab-lambda! block", "src/mirth/elab.mth", 390, 9);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(374, 9, "swap");
+    WORD_ATOM(390, 9, "swap");
     mw_prim_swap();
-    WORD_ATOM(374, 14, "dip");
+    WORD_ATOM(390, 14, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(374, 18, ">Var");
+        WORD_ATOM(390, 18, ">Var");
         mw_Param_3E_Var();
-        WORD_ATOM(374, 23, "dup");
+        WORD_ATOM(390, 23, "dup");
         mw_prim_dup();
-        WORD_ATOM(374, 27, "dip");
+        WORD_ATOM(390, 27, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(374, 31, "Ctx.new");
+            WORD_ATOM(390, 31, "Ctx.new");
             mw_Ctx_2E_new();
             push_value(d3);
         }
         push_value(d2);
     }
-    WORD_ATOM(375, 9, "ab-token");
+    WORD_ATOM(391, 9, "ab-token");
     mw_ab_token();
-    WORD_ATOM(375, 18, "@");
+    WORD_ATOM(391, 18, "@");
     mw_prim_mut_get();
-    WORD_ATOM(375, 20, "elab-expand-tensor!");
+    WORD_ATOM(391, 20, "elab-expand-tensor!");
     mw_elab_expand_tensor_21_();
-    WORD_ATOM(376, 9, "dip");
+    WORD_ATOM(392, 9, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(376, 13, "rotl");
+        WORD_ATOM(392, 13, "rotl");
         mw_rotl();
-        WORD_ATOM(376, 18, "type");
+        WORD_ATOM(392, 18, "type");
         mw_Var_2E_type();
         push_value(d2);
     }
-    WORD_ATOM(376, 24, "elab-type-unify!");
+    WORD_ATOM(392, 24, "elab-type-unify!");
     mw_elab_type_unify_21_();
-    WORD_ATOM(376, 41, "drop2");
+    WORD_ATOM(392, 41, "drop2");
     mw_drop2();
     decref(var_f);
     WORD_EXIT(mb_ab_lambda_21__3);
 }
 
 static void mb_ab_lambda_21__7 (void) {
-    WORD_ENTER(mb_ab_lambda_21__7, "ab-lambda! block", "src/mirth/elab.mth", 387, 9);
+    WORD_ENTER(mb_ab_lambda_21__7, "ab-lambda! block", "src/mirth/elab.mth", 403, 9);
     mw_prim_pack_uncons();
     VAL var_f = pop_value();
     mw_prim_drop();
-    WORD_ATOM(387, 9, "dip");
+    WORD_ATOM(403, 9, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(387, 13, "f");
+        WORD_ATOM(403, 13, "f");
         incref(var_f);
         run_value(var_f);
         push_value(d2);
     }
-    WORD_ATOM(388, 9, "ab-type");
+    WORD_ATOM(404, 9, "ab-type");
     mw_ab_type();
-    WORD_ATOM(388, 17, "@");
+    WORD_ATOM(404, 17, "@");
     mw_prim_mut_get();
-    WORD_ATOM(388, 19, "over");
+    WORD_ATOM(404, 19, "over");
     mw_over();
-    WORD_ATOM(388, 24, "~cod");
+    WORD_ATOM(404, 24, "~cod");
     mw_Lambda_7E_cod();
-    WORD_ATOM(388, 29, "!");
+    WORD_ATOM(404, 29, "!");
     mw_prim_mut_set();
     decref(var_f);
     WORD_EXIT(mb_ab_lambda_21__7);
 }
 
 static void mb_elab_match_sig_21__1 (void) {
-    WORD_ENTER(mb_elab_match_sig_21__1, "elab-match-sig! block", "src/mirth/elab.mth", 421, 9);
+    WORD_ENTER(mb_elab_match_sig_21__1, "elab-match-sig! block", "src/mirth/elab.mth", 437, 9);
     mw_prim_drop();
-    WORD_ATOM(421, 9, "dom");
+    WORD_ATOM(437, 9, "dom");
     mw_Match_2E_dom();
     WORD_EXIT(mb_elab_match_sig_21__1);
 }
 
 static void mb_elab_lambda_sig_21__1 (void) {
-    WORD_ENTER(mb_elab_lambda_sig_21__1, "elab-lambda-sig! block", "src/mirth/elab.mth", 424, 9);
+    WORD_ENTER(mb_elab_lambda_sig_21__1, "elab-lambda-sig! block", "src/mirth/elab.mth", 440, 9);
     mw_prim_drop();
-    WORD_ATOM(424, 9, "dom");
+    WORD_ATOM(440, 9, "dom");
     mw_Lambda_2E_dom();
     WORD_EXIT(mb_elab_lambda_sig_21__1);
 }
 
 static void mb_elab_arrow_fwd_21__1 (void) {
-    WORD_ENTER(mb_elab_arrow_fwd_21__1, "elab-arrow-fwd! block", "src/mirth/elab.mth", 453, 15);
+    WORD_ENTER(mb_elab_arrow_fwd_21__1, "elab-arrow-fwd! block", "src/mirth/elab.mth", 469, 15);
     mw_prim_drop();
-    WORD_ATOM(453, 15, "elab-atoms!");
+    WORD_ATOM(469, 15, "elab-atoms!");
     mw_elab_atoms_21_();
     WORD_EXIT(mb_elab_arrow_fwd_21__1);
 }
 
 static void mb_elab_atoms_21__3 (void) {
-    WORD_ENTER(mb_elab_atoms_21__3, "elab-atoms! block", "src/mirth/elab.mth", 458, 36);
+    WORD_ENTER(mb_elab_atoms_21__3, "elab-atoms! block", "src/mirth/elab.mth", 474, 36);
     mw_prim_drop();
-    WORD_ATOM(458, 36, "next");
+    WORD_ATOM(474, 36, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_atoms_21__3);
 }
 
 static void mb_elab_args_21__1 (void) {
-    WORD_ENTER(mb_elab_args_21__1, "elab-args! block", "src/mirth/elab.mth", 481, 25);
+    WORD_ENTER(mb_elab_args_21__1, "elab-args! block", "src/mirth/elab.mth", 497, 25);
     mw_prim_drop();
-    WORD_ATOM(481, 25, "elab-block-at!");
+    WORD_ATOM(497, 25, "elab-block-at!");
     mw_elab_block_at_21_();
     WORD_EXIT(mb_elab_args_21__1);
 }
 
 static void mb_elab_relativize_name_21__1 (void) {
-    WORD_ENTER(mb_elab_relativize_name_21__1, "elab-relativize-name! block", "src/mirth/elab.mth", 496, 25);
+    WORD_ENTER(mb_elab_relativize_name_21__1, "elab-relativize-name! block", "src/mirth/elab.mth", 512, 25);
     mw_prim_drop();
-    WORD_ATOM(496, 25, "dup");
+    WORD_ATOM(512, 25, "dup");
     mw_prim_dup();
-    WORD_ATOM(496, 29, "could-be-relative");
+    WORD_ATOM(512, 29, "could-be-relative");
     mw_Name_2E_could_be_relative();
     WORD_EXIT(mb_elab_relativize_name_21__1);
 }
 
 static void mb_elab_relativize_name_21__3 (void) {
-    WORD_ENTER(mb_elab_relativize_name_21__3, "elab-relativize-name! block", "src/mirth/elab.mth", 498, 13);
+    WORD_ENTER(mb_elab_relativize_name_21__3, "elab-relativize-name! block", "src/mirth/elab.mth", 514, 13);
     mw_prim_drop();
-    WORD_ATOM(498, 13, ">Str");
+    WORD_ATOM(514, 13, ">Str");
     mw_Name_3E_Str();
-    WORD_ATOM(498, 18, "over");
+    WORD_ATOM(514, 18, "over");
     mw_over();
-    WORD_ATOM(498, 23, "to-overload-suffix");
+    WORD_ATOM(514, 23, "to-overload-suffix");
     mw_Name_2E_to_overload_suffix();
-    WORD_ATOM(498, 42, "cat");
+    WORD_ATOM(514, 42, "cat");
     mw_prim_str_cat();
-    WORD_ATOM(498, 46, "Name.search");
+    WORD_ATOM(514, 46, "Name.search");
     mw_Name_2E_search();
-    WORD_ATOM(498, 58, "for");
+    WORD_ATOM(514, 58, "for");
     push_u64(0);
     push_fnptr(&mb_elab_relativize_name_21__4);
     mw_prim_pack_cons();
@@ -37503,34 +37811,34 @@ static void mb_elab_relativize_name_21__3 (void) {
 }
 
 static void mb_elab_relativize_name_21__4 (void) {
-    WORD_ENTER(mb_elab_relativize_name_21__4, "elab-relativize-name! block", "src/mirth/elab.mth", 499, 17);
+    WORD_ENTER(mb_elab_relativize_name_21__4, "elab-relativize-name! block", "src/mirth/elab.mth", 515, 17);
     mw_prim_drop();
-    WORD_ATOM(499, 17, "name-defined?");
+    WORD_ATOM(515, 17, "name-defined?");
     mw_name_defined_3F_();
-    WORD_ATOM(499, 31, "if");
+    WORD_ATOM(515, 31, "if");
     if (pop_u64()) {
-        WORD_ATOM(500, 21, "nip");
+        WORD_ATOM(516, 21, "nip");
         mw_nip();
     } else {
-        WORD_ATOM(501, 21, "drop");
+        WORD_ATOM(517, 21, "drop");
         mw_prim_drop();
     }
     WORD_EXIT(mb_elab_relativize_name_21__4);
 }
 
 static void mb_elab_check_name_visible_21__1 (void) {
-    WORD_ENTER(mb_elab_check_name_visible_21__1, "elab-check-name-visible! block", "src/mirth/elab.mth", 510, 9);
+    WORD_ENTER(mb_elab_check_name_visible_21__1, "elab-check-name-visible! block", "src/mirth/elab.mth", 526, 9);
     mw_prim_drop();
-    WORD_ATOM(510, 9, "dup");
+    WORD_ATOM(526, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(510, 13, "elab-module-is-visible");
+    WORD_ATOM(526, 13, "elab-module-is-visible");
     mw_elab_module_is_visible();
-    WORD_ATOM(510, 36, "if");
+    WORD_ATOM(526, 36, "if");
     if (pop_u64()) {
-        WORD_ATOM(510, 39, "drop");
+        WORD_ATOM(526, 39, "drop");
         mw_prim_drop();
     } else {
-        WORD_ATOM(511, 13, "");
+        WORD_ATOM(527, 13, "");
         {
             static bool vready = false;
             static VAL v;
@@ -37541,34 +37849,34 @@ static void mb_elab_check_name_visible_21__1 (void) {
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(511, 46, "swap");
+        WORD_ATOM(527, 46, "swap");
         mw_prim_swap();
-        WORD_ATOM(511, 51, "name");
+        WORD_ATOM(527, 51, "name");
         mw_Module_2E_name();
-        WORD_ATOM(511, 56, ">Str");
+        WORD_ATOM(527, 56, ">Str");
         mw_Name_3E_Str();
-        WORD_ATOM(511, 61, "cat");
+        WORD_ATOM(527, 61, "cat");
         mw_prim_str_cat();
-        WORD_ATOM(512, 13, "ab-token");
+        WORD_ATOM(528, 13, "ab-token");
         mw_ab_token();
-        WORD_ATOM(512, 22, "@");
+        WORD_ATOM(528, 22, "@");
         mw_prim_mut_get();
-        WORD_ATOM(512, 24, "swap");
+        WORD_ATOM(528, 24, "swap");
         mw_prim_swap();
-        WORD_ATOM(512, 29, "emit-error!");
+        WORD_ATOM(528, 29, "emit-error!");
         mw_emit_error_21_();
     }
     WORD_EXIT(mb_elab_check_name_visible_21__1);
 }
 
 static void mb_elab_match_exhaustive_21__1 (void) {
-    WORD_ENTER(mb_elab_match_exhaustive_21__1, "elab-match-exhaustive! block", "src/mirth/elab.mth", 659, 9);
+    WORD_ENTER(mb_elab_match_exhaustive_21__1, "elab-match-exhaustive! block", "src/mirth/elab.mth", 675, 9);
     mw_prim_drop();
-    WORD_ATOM(659, 9, "dup");
+    WORD_ATOM(675, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(659, 13, "token");
+    WORD_ATOM(675, 13, "token");
     mw_Match_2E_token();
-    WORD_ATOM(659, 19, "");
+    WORD_ATOM(675, 19, "");
     {
         static bool vready = false;
         static VAL v;
@@ -37579,43 +37887,43 @@ static void mb_elab_match_exhaustive_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(659, 51, "emit-error!");
+    WORD_ATOM(675, 51, "emit-error!");
     mw_emit_error_21_();
     WORD_EXIT(mb_elab_match_exhaustive_21__1);
 }
 
 static void mb_elab_lambda_params_21__5 (void) {
-    WORD_ENTER(mb_elab_lambda_params_21__5, "elab-lambda-params! block", "src/mirth/elab.mth", 633, 13);
+    WORD_ENTER(mb_elab_lambda_params_21__5, "elab-lambda-params! block", "src/mirth/elab.mth", 649, 13);
     mw_prim_drop();
-    WORD_ATOM(633, 13, "dup");
+    WORD_ATOM(649, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(633, 17, "sig-type-var?");
+    WORD_ATOM(649, 17, "sig-type-var?");
     mw_Token_2E_sig_type_var_3F_();
-    WORD_ATOM(633, 31, "if");
+    WORD_ATOM(649, 31, "if");
     if (pop_u64()) {
-        WORD_ATOM(634, 17, "name?");
+        WORD_ATOM(650, 17, "name?");
         mw_Token_2E_name_3F_();
-        WORD_ATOM(634, 23, "unwrap");
+        WORD_ATOM(650, 23, "unwrap");
         mw_Maybe_2E_unwrap();
-        WORD_ATOM(634, 30, "Var.new!");
+        WORD_ATOM(650, 30, "Var.new!");
         mw_Var_2E_new_21_();
     } else {
-        WORD_ATOM(636, 17, "succ");
+        WORD_ATOM(652, 17, "succ");
         mw_Token_2E_succ();
-        WORD_ATOM(636, 22, "dip");
+        WORD_ATOM(652, 22, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(636, 26, "expand");
+            WORD_ATOM(652, 26, "expand");
             mw_Type_2E_expand();
-            WORD_ATOM(636, 33, "dup");
+            WORD_ATOM(652, 33, "dup");
             mw_prim_dup();
-            WORD_ATOM(636, 37, "morphism?");
+            WORD_ATOM(652, 37, "morphism?");
             mw_Type_2E_morphism_3F_();
             push_value(d3);
         }
-        WORD_ATOM(636, 48, "swap");
+        WORD_ATOM(652, 48, "swap");
         mw_prim_swap();
-        WORD_ATOM(636, 53, ".if");
+        WORD_ATOM(652, 53, ".if");
         push_u64(0);
         push_fnptr(&mb_elab_lambda_params_21__9);
         mw_prim_pack_cons();
@@ -37624,56 +37932,56 @@ static void mb_elab_lambda_params_21__5 (void) {
         mw_prim_pack_cons();
         mw_Maybe_2E_if();
     }
-    WORD_ATOM(642, 13, "dip");
+    WORD_ATOM(658, 13, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(642, 17, "dup");
+        WORD_ATOM(658, 17, "dup");
         mw_prim_dup();
-        WORD_ATOM(642, 21, "params");
+        WORD_ATOM(658, 21, "params");
         mw_Lambda_2E_params();
         push_value(d2);
     }
-    WORD_ATOM(642, 29, "sip");
+    WORD_ATOM(658, 29, "sip");
     push_u64(0);
     push_fnptr(&mb_elab_lambda_params_21__12);
     mw_prim_pack_cons();
     mw_sip();
-    WORD_ATOM(643, 13, "dip");
+    WORD_ATOM(659, 13, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(643, 17, "dup");
+        WORD_ATOM(659, 17, "dup");
         mw_prim_dup();
-        WORD_ATOM(643, 21, "inner-ctx");
+        WORD_ATOM(659, 21, "inner-ctx");
         mw_Lambda_2E_inner_ctx();
         push_value(d2);
     }
-    WORD_ATOM(643, 32, "Ctx.new");
+    WORD_ATOM(659, 32, "Ctx.new");
     mw_Ctx_2E_new();
-    WORD_ATOM(643, 40, "over");
+    WORD_ATOM(659, 40, "over");
     mw_over();
-    WORD_ATOM(643, 45, "~inner-ctx");
+    WORD_ATOM(659, 45, "~inner-ctx");
     mw_Lambda_7E_inner_ctx();
-    WORD_ATOM(643, 56, "!");
+    WORD_ATOM(659, 56, "!");
     mw_prim_mut_set();
     WORD_EXIT(mb_elab_lambda_params_21__5);
 }
 
 static void mb_elab_lambda_params_21__9 (void) {
-    WORD_ENTER(mb_elab_lambda_params_21__9, "elab-lambda-params! block", "src/mirth/elab.mth", 637, 21);
+    WORD_ENTER(mb_elab_lambda_params_21__9, "elab-lambda-params! block", "src/mirth/elab.mth", 653, 21);
     mw_prim_drop();
-    WORD_ATOM(637, 21, "name?");
+    WORD_ATOM(653, 21, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(637, 27, "unwrap");
+    WORD_ATOM(653, 27, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(637, 34, "Var.new-auto-run!");
+    WORD_ATOM(653, 34, "Var.new-auto-run!");
     mw_Var_2E_new_auto_run_21_();
     WORD_EXIT(mb_elab_lambda_params_21__9);
 }
 
 static void mb_elab_lambda_params_21__10 (void) {
-    WORD_ENTER(mb_elab_lambda_params_21__10, "elab-lambda-params! block", "src/mirth/elab.mth", 639, 21);
+    WORD_ENTER(mb_elab_lambda_params_21__10, "elab-lambda-params! block", "src/mirth/elab.mth", 655, 21);
     mw_prim_drop();
-    WORD_ATOM(639, 21, "");
+    WORD_ATOM(655, 21, "");
     {
         static bool vready = false;
         static VAL v;
@@ -37684,93 +37992,93 @@ static void mb_elab_lambda_params_21__10 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(639, 59, "emit-fatal-error!");
+    WORD_ATOM(655, 59, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_lambda_params_21__10);
 }
 
 static void mb_elab_lambda_params_21__12 (void) {
-    WORD_ENTER(mb_elab_lambda_params_21__12, "elab-lambda-params! block", "src/mirth/elab.mth", 642, 33);
+    WORD_ENTER(mb_elab_lambda_params_21__12, "elab-lambda-params! block", "src/mirth/elab.mth", 658, 33);
     mw_prim_drop();
-    WORD_ATOM(642, 33, "Var>Param");
+    WORD_ATOM(658, 33, "Var>Param");
     mw_Var_3E_Param();
-    WORD_ATOM(642, 43, "swap");
+    WORD_ATOM(658, 43, "swap");
     mw_prim_swap();
-    WORD_ATOM(642, 48, "cons");
+    WORD_ATOM(658, 48, "cons");
     mw_List_2E_cons();
-    WORD_ATOM(642, 53, "over");
+    WORD_ATOM(658, 53, "over");
     mw_over();
-    WORD_ATOM(642, 58, "~params");
+    WORD_ATOM(658, 58, "~params");
     mw_Lambda_7E_params();
-    WORD_ATOM(642, 66, "!");
+    WORD_ATOM(658, 66, "!");
     mw_prim_mut_set();
     WORD_EXIT(mb_elab_lambda_params_21__12);
 }
 
 static void mb_elab_lambda_pop_from_mid_21__2 (void) {
-    WORD_ENTER(mb_elab_lambda_pop_from_mid_21__2, "elab-lambda-pop-from-mid! block", "src/mirth/elab.mth", 611, 10);
+    WORD_ENTER(mb_elab_lambda_pop_from_mid_21__2, "elab-lambda-pop-from-mid! block", "src/mirth/elab.mth", 627, 10);
     mw_prim_drop();
-    WORD_ATOM(611, 10, "over");
+    WORD_ATOM(627, 10, "over");
     mw_over();
-    WORD_ATOM(611, 15, "~mid");
+    WORD_ATOM(627, 15, "~mid");
     mw_Lambda_7E_mid();
-    WORD_ATOM(611, 20, "!");
+    WORD_ATOM(627, 20, "!");
     mw_prim_mut_set();
     WORD_EXIT(mb_elab_lambda_pop_from_mid_21__2);
 }
 
 static void mb_token_is_lambda_param_3F__3 (void) {
-    WORD_ENTER(mb_token_is_lambda_param_3F__3, "token-is-lambda-param? block", "src/mirth/elab.mth", 617, 9);
+    WORD_ENTER(mb_token_is_lambda_param_3F__3, "token-is-lambda-param? block", "src/mirth/elab.mth", 633, 9);
     mw_prim_drop();
-    WORD_ATOM(617, 9, "dup");
+    WORD_ATOM(633, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(617, 13, "T");
+    WORD_ATOM(633, 13, "T");
     mw_T();
-    WORD_ATOM(618, 9, "dip");
+    WORD_ATOM(634, 9, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(618, 13, "succ");
+        WORD_ATOM(634, 13, "succ");
         mw_Token_2E_succ();
-        WORD_ATOM(618, 18, "dup");
+        WORD_ATOM(634, 18, "dup");
         mw_prim_dup();
-        WORD_ATOM(618, 22, "sig-type-var?");
+        WORD_ATOM(634, 22, "sig-type-var?");
         mw_Token_2E_sig_type_var_3F_();
         push_value(d2);
     }
-    WORD_ATOM(618, 37, "&&");
+    WORD_ATOM(634, 37, "&&");
     mw_Bool_26__26_();
-    WORD_ATOM(619, 9, "dip");
+    WORD_ATOM(635, 9, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(619, 13, "succ");
+        WORD_ATOM(635, 13, "succ");
         mw_Token_2E_succ();
-        WORD_ATOM(619, 18, "dup");
+        WORD_ATOM(635, 18, "dup");
         mw_prim_dup();
-        WORD_ATOM(619, 22, "rsquare?");
+        WORD_ATOM(635, 22, "rsquare?");
         mw_Token_2E_rsquare_3F_();
-        WORD_ATOM(619, 31, "some?");
+        WORD_ATOM(635, 31, "some?");
         mw_Maybe_2E_some_3F_();
         push_value(d2);
     }
-    WORD_ATOM(619, 38, "&&");
+    WORD_ATOM(635, 38, "&&");
     mw_Bool_26__26_();
-    WORD_ATOM(620, 9, "nip");
+    WORD_ATOM(636, 9, "nip");
     mw_nip();
     WORD_EXIT(mb_token_is_lambda_param_3F__3);
 }
 
 static void mb_token_is_lambda_param_3F__6 (void) {
-    WORD_ENTER(mb_token_is_lambda_param_3F__6, "token-is-lambda-param? block", "src/mirth/elab.mth", 621, 9);
+    WORD_ENTER(mb_token_is_lambda_param_3F__6, "token-is-lambda-param? block", "src/mirth/elab.mth", 637, 9);
     mw_prim_drop();
-    WORD_ATOM(621, 9, "F");
+    WORD_ATOM(637, 9, "F");
     mw_F();
     WORD_EXIT(mb_token_is_lambda_param_3F__6);
 }
 
 static void mb_expect_token_arrow_1 (void) {
-    WORD_ENTER(mb_expect_token_arrow_1, "expect-token-arrow block", "src/mirth/elab.mth", 845, 25);
+    WORD_ENTER(mb_expect_token_arrow_1, "expect-token-arrow block", "src/mirth/elab.mth", 861, 25);
     mw_prim_drop();
-    WORD_ATOM(845, 25, "");
+    WORD_ATOM(861, 25, "");
     {
         static bool vready = false;
         static VAL v;
@@ -37781,105 +38089,105 @@ static void mb_expect_token_arrow_1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(845, 43, "emit-fatal-error!");
+    WORD_ATOM(861, 43, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_expect_token_arrow_1);
 }
 
 static void mb_elab_match_case_21__3 (void) {
-    WORD_ENTER(mb_elab_match_case_21__3, "elab-match-case! block", "src/mirth/elab.mth", 678, 21);
+    WORD_ENTER(mb_elab_match_case_21__3, "elab-match-case! block", "src/mirth/elab.mth", 694, 21);
     mw_prim_drop();
-    WORD_ATOM(678, 21, "succ");
+    WORD_ATOM(694, 21, "succ");
     mw_Token_2E_succ();
     WORD_EXIT(mb_elab_match_case_21__3);
 }
 
 static void mb_elab_case_pattern_21__6 (void) {
-    WORD_ENTER(mb_elab_case_pattern_21__6, "elab-case-pattern! block", "src/mirth/elab.mth", 694, 9);
+    WORD_ENTER(mb_elab_case_pattern_21__6, "elab-case-pattern! block", "src/mirth/elab.mth", 710, 9);
     mw_prim_drop();
-    WORD_ATOM(694, 9, ">Def");
+    WORD_ATOM(710, 9, ">Def");
     mw_Name_3E_Def();
-    WORD_ATOM(694, 14, "match");
+    WORD_ATOM(710, 14, "match");
     switch (get_top_data_tag()) {
         case 4LL:
             mw_prim_pack_uncons(); mw_prim_drop();
-            WORD_ATOM(698, 17, "dup");
+            WORD_ATOM(714, 17, "dup");
             mw_prim_dup();
-            WORD_ATOM(698, 21, "PATTERN_TAG");
+            WORD_ATOM(714, 21, "PATTERN_TAG");
             mw_PATTERN_5F_TAG();
-            WORD_ATOM(698, 33, "rotr");
+            WORD_ATOM(714, 33, "rotr");
             mw_rotr();
-            WORD_ATOM(699, 17, "dip2");
+            WORD_ATOM(715, 17, "dip2");
             push_u64(0);
             push_fnptr(&mb_elab_case_pattern_21__8);
             mw_prim_pack_cons();
             mw_dip2();
-            WORD_ATOM(702, 17, "dip2");
+            WORD_ATOM(718, 17, "dip2");
             push_u64(0);
             push_fnptr(&mb_elab_case_pattern_21__9);
             mw_prim_pack_cons();
             mw_dip2();
-            WORD_ATOM(703, 17, "type");
+            WORD_ATOM(719, 17, "type");
             mw_Tag_2E_type();
-            WORD_ATOM(703, 22, "Subst.nil");
+            WORD_ATOM(719, 22, "Subst.nil");
             mw_Subst_2E_nil();
-            WORD_ATOM(703, 32, "swap");
+            WORD_ATOM(719, 32, "swap");
             mw_prim_swap();
-            WORD_ATOM(703, 37, "freshen-sig");
+            WORD_ATOM(719, 37, "freshen-sig");
             mw_ArrowType_2E_freshen_sig();
-            WORD_ATOM(704, 17, "rotr");
+            WORD_ATOM(720, 17, "rotr");
             mw_rotr();
-            WORD_ATOM(704, 22, "dip");
+            WORD_ATOM(720, 22, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(705, 21, "dip");
+                WORD_ATOM(721, 21, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(705, 25, "unpack");
+                    WORD_ATOM(721, 25, "unpack");
                     mw_ArrowType_2E_unpack();
                     push_value(d5);
                 }
-                WORD_ATOM(706, 21, "dip2");
+                WORD_ATOM(722, 21, "dip2");
                 push_u64(0);
                 push_fnptr(&mb_elab_case_pattern_21__12);
                 mw_prim_pack_cons();
                 mw_dip2();
-                WORD_ATOM(706, 32, "elab-stack-type-unify!");
+                WORD_ATOM(722, 32, "elab-stack-type-unify!");
                 mw_elab_stack_type_unify_21_();
-                WORD_ATOM(706, 55, "nip");
+                WORD_ATOM(722, 55, "nip");
                 mw_nip();
-                WORD_ATOM(707, 21, "dip");
+                WORD_ATOM(723, 21, "dip");
                 {
                     VAL d5 = pop_value();
-                    WORD_ATOM(707, 25, "over");
+                    WORD_ATOM(723, 25, "over");
                     mw_over();
-                    WORD_ATOM(707, 30, "~mid");
+                    WORD_ATOM(723, 30, "~mid");
                     mw_Case_7E_mid();
-                    WORD_ATOM(707, 35, "!");
+                    WORD_ATOM(723, 35, "!");
                     mw_prim_mut_set();
                     push_value(d5);
                 }
                 push_value(d4);
             }
-            WORD_ATOM(709, 17, "swap");
+            WORD_ATOM(725, 17, "swap");
             mw_prim_swap();
-            WORD_ATOM(709, 22, "dip");
+            WORD_ATOM(725, 22, "dip");
             {
                 VAL d4 = pop_value();
-                WORD_ATOM(709, 26, "over");
+                WORD_ATOM(725, 26, "over");
                 mw_over();
-                WORD_ATOM(709, 31, "~subst");
+                WORD_ATOM(725, 31, "~subst");
                 mw_Case_7E_subst();
-                WORD_ATOM(709, 38, "!");
+                WORD_ATOM(725, 38, "!");
                 mw_prim_mut_set();
                 push_value(d4);
             }
-            WORD_ATOM(712, 17, "succ");
+            WORD_ATOM(728, 17, "succ");
             mw_Token_2E_succ();
             break;
         case 0LL:
             mw_prim_drop();
-            WORD_ATOM(715, 17, "");
+            WORD_ATOM(731, 17, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -37890,13 +38198,13 @@ static void mb_elab_case_pattern_21__6 (void) {
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(715, 40, "emit-fatal-error!");
+            WORD_ATOM(731, 40, "emit-fatal-error!");
             mw_emit_fatal_error_21_();
             break;
         default:
-            WORD_ATOM(718, 17, "drop");
+            WORD_ATOM(734, 17, "drop");
             mw_prim_drop();
-            WORD_ATOM(718, 22, "");
+            WORD_ATOM(734, 22, "");
             {
                 static bool vready = false;
                 static VAL v;
@@ -37907,7 +38215,7 @@ static void mb_elab_case_pattern_21__6 (void) {
                 push_value(v);
                 incref(v);
             }
-            WORD_ATOM(718, 43, "emit-fatal-error!");
+            WORD_ATOM(734, 43, "emit-fatal-error!");
             mw_emit_fatal_error_21_();
             break;
     
@@ -37915,9 +38223,9 @@ static void mb_elab_case_pattern_21__6 (void) {
 }
 
 static void mb_elab_case_pattern_21__17 (void) {
-    WORD_ENTER(mb_elab_case_pattern_21__17, "elab-case-pattern! block", "src/mirth/elab.mth", 721, 9);
+    WORD_ENTER(mb_elab_case_pattern_21__17, "elab-case-pattern! block", "src/mirth/elab.mth", 737, 9);
     mw_prim_drop();
-    WORD_ATOM(721, 9, "");
+    WORD_ATOM(737, 9, "");
     {
         static bool vready = false;
         static VAL v;
@@ -37928,79 +38236,79 @@ static void mb_elab_case_pattern_21__17 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(721, 38, "emit-fatal-error!");
+    WORD_ATOM(737, 38, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_case_pattern_21__17);
 }
 
 static void mb_elab_case_pattern_21__8 (void) {
-    WORD_ENTER(mb_elab_case_pattern_21__8, "elab-case-pattern! block", "src/mirth/elab.mth", 699, 22);
+    WORD_ENTER(mb_elab_case_pattern_21__8, "elab-case-pattern! block", "src/mirth/elab.mth", 715, 22);
     mw_prim_drop();
-    WORD_ATOM(699, 22, "over");
+    WORD_ATOM(715, 22, "over");
     mw_over();
-    WORD_ATOM(699, 27, "~pattern");
+    WORD_ATOM(715, 27, "~pattern");
     mw_Case_7E_pattern();
-    WORD_ATOM(699, 36, "!");
+    WORD_ATOM(715, 36, "!");
     mw_prim_mut_set();
     WORD_EXIT(mb_elab_case_pattern_21__8);
 }
 
 static void mb_elab_case_pattern_21__9 (void) {
-    WORD_ENTER(mb_elab_case_pattern_21__9, "elab-case-pattern! block", "src/mirth/elab.mth", 702, 22);
+    WORD_ENTER(mb_elab_case_pattern_21__9, "elab-case-pattern! block", "src/mirth/elab.mth", 718, 22);
     mw_prim_drop();
-    WORD_ATOM(702, 22, "dup");
+    WORD_ATOM(718, 22, "dup");
     mw_prim_dup();
-    WORD_ATOM(702, 26, ".match");
+    WORD_ATOM(718, 26, ".match");
     mw_Case_2E_match();
-    WORD_ATOM(702, 33, "dom");
+    WORD_ATOM(718, 33, "dom");
     mw_Match_2E_dom();
     WORD_EXIT(mb_elab_case_pattern_21__9);
 }
 
 static void mb_elab_case_pattern_21__12 (void) {
-    WORD_ENTER(mb_elab_case_pattern_21__12, "elab-case-pattern! block", "src/mirth/elab.mth", 706, 26);
+    WORD_ENTER(mb_elab_case_pattern_21__12, "elab-case-pattern! block", "src/mirth/elab.mth", 722, 26);
     mw_prim_drop();
-    WORD_ATOM(706, 26, "swap");
+    WORD_ATOM(722, 26, "swap");
     mw_prim_swap();
     WORD_EXIT(mb_elab_case_pattern_21__12);
 }
 
 static void mb_elab_case_body_21__4 (void) {
-    WORD_ENTER(mb_elab_case_body_21__4, "elab-case-body! block", "src/mirth/elab.mth", 728, 10);
+    WORD_ENTER(mb_elab_case_body_21__4, "elab-case-body! block", "src/mirth/elab.mth", 744, 10);
     mw_prim_drop();
-    WORD_ATOM(728, 10, "over");
+    WORD_ATOM(744, 10, "over");
     mw_over();
-    WORD_ATOM(728, 15, "~body");
+    WORD_ATOM(744, 15, "~body");
     mw_Case_7E_body();
-    WORD_ATOM(728, 21, "!");
+    WORD_ATOM(744, 21, "!");
     mw_prim_mut_set();
     WORD_EXIT(mb_elab_case_body_21__4);
 }
 
 static void mb_elab_case_body_21__5 (void) {
-    WORD_ENTER(mb_elab_case_body_21__5, "elab-case-body! block", "src/mirth/elab.mth", 729, 10);
+    WORD_ENTER(mb_elab_case_body_21__5, "elab-case-body! block", "src/mirth/elab.mth", 745, 10);
     mw_prim_drop();
-    WORD_ATOM(729, 10, "dup");
+    WORD_ATOM(745, 10, "dup");
     mw_prim_dup();
-    WORD_ATOM(729, 14, ".match");
+    WORD_ATOM(745, 14, ".match");
     mw_Case_2E_match();
-    WORD_ATOM(729, 21, "cod");
+    WORD_ATOM(745, 21, "cod");
     mw_Match_2E_cod();
     WORD_EXIT(mb_elab_case_body_21__5);
 }
 
 static void mb_elab_module_header_21__2 (void) {
-    WORD_ENTER(mb_elab_module_header_21__2, "elab-module-header! block", "src/mirth/elab.mth", 746, 13);
+    WORD_ENTER(mb_elab_module_header_21__2, "elab-module-header! block", "src/mirth/elab.mth", 762, 13);
     mw_prim_drop();
-    WORD_ATOM(746, 13, "next");
+    WORD_ATOM(762, 13, "next");
     mw_Token_2E_next();
     WORD_EXIT(mb_elab_module_header_21__2);
 }
 
 static void mb_elab_module_header_21__3 (void) {
-    WORD_ENTER(mb_elab_module_header_21__3, "elab-module-header! block", "src/mirth/elab.mth", 747, 29);
+    WORD_ENTER(mb_elab_module_header_21__3, "elab-module-header! block", "src/mirth/elab.mth", 763, 29);
     mw_prim_drop();
-    WORD_ATOM(747, 29, "");
+    WORD_ATOM(763, 29, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38011,17 +38319,17 @@ static void mb_elab_module_header_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(747, 53, "emit-fatal-error!");
+    WORD_ATOM(763, 53, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_module_header_21__3);
 }
 
 static void mb_elab_module_header_21__4 (void) {
-    WORD_ENTER(mb_elab_module_header_21__4, "elab-module-header! block", "src/mirth/elab.mth", 748, 28);
+    WORD_ENTER(mb_elab_module_header_21__4, "elab-module-header! block", "src/mirth/elab.mth", 764, 28);
     mw_prim_drop();
-    WORD_ATOM(748, 28, "drop");
+    WORD_ATOM(764, 28, "drop");
     mw_prim_drop();
-    WORD_ATOM(748, 33, "");
+    WORD_ATOM(764, 33, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38032,15 +38340,15 @@ static void mb_elab_module_header_21__4 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(748, 62, "emit-fatal-error!");
+    WORD_ATOM(764, 62, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_module_header_21__4);
 }
 
 static void mb_elab_module_decl_21__1 (void) {
-    WORD_ENTER(mb_elab_module_decl_21__1, "elab-module-decl! block", "src/mirth/elab.mth", 761, 21);
+    WORD_ENTER(mb_elab_module_decl_21__1, "elab-module-decl! block", "src/mirth/elab.mth", 777, 21);
     mw_prim_drop();
-    WORD_ATOM(761, 21, "");
+    WORD_ATOM(777, 21, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38051,15 +38359,15 @@ static void mb_elab_module_decl_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(761, 43, "emit-fatal-error!");
+    WORD_ATOM(777, 43, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_module_decl_21__1);
 }
 
 static void mb_elab_module_decl_21__2 (void) {
-    WORD_ENTER(mb_elab_module_decl_21__2, "elab-module-decl! block", "src/mirth/elab.mth", 762, 26);
+    WORD_ENTER(mb_elab_module_decl_21__2, "elab-module-decl! block", "src/mirth/elab.mth", 778, 26);
     mw_prim_drop();
-    WORD_ATOM(762, 26, "");
+    WORD_ATOM(778, 26, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38070,15 +38378,15 @@ static void mb_elab_module_decl_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(762, 48, "emit-fatal-error!");
+    WORD_ATOM(778, 48, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_module_decl_21__2);
 }
 
 static void mb_elab_module_decl_21__3 (void) {
-    WORD_ENTER(mb_elab_module_decl_21__3, "elab-module-decl! block", "src/mirth/elab.mth", 763, 20);
+    WORD_ENTER(mb_elab_module_decl_21__3, "elab-module-decl! block", "src/mirth/elab.mth", 779, 20);
     mw_prim_drop();
-    WORD_ATOM(763, 20, "");
+    WORD_ATOM(779, 20, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38089,15 +38397,15 @@ static void mb_elab_module_decl_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(763, 42, "emit-fatal-error!");
+    WORD_ATOM(779, 42, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_module_decl_21__3);
 }
 
 static void mb_elab_data_header_21__1 (void) {
-    WORD_ENTER(mb_elab_data_header_21__1, "elab-data-header! block", "src/mirth/elab.mth", 805, 28);
+    WORD_ENTER(mb_elab_data_header_21__1, "elab-data-header! block", "src/mirth/elab.mth", 821, 28);
     mw_prim_drop();
-    WORD_ATOM(805, 28, "");
+    WORD_ATOM(821, 28, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38108,17 +38416,17 @@ static void mb_elab_data_header_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(805, 50, "emit-fatal-error!");
+    WORD_ATOM(821, 50, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_data_header_21__1);
 }
 
 static void mb_elab_data_header_21__2 (void) {
-    WORD_ENTER(mb_elab_data_header_21__2, "elab-data-header! block", "src/mirth/elab.mth", 806, 44);
+    WORD_ENTER(mb_elab_data_header_21__2, "elab-data-header! block", "src/mirth/elab.mth", 822, 44);
     mw_prim_drop();
-    WORD_ATOM(806, 44, "drop2");
+    WORD_ATOM(822, 44, "drop2");
     mw_drop2();
-    WORD_ATOM(806, 50, "");
+    WORD_ATOM(822, 50, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38129,15 +38437,15 @@ static void mb_elab_data_header_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(806, 79, "emit-fatal-error!");
+    WORD_ATOM(822, 79, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_data_header_21__2);
 }
 
 static void mb_elab_data_tag_21__1 (void) {
-    WORD_ENTER(mb_elab_data_tag_21__1, "elab-data-tag! block", "src/mirth/elab.mth", 815, 25);
+    WORD_ENTER(mb_elab_data_tag_21__1, "elab-data-tag! block", "src/mirth/elab.mth", 831, 25);
     mw_prim_drop();
-    WORD_ATOM(815, 25, "");
+    WORD_ATOM(831, 25, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38148,17 +38456,17 @@ static void mb_elab_data_tag_21__1 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(815, 54, "emit-fatal-error!");
+    WORD_ATOM(831, 54, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_data_tag_21__1);
 }
 
 static void mb_elab_data_tag_21__2 (void) {
-    WORD_ENTER(mb_elab_data_tag_21__2, "elab-data-tag! block", "src/mirth/elab.mth", 816, 26);
+    WORD_ENTER(mb_elab_data_tag_21__2, "elab-data-tag! block", "src/mirth/elab.mth", 832, 26);
     mw_prim_drop();
-    WORD_ATOM(816, 26, "drop");
+    WORD_ATOM(832, 26, "drop");
     mw_prim_drop();
-    WORD_ATOM(816, 31, "");
+    WORD_ATOM(832, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38169,83 +38477,90 @@ static void mb_elab_data_tag_21__2 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(816, 67, "emit-fatal-error!");
+    WORD_ATOM(832, 67, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_data_tag_21__2);
 }
 
 static void mb_elab_data_tag_21__9 (void) {
-    WORD_ENTER(mb_elab_data_tag_21__9, "elab-data-tag! block", "src/mirth/elab.mth", 833, 9);
+    WORD_ENTER(mb_elab_data_tag_21__9, "elab-data-tag! block", "src/mirth/elab.mth", 849, 9);
     mw_prim_drop();
-    WORD_ATOM(833, 9, "type-elab-default");
+    WORD_ATOM(849, 9, "type-elab-default");
     mw_type_elab_default();
-    WORD_ATOM(834, 9, "over");
+    WORD_ATOM(850, 9, "over");
     mw_over();
-    WORD_ATOM(834, 14, ".data");
+    WORD_ATOM(850, 14, ".data");
     mw_Tag_2E_data();
-    WORD_ATOM(834, 20, "head?");
+    WORD_ATOM(850, 20, "head?");
     mw_Data_2E_head_3F_();
-    WORD_ATOM(834, 26, "unwrap");
+    WORD_ATOM(850, 26, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(834, 33, "elab-type-atom!");
+    WORD_ATOM(850, 33, "elab-type-atom!");
     mw_elab_type_atom_21_();
-    WORD_ATOM(834, 49, "drop");
+    WORD_ATOM(850, 49, "drop");
     mw_prim_drop();
-    WORD_ATOM(834, 54, "T1");
-    mw_T1();
-    WORD_ATOM(835, 9, "dip");
+    WORD_ATOM(850, 54, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(835, 13, "T0");
+        WORD_ATOM(850, 58, "T0");
         mw_T0();
-        WORD_ATOM(835, 16, "rotl");
+        push_value(d2);
+    }
+    WORD_ATOM(850, 62, "T*+");
+    mw_T_2A__2B_();
+    WORD_ATOM(851, 9, "dip");
+    {
+        VAL d2 = pop_value();
+        WORD_ATOM(851, 13, "T0");
+        mw_T0();
+        WORD_ATOM(851, 16, "rotl");
         mw_rotl();
-        WORD_ATOM(835, 21, "sig?");
+        WORD_ATOM(851, 21, "sig?");
         mw_Tag_2E_sig_3F_();
-        WORD_ATOM(835, 26, "for");
+        WORD_ATOM(851, 26, "for");
         push_u64(0);
-        push_fnptr(&mb_elab_data_tag_21__11);
+        push_fnptr(&mb_elab_data_tag_21__12);
         mw_prim_pack_cons();
         mw_Maybe_2E_for();
         push_value(d2);
     }
-    WORD_ATOM(839, 9, "T->");
+    WORD_ATOM(855, 9, "T->");
     mw_T__3E_();
-    WORD_ATOM(839, 13, "dip");
+    WORD_ATOM(855, 13, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(839, 17, "type-elab-ctx");
+        WORD_ATOM(855, 17, "type-elab-ctx");
         mw_type_elab_ctx();
         push_value(d2);
     }
-    WORD_ATOM(839, 32, "pack2");
+    WORD_ATOM(855, 32, "pack2");
     mw_pack2();
     WORD_EXIT(mb_elab_data_tag_21__9);
 }
 
-static void mb_elab_data_tag_21__11 (void) {
-    WORD_ENTER(mb_elab_data_tag_21__11, "elab-data-tag! block", "src/mirth/elab.mth", 836, 13);
+static void mb_elab_data_tag_21__12 (void) {
+    WORD_ENTER(mb_elab_data_tag_21__12, "elab-data-tag! block", "src/mirth/elab.mth", 852, 13);
     mw_prim_drop();
-    WORD_ATOM(836, 13, "elab-type-stack-rest!");
+    WORD_ATOM(852, 13, "elab-type-stack-rest!");
     mw_elab_type_stack_rest_21_();
-    WORD_ATOM(837, 13, "dup");
+    WORD_ATOM(853, 13, "dup");
     mw_prim_dup();
-    WORD_ATOM(837, 17, "run-end?");
+    WORD_ATOM(853, 17, "run-end?");
     mw_Token_2E_run_end_3F_();
-    WORD_ATOM(837, 26, "else");
+    WORD_ATOM(853, 26, "else");
     push_u64(0);
-    push_fnptr(&mb_elab_data_tag_21__12);
+    push_fnptr(&mb_elab_data_tag_21__13);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(837, 65, "drop");
+    WORD_ATOM(853, 65, "drop");
     mw_prim_drop();
-    WORD_EXIT(mb_elab_data_tag_21__11);
+    WORD_EXIT(mb_elab_data_tag_21__12);
 }
 
-static void mb_elab_data_tag_21__12 (void) {
-    WORD_ENTER(mb_elab_data_tag_21__12, "elab-data-tag! block", "src/mirth/elab.mth", 837, 31);
+static void mb_elab_data_tag_21__13 (void) {
+    WORD_ENTER(mb_elab_data_tag_21__13, "elab-data-tag! block", "src/mirth/elab.mth", 853, 31);
     mw_prim_drop();
-    WORD_ATOM(837, 31, "");
+    WORD_ATOM(853, 31, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38256,42 +38571,42 @@ static void mb_elab_data_tag_21__12 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(837, 46, "emit-fatal-error!");
+    WORD_ATOM(853, 46, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
-    WORD_EXIT(mb_elab_data_tag_21__12);
+    WORD_EXIT(mb_elab_data_tag_21__13);
 }
 
-static void mb_elab_data_tag_21__14 (void) {
-    WORD_ENTER(mb_elab_data_tag_21__14, "elab-data-tag! block", "src/mirth/elab.mth", 842, 9);
+static void mb_elab_data_tag_21__15 (void) {
+    WORD_ENTER(mb_elab_data_tag_21__15, "elab-data-tag! block", "src/mirth/elab.mth", 858, 9);
     mw_prim_drop();
-    WORD_ATOM(842, 9, "num-inputs-from-sig");
+    WORD_ATOM(858, 9, "num-inputs-from-sig");
     mw_Tag_2E_num_inputs_from_sig();
-    WORD_EXIT(mb_elab_data_tag_21__14);
+    WORD_EXIT(mb_elab_data_tag_21__15);
 }
 
 static void mb_token_def_args_3 (void) {
-    WORD_ENTER(mb_token_def_args_3, "token-def-args block", "src/mirth/elab.mth", 857, 9);
+    WORD_ENTER(mb_token_def_args_3, "token-def-args block", "src/mirth/elab.mth", 873, 9);
     mw_prim_drop();
-    WORD_ATOM(857, 9, "over");
+    WORD_ATOM(873, 9, "over");
     mw_over();
-    WORD_ATOM(857, 14, "run-has-arrow?");
+    WORD_ATOM(873, 14, "run-has-arrow?");
     mw_Token_2E_run_has_arrow_3F_();
-    WORD_ATOM(857, 29, "if");
+    WORD_ATOM(873, 29, "if");
     if (pop_u64()) {
-        WORD_ATOM(858, 13, "cons+");
+        WORD_ATOM(874, 13, "cons+");
         mw_List_2B__2E_cons_2B_();
-        WORD_ATOM(858, 19, "dip");
+        WORD_ATOM(874, 19, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(858, 23, "NONE");
+            WORD_ATOM(874, 23, "NONE");
             mw_NONE();
             push_value(d3);
         }
     } else {
-        WORD_ATOM(859, 13, "dip");
+        WORD_ATOM(875, 13, "dip");
         {
             VAL d3 = pop_value();
-            WORD_ATOM(859, 17, "SOME");
+            WORD_ATOM(875, 17, "SOME");
             mw_SOME();
             push_value(d3);
         }
@@ -38300,14 +38615,14 @@ static void mb_token_def_args_3 (void) {
 }
 
 static void mb_token_def_args_8 (void) {
-    WORD_ENTER(mb_token_def_args_8, "token-def-args block", "src/mirth/elab.mth", 861, 9);
+    WORD_ENTER(mb_token_def_args_8, "token-def-args block", "src/mirth/elab.mth", 877, 9);
     mw_prim_drop();
-    WORD_ATOM(861, 9, "L1+");
+    WORD_ATOM(877, 9, "L1+");
     mw_L1_2B_();
-    WORD_ATOM(861, 13, "dip");
+    WORD_ATOM(877, 13, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(861, 17, "NONE");
+        WORD_ATOM(877, 17, "NONE");
         mw_NONE();
         push_value(d2);
     }
@@ -38315,31 +38630,31 @@ static void mb_token_def_args_8 (void) {
 }
 
 static void mb_elab_def_params_21__2 (void) {
-    WORD_ENTER(mb_elab_def_params_21__2, "elab-def-params! block", "src/mirth/elab.mth", 913, 9);
+    WORD_ENTER(mb_elab_def_params_21__2, "elab-def-params! block", "src/mirth/elab.mth", 929, 9);
     mw_prim_drop();
-    WORD_ATOM(913, 9, "dup");
+    WORD_ATOM(929, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(913, 13, "sig-param-name?");
+    WORD_ATOM(929, 13, "sig-param-name?");
     mw_Token_2E_sig_param_name_3F_();
-    WORD_ATOM(913, 29, "else");
+    WORD_ATOM(929, 29, "else");
     push_u64(0);
     push_fnptr(&mb_elab_def_params_21__3);
     mw_prim_pack_cons();
     mw_Bool_2E_else();
-    WORD_ATOM(914, 9, "dup");
+    WORD_ATOM(930, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(914, 13, "succ");
+    WORD_ATOM(930, 13, "succ");
     mw_Token_2E_succ();
-    WORD_ATOM(914, 18, "dup");
+    WORD_ATOM(930, 18, "dup");
     mw_prim_dup();
-    WORD_ATOM(914, 22, "run-end?");
+    WORD_ATOM(930, 22, "run-end?");
     mw_Token_2E_run_end_3F_();
-    WORD_ATOM(914, 31, "if");
+    WORD_ATOM(930, 31, "if");
     if (pop_u64()) {
-        WORD_ATOM(914, 34, "drop");
+        WORD_ATOM(930, 34, "drop");
         mw_prim_drop();
     } else {
-        WORD_ATOM(914, 40, "");
+        WORD_ATOM(930, 40, "");
         {
             static bool vready = false;
             static VAL v;
@@ -38350,34 +38665,34 @@ static void mb_elab_def_params_21__2 (void) {
             push_value(v);
             incref(v);
         }
-        WORD_ATOM(914, 72, "emit-fatal-error!");
+        WORD_ATOM(930, 72, "emit-fatal-error!");
         mw_emit_fatal_error_21_();
     }
-    WORD_ATOM(915, 9, "elab-expand-tensor!");
+    WORD_ATOM(931, 9, "elab-expand-tensor!");
     mw_elab_expand_tensor_21_();
-    WORD_ATOM(916, 9, "over");
+    WORD_ATOM(932, 9, "over");
     mw_over();
-    WORD_ATOM(916, 14, "morphism?");
+    WORD_ATOM(932, 14, "morphism?");
     mw_Type_2E_morphism_3F_();
-    WORD_ATOM(916, 24, "else");
+    WORD_ATOM(932, 24, "else");
     push_u64(0);
     push_fnptr(&mb_elab_def_params_21__6);
     mw_prim_pack_cons();
     mw_Maybe_2E_else();
-    WORD_ATOM(918, 9, "name?");
+    WORD_ATOM(934, 9, "name?");
     mw_Token_2E_name_3F_();
-    WORD_ATOM(918, 15, "unwrap");
+    WORD_ATOM(934, 15, "unwrap");
     mw_Maybe_2E_unwrap();
-    WORD_ATOM(918, 22, "Var.new-auto-run!");
+    WORD_ATOM(934, 22, "Var.new-auto-run!");
     mw_Var_2E_new_auto_run_21_();
-    WORD_ATOM(919, 9, "PARAM");
+    WORD_ATOM(935, 9, "PARAM");
     mw_PARAM();
-    WORD_ATOM(919, 15, "rotr");
+    WORD_ATOM(935, 15, "rotr");
     mw_rotr();
-    WORD_ATOM(919, 20, "dip");
+    WORD_ATOM(935, 20, "dip");
     {
         VAL d2 = pop_value();
-        WORD_ATOM(919, 24, "cons");
+        WORD_ATOM(935, 24, "cons");
         mw_List_2E_cons();
         push_value(d2);
     }
@@ -38385,9 +38700,9 @@ static void mb_elab_def_params_21__2 (void) {
 }
 
 static void mb_elab_def_params_21__3 (void) {
-    WORD_ENTER(mb_elab_def_params_21__3, "elab-def-params! block", "src/mirth/elab.mth", 913, 34);
+    WORD_ENTER(mb_elab_def_params_21__3, "elab-def-params! block", "src/mirth/elab.mth", 929, 34);
     mw_prim_drop();
-    WORD_ATOM(913, 34, "");
+    WORD_ATOM(929, 34, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38398,15 +38713,15 @@ static void mb_elab_def_params_21__3 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(913, 60, "emit-fatal-error!");
+    WORD_ATOM(929, 60, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_params_21__3);
 }
 
 static void mb_elab_def_params_21__6 (void) {
-    WORD_ENTER(mb_elab_def_params_21__6, "elab-def-params! block", "src/mirth/elab.mth", 917, 13);
+    WORD_ENTER(mb_elab_def_params_21__6, "elab-def-params! block", "src/mirth/elab.mth", 933, 13);
     mw_prim_drop();
-    WORD_ATOM(917, 13, "");
+    WORD_ATOM(933, 13, "");
     {
         static bool vready = false;
         static VAL v;
@@ -38417,171 +38732,171 @@ static void mb_elab_def_params_21__6 (void) {
         push_value(v);
         incref(v);
     }
-    WORD_ATOM(917, 44, "emit-fatal-error!");
+    WORD_ATOM(933, 44, "emit-fatal-error!");
     mw_emit_fatal_error_21_();
     WORD_EXIT(mb_elab_def_params_21__6);
 }
 
 static void mb_table_new_21__1 (void) {
-    WORD_ENTER(mb_table_new_21__1, "table-new! block", "src/mirth/elab.mth", 1024, 9);
+    WORD_ENTER(mb_table_new_21__1, "table-new! block", "src/mirth/elab.mth", 1040, 9);
     mw_prim_drop();
-    WORD_ATOM(1024, 9, "dup");
+    WORD_ATOM(1040, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1024, 13, "head");
+    WORD_ATOM(1040, 13, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1024, 18, "ab-token");
+    WORD_ATOM(1040, 18, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1024, 27, "!");
+    WORD_ATOM(1040, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1025, 9, "TABLE_MAX_SIZE");
+    WORD_ATOM(1041, 9, "TABLE_MAX_SIZE");
     mw_TABLE_5F_MAX_5F_SIZE();
-    WORD_ATOM(1025, 24, "ab-int!");
+    WORD_ATOM(1041, 24, "ab-int!");
     mw_ab_int_21_();
     WORD_EXIT(mb_table_new_21__1);
 }
 
 static void mb_table_new_21__2 (void) {
-    WORD_ENTER(mb_table_new_21__2, "table-new! block", "src/mirth/elab.mth", 1036, 9);
+    WORD_ENTER(mb_table_new_21__2, "table-new! block", "src/mirth/elab.mth", 1052, 9);
     mw_prim_drop();
-    WORD_ATOM(1036, 9, "dup");
+    WORD_ATOM(1052, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1036, 13, "head");
+    WORD_ATOM(1052, 13, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1036, 18, "ab-token");
+    WORD_ATOM(1052, 18, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1036, 27, "!");
+    WORD_ATOM(1052, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1037, 9, "");
+    WORD_ATOM(1053, 9, "");
     push_i64(0LL);
-    WORD_ATOM(1037, 11, "ab-int!");
+    WORD_ATOM(1053, 11, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1038, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1054, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1038, 26, "ab-prim!");
+    WORD_ATOM(1054, 26, "ab-prim!");
     mw_ab_prim_21_();
     WORD_EXIT(mb_table_new_21__2);
 }
 
 static void mb_table_new_21__3 (void) {
-    WORD_ENTER(mb_table_new_21__3, "table-new! block", "src/mirth/elab.mth", 1055, 9);
+    WORD_ENTER(mb_table_new_21__3, "table-new! block", "src/mirth/elab.mth", 1071, 9);
     mw_prim_drop();
-    WORD_ATOM(1055, 9, "dup");
+    WORD_ATOM(1071, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1055, 13, "head");
+    WORD_ATOM(1071, 13, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1055, 18, "ab-token");
+    WORD_ATOM(1071, 18, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1055, 27, "!");
+    WORD_ATOM(1071, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1056, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1072, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1056, 26, "ab-prim!");
+    WORD_ATOM(1072, 26, "ab-prim!");
     mw_ab_prim_21_();
     WORD_EXIT(mb_table_new_21__3);
 }
 
 static void mb_table_new_21__4 (void) {
-    WORD_ENTER(mb_table_new_21__4, "table-new! block", "src/mirth/elab.mth", 1067, 9);
+    WORD_ENTER(mb_table_new_21__4, "table-new! block", "src/mirth/elab.mth", 1083, 9);
     mw_prim_drop();
-    WORD_ATOM(1067, 9, "dup");
+    WORD_ATOM(1083, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1067, 13, "head");
+    WORD_ATOM(1083, 13, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1067, 18, "ab-token");
+    WORD_ATOM(1083, 18, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1067, 27, "!");
+    WORD_ATOM(1083, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1068, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1084, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1068, 26, "ab-prim!");
+    WORD_ATOM(1084, 26, "ab-prim!");
     mw_ab_prim_21_();
     WORD_EXIT(mb_table_new_21__4);
 }
 
 static void mb_table_new_21__5 (void) {
-    WORD_ENTER(mb_table_new_21__5, "table-new! block", "src/mirth/elab.mth", 1079, 9);
+    WORD_ENTER(mb_table_new_21__5, "table-new! block", "src/mirth/elab.mth", 1095, 9);
     mw_prim_drop();
-    WORD_ATOM(1079, 9, "dup");
+    WORD_ATOM(1095, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1079, 13, "head");
+    WORD_ATOM(1095, 13, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1079, 18, "ab-token");
+    WORD_ATOM(1095, 18, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1079, 27, "!");
+    WORD_ATOM(1095, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1080, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1096, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1080, 26, "ab-prim!");
+    WORD_ATOM(1096, 26, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1081, 9, "");
+    WORD_ATOM(1097, 9, "");
     push_i64(1LL);
-    WORD_ATOM(1081, 11, "ab-int!");
+    WORD_ATOM(1097, 11, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1082, 9, "PRIM_INT_ADD");
+    WORD_ATOM(1098, 9, "PRIM_INT_ADD");
     mw_PRIM_5F_INT_5F_ADD();
-    WORD_ATOM(1082, 22, "ab-prim!");
+    WORD_ATOM(1098, 22, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1083, 9, "dup");
+    WORD_ATOM(1099, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1083, 13, "num-buffer");
+    WORD_ATOM(1099, 13, "num-buffer");
     mw_Table_2E_num_buffer();
-    WORD_ATOM(1083, 24, "ab-buffer!");
+    WORD_ATOM(1099, 24, "ab-buffer!");
     mw_ab_buffer_21_();
-    WORD_ATOM(1084, 9, "PRIM_U64_GET");
+    WORD_ATOM(1100, 9, "PRIM_U64_GET");
     mw_PRIM_5F_U64_5F_GET();
-    WORD_ATOM(1084, 22, "ab-prim!");
+    WORD_ATOM(1100, 22, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1085, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1101, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1085, 26, "ab-prim!");
+    WORD_ATOM(1101, 26, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1086, 9, "");
+    WORD_ATOM(1102, 9, "");
     push_i64(1LL);
-    WORD_ATOM(1086, 11, "ab-int!");
+    WORD_ATOM(1102, 11, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1087, 9, "PRIM_INT_ADD");
+    WORD_ATOM(1103, 9, "PRIM_INT_ADD");
     mw_PRIM_5F_INT_5F_ADD();
-    WORD_ATOM(1087, 22, "ab-prim!");
+    WORD_ATOM(1103, 22, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1088, 9, "PRIM_INT_MOD");
+    WORD_ATOM(1104, 9, "PRIM_INT_MOD");
     mw_PRIM_5F_INT_5F_MOD();
-    WORD_ATOM(1088, 22, "ab-prim!");
+    WORD_ATOM(1104, 22, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1089, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1105, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1089, 26, "ab-prim!");
+    WORD_ATOM(1105, 26, "ab-prim!");
     mw_ab_prim_21_();
     WORD_EXIT(mb_table_new_21__5);
 }
 
 static void mb_table_new_21__6 (void) {
-    WORD_ENTER(mb_table_new_21__6, "table-new! block", "src/mirth/elab.mth", 1100, 9);
+    WORD_ENTER(mb_table_new_21__6, "table-new! block", "src/mirth/elab.mth", 1116, 9);
     mw_prim_drop();
-    WORD_ATOM(1100, 9, "dup");
+    WORD_ATOM(1116, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1100, 13, "head");
+    WORD_ATOM(1116, 13, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1100, 18, "ab-token");
+    WORD_ATOM(1116, 18, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1100, 27, "!");
+    WORD_ATOM(1116, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1101, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1117, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1101, 26, "ab-prim!");
+    WORD_ATOM(1117, 26, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1102, 9, "PRIM_CORE_DUP");
+    WORD_ATOM(1118, 9, "PRIM_CORE_DUP");
     mw_PRIM_5F_CORE_5F_DUP();
-    WORD_ATOM(1102, 23, "ab-prim!");
+    WORD_ATOM(1118, 23, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1103, 9, "");
+    WORD_ATOM(1119, 9, "");
     push_i64(0LL);
-    WORD_ATOM(1103, 11, "ab-int!");
+    WORD_ATOM(1119, 11, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1104, 9, "PRIM_INT_EQ");
+    WORD_ATOM(1120, 9, "PRIM_INT_EQ");
     mw_PRIM_5F_INT_5F_EQ();
-    WORD_ATOM(1104, 21, "ab-prim!");
+    WORD_ATOM(1120, 21, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1105, 9, "ab-if!");
+    WORD_ATOM(1121, 9, "ab-if!");
     push_u64(0);
     push_fnptr(&mb_table_new_21__7);
     mw_prim_pack_cons();
@@ -38589,37 +38904,37 @@ static void mb_table_new_21__6 (void) {
     push_fnptr(&mb_table_new_21__8);
     mw_prim_pack_cons();
     mw_ab_if_21_();
-    WORD_ATOM(1110, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1126, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1110, 26, "ab-prim!");
+    WORD_ATOM(1126, 26, "ab-prim!");
     mw_ab_prim_21_();
     WORD_EXIT(mb_table_new_21__6);
 }
 
 static void mb_table_new_21__7 (void) {
-    WORD_ENTER(mb_table_new_21__7, "table-new! block", "src/mirth/elab.mth", 1106, 13);
+    WORD_ENTER(mb_table_new_21__7, "table-new! block", "src/mirth/elab.mth", 1122, 13);
     mw_prim_drop();
-    WORD_ATOM(1106, 13, "id");
+    WORD_ATOM(1122, 13, "id");
     mw_prim_id();
     WORD_EXIT(mb_table_new_21__7);
 }
 
 static void mb_table_new_21__8 (void) {
-    WORD_ENTER(mb_table_new_21__8, "table-new! block", "src/mirth/elab.mth", 1107, 13);
+    WORD_ENTER(mb_table_new_21__8, "table-new! block", "src/mirth/elab.mth", 1123, 13);
     mw_prim_drop();
-    WORD_ATOM(1107, 13, "");
+    WORD_ATOM(1123, 13, "");
     push_i64(1LL);
-    WORD_ATOM(1107, 15, "ab-int!");
+    WORD_ATOM(1123, 15, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1108, 13, "PRIM_INT_SUB");
+    WORD_ATOM(1124, 13, "PRIM_INT_SUB");
     mw_PRIM_5F_INT_5F_SUB();
-    WORD_ATOM(1108, 26, "ab-prim!");
+    WORD_ATOM(1124, 26, "ab-prim!");
     mw_ab_prim_21_();
     WORD_EXIT(mb_table_new_21__8);
 }
 
 static void mb_table_new_21__11 (void) {
-    WORD_ENTER(mb_table_new_21__11, "table-new! block", "src/mirth/elab.mth", 1124, 13);
+    WORD_ENTER(mb_table_new_21__11, "table-new! block", "src/mirth/elab.mth", 1140, 13);
     mw_prim_pack_uncons();
     VAL var_x = pop_value();
     mw_prim_pack_uncons();
@@ -38631,23 +38946,23 @@ static void mb_table_new_21__11 (void) {
     mw_prim_pack_uncons();
     VAL var_a = pop_value();
     mw_prim_drop();
-    WORD_ATOM(1124, 13, "t");
+    WORD_ATOM(1140, 13, "t");
     incref(var_t);
     push_value(var_t);
-    WORD_ATOM(1124, 15, "head");
+    WORD_ATOM(1140, 15, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1124, 20, "ab-token");
+    WORD_ATOM(1140, 20, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1124, 29, "!");
+    WORD_ATOM(1140, 29, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1125, 13, "x");
+    WORD_ATOM(1141, 13, "x");
     incref(var_x);
     push_value(var_x);
-    WORD_ATOM(1125, 15, "Var>Param");
+    WORD_ATOM(1141, 15, "Var>Param");
     mw_Var_3E_Param();
-    WORD_ATOM(1125, 25, "L1");
+    WORD_ATOM(1141, 25, "L1");
     mw_L1();
-    WORD_ATOM(1125, 28, "ab-lambda!");
+    WORD_ATOM(1141, 28, "ab-lambda!");
     push_u64(0);
     incref(var_a);
     push_value(var_a);
@@ -38676,7 +38991,7 @@ static void mb_table_new_21__11 (void) {
 }
 
 static void mb_table_new_21__12 (void) {
-    WORD_ENTER(mb_table_new_21__12, "table-new! block", "src/mirth/elab.mth", 1126, 17);
+    WORD_ENTER(mb_table_new_21__12, "table-new! block", "src/mirth/elab.mth", 1142, 17);
     mw_prim_pack_uncons();
     VAL var_x = pop_value();
     mw_prim_pack_uncons();
@@ -38688,11 +39003,11 @@ static void mb_table_new_21__12 (void) {
     mw_prim_pack_uncons();
     VAL var_a = pop_value();
     mw_prim_drop();
-    WORD_ATOM(1126, 17, "");
+    WORD_ATOM(1142, 17, "");
     push_i64(1LL);
-    WORD_ATOM(1126, 19, "ab-int!");
+    WORD_ATOM(1142, 19, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1127, 17, "ab-while!");
+    WORD_ATOM(1143, 17, "ab-while!");
     push_u64(0);
     incref(var_a);
     push_value(var_a);
@@ -38730,9 +39045,9 @@ static void mb_table_new_21__12 (void) {
     push_fnptr(&mb_table_new_21__14);
     mw_prim_pack_cons();
     mw_ab_while_21_();
-    WORD_ATOM(1144, 17, "PRIM_CORE_DROP");
+    WORD_ATOM(1160, 17, "PRIM_CORE_DROP");
     mw_PRIM_5F_CORE_5F_DROP();
-    WORD_ATOM(1144, 32, "ab-prim!");
+    WORD_ATOM(1160, 32, "ab-prim!");
     mw_ab_prim_21_();
     decref(var_x);
     decref(var_t);
@@ -38743,7 +39058,7 @@ static void mb_table_new_21__12 (void) {
 }
 
 static void mb_table_new_21__13 (void) {
-    WORD_ENTER(mb_table_new_21__13, "table-new! block", "src/mirth/elab.mth", 1128, 21);
+    WORD_ENTER(mb_table_new_21__13, "table-new! block", "src/mirth/elab.mth", 1144, 21);
     mw_prim_pack_uncons();
     VAL var_x = pop_value();
     mw_prim_pack_uncons();
@@ -38755,36 +39070,36 @@ static void mb_table_new_21__13 (void) {
     mw_prim_pack_uncons();
     VAL var_a = pop_value();
     mw_prim_drop();
-    WORD_ATOM(1128, 21, "PRIM_CORE_DUP");
+    WORD_ATOM(1144, 21, "PRIM_CORE_DUP");
     mw_PRIM_5F_CORE_5F_DUP();
-    WORD_ATOM(1128, 35, "ab-prim!");
+    WORD_ATOM(1144, 35, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1129, 21, "t");
+    WORD_ATOM(1145, 21, "t");
     incref(var_t);
     push_value(var_t);
-    WORD_ATOM(1129, 23, "num-buffer");
+    WORD_ATOM(1145, 23, "num-buffer");
     mw_Table_2E_num_buffer();
-    WORD_ATOM(1129, 34, "ab-buffer!");
+    WORD_ATOM(1145, 34, "ab-buffer!");
     mw_ab_buffer_21_();
-    WORD_ATOM(1130, 21, "PRIM_U64_GET");
+    WORD_ATOM(1146, 21, "PRIM_U64_GET");
     mw_PRIM_5F_U64_5F_GET();
-    WORD_ATOM(1130, 34, "ab-prim!");
+    WORD_ATOM(1146, 34, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1131, 21, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1147, 21, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1131, 38, "ab-prim!");
+    WORD_ATOM(1147, 38, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1132, 21, "");
+    WORD_ATOM(1148, 21, "");
     push_i64(1LL);
-    WORD_ATOM(1132, 23, "ab-int!");
+    WORD_ATOM(1148, 23, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1133, 21, "PRIM_INT_ADD");
+    WORD_ATOM(1149, 21, "PRIM_INT_ADD");
     mw_PRIM_5F_INT_5F_ADD();
-    WORD_ATOM(1133, 34, "ab-prim!");
+    WORD_ATOM(1149, 34, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1134, 21, "PRIM_INT_LT");
+    WORD_ATOM(1150, 21, "PRIM_INT_LT");
     mw_PRIM_5F_INT_5F_LT();
-    WORD_ATOM(1134, 33, "ab-prim!");
+    WORD_ATOM(1150, 33, "ab-prim!");
     mw_ab_prim_21_();
     decref(var_x);
     decref(var_t);
@@ -38795,7 +39110,7 @@ static void mb_table_new_21__13 (void) {
 }
 
 static void mb_table_new_21__14 (void) {
-    WORD_ENTER(mb_table_new_21__14, "table-new! block", "src/mirth/elab.mth", 1136, 21);
+    WORD_ENTER(mb_table_new_21__14, "table-new! block", "src/mirth/elab.mth", 1152, 21);
     mw_prim_pack_uncons();
     VAL var_x = pop_value();
     mw_prim_pack_uncons();
@@ -38807,11 +39122,11 @@ static void mb_table_new_21__14 (void) {
     mw_prim_pack_uncons();
     VAL var_a = pop_value();
     mw_prim_drop();
-    WORD_ATOM(1136, 21, "PRIM_CORE_DUP");
+    WORD_ATOM(1152, 21, "PRIM_CORE_DUP");
     mw_PRIM_5F_CORE_5F_DUP();
-    WORD_ATOM(1136, 35, "ab-prim!");
+    WORD_ATOM(1152, 35, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1137, 21, "ab-dip!");
+    WORD_ATOM(1153, 21, "ab-dip!");
     push_u64(0);
     incref(var_a);
     push_value(var_a);
@@ -38831,13 +39146,13 @@ static void mb_table_new_21__14 (void) {
     push_fnptr(&mb_table_new_21__15);
     mw_prim_pack_cons();
     mw_ab_dip_21_();
-    WORD_ATOM(1141, 21, "");
+    WORD_ATOM(1157, 21, "");
     push_i64(1LL);
-    WORD_ATOM(1141, 23, "ab-int!");
+    WORD_ATOM(1157, 23, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1142, 21, "PRIM_INT_ADD");
+    WORD_ATOM(1158, 21, "PRIM_INT_ADD");
     mw_PRIM_5F_INT_5F_ADD();
-    WORD_ATOM(1142, 34, "ab-prim!");
+    WORD_ATOM(1158, 34, "ab-prim!");
     mw_ab_prim_21_();
     decref(var_x);
     decref(var_t);
@@ -38848,7 +39163,7 @@ static void mb_table_new_21__14 (void) {
 }
 
 static void mb_table_new_21__15 (void) {
-    WORD_ENTER(mb_table_new_21__15, "table-new! block", "src/mirth/elab.mth", 1138, 25);
+    WORD_ENTER(mb_table_new_21__15, "table-new! block", "src/mirth/elab.mth", 1154, 25);
     mw_prim_pack_uncons();
     VAL var_x = pop_value();
     mw_prim_pack_uncons();
@@ -38860,14 +39175,14 @@ static void mb_table_new_21__15 (void) {
     mw_prim_pack_uncons();
     VAL var_a = pop_value();
     mw_prim_drop();
-    WORD_ATOM(1138, 25, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1154, 25, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1138, 42, "ab-prim!");
+    WORD_ATOM(1154, 42, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1139, 25, "x");
+    WORD_ATOM(1155, 25, "x");
     incref(var_x);
     push_value(var_x);
-    WORD_ATOM(1139, 27, "ab-var!");
+    WORD_ATOM(1155, 27, "ab-var!");
     mw_ab_var_21_();
     decref(var_x);
     decref(var_t);
@@ -38878,75 +39193,75 @@ static void mb_table_new_21__15 (void) {
 }
 
 static void mb_table_new_21__16 (void) {
-    WORD_ENTER(mb_table_new_21__16, "table-new! block", "src/mirth/elab.mth", 1158, 9);
+    WORD_ENTER(mb_table_new_21__16, "table-new! block", "src/mirth/elab.mth", 1174, 9);
     mw_prim_drop();
-    WORD_ATOM(1158, 9, "dup");
+    WORD_ATOM(1174, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1158, 13, "head");
+    WORD_ATOM(1174, 13, "head");
     mw_Table_2E_head();
-    WORD_ATOM(1158, 18, "ab-token");
+    WORD_ATOM(1174, 18, "ab-token");
     mw_ab_token();
-    WORD_ATOM(1158, 27, "!");
+    WORD_ATOM(1174, 27, "!");
     mw_prim_mut_set();
-    WORD_ATOM(1159, 9, "dup");
+    WORD_ATOM(1175, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1159, 13, "num-buffer");
+    WORD_ATOM(1175, 13, "num-buffer");
     mw_Table_2E_num_buffer();
-    WORD_ATOM(1159, 24, "ab-buffer!");
+    WORD_ATOM(1175, 24, "ab-buffer!");
     mw_ab_buffer_21_();
-    WORD_ATOM(1160, 9, "PRIM_U64_GET");
+    WORD_ATOM(1176, 9, "PRIM_U64_GET");
     mw_PRIM_5F_U64_5F_GET();
-    WORD_ATOM(1160, 22, "ab-prim!");
+    WORD_ATOM(1176, 22, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1161, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1177, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1161, 26, "ab-prim!");
+    WORD_ATOM(1177, 26, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1162, 9, "");
+    WORD_ATOM(1178, 9, "");
     push_i64(1LL);
-    WORD_ATOM(1162, 11, "ab-int!");
+    WORD_ATOM(1178, 11, "ab-int!");
     mw_ab_int_21_();
-    WORD_ATOM(1163, 9, "PRIM_INT_ADD");
+    WORD_ATOM(1179, 9, "PRIM_INT_ADD");
     mw_PRIM_5F_INT_5F_ADD();
-    WORD_ATOM(1163, 22, "ab-prim!");
+    WORD_ATOM(1179, 22, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1164, 9, "PRIM_CORE_DUP");
+    WORD_ATOM(1180, 9, "PRIM_CORE_DUP");
     mw_PRIM_5F_CORE_5F_DUP();
-    WORD_ATOM(1164, 23, "ab-prim!");
+    WORD_ATOM(1180, 23, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1165, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1181, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1165, 26, "ab-prim!");
+    WORD_ATOM(1181, 26, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1166, 9, "dup");
+    WORD_ATOM(1182, 9, "dup");
     mw_prim_dup();
-    WORD_ATOM(1166, 13, "num-buffer");
+    WORD_ATOM(1182, 13, "num-buffer");
     mw_Table_2E_num_buffer();
-    WORD_ATOM(1166, 24, "ab-buffer!");
+    WORD_ATOM(1182, 24, "ab-buffer!");
     mw_ab_buffer_21_();
-    WORD_ATOM(1167, 9, "PRIM_U64_SET");
+    WORD_ATOM(1183, 9, "PRIM_U64_SET");
     mw_PRIM_5F_U64_5F_SET();
-    WORD_ATOM(1167, 22, "ab-prim!");
+    WORD_ATOM(1183, 22, "ab-prim!");
     mw_ab_prim_21_();
-    WORD_ATOM(1168, 9, "PRIM_UNSAFE_CAST");
+    WORD_ATOM(1184, 9, "PRIM_UNSAFE_CAST");
     mw_PRIM_5F_UNSAFE_5F_CAST();
-    WORD_ATOM(1168, 26, "ab-prim!");
+    WORD_ATOM(1184, 26, "ab-prim!");
     mw_ab_prim_21_();
     WORD_EXIT(mb_table_new_21__16);
 }
 
 static void mb_field_new_21__1 (void) {
-    WORD_ENTER(mb_field_new_21__1, "field-new! block", "src/mirth/elab.mth", 1193, 16);
+    WORD_ENTER(mb_field_new_21__1, "field-new! block", "src/mirth/elab.mth", 1209, 16);
     mw_prim_drop();
-    WORD_ATOM(1193, 16, "elab-simple-type-arg!");
+    WORD_ATOM(1209, 16, "elab-simple-type-arg!");
     mw_elab_simple_type_arg_21_();
     WORD_EXIT(mb_field_new_21__1);
 }
 
 static void mb_field_new_21__2 (void) {
-    WORD_ENTER(mb_field_new_21__2, "field-new! block", "src/mirth/elab.mth", 1194, 16);
+    WORD_ENTER(mb_field_new_21__2, "field-new! block", "src/mirth/elab.mth", 1210, 16);
     mw_prim_drop();
-    WORD_ATOM(1194, 16, "elab-simple-type-arg!");
+    WORD_ATOM(1210, 16, "elab-simple-type-arg!");
     mw_elab_simple_type_arg_21_();
     WORD_EXIT(mb_field_new_21__2);
 }

--- a/src/data/byte.mth
+++ b/src/data/byte.mth
@@ -1,6 +1,7 @@
 module(data.byte)
 
 import(prelude)
+import(data.maybe)
 
 data(Byte,
     BNUL, BSOH, BSTX, BETX, BEOT, BENQ, BACK, BBEL,
@@ -69,9 +70,18 @@ def(Byte.is-hexdigit, Byte -- Bool,
     B'C' -> T, B'D' -> T, B'E' -> T, B'F' -> T,
     _ -> drop F)
 
+buffer(BYTE_ASCII_BUF, 8)
+def(Byte.to-ascii-str, Byte -- Maybe(Str),
+    dup BNUL BDEL in-range if(
+        >U8 BYTE_ASCII_BUF !U8
+        BYTE_ASCII_BUF 1 prim-str-copy
+        SOME,
+        drop NONE
+    ))
+
 def(Byte.is-string-end, Byte -- Bool,
     BQUOTE -> T, BLF -> T, BNUL -> T, _ -> drop F)
-    
+
 def(Byte.to-lower, Byte -- Byte,
     dup is-upper if(>Int 0x20 + >Byte, id))
 def(Byte.to-upper, Byte -- Byte,

--- a/src/data/either.mth
+++ b/src/data/either.mth
@@ -1,0 +1,7 @@
+module(data.either)
+import(prelude)
+import(data.maybe)
+
+data(Either(a,b), LEFT -> a, RIGHT -> b)
+def(Either.left?, Either(a,b) -- Maybe(a), LEFT -> SOME, RIGHT -> drop NONE)
+def(Either.right?, Either(a,b) -- Maybe(b), LEFT -> drop NONE, RIGHT -> SOME)

--- a/src/data/list.mth
+++ b/src/data/list.mth
@@ -19,6 +19,11 @@ def(L10, t t t t  t t t t  t t     -- List(t), L10+ >List)
 def(L11, t t t t  t t t t  t t t   -- List(t), L11+ >List)
 def(L12, t t t t  t t t t  t t t t -- List(t), L12+ >List)
 
+def(List/L0, List(t) -- Bool, L0 -> T, _ -> drop F)
+def(List/L1, List(t) -- Maybe(t), L1 -> SOME, _ -> drop NONE)
+def(List/L2, List(t) -- Maybe([t t]), L2 -> pack2 SOME, _ -> drop NONE)
+def(List/L3, List(t) -- Maybe([t t t]), L3 -> pack3 SOME, _ -> drop NONE)
+
 data(List+(t),
     L1+ -> t,
     L2+ -> t t,

--- a/src/data/list.mth
+++ b/src/data/list.mth
@@ -146,61 +146,61 @@ def(List+.rebalance, List+(t) List+(t) -- List+(t) List+(t),
         )
     ))
 
-def(split-half-left, List+(t) -- List+(t) List(t),
+def(List+.split-half-left, List+(t) -- List+(t) List(t),
     L1+ -> L0 dip(L1+),
     L2+ -> L1 dip(L1+),
     L3+ -> L1 dip(L2+),
     LCAT+ -> drop List+>List)
 
-def(split-half-right, List+(t) -- List(t) List+(t),
+def(List+.split-half-right, List+(t) -- List(t) List+(t),
     L1+ -> L1+ dip(L0),
     L2+ -> L1+ dip(L1),
     L3+ -> L2+ dip(L1),
     LCAT+ -> drop dip(List+>List))
 
-def(split-half, List(t) -- List(t) List(t),
+def(List.split-half, List(t) -- List(t) List(t),
     L0 -> L0 L0,
     L1 -> L1 dip(L0),
     L2 -> L1 dip(L1),
     L3 -> L2 dip(L1),
     LCAT -> drop dip(List+>List) List+>List)
 
-def(first, List(t) -- Maybe(t), List>List+ map(first+))
-def(last, List(t) -- Maybe(t), List>List+ map(last+))
-def(middle, List(t) -- Maybe(t), List>List+ map(middle+))
+def(List.first, List(t) -- Maybe(t), List>List+ map(first))
+def(List.last, List(t) -- Maybe(t), List>List+ map(last))
+def(List.middle, List(t) -- Maybe(t), List>List+ map(middle))
 
-def(first+, List+(t) -- t,
+def(List+.first, List+(t) -- t,
     L1+ -> id,
     L2+ -> drop,
     L3+ -> drop2,
-    LCAT+ -> drop2 first+)
+    LCAT+ -> drop2 first)
 
-def(last+, List+(t) -- t,
+def(List+.last, List+(t) -- t,
     L1+ -> id,
     L2+ -> dip(drop),
     L3+ -> dip(drop2),
-    LCAT+ -> drop nip last+)
+    LCAT+ -> drop nip last)
 
-def(middle+, List+(t) -- t,
+def(List+.middle, List+(t) -- t,
     L1+ -> id,
     L2+ -> nip,
     L3+ -> drop nip,
-    LCAT+ -> drop nip first+)
+    LCAT+ -> drop nip first)
 
 ||| Reverse the list.
-def(reverse, List(a) -- List(a),
+def(List.reverse, List(a) -- List(a),
     L0 -> L0,
     L1 -> L1,
     L2 -> swap L2,
     L3 -> rotr swap L3,
-    LCAT -> dip(reverse+ swap reverse+) LCAT)
+    LCAT -> dip(reverse swap reverse) LCAT)
 
 ||| Reverse the list.
-def(reverse+, List+(a) -- List+(a),
+def(List+.reverse, List+(a) -- List+(a),
     L1+ -> L1+,
     L2+ -> swap L2+,
     L3+ -> rotr swap L3+,
-    LCAT+ -> dip(reverse+ swap reverse+) LCAT+)
+    LCAT+ -> dip(reverse swap reverse) LCAT+)
 
 ||| Transform each element of the list.
 def(List.map(f), (*c a -- *c b) *c List(a) -- *c List(b),
@@ -208,14 +208,14 @@ def(List.map(f), (*c a -- *c b) *c List(a) -- *c List(b),
     L1 -> f L1,
     L2 -> dip(f) swap dip(f) swap L2,
     L3 -> dip(dip(f)) rotr dip(dip(f)) rotr dip(dip(f)) rotr L3,
-    LCAT -> dip(dip(map+(f)) swap dip(map+(f)) swap) LCAT)
+    LCAT -> dip(dip(map(f)) swap dip(map(f)) swap) LCAT)
 
 ||| Transform each element of the list.
-def(map+(f), (*c a -- *c b) *c List+(a) -- *c List+(b),
+def(List+.map(f), (*c a -- *c b) *c List+(a) -- *c List+(b),
     L1+ -> f L1+,
     L2+ -> dip(f) swap dip(f) swap L2+,
     L3+ -> dip(dip(f)) rotr dip(dip(f)) rotr dip(dip(f)) rotr L3+,
-    LCAT+ -> dip(dip(map+(f)) swap dip(map+(f)) swap) LCAT+)
+    LCAT+ -> dip(dip(map(f)) swap dip(map(f)) swap) LCAT+)
 
 ||| Traverse the list, left to right.
 def(List.for(f), (*c a -- *c) *c List(a) -- *c,
@@ -274,6 +274,13 @@ def(List+.filter(f), (*c a -- *c a Bool) *c List+(a) -- *c List(a),
             nip filter(f)
         )
     )
+
+def(List.filter-some(p), (*c a -- *c Maybe(b)) *c List(a) -- *c List(b),
+    List>List+ if-some(filter-some(p), L0))
+
+def(List+.filter-some(p), (*c a -- *c Maybe(b)) *c List+(a) -- *c List(b),
+    LCAT+ -> drop dip(filter-some(p)) dip'(filter-some(p)) cat,
+    _ -> unsnoc dip(filter-some(p)) dip'(p) if-some(snoc, id))
 
 ||| Find the first element that satisfies the predicate, if it exists.
 def(List.find(f), (*c a -- *c a Bool) *c List(a) -- *c Maybe(a),

--- a/src/data/str.mth
+++ b/src/data/str.mth
@@ -96,3 +96,11 @@ def(str-bytes-for(f), (*a Byte -- *a) *a Str -- *a,
     with-str-data(repeat(
         dup dip(@Byte f 1) .offset-unsafe
     ) drop))
+
+def(Str.first-byte, Str -- Maybe(Byte),
+    with-str-data(
+        1 >= if(
+            @U8 U8>Byte SOME,
+            drop NONE
+        )
+    ))

--- a/src/mirth/codegen.mth
+++ b/src/mirth/codegen.mth
@@ -129,37 +129,28 @@ def(need-block-run, Block --, arrow need-arrow-run)
 # Codegen #
 ###########
 
-var(c99-file-var, File)
-var(c99-depth-var, Int)
-var(c99-buffer-var, Str)
+data(+C99, MKC99 -> File Int Str)
+def(+C99/MKC99, +C99 -- File Int Str, MKC99 -> id)
 
-data(+C99, MKC99-unsafe)
-
+def(+C99.depth@, +C99 -- Int +C99, /MKC99 over dip(MKC99))
+def(+C99.depth!, Int +C99 -- +C99, dip(/MKC99 nip) swap MKC99)
 def(Str+C99., Str +C99 -- +C99,
-    c99-buffer-var modify("")
-    swap cat
-    c99-buffer-var !
-    c99-buffer-var @ num-bytes 512 > then(codegen-flush!))
+    dip(/MKC99) cat
+    dup num-bytes dip(MKC99)
+    512 > then(codegen-flush!))
+
 def(Int+C99.n, Int +C99 -- +C99, int-to-str .)
 def(Byte+C99.b, Byte +C99 -- +C99, to-ascii-str unwrap .)
-def(+C99.depth@, +C99 -- Int +C99, c99-depth-var @)
-def(+C99.depth!, Int +C99 -- +C99, c99-depth-var !)
 
-def(codegen-start!, File +C99 -- +C99,
-    c99-file-var !
-    0 c99-depth-var !
-    "" c99-buffer-var !)
+def(codegen-start!, Path -- +C99,
+    >Str create-file! 0 "" MKC99)
 
 def(codegen-flush!, +C99 -- +C99,
-    c99-file-var @
-    c99-buffer-var modify("")
-    write!)
+    /MKC99 dip(over) write! "" MKC99)
 
-def(codegen-end!, +C99 -- +C99,
+def(codegen-end!, +C99 --,
     codegen-flush!
-    c99-file-var @ close-file!)
-
-def(with-c99, *a [*a +C99 -- *b +C99] -- *b, prim-unsafe-cast run)
+    /MKC99 drop2 close-file!)
 
 def(run-output-c99!, Arrow Path --,
     num-errors @ 0> if(
@@ -168,23 +159,21 @@ def(run-output-c99!, Arrow Path --,
         reset-needs!
         over determine-arrow-needs!
 
-        with-c99(
-            to-output-path >Str
-            create-file! codegen-start!
-            c99-header!
-            c99-tags!
-            c99-buffers!
-            c99-variables!
-            c99-externals!
-            c99-word-sigs!
-            c99-block-sigs!
-            c99-field-sigs!
-            c99-main!
-            c99-field-defs!
-            c99-word-defs!
-            c99-block-defs!
-            codegen-end!
-        )
+        to-output-path
+        codegen-start!
+        c99-header!
+        c99-tags!
+        c99-buffers!
+        c99-variables!
+        c99-externals!
+        c99-word-sigs!
+        c99-block-sigs!
+        c99-field-sigs!
+        c99-main!
+        c99-field-defs!
+        c99-word-defs!
+        c99-block-defs!
+        codegen-end!
     ))
 
 def(+C99.lf, +C99 -- +C99, "\n" .)

--- a/src/mirth/codegen.mth
+++ b/src/mirth/codegen.mth
@@ -102,6 +102,11 @@ def(need-prim, List(Arg) Prim --,
             L1 -> need-arg-run,
             _ -> need-args-push
         ),
+    PRIM_CORE_RDIP ->
+        match(
+            L1 -> need-arg-run,
+            _ -> need-args-push
+        ),
     PRIM_CORE_IF ->
         match(
             L2 -> dip(need-arg-run) need-arg-run,
@@ -382,6 +387,20 @@ def(c99-prim!, List(Arg) Prim --,
                 c99-line("}" .),
             _ ->
                 PRIM_CORE_DIP c99-prim-default!
+        ),
+
+    PRIM_CORE_RDIP ->
+        match(
+            L1 ->
+                c99-line("{" .)
+                c99-nest(
+                    c99-line("VAL d" . c99-depth @ .n " = pop_resource();" .)
+                    c99-arg-run!
+                    c99-line("push_resource(d" . c99-depth @ .n ");" .)
+                )
+                c99-line("}" .),
+            _ ->
+                PRIM_CORE_RDIP c99-prim-default!
         ),
 
     PRIM_CORE_IF ->

--- a/src/mirth/codegen.mth
+++ b/src/mirth/codegen.mth
@@ -232,7 +232,9 @@ def(c99-tag!, Tag +C99 -- +C99,
             "    VAL car = pop_resource();",
             "    VAL car = pop_value();"
         ) put line
-        "    VAL cdr;" put line
+        dup num-resource-inputs over num-type-inputs + 0> then(
+            "    VAL cdr;" put line
+        )
         "    decref("
         over num-resource-inputs repeat(
             "    value_uncons_c(car, &car, &cdr);" put line

--- a/src/mirth/codegen.mth
+++ b/src/mirth/codegen.mth
@@ -134,13 +134,14 @@ def(+C99/MKC99, +C99 -- File Int Str, MKC99 -> id)
 
 def(+C99.depth@, +C99 -- Int +C99, /MKC99 over dip(MKC99))
 def(+C99.depth!, Int +C99 -- +C99, dip(/MKC99 nip) swap MKC99)
-def(Str+C99., Str +C99 -- +C99,
+
+def(Str+C99.put, Str +C99 -- +C99,
     dip(/MKC99) cat
     dup num-bytes dip(MKC99)
     512 > then(codegen-flush!))
-
-def(Int+C99.n, Int +C99 -- +C99, int-to-str .)
-def(Byte+C99.b, Byte +C99 -- +C99, to-ascii-str unwrap .)
+def(Int+C99.put, Int +C99 -- +C99, int-to-str put)
+def(Byte+C99.put, Byte +C99 -- +C99, to-ascii-str unwrap put)
+def(+C99.line, +C99 -- +C99, "\n" put)
 
 def(codegen-start!, Path -- +C99,
     >Str create-file! 0 "" MKC99)
@@ -176,82 +177,81 @@ def(run-output-c99!, Arrow Path --,
         codegen-end!
     ))
 
-def(+C99.lf, +C99 -- +C99, "\n" .)
-def(Str+C99;, Str +C99 -- +C99, . .lf)
-def(Str+C99;;, Str +C99 -- +C99, . .lf .lf)
-def(Name+C99.name, Name +C99 -- +C99, mangled .)
-def(Name+C99.w, Name +C99 -- +C99, "static void mw_" . .name " (void)" .)
-def(Prim+C99.p, Prim +C99 -- +C99, name .w)
-def(Prim+C99.pm, Prim +C99 -- +C99, "#define mw_" . name .name "() " .)
+def(Name+C99.put, Name +C99 -- +C99, mangled put)
+def(Name+C99.sig, Name +C99 -- Str +C99, dip("static void mw_") mangled cat " (void)" cat)
+def(Name+C99.cosig, Name +C99 -- Str +C99, dip("static void mp_") mangled cat " (void)" cat)
+
+# def(Prim+C99.put-sig, Prim +C99 -- +C99, name .w)
+# def(Prim+C99.put-macro, Prim +C99 -- +C99, "#define mw_" . name .name "() " .)
 
 embed-str(c99-header-str, "src/mirth/mirth.h")
-def(c99-header!, +C99 -- +C99, c99-header-str . .lf)
+def(c99-header!, +C99 -- +C99, c99-header-str put line)
 
-def(c99-buffers!, +C99 -- +C99, Buffer.for(c99-buffer!) .lf)
+def(c99-buffers!, +C99 -- +C99, Buffer.for(c99-buffer!) line)
 def(c99-buffer!, Buffer +C99 -- +C99,
-    dup name .w " {" ;
-    "    static uint8_t b[" . dup size .n "] = {0};" ;
-    "    push_ptr(&b);" ;
-    "}" ;
+    dup name sig put " {" put line
+    "    static uint8_t b[" put dup size put "] = {0};" put line
+    "    push_ptr(&b);" put line
+    "}" put line
     drop)
 
-def(c99-variables!, +C99 -- +C99, Variable.for(c99-variable!) .lf)
+def(c99-variables!, +C99 -- +C99, Variable.for(c99-variable!) line)
 def(c99-variable!, Variable +C99 -- +C99,
-    "void mw_" . name .name "() {" ;
-    "    static VAL v = {0};" ;
-    "    push_ptr(&v);" ;
-    "}" ;)
+    name sig put " {" put line
+    "    static VAL v = {0};" put line
+    "    push_ptr(&v);" put line
+    "}" put line)
 
-def(c99-tags!, +C99 -- +C99, Tag.for(c99-tag!) .lf)
+def(c99-tags!, +C99 -- +C99, Tag.for(c99-tag!) line)
 def(c99-tag!, Tag +C99 -- +C99,
-    dup name .w " {" ;
+    dup name sig put " {" put line
     dup is-transparent? if(
         id,
-        "    VAL tag = MKU64(" . dup value .n "LL);" ;
-        "    VAL car = (" .
+        "    VAL tag = MKU64(" put dup value put "LL);" put line
+        "    VAL car = (" put
         dup num-type-inputs repeat(
-            "pop_value());" ;
-            "    car = mkcons(car, " .
+            "pop_value());" put line
+            "    car = mkcons(car, " put
         )
         dup num-resource-inputs repeat(
-            "pop_resource());" ;
-            "    car = mkcons(car, " .
+            "pop_resource());" put line
+            "    car = mkcons(car, " put
         )
-        "tag);" ;
+        "tag);" put line
         dup outputs-resource? if(
-            "    push_resource(car);" ; ,
-            "    push_value(car);" ; ,
-        )
+            "    push_resource(car);",
+            "    push_value(car);"
+        ) put line
     )
-    "}" ;
+    "}" put line
 
-    "void co_" . dup name .name "() {" ;
+    dup name cosig put " {" put line
     dup is-transparent? if(
         id,
         dup outputs-resource? if(
-            "    VAL car = pop_resource();" ; ,
-            "    VAL car = pop_value();" ;
-        )
-        "    VAL cdr;" ;
+            "    VAL car = pop_resource();",
+            "    VAL car = pop_value();"
+        ) put line
+        "    VAL cdr;" put line
         "    decref("
         over num-resource-inputs repeat(
-            "    value_uncons_c(car, &car, &cdr);" ;
-            . "cdr);" ;
+            "    value_uncons_c(car, &car, &cdr);" put line
+            put "cdr);" put line
             "    push_resource("
         )
         over num-type-inputs repeat(
-            "    value_uncons_c(car, &car, &cdr);" ;
-            . "cdr);" ;
+            "    value_uncons_c(car, &car, &cdr);" put line
+            put "cdr);" put line
             "    push_value("
         )
-        . "car);" ;
+        put "car);" put line
     )
-    "}" ;
+    "}" put line
 
     drop)
 
 def(c99-externals!, +C99 -- +C99,
-    External.for(c99-external!) .lf)
+    External.for(c99-external!) line)
 
 def(c99-external!, External +C99 -- +C99,
     dup sig sig-arity
@@ -259,29 +259,29 @@ def(c99-external!, External +C99 -- +C99,
         "can't declare external with multiple return values" panic!,
 
         dup 1 >= if(
-            "int64_t " .,
-            "void " .
-        )
+            "int64_t ",
+            "void "
+        ) put
     )
 
-    dip2(dup name >Str .)
+    dip2(dup name >Str put)
 
-    " (" .
-    over dup 0> if("int64_t" . 1- repeat(", int64_t" .), drop "void" .)
-    ");" ;
+    " (" put
+    over dup 0> if("int64_t" put 1- repeat(", int64_t" put), drop "void" put)
+    ");" put line
 
-    "static void mw_" . dip2(dup name .name) " (void) {" ;
-    over countdown("    int64_t x" . .n " = pop_i64();" ;)
-    dup 0> if("    push_i64(", "    ") .
-    dip2(dup name >Str .)
-    "(" .
+    dip2(dup name sig put) " {" put line
+    over countdown("    int64_t x" put put " = pop_i64();" put line)
+    dup 0> if("    push_i64(", "    ") put
+    dip2(dup name >Str put)
+    "(" put
     dip(dup 0> if(
-        dup 1- dup count("x" . .n ", " .) "x" . .n,
+        dup 1- dup count("x" put put ", " put) "x" put put,
         id
     ))
-    ")" .
-    dup 0> if(");", ";") ;
-    "}" ;
+    ")" put
+    dup 0> if(");", ";") put line
+    "}" put line
     drop3)
 
 def(c99-nest(f), (*a +C99 -- *b +C99) *a +C99 -- *b +C99,
@@ -289,20 +289,20 @@ def(c99-nest(f), (*a +C99 -- *b +C99) *a +C99 -- *b +C99,
     f
     depth@ 1- depth!)
 
-def(c99-indent, +C99 -- +C99, depth@ repeat("    " .))
-def(c99-line(f), (*a +C99 -- *b +C99) *a +C99 -- *b +C99, c99-indent f .lf)
+def(c99-indent, +C99 -- +C99, depth@ repeat("    " put))
+def(c99-line(f), (*a +C99 -- *b +C99) *a +C99 -- *b +C99, c99-indent f line)
 
 def(c99-call!, List(Arg) Name +C99 -- +C99,
     dip(c99-args-push!)
-    c99-line("mw_" . .name "();" .))
+    c99-line("mw_" put put "();" put))
 
 def(c99-arrow!, Arrow +C99 -- +C99, atoms for(c99-atom!))
 def(c99-atom!, Atom +C99 -- +C99,
-    c99-line("WORD_ATOM(" .
-        dup token row >Int .n ", " .
-        dup token col >Int .n ", " .
-        dup token name? if-some(>Str, "") .str
-        ");" .)
+    c99-line("WORD_ATOM(" put
+        dup token row >Int put ", " put
+        dup token col >Int put ", " put
+        dup token name? if-some(>Str, "") put-cstr
+        ");" put)
     sip(args) op
     c99-args-op!)
 
@@ -324,48 +324,49 @@ def(c99-args-op!, List(Arg) Op +C99 -- +C99,
     OP_BLOCK    -> nip c99-block-push!)
 
 def(c99-int!, Int +C99 -- +C99,
-    c99-line("push_i64(" . .n "LL);" .))
+    c99-line("push_i64(" put put "LL);" put))
 
 def(c99-str!, Str +C99 -- +C99,
-    c99-line("{" .)
+    c99-line("{" put)
     c99-nest(
-        c99-line("static bool vready = false;" .)
-        c99-line("static VAL v;" .)
-        c99-line("if (! vready) {" .)
+        c99-line("static bool vready = false;" put)
+        c99-line("static VAL v;" put)
+        c99-line("if (! vready) {" put)
         c99-nest(
             dup num-bytes 4090 > if(
-                "static uint8_t b[] = {" .
+                "static uint8_t b[] = {" put
                 c99-nest(
                     c99-indent dup str-bytes-for(
-                        >Int dup .n "," .
-                        10 = if(.lf c99-indent, id)
-                    ) .lf
+                        >Int dup put "," put
+                        10 = if(line c99-indent, id)
+                    ) line
                 )
-                c99-line("};" .)
-                c99-line("v = mkstr((char*)b, " . dup num-bytes .n ");" .),
-                c99-line("v = mkstr(" . dup .str ", " . dup num-bytes .n ");" .)
+                c99-line("};" put)
+                c99-line("v = mkstr((char*)b, " put dup num-bytes put ");" put),
+                c99-line("v = mkstr(" put dup put-cstr ", " put dup num-bytes put ");" put)
             )
-            c99-line("vready = true;" .)
+            c99-line("vready = true;" put)
         )
-        c99-line("}" .)
-        c99-line("push_value(v);" .)
-        c99-line("incref(v);" .)
+        c99-line("}" put)
+        c99-line("push_value(v);" put)
+        c99-line("incref(v);" put)
     )
-    c99-line("}" .)
+    c99-line("}" put)
     drop)
 
-def(.str, Str +C99 -- +C99, "\"" . str-bytes-for(c99-string-byte!) "\"" .)
+def(+C99.put-cstr, Str +C99 -- +C99,
+    "\"" put str-bytes-for(c99-string-byte!) "\"" put)
 
 def(c99-string-byte!, +C99 Byte -- +C99,
-    B'\' -> "\\\\" .,
-    BQUOTE -> "\\\"" .,
-    BHT -> "\\t" .,
-    BLF -> "\\n" .,
-    BCR -> "\\r" .,
+    B'\' -> "\\\\" put,
+    BQUOTE -> "\\\"" put,
+    BHT -> "\\t" put,
+    BLF -> "\\n" put,
+    BCR -> "\\r" put,
     _ ->
         dup BSPACE B'~' in-range if(
-            .b,
-            "\\x" . to-hexdigits dip(.b) .b
+            put,
+            "\\x" put to-hexdigits dip(put) put
         )
     )
 
@@ -381,13 +382,13 @@ def(c99-prim!, +C99 List(Arg) Prim -- +C99,
     PRIM_CORE_DIP ->
         match(
             L1 ->
-                c99-line("{" .)
+                c99-line("{" put)
                 c99-nest(
-                    c99-line("VAL d" . depth@ .n " = pop_value();" .)
+                    c99-line("VAL d" put depth@ put " = pop_value();" put)
                     c99-arg-run!
-                    c99-line("push_value(d" . depth@ .n ");" .)
+                    c99-line("push_value(d" put depth@ put ");" put)
                 )
-                c99-line("}" .),
+                c99-line("}" put),
             _ ->
                 PRIM_CORE_DIP c99-prim-default!
         ),
@@ -395,13 +396,13 @@ def(c99-prim!, +C99 List(Arg) Prim -- +C99,
     PRIM_CORE_RDIP ->
         match(
             L1 ->
-                c99-line("{" .)
+                c99-line("{" put)
                 c99-nest(
-                    c99-line("VAL d" . depth@ .n " = pop_resource();" .)
+                    c99-line("VAL d" put depth@ put " = pop_resource();" put)
                     c99-arg-run!
-                    c99-line("push_resource(d" . depth@ .n ");" .)
+                    c99-line("push_resource(d" put depth@ put ");" put)
                 )
-                c99-line("}" .),
+                c99-line("}" put),
             _ ->
                 PRIM_CORE_RDIP c99-prim-default!
         ),
@@ -409,11 +410,11 @@ def(c99-prim!, +C99 List(Arg) Prim -- +C99,
     PRIM_CORE_IF ->
         match(
             L2 ->
-                c99-line("if (pop_u64()) {" .)
+                c99-line("if (pop_u64()) {" put)
                 c99-nest(swap c99-arg-run!)
-                c99-line("} else {" .)
+                c99-line("} else {" put)
                 c99-nest(c99-arg-run!)
-                c99-line("}" .),
+                c99-line("}" put),
             _ ->
                 PRIM_CORE_IF c99-prim-default!
         ),
@@ -421,13 +422,13 @@ def(c99-prim!, +C99 List(Arg) Prim -- +C99,
     PRIM_CORE_WHILE ->
         match(
             L2 ->
-                c99-line("while(1) {" .)
+                c99-line("while(1) {" put)
                 c99-nest(
                     swap c99-arg-run!
-                    c99-line("if (! pop_u64()) break;" .)
+                    c99-line("if (! pop_u64()) break;" put)
                     c99-arg-run!
                 )
-                c99-line("}" .),
+                c99-line("}" put),
 
             _ ->
                 PRIM_CORE_WHILE c99-prim-default!
@@ -450,26 +451,26 @@ def(c99-arg-run!, Arg +C99 -- +C99,
 def(c99-block-run!, Block +C99 -- +C99,
     arrow c99-arrow!)
 
-def(Var+C99.var, Var +C99 -- +C99, "var_" . name .name)
-def(Param+C99.param, Param +C99 -- +C99, >Var .var)
+def(Var+C99.put, Var +C99 -- +C99, "var_" put name put)
+def(Param+C99.put, Param +C99 -- +C99, >Var put)
 
 def(c99-pack-ctx!, Ctx +C99 -- +C99,
-    c99-line("push_u64(0);" .)
+    c99-line("push_u64(0);" put)
     physical-vars for(
         c99-var-push!
-        c99-line("mw_prim_pack_cons();" .)
+        c99-line("mw_prim_pack_cons();" put)
     ))
 
 def(c99-unpack-ctx!, Ctx +C99 -- +C99,
     physical-vars reverse-for(
-        c99-line("mw_prim_pack_uncons();" .)
-        c99-line("VAL " . .var " = pop_value();" .)
+        c99-line("mw_prim_pack_uncons();" put)
+        c99-line("VAL " put put " = pop_value();" put)
     )
-    c99-line("mw_prim_drop();" .))
+    c99-line("mw_prim_drop();" put))
 
 def(c99-decref-ctx!, Ctx +C99 -- +C99,
     physical-vars reverse-for(
-        c99-line("decref(" . .var ");" .)
+        c99-line("decref(" put put ");" put)
     ))
 
 def(c99-block-push!, Block +C99 -- +C99,
@@ -477,35 +478,35 @@ def(c99-block-push!, Block +C99 -- +C99,
         SOME -> nip c99-var-push!,
         NONE ->
             dup ctx c99-pack-ctx!
-            c99-line("push_fnptr(&" . .block ");" .)
-            c99-line("mw_prim_pack_cons();" .)
+            c99-line("push_fnptr(&" put put ");" put)
+            c99-line("mw_prim_pack_cons();" put)
     ))
 
 def(c99-var!, Var +C99 -- +C99,
     dup auto-run? if(c99-var-run!, c99-var-push!))
 
 def(c99-var-run!, Var +C99 -- +C99,
-    c99-line("incref(" . dup .var ");" .)
-    c99-line("run_value(" . dup .var ");" .)
+    c99-line("incref(" put dup put ");" put)
+    c99-line("run_value(" put dup put ");" put)
     drop)
 
 def(c99-var-push!, Var +C99 -- +C99,
-    c99-line("incref(" . dup .var ");" .)
-    c99-line("push_value(" . dup .var ");" .)
+    c99-line("incref(" put dup put ");" put)
+    c99-line("push_value(" put dup put ");" put)
     drop)
 
 def(c99-lambda!, Lambda +C99 -- +C99,
-    c99-line("{" .)
+    c99-line("{" put)
     c99-nest(
         dup params reverse-for(
-            c99-line("VAL " . .param " = pop_value();" .)
+            c99-line("VAL " put put " = pop_value();" put)
         )
         dup body c99-arrow!
         params reverse-for(
-            c99-line("decref(" . .param ");" .)
+            c99-line("decref(" put put ");" put)
         )
     )
-    c99-line("}" .))
+    c99-line("}" put))
 
 def(c99-match!, Match +C99 -- +C99,
     dup is-transparent? if(
@@ -514,66 +515,66 @@ def(c99-match!, Match +C99 -- +C99,
         dup scrutinee-data?
         unwrap-or(token "non-uniform match, not supported at present" emit-fatal-error!)
         is-resource? if(
-            c99-line("switch (get_top_resource_data_tag()) {" .),
-            c99-line("switch (get_top_data_tag()) {" .)
+            c99-line("switch (get_top_resource_data_tag()) {" put),
+            c99-line("switch (get_top_data_tag()) {" put)
         )
         c99-nest(
             dup cases for(c99-case!)
             has-default-case? else(
-                c99-line("default: write(2, \"unexpected fallthrough in match\\n\", 32); mw_prim_debug(); exit(99);" .)
+                c99-line("default: write(2, \"unexpected fallthrough in match\\n\", 32); mw_prim_debug(); exit(99);" put)
             )
         )
-        c99-line("}").
+        c99-line("}" put)
     ))
 
 def(c99-case!, Case +C99 -- +C99,
     dup pattern c99-pattern!
     c99-nest(
         body c99-arrow!
-        c99-line("break;" .)
+        c99-line("break;" put)
     ))
 
 def(c99-pattern!, Pattern +C99 -- +C99,
     PATTERN_UNDERSCORE ->
-        c99-line("default:" .),
+        c99-line("default:" put),
 
     PATTERN_TAG ->
-        c99-line("case " . dup value .n "LL:" .)
+        c99-line("case " put dup value put "LL:" put)
         c99-nest(
-            c99-line("co_" . name .name "();" .)
+            c99-line("mp_" put name put "();" put)
         )
     )
 
-def(c99-word-sigs!, +C99 -- +C99, for-needed-words(c99-word-sig!) .lf)
+def(c99-word-sigs!, +C99 -- +C99, for-needed-words(c99-word-sig!) line)
 def(c99-word-sig!, Word +C99 -- +C99,
-    c99-line("static void mw_" . name .name " (void);" .))
+    c99-line("static void mw_" put name put " (void);" put))
 
-def(c99-block-sigs!, +C99 -- +C99, for-needed-blocks(c99-block-sig!) .lf)
+def(c99-block-sigs!, +C99 -- +C99, for-needed-blocks(c99-block-sig!) line)
 def(c99-block-sig!, Block +C99 -- +C99,
-    c99-line("static void " . .block " (void);" .))
+    c99-line("static void " put put " (void);" put))
 
-def(c99-field-sigs!, +C99 -- +C99, Field.for(c99-field-sig!) .lf)
+def(c99-field-sigs!, +C99 -- +C99, Field.for(c99-field-sig!) line)
 def(c99-field-sig!, Field +C99 -- +C99,
-    c99-line("static void mw_" . name .name " (void);" .))
+    c99-line("static void mw_" put name put " (void);" put))
 
 def(c99-block-enter!, Block +C99 -- +C99,
-    c99-line("WORD_ENTER(" .
-        dup .block ", " .
+    c99-line("WORD_ENTER(" put
+        dup put ", " put
         dup arrow home match(
             NONE -> "block",
             SOME -> name >Str " block" cat,
-        ) .str ", " .
-        dup token .module source-path >Str .str ", " .
-        dup token row >Int .n ", " .
-        dup token col >Int .n ");" . )
+        ) put-cstr ", " put
+        dup token .module source-path >Str put-cstr ", " put
+        dup token row >Int put ", " put
+        dup token col >Int put ");" put)
     drop)
 
 def(c99-block-exit!, Block +C99 -- +C99,
-    c99-line("WORD_EXIT(" . .block ");" .))
+    c99-line("WORD_EXIT(" put put ");" put))
 
-def(c99-block-defs!, +C99 -- +C99, for-needed-blocks(c99-block-def!) .lf)
+def(c99-block-defs!, +C99 -- +C99, for-needed-blocks(c99-block-def!) line)
 def(c99-block-def!, Block +C99 -- +C99,
-    c99-line("static void " . dup .block " (void) {" .)
+    c99-line("static void " put dup put " (void) {" put)
     c99-nest(
         dup c99-block-enter!
         dup arrow
@@ -582,74 +583,74 @@ def(c99-block-def!, Block +C99 -- +C99,
         ctx c99-decref-ctx!
         c99-block-exit!
     )
-    c99-line("}" .) .lf)
+    c99-line("}" put) line)
 
-def(Block+C99.block, Block +C99 -- +C99,
-    "mb_" .
+def(Block+C99.put, Block +C99 -- +C99,
+    "mb_" put
     dup arrow dup home match(
-        NONE -> drop Block.id .n,
+        NONE -> drop Block.id put,
         SOME ->
-            name .name "_" .
-            homeidx .n drop
+            name put "_" put
+            homeidx put drop
     ))
 
 def(c99-word-enter!, Word +C99 -- +C99,
-    c99-line("WORD_ENTER(" .
-        "mw_" . dup name .name ", " .
-        dup name >Str .str ", " .
-        dup body .module source-path >Str .str ", " .
-        dup body row >Int .n ", " .
-        dup body col >Int .n ");" . )
+    c99-line("WORD_ENTER(" put
+        "mw_" put dup name put ", " put
+        dup name >Str put-cstr ", " put
+        dup body .module source-path >Str put-cstr ", " put
+        dup body row >Int put ", " put
+        dup body col >Int put ");" put)
     drop)
 
 def(c99-word-exit!, Word +C99 -- +C99,
-    c99-line("WORD_EXIT(" .
-        "mw_" . dup name .name ");" .)
+    c99-line("WORD_EXIT(" put
+        "mw_" put dup name put ");" put)
     drop)
 
-def(c99-word-defs!, +C99 -- +C99, for-needed-words(c99-word-def!) .lf)
+def(c99-word-defs!, +C99 -- +C99, for-needed-words(c99-word-def!) line)
 def(c99-word-def!, Word +C99 -- +C99,
-    c99-line(dup name .w "{" .)
+    c99-line(dup name sig put " {" put)
     c99-nest(
         dup c99-word-enter!
         dup arrow c99-arrow!
         dup c99-word-exit!
     )
-    c99-line("}" .)
+    c99-line("}" put)
     drop)
 
-def(c99-field-defs!, +C99 -- +C99, Field.for(c99-field-def!) .lf)
+def(c99-field-defs!, +C99 -- +C99, Field.for(c99-field-def!) line)
 def(c99-field-def!, Field +C99 -- +C99,
-    "static VAL* fieldptr_" . dup name .name " (size_t i) {" ;
-    "    static struct VAL * p = 0;";
-    "    size_t m = " . TABLE_MAX_SIZE .n ";" ;
-    "    if (! p) { p = calloc(m, sizeof *p); }" ;
-    "    if (i>=m) { write(2,\"table too big\\n\",14); exit(123); }" ;
-    "    return p+i;" ;
-    "}" ;;  # TODO make this more flexible wrt table size
-            # note it's important to have stability,
-            # so we can't just realloc as we used to.
-    dup name .w "{" ;
-    "    size_t index = (size_t)pop_u64();" ;
-    "    VAL *v = fieldptr_" . dup name .name "(index);" ;
-    "    push_ptr(v);" ;
-    "}" ;;
-
+    "static VAL* fieldptr_" put dup name put " (size_t i) {" put line
+    "    static struct VAL * p = 0;" put line
+    "    size_t m = " put TABLE_MAX_SIZE put ";" put line
+    "    if (! p) { p = calloc(m, sizeof *p); }" put line
+    "    if (i>=m) { write(2,\"table too big\\n\",14); exit(123); }" put line
+    "    return p+i;" put line
+    "}" put line line
+        # TODO make this more flexible wrt table size
+        # note it's important to have stability,
+        # so we can't just realloc as we used to.
+    dup name sig put "{" put
+    "    size_t index = (size_t)pop_u64();" put line
+    "    VAL *v = fieldptr_" put dup name put "(index);" put line
+    "    push_ptr(v);" put line
+    "}" put line line
     drop)
 
 def(c99-main!, Arrow +C99 -- +C99,
-    c99-line("int main (int argc, char** argv) {" .)
+    c99-line("int main (int argc, char** argv) {" put)
     c99-nest(
-        c99-line("global_argc = argc;" .)
-        c99-line("global_argv = argv;" .)
-        c99-line("WORD_ENTER(" .
-            "(void(*)(void))0, " .
-            "\"<main>\", " .
-            dup token-start .module source-path >Str .str ", " .
-            dup token-start row >Int .n ", " .
-            dup token-start col >Int .n ");" .)
+        c99-line("global_argc = argc;" put)
+        c99-line("global_argv = argv;" put)
+        c99-line("WORD_ENTER(" put
+            "(void(*)(void))0, " put
+            "\"<main>\", " put
+            dup token-start .module source-path >Str put-cstr ", " put
+            dup token-start row >Int put ", " put
+            dup token-start col >Int put ");" put)
         c99-arrow!
-        c99-line("WORD_EXIT((void(*)(void))0);" .)
-        c99-line("return 0;" .)
+        c99-line("WORD_EXIT((void(*)(void))0);" put)
+        c99-line("return 0;" put)
     )
-    c99-line("}" .))
+    c99-line("}" put))

--- a/src/mirth/codegen.mth
+++ b/src/mirth/codegen.mth
@@ -351,10 +351,10 @@ def(.str, Str --, "\"" . str-bytes-for(c99-string-byte!) "\"" .)
 def(c99-string-byte!, Byte --,
     B'\' -> "\\\\" .,
     BQUOTE -> "\\\"" .,
-    BHT -> "\\t" ., 
+    BHT -> "\\t" .,
     BLF -> "\\n" .,
     BCR -> "\\r" .,
-    _ -> 
+    _ ->
         dup BSPACE B'~' in-range if(
             .b,
             "\\x" . to-hexdigits dip(.b) .b
@@ -489,7 +489,12 @@ def(c99-match!, Match --,
     dup is-transparent? if(
         cases first unwrap body c99-arrow!,
 
-        c99-line("switch (get_top_data_tag()) {" .)
+        dup scrutinee-data?
+        unwrap-or(token "non-uniform match, not supported at present" emit-fatal-error!)
+        is-resource? if(
+            c99-line("switch (get_top_resource_data_tag()) {" .),
+            c99-line("switch (get_top_data_tag()) {" .)
+        )
         c99-nest(
             dup cases for(c99-case!)
             has-default-case? else(

--- a/src/mirth/codegen.mth
+++ b/src/mirth/codegen.mth
@@ -28,14 +28,10 @@ import(mirth.data.var)
 import(mirth.data.match)
 import(mirth.elab)
 
-###########
-# Codegen #
-###########
+#########
+# NEEDS #
+#########
 
-def(CODEGEN_BUF_SIZE, Size, 0x2000)
-var(codegen-file, File)
-var(codegen-length, Size)
-buffer(CODEGEN_BUF, 0x2000)
 data(Need,
     NEED_WORD -> Word,
     NEED_BLOCK -> Block)
@@ -129,51 +125,41 @@ def(need-block-push, Block --,
     ))
 def(need-block-run, Block --, arrow need-arrow-run)
 
-def(codegen-full?, Bool,
-    codegen-length @ 4 + CODEGEN_BUF_SIZE >=)
+###########
+# Codegen #
+###########
 
-def(codegen-flush!, --,
-    codegen-length @ 0> if(
-        codegen-file @ File>Int CODEGEN_BUF codegen-length @
-        posix-write!
-        expect!(dup 0>, "codegen write failed")
-        expect!(dup codegen-length @ =, "codegen wrote fewer bytes than expected")
-        drop
-        0 codegen-length !,
-        id
-    ))
+var(c99-file-var, File)
+var(c99-depth-var, Int)
+var(c99-buffer-var, Str)
 
-def(.b, Byte --,
-    >U8
-    codegen-full? if(codegen-flush!, id)
-    codegen-length modify(dup 1+)
-    CODEGEN_BUF !!U8)
+data(+C99, MKC99-unsafe)
 
-def(., Str --,
-    dup prim-str-base over num-bytes
-    dup codegen-length @ + CODEGEN_BUF_SIZE > if(
-        codegen-flush!
-        while(dup CODEGEN_BUF_SIZE >,
-            over CODEGEN_BUF_SIZE CODEGEN_BUF prim-ptr-copy
-            CODEGEN_BUF_SIZE codegen-length !
-            codegen-flush!
-            dip(CODEGEN_BUF_SIZE swap .offset-unsafe)
-            CODEGEN_BUF_SIZE -
-        )
-        dup codegen-length ! CODEGEN_BUF prim-ptr-copy,
+def(Str+C99., Str +C99 -- +C99,
+    c99-buffer-var modify("")
+    swap cat
+    c99-buffer-var !
+    c99-buffer-var @ num-bytes 512 > then(codegen-flush!))
+def(Int+C99.n, Int +C99 -- +C99, int-to-str .)
+def(Byte+C99.b, Byte +C99 -- +C99, to-ascii-str unwrap .)
+def(+C99.depth@, +C99 -- Int +C99, c99-depth-var @)
+def(+C99.depth!, Int +C99 -- +C99, c99-depth-var !)
 
-        sip(codegen-length @ CODEGEN_BUF .offset-unsafe prim-ptr-copy)
-        codegen-length modify(+)
-    ) drop)
+def(codegen-start!, File +C99 -- +C99,
+    c99-file-var !
+    0 c99-depth-var !
+    "" c99-buffer-var !)
 
-def(codegen-start!, File --,
-    codegen-file ! 0 codegen-length !)
+def(codegen-flush!, +C99 -- +C99,
+    c99-file-var @
+    c99-buffer-var modify("")
+    write!)
 
-def(codegen-end!, --,
+def(codegen-end!, +C99 -- +C99,
     codegen-flush!
-    codegen-file @ close-file!
-    STDOUT codegen-file !
-    0 codegen-length !)
+    c99-file-var @ close-file!)
+
+def(with-c99, *a [*a +C99 -- *b +C99] -- *b, prim-unsafe-cast run)
 
 def(run-output-c99!, Arrow Path --,
     num-errors @ 0> if(
@@ -182,75 +168,103 @@ def(run-output-c99!, Arrow Path --,
         reset-needs!
         over determine-arrow-needs!
 
-        0 c99-depth !
-        to-output-path >Str
-        create-file! codegen-start!
-        c99-header!
-        c99-tags!
-        c99-buffers!
-        c99-variables!
-        c99-externals!
-        c99-word-sigs!
-        c99-block-sigs!
-        c99-field-sigs!
-        c99-main!
-        c99-field-defs!
-        c99-word-defs!
-        c99-block-defs!
-        codegen-end!
+        with-c99(
+            to-output-path >Str
+            create-file! codegen-start!
+            c99-header!
+            c99-tags!
+            c99-buffers!
+            c99-variables!
+            c99-externals!
+            c99-word-sigs!
+            c99-block-sigs!
+            c99-field-sigs!
+            c99-main!
+            c99-field-defs!
+            c99-word-defs!
+            c99-block-defs!
+            codegen-end!
+        )
     ))
 
-var(c99-depth, Int)
-
-def(.lf, --, BLF .b)
-def(;, Str --, . .lf)
-def(;;, Str --, . .lf .lf)
-def(.n, Int --, int-to-str .)
-def(.name, Name --, mangled .)
-
-def(.w, Name --, "static void mw_" . .name " (void)" .)
-def(.p, Prim --, name .w)
-def(.pm, Prim --, "#define mw_" . name .name "() " .)
+def(+C99.lf, +C99 -- +C99, "\n" .)
+def(Str+C99;, Str +C99 -- +C99, . .lf)
+def(Str+C99;;, Str +C99 -- +C99, . .lf .lf)
+def(Name+C99.name, Name +C99 -- +C99, mangled .)
+def(Name+C99.w, Name +C99 -- +C99, "static void mw_" . .name " (void)" .)
+def(Prim+C99.p, Prim +C99 -- +C99, name .w)
+def(Prim+C99.pm, Prim +C99 -- +C99, "#define mw_" . name .name "() " .)
 
 embed-str(c99-header-str, "src/mirth/mirth.h")
-def(c99-header!, --, c99-header-str . .lf)
+def(c99-header!, +C99 -- +C99, c99-header-str . .lf)
 
-def(c99-buffers!, --, Buffer.for(c99-buffer!) .lf)
-def(c99-buffer!, Buffer --,
+def(c99-buffers!, +C99 -- +C99, Buffer.for(c99-buffer!) .lf)
+def(c99-buffer!, Buffer +C99 -- +C99,
     dup name .w " {" ;
     "    static uint8_t b[" . dup size .n "] = {0};" ;
     "    push_ptr(&b);" ;
     "}" ;
     drop)
 
-def(c99-variables!, --, Variable.for(c99-variable!) .lf)
-def(c99-variable!, Variable --,
+def(c99-variables!, +C99 -- +C99, Variable.for(c99-variable!) .lf)
+def(c99-variable!, Variable +C99 -- +C99,
     "void mw_" . name .name "() {" ;
     "    static VAL v = {0};" ;
     "    push_ptr(&v);" ;
     "}" ;)
 
-def(c99-tags!, --, Tag.for(c99-tag!) .lf)
-def(c99-tag!, Tag --,
+def(c99-tags!, +C99 -- +C99, Tag.for(c99-tag!) .lf)
+def(c99-tag!, Tag +C99 -- +C99,
     dup name .w " {" ;
     dup is-transparent? if(
-        drop,
-        dup num-inputs 0= if(
-            "    push_u64(" . value .n "LL);" ;,
-
-            "    VAL car = pop_value();" ;
-            dup num-inputs 1- repeat("    car = mkcons(car, pop_value());" ;)
-            "    VAL tag = MKU64(" . value .n "LL);" ;
-            "    car = mkcons(car, tag);" ;
-            "    push_value(car);" ;
+        id,
+        "    VAL tag = MKU64(" . dup value .n "LL);" ;
+        "    VAL car = (" .
+        dup num-type-inputs repeat(
+            "pop_value());" ;
+            "    car = mkcons(car, " .
+        )
+        dup num-resource-inputs repeat(
+            "pop_resource());" ;
+            "    car = mkcons(car, " .
+        )
+        "tag);" ;
+        dup outputs-resource? if(
+            "    push_resource(car);" ; ,
+            "    push_value(car);" ; ,
         )
     )
-    "}" ;)
+    "}" ;
 
-def(c99-externals!, --,
+    "void co_" . dup name .name "() {" ;
+    dup is-transparent? if(
+        id,
+        dup outputs-resource? if(
+            "    VAL car = pop_resource();" ; ,
+            "    VAL car = pop_value();" ;
+        )
+        "    VAL cdr;" ;
+        "    decref("
+        over num-resource-inputs repeat(
+            "    value_uncons_c(car, &car, &cdr);" ;
+            . "cdr);" ;
+            "    push_resource("
+        )
+        over num-type-inputs repeat(
+            "    value_uncons_c(car, &car, &cdr);" ;
+            . "cdr);" ;
+            "    push_value("
+        )
+        . "car);" ;
+    )
+    "}" ;
+
+    drop)
+
+def(c99-externals!, +C99 -- +C99,
     External.for(c99-external!) .lf)
 
-def(c99-external!, External --,
+def(c99-external!, External +C99 -- +C99,
     dup sig sig-arity
     dup 2 >= if(
         "can't declare external with multiple return values" panic!,
@@ -281,20 +295,20 @@ def(c99-external!, External --,
     "}" ;
     drop3)
 
-def(c99-nest(f), (*a -- *b) *a -- *b,
-    c99-depth modify(1+)
+def(c99-nest(f), (*a +C99 -- *b +C99) *a +C99 -- *b +C99,
+    depth@ 1+ depth!
     f
-    c99-depth modify(1-))
+    depth@ 1- depth!)
 
-def(c99-indent, --, c99-depth @ repeat("    " .))
-def(c99-line(f), (*a -- *b) *a -- *b, c99-indent f .lf)
+def(c99-indent, +C99 -- +C99, depth@ repeat("    " .))
+def(c99-line(f), (*a +C99 -- *b +C99) *a +C99 -- *b +C99, c99-indent f .lf)
 
-def(c99-call!, List(Arg) Name --,
+def(c99-call!, List(Arg) Name +C99 -- +C99,
     dip(c99-args-push!)
     c99-line("mw_" . .name "();" .))
 
-def(c99-arrow!, Arrow --, atoms for(c99-atom!))
-def(c99-atom!, Atom --,
+def(c99-arrow!, Arrow +C99 -- +C99, atoms for(c99-atom!))
+def(c99-atom!, Atom +C99 -- +C99,
     c99-line("WORD_ATOM(" .
         dup token row >Int .n ", " .
         dup token col >Int .n ", " .
@@ -303,7 +317,7 @@ def(c99-atom!, Atom --,
     sip(args) op
     c99-args-op!)
 
-def(c99-args-op!, List(Arg) Op --,
+def(c99-args-op!, List(Arg) Op +C99 -- +C99,
     OP_NONE     -> drop,
     OP_INT      -> nip c99-int!,
     OP_STR      -> nip c99-str!,
@@ -320,10 +334,10 @@ def(c99-args-op!, List(Arg) Op --,
     OP_VAR      -> nip c99-var!,
     OP_BLOCK    -> nip c99-block-push!)
 
-def(c99-int!, Int --,
+def(c99-int!, Int +C99 -- +C99,
     c99-line("push_i64(" . .n "LL);" .))
 
-def(c99-str!, Str --,
+def(c99-str!, Str +C99 -- +C99,
     c99-line("{" .)
     c99-nest(
         c99-line("static bool vready = false;" .)
@@ -351,9 +365,9 @@ def(c99-str!, Str --,
     c99-line("}" .)
     drop)
 
-def(.str, Str --, "\"" . str-bytes-for(c99-string-byte!) "\"" .)
+def(.str, Str +C99 -- +C99, "\"" . str-bytes-for(c99-string-byte!) "\"" .)
 
-def(c99-string-byte!, Byte --,
+def(c99-string-byte!, +C99 Byte -- +C99,
     B'\' -> "\\\\" .,
     BQUOTE -> "\\\"" .,
     BHT -> "\\t" .,
@@ -366,23 +380,23 @@ def(c99-string-byte!, Byte --,
         )
     )
 
-def(c99-constant!, Constant --,
+def(c99-constant!, Constant +C99 -- +C99,
     value c99-value!)
 
-def(c99-value!, Value --,
+def(c99-value!, Value +C99 -- +C99,
     VALUE_INT -> c99-int!,
     VALUE_STR -> c99-str!,
     VALUE_BLOCK -> c99-block-push!)
 
-def(c99-prim!, List(Arg) Prim --,
+def(c99-prim!, +C99 List(Arg) Prim -- +C99,
     PRIM_CORE_DIP ->
         match(
             L1 ->
                 c99-line("{" .)
                 c99-nest(
-                    c99-line("VAL d" . c99-depth @ .n " = pop_value();" .)
+                    c99-line("VAL d" . depth@ .n " = pop_value();" .)
                     c99-arg-run!
-                    c99-line("push_value(d" . c99-depth @ .n ");" .)
+                    c99-line("push_value(d" . depth@ .n ");" .)
                 )
                 c99-line("}" .),
             _ ->
@@ -394,9 +408,9 @@ def(c99-prim!, List(Arg) Prim --,
             L1 ->
                 c99-line("{" .)
                 c99-nest(
-                    c99-line("VAL d" . c99-depth @ .n " = pop_resource();" .)
+                    c99-line("VAL d" . depth@ .n " = pop_resource();" .)
                     c99-arg-run!
-                    c99-line("push_resource(d" . c99-depth @ .n ");" .)
+                    c99-line("push_resource(d" . depth@ .n ");" .)
                 )
                 c99-line("}" .),
             _ ->
@@ -432,44 +446,44 @@ def(c99-prim!, List(Arg) Prim --,
 
     _ -> c99-prim-default!)
 
-def(c99-prim-default!, List(Arg) Prim --,
+def(c99-prim-default!, List(Arg) Prim +C99 -- +C99,
     name c99-call!)
 
-def(c99-args-push!, List(Arg) --,
+def(c99-args-push!, List(Arg) +C99 -- +C99,
     for(c99-arg-push!))
 
-def(c99-arg-push!, Arg --,
+def(c99-arg-push!, Arg +C99 -- +C99,
     ARG_BLOCK -> c99-block-push!)
 
-def(c99-arg-run!, Arg --,
+def(c99-arg-run!, Arg +C99 -- +C99,
     ARG_BLOCK -> c99-block-run!)
 
-def(c99-block-run!, Block --,
+def(c99-block-run!, Block +C99 -- +C99,
     arrow c99-arrow!)
 
-def(.var, Var --, "var_" . name .name)
-def(.param, Param --, >Var .var)
+def(Var+C99.var, Var +C99 -- +C99, "var_" . name .name)
+def(Param+C99.param, Param +C99 -- +C99, >Var .var)
 
-def(c99-pack-ctx!, Ctx --,
+def(c99-pack-ctx!, Ctx +C99 -- +C99,
     c99-line("push_u64(0);" .)
     physical-vars for(
         c99-var-push!
         c99-line("mw_prim_pack_cons();" .)
     ))
 
-def(c99-unpack-ctx!, Ctx --,
+def(c99-unpack-ctx!, Ctx +C99 -- +C99,
     physical-vars reverse-for(
         c99-line("mw_prim_pack_uncons();" .)
         c99-line("VAL " . .var " = pop_value();" .)
     )
     c99-line("mw_prim_drop();" .))
 
-def(c99-decref-ctx!, Ctx --,
+def(c99-decref-ctx!, Ctx +C99 -- +C99,
     physical-vars reverse-for(
         c99-line("decref(" . .var ");" .)
     ))
 
-def(c99-block-push!, Block --,
+def(c99-block-push!, Block +C99 -- +C99,
     dup block-to-run-var match(
         SOME -> nip c99-var-push!,
         NONE ->
@@ -478,20 +492,20 @@ def(c99-block-push!, Block --,
             c99-line("mw_prim_pack_cons();" .)
     ))
 
-def(c99-var!, Var --,
+def(c99-var!, Var +C99 -- +C99,
     dup auto-run? if(c99-var-run!, c99-var-push!))
 
-def(c99-var-run!, Var --,
+def(c99-var-run!, Var +C99 -- +C99,
     c99-line("incref(" . dup .var ");" .)
     c99-line("run_value(" . dup .var ");" .)
     drop)
 
-def(c99-var-push!, Var --,
+def(c99-var-push!, Var +C99 -- +C99,
     c99-line("incref(" . dup .var ");" .)
     c99-line("push_value(" . dup .var ");" .)
     drop)
 
-def(c99-lambda!, Lambda --,
+def(c99-lambda!, Lambda +C99 -- +C99,
     c99-line("{" .)
     c99-nest(
         dup params reverse-for(
@@ -504,7 +518,7 @@ def(c99-lambda!, Lambda --,
     )
     c99-line("}" .))
 
-def(c99-match!, Match --,
+def(c99-match!, Match +C99 -- +C99,
     dup is-transparent? if(
         cases first unwrap body c99-arrow!,
 
@@ -523,41 +537,37 @@ def(c99-match!, Match --,
         c99-line("}").
     ))
 
-def(c99-case!, Case --,
+def(c99-case!, Case +C99 -- +C99,
     dup pattern c99-pattern!
     c99-nest(
         body c99-arrow!
         c99-line("break;" .)
     ))
 
-def(c99-pattern!, Pattern --,
+def(c99-pattern!, Pattern +C99 -- +C99,
     PATTERN_UNDERSCORE ->
         c99-line("default:" .),
 
     PATTERN_TAG ->
         c99-line("case " . dup value .n "LL:" .)
         c99-nest(
-            num-inputs dup 0> if(
-                c99-line("mw_prim_pack_uncons(); mw_prim_drop();" .)
-                1- repeat(c99-line("mw_prim_pack_uncons(); mw_prim_swap();" .)),
-                drop c99-line("mw_prim_drop();" .)
-            )
+            c99-line("co_" . name .name "();" .)
         )
     )
 
-def(c99-word-sigs!, --, for-needed-words(c99-word-sig!) .lf)
-def(c99-word-sig!, Word --,
+def(c99-word-sigs!, +C99 -- +C99, for-needed-words(c99-word-sig!) .lf)
+def(c99-word-sig!, Word +C99 -- +C99,
     c99-line("static void mw_" . name .name " (void);" .))
 
-def(c99-block-sigs!, --, for-needed-blocks(c99-block-sig!) .lf)
-def(c99-block-sig!, Block --,
+def(c99-block-sigs!, +C99 -- +C99, for-needed-blocks(c99-block-sig!) .lf)
+def(c99-block-sig!, Block +C99 -- +C99,
     c99-line("static void " . .block " (void);" .))
 
-def(c99-field-sigs!, --, Field.for(c99-field-sig!) .lf)
-def(c99-field-sig!, Field --,
+def(c99-field-sigs!, +C99 -- +C99, Field.for(c99-field-sig!) .lf)
+def(c99-field-sig!, Field +C99 -- +C99,
     c99-line("static void mw_" . name .name " (void);" .))
 
-def(c99-block-enter!, Block --,
+def(c99-block-enter!, Block +C99 -- +C99,
     c99-line("WORD_ENTER(" .
         dup .block ", " .
         dup arrow home match(
@@ -569,11 +579,11 @@ def(c99-block-enter!, Block --,
         dup token col >Int .n ");" . )
     drop)
 
-def(c99-block-exit!, Block --,
+def(c99-block-exit!, Block +C99 -- +C99,
     c99-line("WORD_EXIT(" . .block ");" .))
 
-def(c99-block-defs!, --, for-needed-blocks(c99-block-def!) .lf)
-def(c99-block-def!, Block --,
+def(c99-block-defs!, +C99 -- +C99, for-needed-blocks(c99-block-def!) .lf)
+def(c99-block-def!, Block +C99 -- +C99,
     c99-line("static void " . dup .block " (void) {" .)
     c99-nest(
         dup c99-block-enter!
@@ -585,7 +595,7 @@ def(c99-block-def!, Block --,
     )
     c99-line("}" .) .lf)
 
-def(.block, Block -- ,
+def(Block+C99.block, Block +C99 -- +C99,
     "mb_" .
     dup arrow dup home match(
         NONE -> drop Block.id .n,
@@ -594,7 +604,7 @@ def(.block, Block -- ,
             homeidx .n drop
     ))
 
-def(c99-word-enter!, Word --,
+def(c99-word-enter!, Word +C99 -- +C99,
     c99-line("WORD_ENTER(" .
         "mw_" . dup name .name ", " .
         dup name >Str .str ", " .
@@ -603,13 +613,13 @@ def(c99-word-enter!, Word --,
         dup body col >Int .n ");" . )
     drop)
 
-def(c99-word-exit!, Word --,
+def(c99-word-exit!, Word +C99 -- +C99,
     c99-line("WORD_EXIT(" .
         "mw_" . dup name .name ");" .)
     drop)
 
-def(c99-word-defs!, --, for-needed-words(c99-word-def!) .lf)
-def(c99-word-def!, Word --,
+def(c99-word-defs!, +C99 -- +C99, for-needed-words(c99-word-def!) .lf)
+def(c99-word-def!, Word +C99 -- +C99,
     c99-line(dup name .w "{" .)
     c99-nest(
         dup c99-word-enter!
@@ -619,8 +629,8 @@ def(c99-word-def!, Word --,
     c99-line("}" .)
     drop)
 
-def(c99-field-defs!, --, Field.for(c99-field-def!) .lf)
-def(c99-field-def!, Field --,
+def(c99-field-defs!, +C99 -- +C99, Field.for(c99-field-def!) .lf)
+def(c99-field-def!, Field +C99 -- +C99,
     "static VAL* fieldptr_" . dup name .name " (size_t i) {" ;
     "    static struct VAL * p = 0;";
     "    size_t m = " . TABLE_MAX_SIZE .n ";" ;
@@ -638,7 +648,7 @@ def(c99-field-def!, Field --,
 
     drop)
 
-def(c99-main!, Arrow --,
+def(c99-main!, Arrow +C99 -- +C99,
     c99-line("int main (int argc, char** argv) {" .)
     c99-nest(
         c99-line("global_argc = argc;" .)

--- a/src/mirth/data/data.mth
+++ b/src/mirth/data/data.mth
@@ -21,23 +21,6 @@ def(Data.name, Data -- Name, ~name @)
 def(Data.arity, Data -- Int, ~arity @)
 def(Data.tags, Data -- List(Tag), ~tags @)
 
-table(Tag)
-field(Tag~data, Tag, Data)
-field(Tag~name, Tag, Name)
-field(Tag~value, Tag, Int)
-field(Tag~num-inputs, Tag, Int)
-field(Tag~sig?, Tag, Maybe(Token))
-field(Tag~ctx-type, Tag, Lazy([Ctx ArrowType]))
-
-def(Tag.data, Tag -- Data, ~data @)
-def(Tag.name, Tag -- Name, ~name @)
-def(Tag.value, Tag -- Int, ~value @)
-def(Tag.num-inputs, Tag -- Int, ~num-inputs @)
-def(Tag.sig?, Tag -- Maybe(Token), ~sig? @)
-def(Tag.ctx-type, Tag -- Ctx ArrowType, ~ctx-type force! unpack2)
-def(Tag.ctx, Tag -- Ctx, ctx-type drop)
-def(Tag.type, Tag -- ArrowType, ctx-type nip)
-
 var(DATA_BOOL, Data)
 var(TAG_T, Tag)
 var(TAG_F, Tag)
@@ -82,7 +65,8 @@ def(make-tag!, Str Int List(Type) Mut(Tag) --,
     @
     dip(sip(len) TT)
     sip(CTX0 rotr .data TData T1 T-> pack2 LAZY_READY) sip(~ctx-type !)
-    sip(~num-inputs !)
+    sip(~num-type-inputs !)
+    sip(0 swap ~num-resource-inputs !)
     sip(~value !)
     dip(>Name) dup2 ~name !
     DEF_TAG swap ~Def !)
@@ -114,12 +98,15 @@ def(Data.add-tag!, Tag Data --,
     dup tags rotr dip(snoc) ~tags !)
 
 def(Data.is-enum?, Data -- Bool,
-    tags all?(dup num-inputs 0=) nip)
+    tags all?(dup num-type-inputs 0= and(dup num-resource-inputs 0=)) nip)
 
 def(Data.is-transparent?, Data -- Bool,
-    tags match(
-        L1 -> num-inputs 1 =,
-        _ -> drop F
+    dup is-resource? if(
+        drop F,
+        tags match(
+            L1 -> dup num-type-inputs 1 = swap num-resource-inputs 0 = &&,
+            _ -> drop F
+        )
     ))
 
 def(Data.is-resource?, Data -- Bool,
@@ -129,10 +116,44 @@ def(Data.is-resource?, Data -- Bool,
 # TAG #
 #######
 
-def(Tag.num-inputs-from-sig, Tag -- Int,
-    sig? if-some(run-length, 0))
+table(Tag)
+field(Tag~data, Tag, Data)
+field(Tag~name, Tag, Name)
+field(Tag~value, Tag, Int)
+field(Tag~num-type-inputs, Tag, Int)
+field(Tag~num-resource-inputs, Tag, Int)
+field(Tag~sig?, Tag, Maybe(Token))
+field(Tag~ctx-type, Tag, Lazy([Ctx ArrowType]))
+
+def(Tag.data, Tag -- Data, ~data @)
+def(Tag.name, Tag -- Name, ~name @)
+def(Tag.value, Tag -- Int, ~value @)
+def(Tag.num-type-inputs, Tag -- Int, ~num-type-inputs @)
+def(Tag.num-resource-inputs, Tag -- Int, ~num-resource-inputs @)
+def(Tag.sig?, Tag -- Maybe(Token), ~sig? @)
+def(Tag.ctx-type, Tag -- Ctx ArrowType, ~ctx-type force! unpack2)
+def(Tag.ctx, Tag -- Ctx, ctx-type drop)
+def(Tag.type, Tag -- ArrowType, ctx-type nip)
+
+def(Tag.num-type-inputs-from-sig, Tag -- Int,
+    dup sig? if-some(
+        run-length
+        swap num-resource-inputs-from-sig -,
+        drop 0
+    ))
+
+def(Tag.num-resource-inputs-from-sig, Tag -- Int,
+    sig? if-some(
+        run-tokens filter-some(name?)
+        filter(dup could-be-resource-var or(dup could-be-resource-con))
+        len,
+        0
+    ))
 
 def(Tag.is-transparent?, Tag -- Bool,
     .data is-transparent?)
+
+def(Tag.outputs-resource?, Tag -- Bool,
+    .data is-resource?)
 
 def(Tag=, Tag Tag -- Bool, both(.id) =)

--- a/src/mirth/data/data.mth
+++ b/src/mirth/data/data.mth
@@ -122,6 +122,9 @@ def(Data.is-transparent?, Data -- Bool,
         _ -> drop F
     ))
 
+def(Data.is-resource?, Data -- Bool,
+    name could-be-resource-con)
+
 #######
 # TAG #
 #######

--- a/src/mirth/data/def.mth
+++ b/src/mirth/data/def.mth
@@ -68,3 +68,17 @@ def(Def.typecheck!, Def --,
     DEF_TAG -> type drop,
     DEF_VARIABLE -> type drop,
     DEF_CONSTANT -> drop)
+
+def(Def.callable?, Def -- Bool,
+    DEF_NONE -> F,
+    DEF_ALIAS -> target >Def callable?,
+    DEF_MODULE -> drop F,
+    DEF_BUFFER -> drop T,
+    DEF_PRIM -> drop T,
+    DEF_TYPE -> drop F,
+    DEF_EXTERNAL -> drop T,
+    DEF_WORD -> drop T,
+    DEF_FIELD -> drop T,
+    DEF_TAG -> drop T,
+    DEF_VARIABLE -> drop T,
+    DEF_CONSTANT -> drop T)

--- a/src/mirth/data/match.mth
+++ b/src/mirth/data/match.mth
@@ -46,23 +46,35 @@ def(Match.is-exhaustive?, Match -- Bool,
                 num-tags
                 over cases len =,
             NONE ->
-                T # presume exhaustiveness
+                dup cases len 0>,
+                # presume exhaustiveness generally.
+                # and don't support empty matches for now.
         )
     ) nip)
 
 def(Match.has-default-case?, Match -- Bool,
     cases any(dup is-default-case?))
 
-||| Get type we're matching over.
-def(Match.scrutinee?, Match -- Maybe(Type),
-    dom top-type)
-
-||| Get "data" associated with scrutinee.
+||| Get "data" associated with scrutinee. Only returns Data if all the
+||| TAG patterns use it.
 def(Match.scrutinee-data?, Match -- Maybe(Data),
-    scrutinee? bind(data?))
+    cases filter(dup is-default-case? not) dup
+    first bind(pattern tag?) map(.data) if-some(
+        swap all(dup pattern tag? if-some(dip(over) .data =, F)) if(
+            SOME,
+            drop NONE
+        ),
+        drop NONE
+    ))
 
 def(Match.is-transparent?, Match -- Bool,
-    scrutinee-data? if-some(is-transparent?, F))
+    cases match(
+        L1 -> pattern match(
+            PATTERN_TAG -> .data is-transparent?,
+            PATTERN_UNDERSCORE -> T
+        ),
+        _ -> drop F
+    ))
 
 def(Match.add-case!, Case Match --,
     dup2 case-redundant? if(

--- a/src/mirth/data/name.mth
+++ b/src/mirth/data/name.mth
@@ -86,14 +86,15 @@ def(Name.tail, Name -- Name,
         dup 2 >=
         if(dip(dip(1) .offset-unsafe) 1- prim-str-copy, drop2 "")
     ) >Name)
-    
+
 def(Name.could-be-type, Name -- Bool, head is-alpha)
 def(Name.could-be-type-var, Name -- Bool, head is-lower)
 def(Name.could-be-type-con, Name -- Bool, head is-upper)
 def(Name.is-type-hole, Name -- Bool, dup head B'?' = swap tail-head dup BNUL = swap is-lower || &&)
 def(Name.is-underscore, Name -- Bool, dup head B'_' = swap tail-head BNUL = &&)
 def(Name.could-be-stack-var, Name -- Bool, dup head B'*' = swap tail-head is-lower &&)
-def(Name.could-be-effect-con, Name -- Bool, dup head B'+' = swap tail-head is-upper &&)
+def(Name.could-be-resource-var, Name -- Bool, dup head B'+' = swap tail-head is-lower &&)
+def(Name.could-be-resource-con, Name -- Bool, dup head B'+' = swap tail-head is-upper &&)
 def(Name.print-mangled!, Name --, mangled print!)
 def(Name.mangle-compute!, Name -- Str,
     build-str!(>Str str-bytes-for(

--- a/src/mirth/data/prim.mth
+++ b/src/mirth/data/prim.mth
@@ -26,6 +26,9 @@ data(Prim,
     PRIM_CORE_MATCH,
     PRIM_CORE_LAMBDA,
 
+    PRIM_CORE_RSWAP,
+    PRIM_CORE_RDIP,
+
     PRIM_UNSAFE_CAST,
 
     PRIM_INT_EQ,
@@ -174,6 +177,9 @@ def(init-prims!, --,
     PRIM_CORE_RUN "prim-run" def-prim!
     PRIM_CORE_MATCH "prim-match" def-prim!
     PRIM_CORE_LAMBDA "prim-lambda" def-prim!
+
+    PRIM_CORE_RSWAP "prim-rswap" def-prim!
+    PRIM_CORE_RDIP "prim-rdip" def-prim!
 
     PRIM_UNSAFE_CAST "prim-unsafe-cast" def-prim!
 
@@ -390,10 +396,15 @@ def(init-prims!, --,
     TYPE_TYPE "a" >Name Var.new!
     TYPE_TYPE "b" >Name Var.new!
     TYPE_TYPE "c" >Name Var.new!
+    TYPE_RESOURCE "+r" >Name Var.new!
+    TYPE_RESOURCE "+s" >Name Var.new!
     TYPE_STACK "*x" >Name Var.new!
     TYPE_STACK "*y" >Name Var.new!
-    \( a b c xs ys -> a TVar b TVar c TVar xs STVar ys STVar
-    \( ta tb tc txs tys ->
+    \( a b c rr sr xs ys ->
+        a TVar b TVar c TVar
+        rr TVar RESOURCE sr TVar RESOURCE
+        xs STVar ys STVar
+    \( ta tb tc trr tsr txs tys ->
         a CTX1
         ta T1 T0 T->
         PRIM_CORE_DROP ctx-type!
@@ -435,6 +446,14 @@ def(init-prims!, --,
             txs txs T-> >Type T*
         txs T->
         PRIM_CORE_WHILE ctx-type!
+
+        rr sr CTX2
+        T0 trr T+ tsr T+ T0 tsr T+ trr T+ T->
+        PRIM_CORE_RSWAP ctx-type!
+
+        xs ys rr CTX3
+        txs trr T+ txs tys T-> >Type T* tys trr T+ T->
+        PRIM_CORE_RDIP ctx-type!
 
         xs b CTX2
         txs >Type tb T2 txs tb T* >Type T1 T->

--- a/src/mirth/data/token.mth
+++ b/src/mirth/data/token.mth
@@ -66,7 +66,8 @@ def(TokenValue.sig-type-hole?, TokenValue -- Bool, name? and-some(is-type-hole))
 def(TokenValue.sig-type-var?, TokenValue -- Bool, name? and-some(could-be-type-var))
 def(TokenValue.sig-param-name?, TokenValue -- Bool, sig-type-var?)
 def(TokenValue.sig-stack-var?, TokenValue -- Bool, name? and-some(could-be-stack-var))
-def(TokenValue.sig-effect-con?, TokenValue -- Bool, name? and-some(could-be-effect-con))
+def(TokenValue.sig-resource-var?, TokenValue -- Bool, name? and-some(could-be-resource-var))
+def(TokenValue.sig-resource-con?, TokenValue -- Bool, name? and-some(could-be-resource-con))
 def(TokenValue.sig-dashes?, TokenValue -- Bool, name? and-some(PRIM_SYNTAX_DASHES name =))
 def(TokenValue.pat-arrow?, TokenValue -- Bool, name? and-some(PRIM_SYNTAX_ARROW name =))
 def(TokenValue.pat-underscore?, TokenValue -- Bool, name? and-some(is-underscore))
@@ -106,7 +107,8 @@ def(Token.sig-type-hole?, Token -- Bool, value sig-type-hole?)
 def(Token.sig-type-var?, Token -- Bool, value sig-type-var?)
 def(Token.sig-param-name?, Token -- Bool, value sig-param-name?)
 def(Token.sig-stack-var?, Token -- Bool, value sig-stack-var?)
-def(Token.sig-effect-con?, Token -- Bool, value sig-effect-con?)
+def(Token.sig-resource-var?, Token -- Bool, value sig-resource-var?)
+def(Token.sig-resource-con?, Token -- Bool, value sig-resource-con?)
 def(Token.sig-dashes?, Token -- Bool, value sig-dashes?)
 def(Token.pat-arrow?, Token -- Bool, value pat-arrow?)
 def(Token.pat-underscore?, Token -- Bool, value pat-underscore?)
@@ -268,9 +270,6 @@ def(Token.run-has-arrow?, Token -- Bool,
 def(Token.sig-stack-end?, Token -- Bool,
     dup sig-dashes? or(dup run-end?) nip)
 
-def(Token.sig-stack-end2?, Token -- Bool,
-    dup sig-stack-end? or(dup sig-effect-con?) nip)
-
 def(Token.sig-next-stack-end, Token -- Token,
     while(dup sig-stack-end? not, next))
 
@@ -296,4 +295,3 @@ def(Token.sig-count-types, Token -- Int Token,
 
 def(Token.sig-skip-dashes, Token -- Token,
     dup sig-has-dashes? then(sig-next-stack-end next))
-

--- a/src/mirth/data/token.mth
+++ b/src/mirth/data/token.mth
@@ -71,7 +71,7 @@ def(TokenValue.sig-resource-con?, TokenValue -- Bool, name? and-some(could-be-re
 def(TokenValue.sig-dashes?, TokenValue -- Bool, name? and-some(PRIM_SYNTAX_DASHES name =))
 def(TokenValue.pat-arrow?, TokenValue -- Bool, name? and-some(PRIM_SYNTAX_ARROW name =))
 def(TokenValue.pat-underscore?, TokenValue -- Bool, name? and-some(is-underscore))
-def(TokenValue.module-header?, TokenValue -- Bool, name? and-some(PRIM_SYNTAX_MODULE name =))
+def(TokenValue.module-header?, TokenValue -- Bool, name? and-some(>Str "module" =))
 
 table(Token)
 field(Token~value, Token, TokenValue)

--- a/src/mirth/data/type.mth
+++ b/src/mirth/data/type.mth
@@ -43,7 +43,9 @@ data(PrimType,
     PRIM_TYPE_RESOURCE,
     PRIM_TYPE_INT,
     PRIM_TYPE_PTR,
-    PRIM_TYPE_STR)
+    PRIM_TYPE_STR,
+    PRIM_TYPE_+PLATFORM,
+    )
 
 def(PrimType.is-physical?, PrimType -- Bool,
     PRIM_TYPE_TYPE -> F,
@@ -74,7 +76,8 @@ def(PrimType.tycon-name, PrimType -- Maybe(Name),
     PRIM_TYPE_RESOURCE -> NONE,
     PRIM_TYPE_INT -> "Int" >Name SOME,
     PRIM_TYPE_STR -> "Str" >Name SOME,
-    PRIM_TYPE_PTR -> "Ptr" >Name SOME)
+    PRIM_TYPE_PTR -> "Ptr" >Name SOME,
+    PRIM_TYPE_+PLATFORM -> "+Platform" >Name SOME)
 
 ||| Get value type constructor name.
 def(Value.tycon-name, Value -- Maybe(Name),
@@ -91,6 +94,7 @@ def(init-types!, --,
     TYPE_INT "Int" def-type!
     TYPE_PTR "Ptr" def-type!
     TYPE_STR "Str" def-type!
+    TYPE_+PLATFORM "+Platform" def-type!
     init-data!)
 
 #########
@@ -158,6 +162,8 @@ def(TYPE_STR, Type, PRIM_TYPE_STR TPrim) # string pointer (just a pointer but no
 # def(TYPE_I16, Type, PRIM_TYPE_I16 TPrim) # fixed width integer type -- signed 16 bit
 # def(TYPE_I32, Type, PRIM_TYPE_I32 TPrim) # fixed width integer type -- signed 32 bit
 # def(TYPE_I64, Type, PRIM_TYPE_I64 TPrim) # fixed width integer type -- signed 64 bit
+def(TYPE_+PLATFORM, Type, PRIM_TYPE_+PLATFORM TPrim)
+def(RESOURCE_+PLATFORM, Resource, TYPE_+PLATFORM RESOURCE)
 
 def(Type.expand, Type -- Type,
     TMeta -> expand,
@@ -349,6 +355,7 @@ def(PrimType.trace!, PrimType --,
         PRIM_TYPE_INT -> "Int",
         PRIM_TYPE_PTR -> "Ptr",
         PRIM_TYPE_STR -> "Str",
+        PRIM_TYPE_+PLATFORM -> "+Platform"
     ) trace!)
 
 # ||| Freshen a type signature in preparation for type sig application.
@@ -550,9 +557,7 @@ def(Type>Resource, Type -- Resource, RESOURCE)
 def(Resource.has-meta?, MetaVar Resource -- Bool, >Type has-meta?)
 def(Resource.unify!, Gamma Resource Resource -- Gamma Resource,
     both(>Type) unify! >Resource)
-def(Resource.trace!, Resource --,
-    "+" trace!
-    >Type trace!)
+def(Resource.trace!, Resource --, >Type trace!)
 def(Resource.freshen, Subst Resource -- Subst Resource,
     >Type freshen >Resource)
 def(Resource.rigidify!, Ctx Resource -- Ctx Resource,
@@ -617,12 +622,25 @@ def(StackType.resources, StackType -- List(Resource), split3 dip(drop2))
 def(StackType.top-type, StackType -- Maybe(Type),
     expand match(
         STCons -> nip SOME,
+        STWith -> drop top-type,
         _ -> drop NONE
     ))
 
 ||| Get the top type constructor name.
 def(StackType.top-tycon-name, StackType -- Maybe(Name),
     top-type bind(tycon-name))
+
+||| Get top resource if possible.
+def(StackType.top-resource, StackType -- Maybe(Resource),
+    expand match(
+        STWith -> nip SOME,
+        STCons -> drop top-resource,
+        _ -> drop NONE
+    ))
+
+||| Get the top resource name.
+def(StackType.top-resource-name, StackType -- Maybe(Name),
+    top-resource bind(>Type tycon-name))
 
 def(StackType.has-meta?, MetaVar StackType -- Bool,
     expand match(

--- a/src/mirth/data/type.mth
+++ b/src/mirth/data/type.mth
@@ -40,7 +40,7 @@ data(Value,
 data(PrimType,
     PRIM_TYPE_TYPE,
     PRIM_TYPE_STACK,
-    PRIM_TYPE_EFFECT,
+    PRIM_TYPE_RESOURCE,
     PRIM_TYPE_INT,
     PRIM_TYPE_PTR,
     PRIM_TYPE_STR)
@@ -48,7 +48,7 @@ data(PrimType,
 def(PrimType.is-physical?, PrimType -- Bool,
     PRIM_TYPE_TYPE -> F,
     PRIM_TYPE_STACK -> F,
-    PRIM_TYPE_EFFECT -> F,
+    PRIM_TYPE_RESOURCE -> F,
     _ -> drop T)
 
 ||| Get type constructor name for a type, if possible.
@@ -71,7 +71,7 @@ def(Type.tycon-name, Type -- Maybe(Name),
 def(PrimType.tycon-name, PrimType -- Maybe(Name),
     PRIM_TYPE_TYPE -> NONE,
     PRIM_TYPE_STACK -> NONE,
-    PRIM_TYPE_EFFECT -> NONE,
+    PRIM_TYPE_RESOURCE -> NONE,
     PRIM_TYPE_INT -> "Int" >Name SOME,
     PRIM_TYPE_STR -> "Str" >Name SOME,
     PRIM_TYPE_PTR -> "Ptr" >Name SOME)
@@ -97,6 +97,7 @@ def(init-types!, --,
 # Types #
 #########
 
+def(T+, StackType Resource -- StackType, STWith)
 def(T*, StackType Type -- StackType, STCons)
 def(T->, StackType StackType -- ArrowType, ARROW_TYPE)
 
@@ -144,7 +145,7 @@ def(Type.is-physical?, Type -- Bool,
 def(TYPE_UNIT, Type, STACK_TYPE_UNIT TTensor) # unit type
 def(TYPE_TYPE, Type, PRIM_TYPE_TYPE TPrim) # type of types
 def(TYPE_STACK, Type, PRIM_TYPE_STACK TPrim) # type of stack types
-def(TYPE_EFFECT, Type, PRIM_TYPE_EFFECT TPrim) # type of effect types
+def(TYPE_RESOURCE, Type, PRIM_TYPE_RESOURCE TPrim) # type of (linear) resources
 def(TYPE_INT, Type, PRIM_TYPE_INT TPrim) # generic integer type for integer literals
 def(TYPE_PTR, Type, PRIM_TYPE_PTR TPrim) # generic pointer type (e.g. void*)
 def(TYPE_STR, Type, PRIM_TYPE_STR TPrim) # string pointer (just a pointer but nominally)
@@ -343,7 +344,7 @@ def(PrimType.trace!, PrimType --,
     match(
         PRIM_TYPE_TYPE -> "<TYPE>",
         PRIM_TYPE_STACK -> "<STACK>",
-        PRIM_TYPE_EFFECT -> "<EFFECT>",
+        PRIM_TYPE_RESOURCE -> "<RESOURCE>",
         PRIM_TYPE_INT -> "Int",
         PRIM_TYPE_PTR -> "Ptr",
         PRIM_TYPE_STR -> "Str",
@@ -519,18 +520,6 @@ def(type-hole-unify!, Type Name -- Type,
     dup trace!
     line-trace!)
 
-##########
-# Params #
-##########
-
-def(ArrowType.max-num-params, ArrowType -- Int,
-    dom num-morphisms-on-top)
-
-def(StackType.num-morphisms-on-top, StackType -- Int,
-    STMeta -> expand-if(>StackType num-morphisms-on-top, drop 0),
-    STCons -> morphism? .if(num-morphisms-on-top 1+, drop 0),
-    _ -> drop 0)
-
 ############
 # APP TYPE #
 ############
@@ -550,6 +539,24 @@ def(Type.trace-app-open!, Type Type --,
             trace!
     ))
 
+#################
+# RESOURCE TYPE #
+#################
+
+data(Resource, RESOURCE -> Type)
+def(Resource>Type, Resource -- Type, RESOURCE -> id)
+def(Type>Resource, Type -- Resource, RESOURCE)
+def(Resource.has-meta?, MetaVar Resource -- Bool, >Type has-meta?)
+def(Resource.unify!, Gamma Resource Resource -- Gamma Resource,
+    both(>Type) unify! >Resource)
+def(Resource.trace!, Resource --,
+    "+" trace!
+    >Type trace!)
+def(Resource.freshen, Subst Resource -- Subst Resource,
+    >Type freshen >Resource)
+def(Resource.rigidify!, Ctx Resource -- Ctx Resource,
+    >Type rigidify! >Resource)
+
 ##############
 # STACK TYPE #
 ##############
@@ -560,7 +567,8 @@ data(StackType,
     STACK_TYPE_UNIT,
     STVar -> Var,
     STMeta -> MetaVar,
-    STCons -> StackType Type)
+    STCons -> StackType Type,
+    STWith -> StackType Resource)
 
 def(Type>StackType, Type -- StackType,
     TYPE_ERROR -> STACK_TYPE_ERROR,
@@ -587,18 +595,22 @@ def(StackType.unit?, StackType -- Bool,
         _ -> drop F
     ))
 
-||| Split stack type into bottom and top types.
-def(StackType.split, StackType -- StackType List(Type),
+||| Split stack type into base, types, and resources.
+def(StackType.split3, StackType -- StackType List(Type) List(Resource),
     expand match(
-        STCons -> dip(split) snoc,
-        _ -> L0
+        STCons -> dip(split3) swap dip(snoc),
+        STWith -> dip(split3) snoc,
+        _ -> L0 L0
     ))
 
 ||| Get bottom of stack.
-def(StackType.bottom, StackType -- StackType, split drop)
+def(StackType.base, StackType -- StackType, split3 drop2)
 
-||| Get top types on stack.
-def(StackType.top-types, StackType -- List(Type), split nip)
+||| Get types on stack.
+def(StackType.types, StackType -- List(Type), split3 drop nip)
+
+||| Get resources on stack.
+def(StackType.resources, StackType -- List(Resource), split3 dip(drop2))
 
 ||| Get top stack type if possible.
 def(StackType.top-type, StackType -- Maybe(Type),
@@ -618,7 +630,8 @@ def(StackType.has-meta?, MetaVar StackType -- Bool,
         STACK_TYPE_DONT_CARE -> drop F,
         STVar -> drop2 F,
         STACK_TYPE_UNIT -> drop F,
-        STCons -> dip(over) has-meta? if(drop2 T, has-meta?)
+        STCons -> dip(over) has-meta? if(drop2 T, has-meta?),
+        STWith -> dip(over) has-meta? if(drop2 T, has-meta?),
     ))
 
 def(StackType.unify-failed!, Gamma StackType StackType -- Gamma StackType,
@@ -653,9 +666,44 @@ def(StackType.unify!, Gamma StackType StackType -- Gamma StackType,
             STACK_TYPE_ERROR -> drop2 STACK_TYPE_ERROR,
             STMeta -> dip(STCons >Type) unify! >StackType,
             STACK_TYPE_DONT_CARE -> STCons,
-            STCons -> dip(swap dip(unify! swap)) unify! dip(swap) STCons,
-            _ -> dip(STCons) unify-failed!
+            _ -> dup force-cons?! if-some(
+                nip unpack2 dip(swap dip(unify! swap)) unify! dip(swap) STCons,
+                dip(STCons) unify-failed!
+            )
         ),
+        STWith -> rotl expand match(
+            STACK_TYPE_ERROR -> drop2 STACK_TYPE_ERROR,
+            STMeta -> dip(STWith >Type) unify! >StackType,
+            STACK_TYPE_DONT_CARE -> STWith,
+            _ -> dup force-with?! if-some(
+                nip unpack2 dip(swap dip(unify! swap)) unify! dip(swap) STWith,
+                dip(STWith) unify-failed!
+            )
+        ),
+    ))
+
+def(StackType.force-cons?!, StackType -- Maybe([StackType Type]),
+    expand match(
+        STCons -> pack2 SOME,
+        STWith -> swap force-cons?! map(unpack2 dip(over STWith) pack2) nip,
+        STMeta ->
+            dip(MetaVar.alloc! STMeta
+                MetaVar.alloc! TMeta
+                dup2 STCons >Type SOME) ~type? !
+            pack2 SOME,
+        _ -> drop NONE
+    ))
+
+def(StackType.force-with?!, StackType -- Maybe([StackType Resource]),
+    expand match(
+        STWith -> pack2 SOME,
+        STCons -> swap force-with?! map(unpack2 dip(over STCons) pack2) nip,
+        STMeta ->
+            dip(MetaVar.alloc! STMeta
+                MetaVar.alloc! TMeta RESOURCE
+                dup2 STWith >Type SOME) ~type? !
+            pack2 SOME,
+        _ -> drop NONE
     ))
 
 def(StackType.trace-dom!, StackType --,
@@ -672,20 +720,41 @@ def(StackType.trace-cod!, StackType --,
         trace!
     ))
 
-def(StackType.trace!, StackType --,
-    expand match(
-        STACK_TYPE_ERROR -> TYPE_ERROR trace!,
-        STACK_TYPE_DONT_CARE -> TYPE_DONT_CARE trace!,
-        STMeta -> MetaVar.trace!,
+def(StackType.trace-base!, StackType --,
+    match(
         STVar -> dup Var.trace! is-stack? else(" ." trace!),
-        STACK_TYPE_UNIT -> id,
-        STCons -> dip(trace-dom!) trace!,
+        _ -> >Type trace!
     ))
+
+def(StackType.trace!, StackType --,
+    split3
+    dip2(trace-base!)
+    dip(for(" " trace! trace!))
+    reverse-for(" " trace! trace!))
+
+    # rotl match(
+    #     STVar -> dup Var.trace! is-stack? else(" ." trace!),
+    #     _ -> >Type trace!,
+    # )
+
+
+    # )
+
+    # expand match(
+    #     STACK_TYPE_ERROR -> TYPE_ERROR trace!,
+    #     STACK_TYPE_DONT_CARE -> TYPE_DONT_CARE trace!,
+    #     STMeta -> MetaVar.trace!,
+    #     STVar ->
+    #     STACK_TYPE_UNIT -> id,
+    #     STCons -> dip(trace-dom!) trace!,
+    #     STWith -> dip(trace-dom!) trace!,
+    # ))
 
 def(StackType.semifreshen, StackType StackType -- StackType StackType,
     expand match(
         STACK_TYPE_UNIT -> dup,
         STCons -> dip(semifreshen) STCons,
+        STWith -> dip(semifreshen) STWith,
         _ -> "expected unit-based stack in semifreshen!" panic!
     ))
 
@@ -693,6 +762,7 @@ def(StackType.freshen, Subst StackType -- Subst StackType,
     expand match(
         STACK_TYPE_UNIT -> STACK_TYPE_UNIT,
         STCons -> dip(freshen) swap dip(freshen) swap STCons,
+        STWith -> dip(freshen) swap dip(freshen) swap STWith,
         _ -> >Type freshen >StackType
     ))
 
@@ -700,6 +770,7 @@ def(StackType.freshen-aux, StackType Subst StackType -- StackType Subst StackTyp
     expand match(
         STACK_TYPE_UNIT -> over,
         STCons -> dip(freshen-aux) swap dip(freshen) swap STCons,
+        STWith -> dip(freshen-aux) swap dip(freshen) swap STWith,
         _ -> >Type freshen >StackType
     ))
 
@@ -709,7 +780,14 @@ def(StackType.rigidify!, Ctx StackType -- Ctx StackType,
     STACK_TYPE_UNIT -> STACK_TYPE_UNIT,
     STMeta -> expand-or-update!(fresh-stack-type-var! TVar) >StackType rigidify!,
     STVar -> STVar,
-    STCons -> dip(rigidify!) swap dip(rigidify!) swap STCons)
+    STCons -> dip(rigidify!) swap dip(rigidify!) swap STCons,
+    STWith -> dip(rigidify!) swap dip(rigidify!) swap STWith)
+
+def(StackType.num-morphisms-on-top, StackType -- Int,
+    STMeta -> expand-if(>StackType num-morphisms-on-top, drop 0),
+    STCons -> morphism? .if(num-morphisms-on-top 1+, drop 0),
+    STWith -> drop num-morphisms-on-top,
+    _ -> drop 0)
 
 ##############
 # ARROW TYPE #
@@ -746,8 +824,8 @@ def(ArrowType.semifreshen-aux, ArrowType -- ArrowType,
     ARROW_TYPE nip)
 
 def(ArrowType.needs-fresh-stack-rest?, ArrowType -- Bool,
-    unpack bottom unit? if(
-        bottom unit?,
+    unpack base unit? if(
+        base unit?,
         drop F
     ))
 
@@ -774,6 +852,9 @@ def(ArrowType.rigidify!, Ctx ArrowType -- Ctx ArrowType,
     dip(rigidify!) swap
     dip(rigidify!) swap
     ARROW_TYPE)
+
+def(ArrowType.max-num-params, ArrowType -- Int,
+    dom num-morphisms-on-top)
 
 #########
 # Subst #

--- a/src/mirth/data/type.mth
+++ b/src/mirth/data/type.mth
@@ -724,7 +724,7 @@ def(StackType.trace-cod!, StackType --,
 def(StackType.trace-base!, StackType -- Bool,
     match(
         STACK_TYPE_UNIT -> id F,
-        STMeta -> trace! " ." trace! T,
+        STMeta -> "*" trace! trace! T,
         STVar -> dup trace! is-stack? else(" ." trace!) T,
         _ -> >Type trace! T
     ))
@@ -733,7 +733,7 @@ def(StackType.trace!, StackType --,
     split3
     dip2(trace-base!)
     dip(for(swap then(" " trace!) trace! T))
-    reverse-for(swap then(" " trace!) trace! T) drop)
+    for(swap then(" " trace!) trace! T) drop)
 
     # rotl match(
     #     STVar -> dup Var.trace! is-stack? else(" ." trace!),

--- a/src/mirth/data/type.mth
+++ b/src/mirth/data/type.mth
@@ -99,6 +99,7 @@ def(init-types!, --,
 
 def(T+, StackType Resource -- StackType, STWith)
 def(T*, StackType Type -- StackType, STCons)
+def(T*+, StackType Either(Type, Resource) -- StackType, match(LEFT -> T*, RIGHT -> T+))
 def(T->, StackType StackType -- ArrowType, ARROW_TYPE)
 
 def(TT, List(Type) -- StackType, T0 swap for(T*))
@@ -687,8 +688,8 @@ def(StackType.force-cons?!, StackType -- Maybe([StackType Type]),
         STCons -> pack2 SOME,
         STWith -> swap force-cons?! map(unpack2 dip(over STWith) pack2) nip,
         STMeta ->
-            dip(MetaVar.alloc! STMeta
-                MetaVar.alloc! TMeta
+            dip(MetaVar.new! STMeta
+                MetaVar.new! TMeta
                 dup2 STCons >Type SOME) ~type? !
             pack2 SOME,
         _ -> drop NONE
@@ -699,8 +700,8 @@ def(StackType.force-with?!, StackType -- Maybe([StackType Resource]),
         STWith -> pack2 SOME,
         STCons -> swap force-with?! map(unpack2 dip(over STCons) pack2) nip,
         STMeta ->
-            dip(MetaVar.alloc! STMeta
-                MetaVar.alloc! TMeta RESOURCE
+            dip(MetaVar.new! STMeta
+                MetaVar.new! TMeta RESOURCE
                 dup2 STWith >Type SOME) ~type? !
             pack2 SOME,
         _ -> drop NONE
@@ -720,17 +721,19 @@ def(StackType.trace-cod!, StackType --,
         trace!
     ))
 
-def(StackType.trace-base!, StackType --,
+def(StackType.trace-base!, StackType -- Bool,
     match(
-        STVar -> dup Var.trace! is-stack? else(" ." trace!),
-        _ -> >Type trace!
+        STACK_TYPE_UNIT -> id F,
+        STMeta -> trace! " ." trace! T,
+        STVar -> dup trace! is-stack? else(" ." trace!) T,
+        _ -> >Type trace! T
     ))
 
 def(StackType.trace!, StackType --,
     split3
     dip2(trace-base!)
-    dip(for(" " trace! trace!))
-    reverse-for(" " trace! trace!))
+    dip(for(swap then(" " trace!) trace! T))
+    reverse-for(swap then(" " trace!) trace! T) drop)
 
     # rotl match(
     #     STVar -> dup Var.trace! is-stack? else(" ." trace!),

--- a/src/mirth/data/var.mth
+++ b/src/mirth/data/var.mth
@@ -23,7 +23,7 @@ def(Var=, Var Var -- Bool, both(.id) =)
 def(Var.trace!, Var --, name trace!)
 def(Var.is-type?, Var -- Bool, type prim? and-some(PRIM_TYPE_TYPE =))
 def(Var.is-stack?, Var -- Bool, type prim? and-some(PRIM_TYPE_STACK =))
-def(Var.is-effect?, Var -- Bool, type prim? and-some(PRIM_TYPE_EFFECT =))
+def(Var.is-resource?, Var -- Bool, type prim? and-some(PRIM_TYPE_RESOURCE =))
 def(Var.is-physical?, Var -- Bool, type is-physical?)
 
 def(Var.new!, Type Name -- Var,

--- a/src/mirth/elab.mth
+++ b/src/mirth/elab.mth
@@ -8,6 +8,7 @@ import(data.list)
 import(data.maybe)
 import(data.either)
 import(data.path)
+import(data.byte)
 import(mirth.data.name)
 import(mirth.data.def)
 import(mirth.data.token)
@@ -508,18 +509,30 @@ def(elab-atom-name!, Name --,
             elab-atom-name-global!
     ))
 
-def(elab-relativize-name!, Name -- Name,
-    name-undefined? and(dup could-be-relative) if(
-        ab-type @ top-tycon-name for(
-            >Str over to-overload-suffix cat Name.search for(
-                name-defined? if(
-                    nip,
-                    drop
-                )
-            )
-        ),
+
+def(elab-needs-dot, Str -- Bool,
+    first-byte if-some(is-alpha, F))
+
+def(elab-combine-prefix, Str Str -- Str,
+    over elab-needs-dot then("." cat) swap cat)
+
+def(elab-combine-prefixes, List+(Str) Maybe(Str) -- List+(Str),
+    if-some(
+        over map(over elab-combine-prefix) nip cat+,
         id
     ))
+
+def(elab-word-search, Str -- Maybe(Name),
+    Name.search filter(dup >Def callable?))
+
+def(elab-name-candidates, Name -- List(Name),
+    >Str L1+
+    ab-type @ top-resource-name map(>Str) elab-combine-prefixes
+    ab-type @ top-tycon-name map(>Str) elab-combine-prefixes
+    filter-some(elab-word-search))
+
+def(elab-relativize-name!, Name -- Name,
+    dup elab-name-candidates first if-some(nip, id))
 
 def(elab-check-name-visible!, Name -- Name,
     dup >Def >Module? for(
@@ -586,7 +599,7 @@ def(elab-match-at!, StackType Token --,
 
 def(elab-atom-match!, --,
     MetaVar.new! STMeta
-    ab-token @ args+ first+
+    ab-token @ args+ first
     elab-match-at!)
 
 def(elab-lambda!, Lambda -- Lambda,
@@ -993,7 +1006,7 @@ def(elab-target-c99!, Token -- Token,
     typecheck-everything!
     sip(next) args-2
     dip(dup str? unwrap-or("expected output path" emit-fatal-error!) nip >Path)
-    dip(CTX0 T0 T0 T->)
+    dip(CTX0 T0 RESOURCE_+PLATFORM T+ T0 RESOURCE_+PLATFORM T+ T->)
     elab-arrow!
     swap run-output-c99!)
 

--- a/src/mirth/elab.mth
+++ b/src/mirth/elab.mth
@@ -74,42 +74,55 @@ def(elab-type-stack!, TypeElab Token -- TypeElab StackType Token,
 def(elab-type-stack-rest!, TypeElab StackType Token -- TypeElab StackType Token,
     while(dup sig-stack-end? not,
         swap dip(elab-type-atom!) swap
-        dip(swap T*)
+        dip(swap T*+)
     ))
 
 def(elab-type-arg!, TypeElab Token -- TypeElab Type Token,
     elab-type-atom!
+    swap match(
+        LEFT -> swap,
+        RIGHT -> drop "Expected type, not resource." emit-fatal-error!
+    )
     dup arg-end? if(
         id,
         "Unexpected token after type." emit-fatal-error!
     ))
 
-def(elab-type-atom!, TypeElab Token -- TypeElab Type Token,
+def(elab-type-atom!, TypeElab Token -- TypeElab Either(Type, Resource) Token,
     # TODO: handle Mut sugar
     dup sig-type-var? if(
-        elab-type-var! dip(TVar),
+        elab-type-var! dip(TVar LEFT),
 
     dup sig-type-con? if(
-        elab-type-con!,
+        elab-type-con! dip(LEFT),
+
+    dup sig-resource-var? if(
+        elab-resource-var! dip(TVar RESOURCE RIGHT),
+
+    dup sig-resource-con? if(
+        elab-resource-con! dip(RIGHT),
 
     dup pat-underscore? if(
-        elab-type-dont-care!,
+        elab-type-dont-care! dip(LEFT),
 
     dup sig-type-hole? if(
-        elab-type-hole!,
+        elab-type-hole! dip(LEFT),
 
     dup lsquare? .if(
-        elab-type-quote!,
+        elab-type-quote! dip(LEFT),
 
         dup "Expected type, got unknown token." emit-error!
-        dip(TYPE_ERROR) next
-    ))))))
+        dip(TYPE_ERROR LEFT) next
+    ))))))))
 
 def(elab-stack-var!, TypeElab Token -- TypeElab Var Token,
     TYPE_STACK elab-implicit-var!)
 
 def(elab-type-var!, TypeElab Token -- TypeElab Var Token,
     TYPE_TYPE elab-implicit-var!)
+
+def(elab-resource-var!, TypeElab Token -- TypeElab Var Token,
+    TYPE_RESOURCE elab-implicit-var!)
 
 def(elab-implicit-var!, TypeElab Token Type -- TypeElab Var Token,
     dip2(type-elab-ctx?) over
@@ -149,6 +162,9 @@ def(elab-type-con!, TypeElab Token -- TypeElab Type Token,
         )
         swap next
     ))
+
+def(elab-resource-con!, TypeElab Token -- TypeElab Resource Token,
+    elab-type-con! dip(RESOURCE))
 
 def(elab-type-args!, TypeElab Token Type -- TypeElab Token Type,
     over has-args? if(
@@ -831,7 +847,7 @@ def(elab-data-tag!, Data Token -- Data,
     { Data Tag }
     dup delay(
         type-elab-default
-        over .data head? unwrap elab-type-atom! drop T1
+        over .data head? unwrap elab-type-atom! drop dip(T0) T*+
         dip(T0 rotl sig? for(
             elab-type-stack-rest!
             dup run-end? else("syntax error" emit-fatal-error!) drop

--- a/src/mirth/elab.mth
+++ b/src/mirth/elab.mth
@@ -280,8 +280,8 @@ def(atom-accepts-args?, Atom -- Atom Bool,
         OP_WORD -> dip(dup args len) type max-num-params <,
         OP_PRIM ->
             match(
-                PRIM_CORE_RUN -> dup args len 1 <, # this one's dubious
                 PRIM_CORE_DIP -> dup args len 1 <,
+                PRIM_CORE_RDIP -> dup args len 1 <,
                 PRIM_CORE_IF -> dup args len 2 <,
                 PRIM_CORE_WHILE -> dup args len 2 <,
                 _ -> drop F

--- a/src/mirth/elab.mth
+++ b/src/mirth/elab.mth
@@ -868,7 +868,9 @@ def(elab-data-tag!, Data Token -- Data,
         T-> dip(type-elab-ctx) pack2
     )
     over ~ctx-type !
-    sip(num-inputs-from-sig) ~num-inputs !)
+    sip(num-type-inputs-from-sig) sip(~num-type-inputs !)
+    sip(num-resource-inputs-from-sig) sip(~num-resource-inputs !)
+    drop)
 
 def(expect-token-arrow, Token -- Token,
     dup pat-arrow? else("Expected arrow." emit-fatal-error!))

--- a/src/mirth/elab.mth
+++ b/src/mirth/elab.mth
@@ -818,7 +818,7 @@ def(elab-data!, Token -- Token,
 ||| Get the header, name, arity for a data type.
 def(elab-data-header!, Data Token -- Data,
     dup2 SOME swap ~head? !
-    dup sig-type-con? else("Expected type name." emit-fatal-error!)
+    dup sig-type-con? or(dup sig-resource-con?) else("Expected type name." emit-fatal-error!)
     dup2 name? unwrap name-undefined? else(drop2 "Type name already defined." emit-fatal-error!)
     over TData DEF_TYPE over ~Def !
     swap ~name !

--- a/src/mirth/elab.mth
+++ b/src/mirth/elab.mth
@@ -6,6 +6,7 @@ import(data.str)
 import(data.lazy)
 import(data.list)
 import(data.maybe)
+import(data.either)
 import(data.path)
 import(mirth.data.name)
 import(mirth.data.def)
@@ -71,7 +72,7 @@ def(elab-type-stack!, TypeElab Token -- TypeElab StackType Token,
     elab-type-stack-rest!)
 
 def(elab-type-stack-rest!, TypeElab StackType Token -- TypeElab StackType Token,
-    while(dup sig-stack-end2? not,
+    while(dup sig-stack-end? not,
         swap dip(elab-type-atom!) swap
         dip(swap T*)
     ))

--- a/src/mirth/mirth.h
+++ b/src/mirth/mirth.h
@@ -370,6 +370,10 @@ static USIZE get_top_data_tag(void) {
     return get_data_tag(top_value());
 }
 
+static USIZE get_top_resource_data_tag(void) {
+    return get_data_tag(top_resource());
+}
+
 static int value_cmp_(VAL v1, VAL v2) {
     while (IS_CONS(v1) || IS_CONS(v2)) {
         VAL v1car, v1cdr; value_uncons(v1, &v1car, &v1cdr);

--- a/src/platform/posix.mth
+++ b/src/platform/posix.mth
@@ -114,3 +114,19 @@ def(st_mode@, Ptr -- U16,
         OS_WINDOWS -> 6,
         _ -> drop 8
     ) swap .offset(@U16))
+
+
+
+data(+IO, IO-unsafe)
+data(+Out, OUT_STR -> Str, OUT_FILE -> File +IO)
+# def(+Out.new(f), )
+# def(+Out.del, +Out(+a) -- +a)
+
+def(Str.put!, Str +Out -- +Out,
+    OUT_STR -> swap cat OUT_STR,
+    OUT_FILE -> tuck dip(Str.write!) OUT_FILE)
+
+    # OUT(f) -> f OUT(f))
+
+# data(+StrBuf, STRBUF -> Str)
+# def(StrBuf.cat, Str +StrBuf -- +StrBuf)

--- a/src/platform/posix.mth
+++ b/src/platform/posix.mth
@@ -114,19 +114,3 @@ def(st_mode@, Ptr -- U16,
         OS_WINDOWS -> 6,
         _ -> drop 8
     ) swap .offset(@U16))
-
-
-
-data(+IO, IO-unsafe)
-data(+Out, OUT_STR -> Str, OUT_FILE -> File +IO)
-# def(+Out.new(f), )
-# def(+Out.del, +Out(+a) -- +a)
-
-def(Str.put!, Str +Out -- +Out,
-    OUT_STR -> swap cat OUT_STR,
-    OUT_FILE -> tuck dip(Str.write!) OUT_FILE)
-
-    # OUT(f) -> f OUT(f))
-
-# data(+StrBuf, STRBUF -> Str)
-# def(StrBuf.cat, Str +StrBuf -- +StrBuf)

--- a/src/prelude.mth
+++ b/src/prelude.mth
@@ -27,8 +27,6 @@ alias(run, prim-run)
 alias(rswap, prim-rswap)
 alias(rdip, prim-rdip)
 
-# def(my-fail, +a +b -- +b +a, rswap)
-
 alias(Int+, prim-int-add)
 alias(Int-, prim-int-sub)
 alias(Int*, prim-int-mul)
@@ -127,6 +125,9 @@ alias(posix-exit!, prim-posix-exit)
 def(rotr, a b c -- c a b, swap dip(swap))
 def(rotl, a b c -- b c a, dip(swap) swap)
 
+def(rrotr, +a +b +c -- +c +a +b, rswap rdip(rswap))
+def(rrotl, +a +b +c -- +b +c +a, rdip(rswap) rswap)
+
 def(over, a b -- a b a, dip(dup) swap)
 def(over2, a b1 b2 -- a b1 b2 a, dip(over) swap)
 def(over3, a b1 b2 b3 -- a b1 b2 b3 a, dip(over2) swap)
@@ -147,6 +148,11 @@ def(dip2(f), (*a -- *b) *a c1 c2 -- *b c1 c2,
 def(dip3(f), (*a -- *b) *a c1 c2 c3 -- *b c1 c2 c3,
     dip(dip(dip(f))))
 
+def(rdip2(f), (*a -- *b) *a +c1 +c2 -- *b +c1 +c2,
+    rdip(rdip(f)))
+def(rdip3(f), (*a -- *b) *a +c1 +c2 +c3 -- *b +c1 +c2 +c3,
+    rdip(rdip(rdip(f))))
+
 def(sip(f), (*a x -- *b) *a x -- *b x,
     dup dip(f))
 def(sip2(f), (*a x1 x2 -- *b) *a x1 x2 -- *b x1 x2,
@@ -161,6 +167,9 @@ def(drop4, a b c d --, drop drop drop drop)
 
 def(rot4r, a b c d -- d a b c, swap dip(rotr))
 def(rot4l, a b c d -- b c d a, dip(rotl) swap)
+
+def(rrot4r, +a +b +c +d -- +d +a +b +c, rswap rdip(rrotr))
+def(rrot4l, +a +b +c +d -- +b +c +d +a, rdip(rrotl) rswap)
 
 def(repeat(f), (*a -- *a) *a Int -- *a,
     while(dup 0>, dip(f) 1-) drop)

--- a/src/prelude.mth
+++ b/src/prelude.mth
@@ -24,6 +24,11 @@ alias(dup, prim-dup)
 alias(drop, prim-drop)
 alias(run, prim-run)
 
+alias(rswap, prim-rswap)
+alias(rdip, prim-rdip)
+
+# def(my-fail, +a +b -- +b +a, rswap)
+
 alias(Int+, prim-int-add)
 alias(Int-, prim-int-sub)
 alias(Int*, prim-int-mul)

--- a/src/scratch/resources.mth
+++ b/src/scratch/resources.mth
@@ -1,0 +1,21 @@
+module(scratch.resources)
+import(prelude)
+import(platform.posix)
+
+def(main, +Platform -- +Platform,
+    "hello world!" put!)
+
+target-c99("resources.c", main)
+
+def(Str+File.put!, Str +File -- +File,
+    write!)
+def(Int.put!, { put! : *a Str -- *a, put! : *a Str -- *b} *a Str -- *a ,
+    write!)
+
+print! : *a Str -- *b
+---------------------
+Int.print! : *a Str -- *b
+Int.print! = >Str print!
+
+Int. : *a Str -- *b
+Int. = >Str print!

--- a/src/tests/error-recursive-block-type.mth
+++ b/src/tests/error-recursive-block-type.mth
@@ -3,6 +3,6 @@ import(prelude)
 
 def( diverge, *a -- *b,
     [ dup run ] dup run)
-# mirth-test # merr # 5:11: error: Failed to unify [?5 ?6 -- ?8] with ?6
-# mirth-test # merr # 5:21: error: Failed to unify [*a ?6 -- ?8] with ?6
+# mirth-test # merr # 5:11: error: Failed to unify [*?5 ?6 -- *?8] with ?6
+# mirth-test # merr # 5:21: error: Failed to unify [*a ?6 -- *?8] with ?6
 # mirth-test # mret # 1


### PR DESCRIPTION
This PR adds a resource stack alongside the usual value stack. Resources are linear, so they cannot be `dup`ed or `drop`ed. They can be used to represent mutable state in a program. They can also be used as capabilities for external interaction (e.g. file handles) requiring explicit creation, destruction, and sequencing of all the operations in between.

What is implemented in this PR:

1. TYPES: Resources are incorporated into `StackType` with the `STWith` constructor. This means that `StackType` represents both the value stack and the resource stack. There's special logic inside `StackType` unification so that the `STCons` and `STWith` stack type constructors commute against each other as needed, which makes resources and values act as independent stacks for the purposes of type checking.

    - When printing out a `StackType`, the value types are printed before all the resource types, giving a normalized representation. The internal representation via `STWith` and `STCons` should not matter to the language user.

2. PARSING: Resources can show up in type signatures, whenever a stack type is written. Resource types all start with a `+` to distinguish them from value types. Defined resource types have an uppercase letter following the `+`, e.g. `+C99` is a resource defined in the C99 codegen module, while resource type variables have a lowercase letter, e.g. `+a`. Resources can be placed anywhere along the stack, it should not matter if you put them before or after the values, but there is a preference to use the normalized representation (except: see pattern matching unification bug below).

3. ALGEBRAIC RESOURCES: The language user can define their own resource types via `data`, similar to defining a value type. These algebraic resource types can have multiple constructors, and these constructors can take both value types and resource types as input. In this PR, this has been used to define a `+C99` resource that wraps over the shared state needed in the C99 codegen.

4. OVERLOADING: The top resource type on the stack can be used for name overloading, either by itself (e.g. `+C99.line` can be invoked as `line` in a `+C99` context), or together with the top value type on the stack (e.g. the word `Str+C99.put` with type `Str +C99 -- +C99` can be invoked as `put` in the appropriate context). In this PR, this has been used to significantly clean up the C99 codegen.

Small issues that need to be addressed very soon:

- Pattern matching unification bug: When pattern matching with an underscore `_`, the presence of a resource type on the top of the stack causes a unification error. Moving the resource type below the top of the value stack eliminates the unification error, so I'm sure this is a unification bug relating to the `STCons` and `STWith` commutation.

- Smuggling resources into values: Right now there is nothing preventing the language user from defining a value type via `data` with a constructor that takes a resource as input. This needs to be prevented, because the value type can be used to `dup` and `drop`, leading to non-linear resource usage.

Broader issues to tackle later:

- Kind checking & higher-order resources: Right now, only value types can be used as arguments to type constructors. Resource types cannot be used, and so higher-order resource types are possible, but they can only take value types as an argument. :-( This issue goes hand in hand with implementing kind checking, which is completely absent from Mirth at present because there weren't any meaningful kind distinctions until now.

- Reusing value types as resources: Right now resource types and value types have different names, so e.g. there isn't a way to reuse `Maybe` or `Either` as a resource type (not that you could use it meaningfully, due to the previous point), without defining also a `+Maybe` and `+Either`. At this point, I don't know if reuse of the definition of value types is reasonable, or if explicit redefinition is better (in some cases, or in all cases). It's something to investigate.

- Records: `data` resources are useful for modelling resources with multiple possible states, e.g. a ready state and an error state, but more commonly we would like to work with resources that represent multiple parts that can be used independently, for which these algebraic resource types (ARTs!) are a bit cumbersome to use because they rely exclusively on positional notation. Mirth is long overdue some kind of record type construction (tables tend to fill the role of records in the compiler), and resources make that need more dire.

- Using resources consistently: Up until now, Mirth has had a very relaxed approach to mutability and side effects. This was crucial to getting things up and running. But, resources are a way to model both mutable state and many "side effects" in a referentially transparent way. It would be good to move the existing compiler onto resources, as has already been done with the bulk of the C99 codegen in this PR, and perhaps in doing so find out where the weaknesses in using resources lie. But this is a big undertaking, so expect it to happen in pieces over a span of time.

[self-promo] If you enjoyed reading this PR summary, please consider supporting my [Patreon](https://patreon.com/typeswitch), and/or consider hiring me to work on your compiler project (my email is typeswitch at protonmail dot com).