### PR TITLE
Generate unpacking and label projection functions for single-constructor data types automatically.

### DIFF
--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -316,9 +316,6 @@ static VAL pop_value(void) {
 	return stack[stack_counter++];
 }
 
-#define LPOP(v) do { VAL lcar, lcdr; value_uncons_c((v), &lcar, &lcdr); push_value(lcdr); (v) = lcar; } while(0)
-#define LPUSH(v) do { (v) = mkcons((v), pop_value()); } while(0)
-
 static void push_resource(VAL x) {
 	ASSERT(rstack_counter > 0);
 	rstack[--rstack_counter] = x;
@@ -344,6 +341,14 @@ static VAL mkcons (VAL car, VAL cdr) {
 	cons->cdr = cdr;
 	return MKCONS(cons);
 }
+
+static VAL lpop(VAL* stk) {
+	VAL cons=*stk, lcar, lcdr; value_uncons(cons, &lcar, &lcdr);
+	*stk=lcar; incref(lcar); incref(lcdr); decref(cons); return lcdr;
+}
+static void lpush(VAL* stk, VAL cdr) { *stk = mkcons(*stk, cdr); }
+#define LPOP(v) push_value(lpop(&(v)))
+#define LPUSH(v) lpush(&(v),pop_value())
 
 static STR* str_alloc (USIZE cap) {
 	ASSERT(cap <= SIZE_MAX - sizeof(STR) - 4);
@@ -7207,11 +7212,13 @@ static void mw_mirth_data_Tag_alloc_21_ (void);
 static void mw_mirth_data_Tag_data (void);
 static void mw_mirth_data_Tag_qname (void);
 static void mw_mirth_data_Tag_value (void);
+static void mw_mirth_data_Tag_label_inputs (void);
 static void mw_mirth_data_Tag_num_type_inputs (void);
 static void mw_mirth_data_Tag_num_resource_inputs (void);
 static void mw_mirth_data_Tag_sig_3F_ (void);
 static void mw_mirth_data_Tag_ctx_type (void);
 static void mw_mirth_data_Tag_type (void);
+static void mw_mirth_data_Tag_label_inputs_from_sig (void);
 static void mw_mirth_data_Tag_num_type_inputs_from_sig (void);
 static void mw_mirth_data_Tag_num_resource_inputs_from_sig (void);
 static void mw_mirth_data_Tag_is_transparent_3F_ (void);
@@ -8271,9 +8278,13 @@ static void mb_mirth_data_make_prim_tag_21__11 (void);
 static void mb_mirth_data_make_prim_tag_21__22 (void);
 static void mb_mirth_data_make_prim_tag_21__27 (void);
 static void mb_mirth_data_make_prim_tag_21__32 (void);
-static void mb_mirth_data_make_prim_tag_21__40 (void);
+static void mb_mirth_data_make_prim_tag_21__39 (void);
+static void mb_mirth_data_make_prim_tag_21__47 (void);
+static void mb_mirth_data_Tag_label_inputs_from_sig_3 (void);
+static void mb_mirth_data_Tag_label_inputs_from_sig_9 (void);
+static void mb_mirth_data_Tag_label_inputs_from_sig_6 (void);
 static void mb_mirth_data_Tag_num_type_inputs_from_sig_4 (void);
-static void mb_mirth_data_Tag_num_type_inputs_from_sig_9 (void);
+static void mb_mirth_data_Tag_num_type_inputs_from_sig_14 (void);
 static void mb_mirth_data_Tag_num_resource_inputs_from_sig_3 (void);
 static void mb_mirth_data_Tag_num_resource_inputs_from_sig_20 (void);
 static void mb_mirth_data_Tag_num_resource_inputs_from_sig_6 (void);
@@ -8430,9 +8441,11 @@ static void mb_mirth_elab_elab_data_tag_21__113 (void);
 static void mb_mirth_elab_elab_data_tag_21__117 (void);
 static void mb_mirth_elab_elab_data_tag_21__122 (void);
 static void mb_mirth_elab_elab_data_tag_21__126 (void);
-static void mb_mirth_elab_elab_data_tag_21__138 (void);
-static void mb_mirth_elab_elab_data_tag_21__143 (void);
+static void mb_mirth_elab_elab_data_tag_21__131 (void);
+static void mb_mirth_elab_elab_data_tag_21__135 (void);
 static void mb_mirth_elab_elab_data_tag_21__147 (void);
+static void mb_mirth_elab_elab_data_tag_21__152 (void);
+static void mb_mirth_elab_elab_data_tag_21__156 (void);
 static void mb_mirth_elab_elab_data_done_21__8 (void);
 static void mb_mirth_elab_elab_data_done_21__29 (void);
 static void mb_mirth_elab_elab_data_done_21__55 (void);
@@ -8500,10 +8513,12 @@ static void mb_mirth_c99_c99_block_defs_21__5 (void);
 static void mb_mirth_c99_c99_tag_21__10 (void);
 static void mb_mirth_c99_c99_tag_21__25 (void);
 static void mb_mirth_c99_c99_tag_21__35 (void);
-static void mb_mirth_c99_c99_tag_21__68 (void);
-static void mb_mirth_c99_c99_tag_21__86 (void);
-static void mb_mirth_c99_c99_tag_21__95 (void);
-static void mb_mirth_c99_c99_tag_21__108 (void);
+static void mb_mirth_c99_c99_tag_21__45 (void);
+static void mb_mirth_c99_c99_tag_21__83 (void);
+static void mb_mirth_c99_c99_tag_21__105 (void);
+static void mb_mirth_c99_c99_tag_21__114 (void);
+static void mb_mirth_c99_c99_tag_21__134 (void);
+static void mb_mirth_c99_c99_tag_21__147 (void);
 static void mb_mirth_c99_c99_external_21__26 (void);
 static void mb_mirth_c99_c99_external_21__42 (void);
 static void mb_mirth_c99_c99_external_21__55 (void);
@@ -8652,6 +8667,7 @@ static void mw_mirth_data_Data__7E_tags (void);
 static void mw_mirth_data_Tag__7E_data (void);
 static void mw_mirth_data_Tag__7E_qname (void);
 static void mw_mirth_data_Tag__7E_value (void);
+static void mw_mirth_data_Tag__7E_label_inputs (void);
 static void mw_mirth_data_Tag__7E_num_type_inputs (void);
 static void mw_mirth_data_Tag__7E_num_resource_inputs (void);
 static void mw_mirth_data_Tag__7E_sig_3F_ (void);
@@ -9041,6 +9057,19 @@ static VAL* fieldptr_mirth_data_Tag__7E_value (size_t i) {
 
 static void mw_mirth_data_Tag__7E_value (void){	size_t index = (size_t)pop_u64();
 	VAL *v = fieldptr_mirth_data_Tag__7E_value(index);
+	push_ptr(v);
+}
+
+static VAL* fieldptr_mirth_data_Tag__7E_label_inputs (size_t i) {
+	static struct VAL * p = 0;
+	size_t m = 65536;
+	if (! p) { p = calloc(m, sizeof *p); }
+	if (i>=m) { write(2,"table too big\n",14); exit(123); }
+	return p+i;
+}
+
+static void mw_mirth_data_Tag__7E_label_inputs (void){	size_t index = (size_t)pop_u64();
+	VAL *v = fieldptr_mirth_data_Tag__7E_label_inputs(index);
 	push_ptr(v);
 }
 
@@ -16060,7 +16089,11 @@ static void mw_mirth_data_make_prim_tag_21_ (void) {
 	mw_std_prim_prim_pack_cons();
 	mw_std_prelude_sip();
 	push_u64(0);
-	push_fnptr(&mb_mirth_data_make_prim_tag_21__40);
+	push_fnptr(&mb_mirth_data_make_prim_tag_21__39);
+	mw_std_prim_prim_pack_cons();
+	mw_std_prelude_sip();
+	push_u64(0);
+	push_fnptr(&mb_mirth_data_make_prim_tag_21__47);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prelude_sip();
 	{
@@ -16467,6 +16500,10 @@ static void mw_mirth_data_Tag_value (void) {
 	mw_mirth_data_Tag__7E_value();
 	mw_std_prim_prim_mut_get();
 }
+static void mw_mirth_data_Tag_label_inputs (void) {
+	mw_mirth_data_Tag__7E_label_inputs();
+	mw_std_prim_prim_mut_get();
+}
 static void mw_mirth_data_Tag_num_type_inputs (void) {
 	mw_mirth_data_Tag__7E_num_type_inputs();
 	mw_std_prim_prim_mut_get();
@@ -16488,6 +16525,16 @@ static void mw_mirth_data_Tag_type (void) {
 	mw_mirth_data_Tag_ctx_type();
 	mw_std_prelude_nip();
 }
+static void mw_mirth_data_Tag_label_inputs_from_sig (void) {
+	mw_mirth_data_Tag_sig_3F_();
+	push_u64(0);
+	push_fnptr(&mb_mirth_data_Tag_label_inputs_from_sig_3);
+	mw_std_prim_prim_pack_cons();
+	push_u64(0);
+	push_fnptr(&mb_mirth_data_Tag_label_inputs_from_sig_9);
+	mw_std_prim_prim_pack_cons();
+	mw_std_maybe_Maybe_if_some();
+}
 static void mw_mirth_data_Tag_num_type_inputs_from_sig (void) {
 	mw_std_prim_prim_dup();
 	mw_mirth_data_Tag_sig_3F_();
@@ -16495,7 +16542,7 @@ static void mw_mirth_data_Tag_num_type_inputs_from_sig (void) {
 	push_fnptr(&mb_mirth_data_Tag_num_type_inputs_from_sig_4);
 	mw_std_prim_prim_pack_cons();
 	push_u64(0);
-	push_fnptr(&mb_mirth_data_Tag_num_type_inputs_from_sig_9);
+	push_fnptr(&mb_mirth_data_Tag_num_type_inputs_from_sig_14);
 	mw_std_prim_prim_pack_cons();
 	mw_std_maybe_Maybe_if_some();
 }
@@ -28765,6 +28812,14 @@ static void mw_mirth_elab_elab_data_tag_21_ (void) {
 	push_fnptr(&mb_mirth_elab_elab_data_tag_21__126);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prelude_sip();
+	push_u64(0);
+	push_fnptr(&mb_mirth_elab_elab_data_tag_21__131);
+	mw_std_prim_prim_pack_cons();
+	mw_std_prelude_sip();
+	push_u64(0);
+	push_fnptr(&mb_mirth_elab_elab_data_tag_21__135);
+	mw_std_prim_prim_pack_cons();
+	mw_std_prelude_sip();
 	mw_std_prim_prim_dup();
 	mw_mirth_data_Tag_outputs_resource_3F_();
 	mw_std_prim_Bool_not();
@@ -28773,7 +28828,7 @@ static void mw_mirth_elab_elab_data_tag_21_ (void) {
 	mw_std_prelude_Nat_0_3E_();
 	mw_std_prim_Bool__26__26_();
 	push_u64(0);
-	push_fnptr(&mb_mirth_elab_elab_data_tag_21__138);
+	push_fnptr(&mb_mirth_elab_elab_data_tag_21__147);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prim_Bool_then();
 	mw_std_prim_prim_drop();
@@ -31012,9 +31067,6 @@ static void mw_mirth_c99_c99_header_21_ (void) {
 				"\treturn stack[stack_counter++];\n"
 				"}\n"
 				"\n"
-				"#define LPOP(v) do { VAL lcar, lcdr; value_uncons_c((v), &lcar, &lcdr); push_value(lcdr); (v) = lcar; } while(0)\n"
-				"#define LPUSH(v) do { (v) = mkcons((v), pop_value()); } while(0)\n"
-				"\n"
 				"static void push_resource(VAL x) {\n"
 				"\tASSERT(rstack_counter > 0);\n"
 				"\trstack[--rstack_counter] = x;\n"
@@ -31040,6 +31092,14 @@ static void mw_mirth_c99_c99_header_21_ (void) {
 				"\tcons->cdr = cdr;\n"
 				"\treturn MKCONS(cons);\n"
 				"}\n"
+				"\n"
+				"static VAL lpop(VAL* stk) {\n"
+				"\tVAL cons=*stk, lcar, lcdr; value_uncons(cons, &lcar, &lcdr);\n"
+				"\t*stk=lcar; incref(lcar); incref(lcdr); decref(cons); return lcdr;\n"
+				"}\n"
+				"static void lpush(VAL* stk, VAL cdr) { *stk = mkcons(*stk, cdr); }\n"
+				"#define LPOP(v) push_value(lpop(&(v)))\n"
+				"#define LPUSH(v) lpush(&(v),pop_value())\n"
 				"\n"
 				"static STR* str_alloc (USIZE cap) {\n"
 				"\tASSERT(cap <= SIZE_MAX - sizeof(STR) - 4);\n"
@@ -31898,7 +31958,7 @@ static void mw_mirth_c99_c99_header_21_ (void) {
 				"}\n"
 				"\n"
 				"/* GENERATED C99 */\n",
-				30984
+				31112
 			);
 			vready = true;
 		}
@@ -32099,7 +32159,7 @@ static void mw_mirth_c99_c99_tag_21_ (void) {
 	mw_std_prim_prim_dup();
 	mw_mirth_data_Tag_is_transparent_3F_();
 	push_u64(0);
-	push_fnptr(&mb_mirth_c99_c99_tag_21__68);
+	push_fnptr(&mb_mirth_c99_c99_tag_21__83);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prim_Bool_else();
 	{
@@ -36303,13 +36363,20 @@ static void mb_mirth_data_make_prim_tag_21__27 (void) {
 }
 static void mb_mirth_data_make_prim_tag_21__32 (void) {
 	mw_std_prim_prim_drop();
+	mw_std_list_List_L0();
+	mw_std_prim_prim_swap();
+	mw_mirth_data_Tag__7E_label_inputs();
+	mw_std_prim_prim_mut_set();
+}
+static void mb_mirth_data_make_prim_tag_21__39 (void) {
+	mw_std_prim_prim_drop();
 	push_i64(0LL);
 	mw_std_prim_Int__3E_Nat();
 	mw_std_prim_prim_swap();
 	mw_mirth_data_Tag__7E_num_resource_inputs();
 	mw_std_prim_prim_mut_set();
 }
-static void mb_mirth_data_make_prim_tag_21__40 (void) {
+static void mb_mirth_data_make_prim_tag_21__47 (void) {
 	mw_std_prim_prim_drop();
 	{
 		VAL d2 = pop_value();
@@ -36319,14 +36386,35 @@ static void mb_mirth_data_make_prim_tag_21__40 (void) {
 	mw_mirth_data_Tag__7E_value();
 	mw_std_prim_prim_mut_set();
 }
+static void mb_mirth_data_Tag_label_inputs_from_sig_3 (void) {
+	mw_std_prim_prim_drop();
+	mw_mirth_token_Token_run_tokens();
+	push_u64(0);
+	push_fnptr(&mb_mirth_data_Tag_label_inputs_from_sig_6);
+	mw_std_prim_prim_pack_cons();
+	mw_std_list_List_filter_some();
+}
+static void mb_mirth_data_Tag_label_inputs_from_sig_9 (void) {
+	mw_std_prim_prim_drop();
+	mw_std_list_List_L0();
+}
+static void mb_mirth_data_Tag_label_inputs_from_sig_6 (void) {
+	mw_std_prim_prim_drop();
+	mw_mirth_token_Token_label_3F_();
+}
 static void mb_mirth_data_Tag_num_type_inputs_from_sig_4 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_token_Token_run_length();
-	mw_std_prim_prim_swap();
+	mw_std_prelude_over();
 	mw_mirth_data_Tag_num_resource_inputs_from_sig();
 	mw_std_prelude_Nat__();
+	mw_std_prim_prim_swap();
+	mw_mirth_data_Tag_label_inputs_from_sig();
+	mw_std_list_List_len();
+	mw_std_prelude_Nat_2_2A_();
+	mw_std_prelude_Nat__();
 }
-static void mb_mirth_data_Tag_num_type_inputs_from_sig_9 (void) {
+static void mb_mirth_data_Tag_num_type_inputs_from_sig_14 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prim_prim_drop();
 	push_i64(0LL);
@@ -38087,13 +38175,22 @@ static void mb_mirth_elab_elab_data_tag_21__126 (void) {
 	mw_mirth_data_Tag__7E_num_resource_inputs();
 	mw_std_prim_prim_mut_set();
 }
-static void mb_mirth_elab_elab_data_tag_21__138 (void) {
+static void mb_mirth_elab_elab_data_tag_21__131 (void) {
+	mw_std_prim_prim_drop();
+	mw_mirth_data_Tag_label_inputs_from_sig();
+}
+static void mb_mirth_elab_elab_data_tag_21__135 (void) {
+	mw_std_prim_prim_drop();
+	mw_mirth_data_Tag__7E_label_inputs();
+	mw_std_prim_prim_mut_set();
+}
+static void mb_mirth_elab_elab_data_tag_21__147 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_data_Tag_sig_3F_();
 	mw_std_maybe_Maybe_unwrap();
 	mw_mirth_token_Token_run_tokens();
 	push_u64(0);
-	push_fnptr(&mb_mirth_elab_elab_data_tag_21__143);
+	push_fnptr(&mb_mirth_elab_elab_data_tag_21__152);
 	mw_std_prim_prim_pack_cons();
 	mw_std_list_List_find();
 	mw_std_maybe_Maybe_unwrap();
@@ -38109,16 +38206,16 @@ static void mb_mirth_elab_elab_data_tag_21__138 (void) {
 	}
 	mw_mirth_token_emit_fatal_error_21_();
 }
-static void mb_mirth_elab_elab_data_tag_21__143 (void) {
+static void mb_mirth_elab_elab_data_tag_21__152 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prim_prim_dup();
 	mw_mirth_token_Token_sig_resource_con_3F_();
 	push_u64(0);
-	push_fnptr(&mb_mirth_elab_elab_data_tag_21__147);
+	push_fnptr(&mb_mirth_elab_elab_data_tag_21__156);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prim_Bool_or();
 }
-static void mb_mirth_elab_elab_data_tag_21__147 (void) {
+static void mb_mirth_elab_elab_data_tag_21__156 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prim_prim_dup();
 	mw_mirth_token_Token_sig_resource_var_3F_();
@@ -39193,6 +39290,12 @@ static void mb_mirth_c99_c99_tag_21__10 (void) {
 	push_fnptr(&mb_mirth_c99_c99_tag_21__35);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prelude_repeat();
+	mw_std_prim_prim_dup();
+	mw_mirth_data_Tag_label_inputs();
+	push_u64(0);
+	push_fnptr(&mb_mirth_c99_c99_tag_21__45);
+	mw_std_prim_prim_pack_cons();
+	mw_std_list_List_reverse_for();
 	{
 		static bool vready = false;
 		static VAL v;
@@ -39285,7 +39388,47 @@ static void mb_mirth_c99_c99_tag_21__35 (void) {
 	}
 	mw_mirth_c99__2B_C99_put();
 }
-static void mb_mirth_c99_c99_tag_21__68 (void) {
+static void mb_mirth_c99_c99_tag_21__45 (void) {
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("lpop(&lbl_", 10);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	mw_mirth_label_Label_name();
+	mw_mirth_name_Name_mangled();
+	mw_mirth_c99__2B_C99_put();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("));", 3);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	mw_mirth_c99__2B_C99_line();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("\tcar = mkcons(car, ", 19);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+}
+static void mb_mirth_c99_c99_tag_21__83 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prim_prim_dup();
 	mw_mirth_data_Tag_outputs_resource_3F_();
@@ -39319,9 +39462,13 @@ static void mb_mirth_c99_c99_tag_21__68 (void) {
 	mw_std_prelude_over();
 	mw_mirth_data_Tag_num_type_inputs();
 	mw_std_prelude_Nat__2B_();
+	mw_std_prelude_over();
+	mw_mirth_data_Tag_label_inputs();
+	mw_std_list_List_len();
+	mw_std_prelude_Nat__2B_();
 	mw_std_prelude_Nat_0_3E_();
 	push_u64(0);
-	push_fnptr(&mb_mirth_c99_c99_tag_21__86);
+	push_fnptr(&mb_mirth_c99_c99_tag_21__105);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prim_Bool_then();
 	{
@@ -39335,15 +39482,21 @@ static void mb_mirth_c99_c99_tag_21__68 (void) {
 		incref(v);
 	}
 	mw_std_prelude_over();
+	mw_mirth_data_Tag_label_inputs();
+	push_u64(0);
+	push_fnptr(&mb_mirth_c99_c99_tag_21__114);
+	mw_std_prim_prim_pack_cons();
+	mw_std_list_List_for();
+	mw_std_prelude_over();
 	mw_mirth_data_Tag_num_resource_inputs();
 	push_u64(0);
-	push_fnptr(&mb_mirth_c99_c99_tag_21__95);
+	push_fnptr(&mb_mirth_c99_c99_tag_21__134);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prelude_repeat();
 	mw_std_prelude_over();
 	mw_mirth_data_Tag_num_type_inputs();
 	push_u64(0);
-	push_fnptr(&mb_mirth_c99_c99_tag_21__108);
+	push_fnptr(&mb_mirth_c99_c99_tag_21__147);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prelude_repeat();
 	mw_mirth_c99__2B_C99_put();
@@ -39360,7 +39513,7 @@ static void mb_mirth_c99_c99_tag_21__68 (void) {
 	mw_mirth_c99__2B_C99_put();
 	mw_mirth_c99__2B_C99_line();
 }
-static void mb_mirth_c99_c99_tag_21__86 (void) {
+static void mb_mirth_c99_c99_tag_21__105 (void) {
 	mw_std_prim_prim_drop();
 	{
 		static bool vready = false;
@@ -39375,7 +39528,61 @@ static void mb_mirth_c99_c99_tag_21__86 (void) {
 	mw_mirth_c99__2B_C99_put();
 	mw_mirth_c99__2B_C99_line();
 }
-static void mb_mirth_c99_c99_tag_21__95 (void) {
+static void mb_mirth_c99_c99_tag_21__114 (void) {
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("\tvalue_uncons_c(car, &car, &cdr);", 33);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	mw_mirth_c99__2B_C99_line();
+	mw_std_prim_prim_swap();
+	mw_mirth_c99__2B_C99_put();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("cdr);", 5);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	mw_mirth_c99__2B_C99_line();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("\tlpush(&lbl_", 12);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_std_prim_prim_swap();
+	mw_mirth_label_Label_name();
+	mw_mirth_name_Name_mangled();
+	mw_std_prim_prim_str_cat();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr(", ", 2);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_std_prim_prim_str_cat();
+}
+static void mb_mirth_c99_c99_tag_21__134 (void) {
 	mw_std_prim_prim_drop();
 	{
 		static bool vready = false;
@@ -39413,7 +39620,7 @@ static void mb_mirth_c99_c99_tag_21__95 (void) {
 		incref(v);
 	}
 }
-static void mb_mirth_c99_c99_tag_21__108 (void) {
+static void mb_mirth_c99_c99_tag_21__147 (void) {
 	mw_std_prim_prim_drop();
 	{
 		static bool vready = false;

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -7226,6 +7226,7 @@ static void mw_mirth_data_Tag_num_resource_inputs (void);
 static void mw_mirth_data_Tag_sig_3F_ (void);
 static void mw_mirth_data_Tag_ctx_type (void);
 static void mw_mirth_data_Tag_type (void);
+static void mw_mirth_data_Tag_untag (void);
 static void mw_mirth_data_Tag_label_inputs_from_sig (void);
 static void mw_mirth_data_Tag_num_type_inputs_from_sig (void);
 static void mw_mirth_data_Tag_num_resource_inputs_from_sig (void);
@@ -7839,6 +7840,7 @@ static void mw_mirth_elab_data_qname (void);
 static void mw_mirth_elab_data_word_qname (void);
 static void mw_mirth_elab_data_word_new_21_ (void);
 static void mw_mirth_elab_elab_data_done_21_ (void);
+static void mw_mirth_elab_create_projectors_21_ (void);
 static void mw_mirth_elab_expect_token_arrow (void);
 static void mw_mirth_elab_token_def_args (void);
 static void mw_mirth_elab_elab_alias_21_ (void);
@@ -8448,18 +8450,18 @@ static void mb_mirth_elab_load_module_9 (void);
 static void mb_mirth_elab_elab_data_header_21__9 (void);
 static void mb_mirth_elab_elab_data_header_21__14 (void);
 static void mb_mirth_elab_elab_data_tag_21__4 (void);
-static void mb_mirth_elab_elab_data_tag_21__71 (void);
-static void mb_mirth_elab_elab_data_tag_21__90 (void);
-static void mb_mirth_elab_elab_data_tag_21__95 (void);
-static void mb_mirth_elab_elab_data_tag_21__113 (void);
+static void mb_mirth_elab_elab_data_tag_21__75 (void);
+static void mb_mirth_elab_elab_data_tag_21__94 (void);
+static void mb_mirth_elab_elab_data_tag_21__99 (void);
 static void mb_mirth_elab_elab_data_tag_21__117 (void);
-static void mb_mirth_elab_elab_data_tag_21__122 (void);
+static void mb_mirth_elab_elab_data_tag_21__121 (void);
 static void mb_mirth_elab_elab_data_tag_21__126 (void);
-static void mb_mirth_elab_elab_data_tag_21__131 (void);
+static void mb_mirth_elab_elab_data_tag_21__130 (void);
 static void mb_mirth_elab_elab_data_tag_21__135 (void);
-static void mb_mirth_elab_elab_data_tag_21__147 (void);
-static void mb_mirth_elab_elab_data_tag_21__152 (void);
+static void mb_mirth_elab_elab_data_tag_21__139 (void);
+static void mb_mirth_elab_elab_data_tag_21__151 (void);
 static void mb_mirth_elab_elab_data_tag_21__156 (void);
+static void mb_mirth_elab_elab_data_tag_21__160 (void);
 static void mb_mirth_elab_elab_data_done_21__8 (void);
 static void mb_mirth_elab_elab_data_done_21__29 (void);
 static void mb_mirth_elab_elab_data_done_21__55 (void);
@@ -8469,6 +8471,13 @@ static void mb_mirth_elab_elab_data_done_21__99 (void);
 static void mb_mirth_elab_elab_data_done_21__109 (void);
 static void mb_mirth_elab_elab_data_done_21__116 (void);
 static void mb_mirth_elab_elab_def_qname_undefined_6 (void);
+static void mb_mirth_elab_create_projectors_21__15 (void);
+static void mb_mirth_elab_create_projectors_21__26 (void);
+static void mb_mirth_elab_create_projectors_21__37 (void);
+static void mb_mirth_elab_create_projectors_21__52 (void);
+static void mb_mirth_elab_create_projectors_21__68 (void);
+static void mb_mirth_elab_create_projectors_21__70 (void);
+static void mb_mirth_elab_create_projectors_21__84 (void);
 static void mb_mirth_elab_token_def_args_9 (void);
 static void mb_mirth_elab_elab_def_qname_4 (void);
 static void mb_mirth_elab_elab_def_params_21__13 (void);
@@ -8691,6 +8700,7 @@ static void mw_mirth_data_Tag__7E_num_type_inputs (void);
 static void mw_mirth_data_Tag__7E_num_resource_inputs (void);
 static void mw_mirth_data_Tag__7E_sig_3F_ (void);
 static void mw_mirth_data_Tag__7E_ctx_type (void);
+static void mw_mirth_data_Tag__7E_untag (void);
 static void mw_mirth_match_Match__7E_ctx (void);
 static void mw_mirth_match_Match__7E_dom (void);
 static void mw_mirth_match_Match__7E_cod (void);
@@ -9142,6 +9152,19 @@ static VAL* fieldptr_mirth_data_Tag__7E_ctx_type (size_t i) {
 
 static void mw_mirth_data_Tag__7E_ctx_type (void){	size_t index = (size_t)pop_u64();
 	VAL *v = fieldptr_mirth_data_Tag__7E_ctx_type(index);
+	push_ptr(v);
+}
+
+static VAL* fieldptr_mirth_data_Tag__7E_untag (size_t i) {
+	static struct VAL * p = 0;
+	size_t m = 65536;
+	if (! p) { p = calloc(m, sizeof *p); }
+	if (i>=m) { write(2,"table too big\n",14); exit(123); }
+	return p+i;
+}
+
+static void mw_mirth_data_Tag__7E_untag (void){	size_t index = (size_t)pop_u64();
+	VAL *v = fieldptr_mirth_data_Tag__7E_untag(index);
 	push_ptr(v);
 }
 
@@ -16561,6 +16584,10 @@ static void mw_mirth_data_Tag_ctx_type (void) {
 static void mw_mirth_data_Tag_type (void) {
 	mw_mirth_data_Tag_ctx_type();
 	mw_std_prelude_nip();
+}
+static void mw_mirth_data_Tag_untag (void) {
+	mw_mirth_data_Tag__7E_untag();
+	mw_std_prim_prim_mut_get();
 }
 static void mw_mirth_data_Tag_label_inputs_from_sig (void) {
 	mw_mirth_data_Tag_sig_3F_();
@@ -28951,6 +28978,10 @@ static void mw_mirth_elab_elab_data_tag_21_ (void) {
 	mw_std_maybe_Maybe_unwrap_or();
 	mw_mirth_elab_data_qname();
 	mw_mirth_data_Tag_alloc_21_();
+	mw_std_maybe_Maybe_NONE();
+	mw_std_prelude_over();
+	mw_mirth_data_Tag__7E_untag();
+	mw_std_prim_prim_mut_set();
 	mw_std_prelude_tuck();
 	mw_mirth_data_Tag__7E_qname();
 	mw_std_prim_prim_mut_set();
@@ -29006,22 +29037,18 @@ static void mw_mirth_elab_elab_data_tag_21_ (void) {
 	}
 	mw_std_prim_prim_dup();
 	push_u64(0);
-	push_fnptr(&mb_mirth_elab_elab_data_tag_21__71);
+	push_fnptr(&mb_mirth_elab_elab_data_tag_21__75);
 	mw_std_prim_prim_pack_cons();
 	mw_std_lazy_delay();
 	mw_std_prelude_over();
 	mw_mirth_data_Tag__7E_ctx_type();
 	mw_std_prim_prim_mut_set();
 	push_u64(0);
-	push_fnptr(&mb_mirth_elab_elab_data_tag_21__113);
-	mw_std_prim_prim_pack_cons();
-	mw_std_prelude_sip();
-	push_u64(0);
 	push_fnptr(&mb_mirth_elab_elab_data_tag_21__117);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prelude_sip();
 	push_u64(0);
-	push_fnptr(&mb_mirth_elab_elab_data_tag_21__122);
+	push_fnptr(&mb_mirth_elab_elab_data_tag_21__121);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prelude_sip();
 	push_u64(0);
@@ -29029,11 +29056,15 @@ static void mw_mirth_elab_elab_data_tag_21_ (void) {
 	mw_std_prim_prim_pack_cons();
 	mw_std_prelude_sip();
 	push_u64(0);
-	push_fnptr(&mb_mirth_elab_elab_data_tag_21__131);
+	push_fnptr(&mb_mirth_elab_elab_data_tag_21__130);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prelude_sip();
 	push_u64(0);
 	push_fnptr(&mb_mirth_elab_elab_data_tag_21__135);
+	mw_std_prim_prim_pack_cons();
+	mw_std_prelude_sip();
+	push_u64(0);
+	push_fnptr(&mb_mirth_elab_elab_data_tag_21__139);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prelude_sip();
 	mw_std_prim_prim_dup();
@@ -29044,7 +29075,7 @@ static void mw_mirth_elab_elab_data_tag_21_ (void) {
 	mw_std_prelude_Nat_0_3E_();
 	mw_std_prim_Bool__26__26_();
 	push_u64(0);
-	push_fnptr(&mb_mirth_elab_elab_data_tag_21__147);
+	push_fnptr(&mb_mirth_elab_elab_data_tag_21__151);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prim_Bool_then();
 	mw_std_prim_prim_drop();
@@ -29154,6 +29185,16 @@ static void mw_mirth_elab_elab_data_done_21_ (void) {
 						push_value(var_untag);
 						mw_mirth_word_Word__7E_arrow();
 						mw_std_prim_prim_mut_set();
+						incref(var_untag);
+						push_value(var_untag);
+						mw_std_maybe_Maybe_SOME();
+						incref(var_tag);
+						push_value(var_tag);
+						mw_mirth_data_Tag__7E_untag();
+						mw_std_prim_prim_mut_set();
+						incref(var_tag);
+						push_value(var_tag);
+						mw_mirth_elab_create_projectors_21_();
 						decref(var_untag);
 					}
 					decref(var_tag);
@@ -29164,6 +29205,37 @@ static void mw_mirth_elab_elab_data_done_21_ (void) {
 				break;
 		}
 		decref(var_dat);
+	}
+}
+static void mw_mirth_elab_create_projectors_21_ (void) {
+	mw_std_prim_prim_dup();
+	mw_mirth_data_Tag_data();
+	mw_std_prelude_over();
+	mw_mirth_data_Tag_untag();
+	mw_std_maybe_Maybe_unwrap();
+	{
+		VAL var_untag = pop_value();
+		VAL var_dat = pop_value();
+		VAL var_tag = pop_value();
+		incref(var_tag);
+		push_value(var_tag);
+		mw_mirth_data_Tag_label_inputs();
+		push_u64(0);
+		incref(var_untag);
+		push_value(var_untag);
+		mw_std_prim_prim_pack_cons();
+		incref(var_dat);
+		push_value(var_dat);
+		mw_std_prim_prim_pack_cons();
+		incref(var_tag);
+		push_value(var_tag);
+		mw_std_prim_prim_pack_cons();
+		push_fnptr(&mb_mirth_elab_create_projectors_21__15);
+		mw_std_prim_prim_pack_cons();
+		mw_std_list_List_reverse_for();
+		decref(var_untag);
+		decref(var_dat);
+		decref(var_tag);
 	}
 }
 static void mw_mirth_elab_expect_token_arrow (void) {
@@ -38358,7 +38430,7 @@ static void mb_mirth_elab_elab_data_tag_21__4 (void) {
 	}
 	mw_mirth_token_emit_fatal_error_21_();
 }
-static void mb_mirth_elab_elab_data_tag_21__71 (void) {
+static void mb_mirth_elab_elab_data_tag_21__75 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_elab_type_elab_default();
 	mw_std_prelude_over();
@@ -38379,7 +38451,7 @@ static void mb_mirth_elab_elab_data_tag_21__71 (void) {
 		mw_std_prelude_rotl();
 		mw_mirth_data_Tag_sig_3F_();
 		push_u64(0);
-		push_fnptr(&mb_mirth_elab_elab_data_tag_21__90);
+		push_fnptr(&mb_mirth_elab_elab_data_tag_21__94);
 		mw_std_prim_prim_pack_cons();
 		mw_std_maybe_Maybe_for();
 		push_value(d2);
@@ -38392,18 +38464,18 @@ static void mb_mirth_elab_elab_data_tag_21__71 (void) {
 	}
 	mw_std_prelude_pack2();
 }
-static void mb_mirth_elab_elab_data_tag_21__90 (void) {
+static void mb_mirth_elab_elab_data_tag_21__94 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_elab_elab_type_stack_rest_21_();
 	mw_std_prim_prim_dup();
 	mw_mirth_token_Token_run_end_3F_();
 	push_u64(0);
-	push_fnptr(&mb_mirth_elab_elab_data_tag_21__95);
+	push_fnptr(&mb_mirth_elab_elab_data_tag_21__99);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prim_Bool_else();
 	mw_std_prim_prim_drop();
 }
-static void mb_mirth_elab_elab_data_tag_21__95 (void) {
+static void mb_mirth_elab_elab_data_tag_21__99 (void) {
 	mw_std_prim_prim_drop();
 	{
 		static bool vready = false;
@@ -38417,40 +38489,40 @@ static void mb_mirth_elab_elab_data_tag_21__95 (void) {
 	}
 	mw_mirth_token_emit_fatal_error_21_();
 }
-static void mb_mirth_elab_elab_data_tag_21__113 (void) {
+static void mb_mirth_elab_elab_data_tag_21__117 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_data_Tag_num_type_inputs_from_sig();
 }
-static void mb_mirth_elab_elab_data_tag_21__117 (void) {
+static void mb_mirth_elab_elab_data_tag_21__121 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_data_Tag__7E_num_type_inputs();
 	mw_std_prim_prim_mut_set();
 }
-static void mb_mirth_elab_elab_data_tag_21__122 (void) {
+static void mb_mirth_elab_elab_data_tag_21__126 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_data_Tag_num_resource_inputs_from_sig();
 }
-static void mb_mirth_elab_elab_data_tag_21__126 (void) {
+static void mb_mirth_elab_elab_data_tag_21__130 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_data_Tag__7E_num_resource_inputs();
 	mw_std_prim_prim_mut_set();
 }
-static void mb_mirth_elab_elab_data_tag_21__131 (void) {
+static void mb_mirth_elab_elab_data_tag_21__135 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_data_Tag_label_inputs_from_sig();
 }
-static void mb_mirth_elab_elab_data_tag_21__135 (void) {
+static void mb_mirth_elab_elab_data_tag_21__139 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_data_Tag__7E_label_inputs();
 	mw_std_prim_prim_mut_set();
 }
-static void mb_mirth_elab_elab_data_tag_21__147 (void) {
+static void mb_mirth_elab_elab_data_tag_21__151 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_data_Tag_sig_3F_();
 	mw_std_maybe_Maybe_unwrap();
 	mw_mirth_token_Token_run_tokens();
 	push_u64(0);
-	push_fnptr(&mb_mirth_elab_elab_data_tag_21__152);
+	push_fnptr(&mb_mirth_elab_elab_data_tag_21__156);
 	mw_std_prim_prim_pack_cons();
 	mw_std_list_List_find();
 	mw_std_maybe_Maybe_unwrap();
@@ -38466,16 +38538,16 @@ static void mb_mirth_elab_elab_data_tag_21__147 (void) {
 	}
 	mw_mirth_token_emit_fatal_error_21_();
 }
-static void mb_mirth_elab_elab_data_tag_21__152 (void) {
+static void mb_mirth_elab_elab_data_tag_21__156 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prim_prim_dup();
 	mw_mirth_token_Token_sig_resource_con_3F_();
 	push_u64(0);
-	push_fnptr(&mb_mirth_elab_elab_data_tag_21__156);
+	push_fnptr(&mb_mirth_elab_elab_data_tag_21__160);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prim_Bool_or();
 }
-static void mb_mirth_elab_elab_data_tag_21__156 (void) {
+static void mb_mirth_elab_elab_data_tag_21__160 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prim_prim_dup();
 	mw_mirth_token_Token_sig_resource_var_3F_();
@@ -38730,6 +38802,311 @@ static void mb_mirth_elab_elab_def_qname_undefined_6 (void) {
 		incref(v);
 	}
 	mw_mirth_token_emit_fatal_error_21_();
+}
+static void mb_mirth_elab_create_projectors_21__15 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_dat = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_untag = pop_value();
+	mw_std_prim_prim_drop();
+	{
+		VAL var_lbl = pop_value();
+		incref(var_dat);
+		push_value(var_dat);
+		incref(var_lbl);
+		push_value(var_lbl);
+		mw_mirth_label_Label_name();
+		mw_mirth_elab_data_qname();
+		mw_mirth_name_QName_undefined_3F_();
+		push_u64(0);
+		incref(var_untag);
+		push_value(var_untag);
+		mw_std_prim_prim_pack_cons();
+		incref(var_dat);
+		push_value(var_dat);
+		mw_std_prim_prim_pack_cons();
+		incref(var_tag);
+		push_value(var_tag);
+		mw_std_prim_prim_pack_cons();
+		incref(var_lbl);
+		push_value(var_lbl);
+		mw_std_prim_prim_pack_cons();
+		push_fnptr(&mb_mirth_elab_create_projectors_21__26);
+		mw_std_prim_prim_pack_cons();
+		mw_std_prim_Bool_then();
+		decref(var_lbl);
+	}
+	decref(var_tag);
+	decref(var_dat);
+	decref(var_untag);
+}
+static void mb_mirth_elab_create_projectors_21__26 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_dat = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_untag = pop_value();
+	mw_std_prim_prim_drop();
+	incref(var_dat);
+	push_value(var_dat);
+	incref(var_lbl);
+	push_value(var_lbl);
+	mw_mirth_label_Label__3E_Str();
+	mw_mirth_elab_data_word_new_21_();
+	{
+		VAL var_lbl_5F_proj = pop_value();
+		incref(var_tag);
+		push_value(var_tag);
+		push_u64(0);
+		incref(var_untag);
+		push_value(var_untag);
+		mw_std_prim_prim_pack_cons();
+		incref(var_dat);
+		push_value(var_dat);
+		mw_std_prim_prim_pack_cons();
+		incref(var_tag);
+		push_value(var_tag);
+		mw_std_prim_prim_pack_cons();
+		incref(var_lbl);
+		push_value(var_lbl);
+		mw_std_prim_prim_pack_cons();
+		incref(var_lbl_5F_proj);
+		push_value(var_lbl_5F_proj);
+		mw_std_prim_prim_pack_cons();
+		push_fnptr(&mb_mirth_elab_create_projectors_21__37);
+		mw_std_prim_prim_pack_cons();
+		mw_std_lazy_delay();
+		incref(var_lbl_5F_proj);
+		push_value(var_lbl_5F_proj);
+		mw_mirth_word_Word__7E_ctx_type();
+		mw_std_prim_prim_mut_set();
+		incref(var_lbl_5F_proj);
+		push_value(var_lbl_5F_proj);
+		push_u64(0);
+		incref(var_untag);
+		push_value(var_untag);
+		mw_std_prim_prim_pack_cons();
+		incref(var_dat);
+		push_value(var_dat);
+		mw_std_prim_prim_pack_cons();
+		incref(var_tag);
+		push_value(var_tag);
+		mw_std_prim_prim_pack_cons();
+		incref(var_lbl);
+		push_value(var_lbl);
+		mw_std_prim_prim_pack_cons();
+		incref(var_lbl_5F_proj);
+		push_value(var_lbl_5F_proj);
+		mw_std_prim_prim_pack_cons();
+		push_fnptr(&mb_mirth_elab_create_projectors_21__68);
+		mw_std_prim_prim_pack_cons();
+		mw_std_lazy_delay();
+		incref(var_lbl_5F_proj);
+		push_value(var_lbl_5F_proj);
+		mw_mirth_word_Word__7E_arrow();
+		mw_std_prim_prim_mut_set();
+		decref(var_lbl_5F_proj);
+	}
+	decref(var_lbl);
+	decref(var_tag);
+	decref(var_dat);
+	decref(var_untag);
+}
+static void mb_mirth_elab_create_projectors_21__37 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl_5F_proj = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_dat = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_untag = pop_value();
+	mw_std_prim_prim_drop();
+	mw_mirth_data_Tag_ctx_type();
+	mw_mirth_type_ArrowType_unpack();
+	incref(var_lbl);
+	push_value(var_lbl);
+	mw_std_prelude_rotl();
+	mw_mirth_type_StackType_force_cons_label_3F__21_();
+	mw_std_maybe_Maybe_unwrap();
+	mw_std_prelude_unpack2();
+	{
+		VAL d2 = pop_value();
+		mw_std_prim_prim_drop();
+		mw_mirth_type_T0();
+		incref(var_dat);
+		push_value(var_dat);
+		mw_mirth_data_Data_is_resource_3F_();
+		push_u64(0);
+		incref(var_untag);
+		push_value(var_untag);
+		mw_std_prim_prim_pack_cons();
+		incref(var_dat);
+		push_value(var_dat);
+		mw_std_prim_prim_pack_cons();
+		incref(var_tag);
+		push_value(var_tag);
+		mw_std_prim_prim_pack_cons();
+		incref(var_lbl);
+		push_value(var_lbl);
+		mw_std_prim_prim_pack_cons();
+		incref(var_lbl_5F_proj);
+		push_value(var_lbl_5F_proj);
+		mw_std_prim_prim_pack_cons();
+		push_fnptr(&mb_mirth_elab_create_projectors_21__52);
+		mw_std_prim_prim_pack_cons();
+		mw_std_prim_Bool_then();
+		push_value(d2);
+	}
+	mw_mirth_type_T_2A_();
+	mw_mirth_type_T__3E_();
+	mw_std_prelude_pack2();
+	decref(var_lbl_5F_proj);
+	decref(var_lbl);
+	decref(var_tag);
+	decref(var_dat);
+	decref(var_untag);
+}
+static void mb_mirth_elab_create_projectors_21__52 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl_5F_proj = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_dat = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_untag = pop_value();
+	mw_std_prim_prim_drop();
+	incref(var_dat);
+	push_value(var_dat);
+	mw_mirth_type_Type_TData();
+	mw_mirth_type_Resource_RESOURCE();
+	mw_mirth_type_T_2B_();
+	decref(var_lbl_5F_proj);
+	decref(var_lbl);
+	decref(var_tag);
+	decref(var_dat);
+	decref(var_untag);
+}
+static void mb_mirth_elab_create_projectors_21__68 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl_5F_proj = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_dat = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_untag = pop_value();
+	mw_std_prim_prim_drop();
+	push_u64(0);
+	incref(var_untag);
+	push_value(var_untag);
+	mw_std_prim_prim_pack_cons();
+	incref(var_dat);
+	push_value(var_dat);
+	mw_std_prim_prim_pack_cons();
+	incref(var_tag);
+	push_value(var_tag);
+	mw_std_prim_prim_pack_cons();
+	incref(var_lbl);
+	push_value(var_lbl);
+	mw_std_prim_prim_pack_cons();
+	incref(var_lbl_5F_proj);
+	push_value(var_lbl_5F_proj);
+	mw_std_prim_prim_pack_cons();
+	push_fnptr(&mb_mirth_elab_create_projectors_21__70);
+	mw_std_prim_prim_pack_cons();
+	mw_mirth_elab_ab_build_word_arrow_21_();
+	decref(var_lbl_5F_proj);
+	decref(var_lbl);
+	decref(var_tag);
+	decref(var_dat);
+	decref(var_untag);
+}
+static void mb_mirth_elab_create_projectors_21__70 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl_5F_proj = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_dat = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_untag = pop_value();
+	mw_std_prim_prim_drop();
+	incref(var_untag);
+	push_value(var_untag);
+	mw_mirth_elab_ab_word_21_();
+	incref(var_lbl);
+	push_value(var_lbl);
+	mw_mirth_elab_ab_label_pop_21_();
+	mw_mirth_prim_Prim_PRIM_5F_CORE_5F_DUP();
+	mw_mirth_elab_ab_prim_21_();
+	incref(var_lbl);
+	push_value(var_lbl);
+	mw_mirth_elab_ab_label_push_21_();
+	incref(var_tag);
+	push_value(var_tag);
+	mw_mirth_elab_ab_tag_21_();
+	incref(var_dat);
+	push_value(var_dat);
+	mw_mirth_data_Data_is_resource_3F_();
+	push_u64(0);
+	incref(var_untag);
+	push_value(var_untag);
+	mw_std_prim_prim_pack_cons();
+	incref(var_dat);
+	push_value(var_dat);
+	mw_std_prim_prim_pack_cons();
+	incref(var_tag);
+	push_value(var_tag);
+	mw_std_prim_prim_pack_cons();
+	incref(var_lbl);
+	push_value(var_lbl);
+	mw_std_prim_prim_pack_cons();
+	incref(var_lbl_5F_proj);
+	push_value(var_lbl_5F_proj);
+	mw_std_prim_prim_pack_cons();
+	push_fnptr(&mb_mirth_elab_create_projectors_21__84);
+	mw_std_prim_prim_pack_cons();
+	mw_std_prim_Bool_else();
+	decref(var_lbl_5F_proj);
+	decref(var_lbl);
+	decref(var_tag);
+	decref(var_dat);
+	decref(var_untag);
+}
+static void mb_mirth_elab_create_projectors_21__84 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl_5F_proj = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_dat = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_untag = pop_value();
+	mw_std_prim_prim_drop();
+	mw_mirth_prim_Prim_PRIM_5F_CORE_5F_DROP();
+	mw_mirth_elab_ab_prim_21_();
+	decref(var_lbl_5F_proj);
+	decref(var_lbl);
+	decref(var_tag);
+	decref(var_dat);
+	decref(var_untag);
 }
 static void mb_mirth_elab_token_def_args_9 (void) {
 	mw_std_prim_prim_drop();

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -1214,6 +1214,13 @@ static VAL lbl_output_file = {0};
 static VAL lbl_entry_point = {0};
 static VAL lbl_packages = {0};
 static VAL lbl_output_path = {0};
+static VAL lbl_ctx = {0};
+static VAL lbl_dom = {0};
+static VAL lbl_cod = {0};
+static VAL lbl_token = {0};
+static VAL lbl_body = {0};
+static VAL lbl_home = {0};
+static VAL lbl_match = {0};
 static void mw_std_prim_F (void) {
 	VAL tag = MKU64(0LL);
 	VAL car = (tag);
@@ -7211,6 +7218,7 @@ static void mw_mirth_data_Tag_for (void);
 static void mw_mirth_data_Tag_alloc_21_ (void);
 static void mw_mirth_data_Tag_data (void);
 static void mw_mirth_data_Tag_qname (void);
+static void mw_mirth_data_Tag_name (void);
 static void mw_mirth_data_Tag_value (void);
 static void mw_mirth_data_Tag_label_inputs (void);
 static void mw_mirth_data_Tag_num_type_inputs (void);
@@ -7230,7 +7238,9 @@ static void mw_mirth_match_Match_dom (void);
 static void mw_mirth_match_Match_cod (void);
 static void mw_mirth_match_Match_token (void);
 static void mw_mirth_match_Match_body (void);
+static void mw_mirth_match_Match_home (void);
 static void mw_mirth_match_Match_cases (void);
+static void mw_mirth_match_Match_new_21_ (void);
 static void mw_mirth_match_Case_alloc_21_ (void);
 static void mw_mirth_match_Case_match (void);
 static void mw_mirth_match_Case_token (void);
@@ -7439,6 +7449,7 @@ static void mw_mirth_type_StackType_num_morphisms_on_top (void);
 static void mw_mirth_type_ArrowType__3E_Type (void);
 static void mw_mirth_type_ArrowType_unpack (void);
 static void mw_mirth_type_ArrowType_dom (void);
+static void mw_mirth_type_ArrowType_cod (void);
 static void mw_mirth_type_ArrowType_unify_21_ (void);
 static void mw_mirth_type_ArrowType_has_meta_3F_ (void);
 static void mw_mirth_type_ArrowType_trace_21_ (void);
@@ -7721,7 +7732,7 @@ static void mw_mirth_elab_elab_type_quote_21_ (void);
 static void mw_mirth_elab_elab_type_unify_21_ (void);
 static void mw_mirth_elab_elab_stack_type_unify_21_ (void);
 static void mw_mirth_elab_elab_simple_type_arg_21_ (void);
-static void mw_mirth_elab__2F_MKAB (void);
+static void mw_mirth_elab__2B_AB__2F_MKAB (void);
 static void mw_mirth_elab_ab_arrow_40_ (void);
 static void mw_mirth_elab_ab_ctx_40_ (void);
 static void mw_mirth_elab_ab_token_40_ (void);
@@ -7798,6 +7809,8 @@ static void mw_mirth_elab_elab_prim_21_ (void);
 static void mw_mirth_elab_elab_atom_assert_21_ (void);
 static void mw_mirth_elab_elab_atom_lambda_21_ (void);
 static void mw_mirth_elab_elab_match_at_21_ (void);
+static void mw_mirth_elab_ab_match_21_ (void);
+static void mw_mirth_elab_ab_case_21_ (void);
 static void mw_mirth_elab_elab_atom_match_21_ (void);
 static void mw_mirth_elab_elab_lambda_21_ (void);
 static void mw_mirth_elab_elab_expand_tensor_21_ (void);
@@ -7809,6 +7822,7 @@ static void mw_mirth_elab_elab_match_exhaustive_21_ (void);
 static void mw_mirth_elab_elab_match_cases_21_ (void);
 static void mw_mirth_elab_elab_match_case_21_ (void);
 static void mw_mirth_elab_elab_case_pattern_21_ (void);
+static void mw_mirth_elab_determine_case_subst_and_mid_21_ (void);
 static void mw_mirth_elab_elab_case_body_21_ (void);
 static void mw_mirth_elab_elab_module_21_ (void);
 static void mw_mirth_elab_elab_module_package_name (void);
@@ -8365,6 +8379,9 @@ static void mb_mirth_elab_elab_atom_qname_21__22 (void);
 static void mb_mirth_elab_elab_ambiguous_name_error_21__6 (void);
 static void mb_mirth_elab_elab_qname_from_nonrelative_dname_4 (void);
 static void mb_mirth_elab_elab_match_exhaustive_21__4 (void);
+static void mb_mirth_elab_ab_case_21__35 (void);
+static void mb_mirth_elab_determine_case_subst_and_mid_21__31 (void);
+static void mb_mirth_elab_determine_case_subst_and_mid_21__50 (void);
 static void mb_mirth_elab_elab_lambda_params_21__32 (void);
 static void mb_mirth_elab_elab_lambda_params_21__50 (void);
 static void mb_mirth_elab_elab_lambda_params_21__54 (void);
@@ -8374,12 +8391,9 @@ static void mb_mirth_elab_token_is_lambda_param_3F__12 (void);
 static void mb_mirth_elab_token_is_lambda_param_3F__31 (void);
 static void mb_mirth_elab_expect_token_arrow_4 (void);
 static void mb_mirth_elab_elab_match_case_21__24 (void);
-static void mb_mirth_elab_elab_case_pattern_21__33 (void);
-static void mb_mirth_elab_elab_case_pattern_21__103 (void);
-static void mb_mirth_elab_elab_case_pattern_21__36 (void);
-static void mb_mirth_elab_elab_case_pattern_21__52 (void);
-static void mb_mirth_elab_elab_case_pattern_21__58 (void);
-static void mb_mirth_elab_elab_case_pattern_21__81 (void);
+static void mb_mirth_elab_elab_case_pattern_21__15 (void);
+static void mb_mirth_elab_elab_case_pattern_21__38 (void);
+static void mb_mirth_elab_elab_case_pattern_21__18 (void);
 static void mb_mirth_elab_elab_case_body_21__29 (void);
 static void mb_mirth_elab_elab_case_body_21__41 (void);
 static void mb_mirth_elab_elab_module_header_21__6 (void);
@@ -8449,6 +8463,11 @@ static void mb_mirth_elab_elab_data_tag_21__156 (void);
 static void mb_mirth_elab_elab_data_done_21__8 (void);
 static void mb_mirth_elab_elab_data_done_21__29 (void);
 static void mb_mirth_elab_elab_data_done_21__55 (void);
+static void mb_mirth_elab_elab_data_done_21__85 (void);
+static void mb_mirth_elab_elab_data_done_21__97 (void);
+static void mb_mirth_elab_elab_data_done_21__99 (void);
+static void mb_mirth_elab_elab_data_done_21__109 (void);
+static void mb_mirth_elab_elab_data_done_21__116 (void);
 static void mb_mirth_elab_elab_def_qname_undefined_6 (void);
 static void mb_mirth_elab_token_def_args_9 (void);
 static void mb_mirth_elab_elab_def_qname_4 (void);
@@ -8677,6 +8696,7 @@ static void mw_mirth_match_Match__7E_dom (void);
 static void mw_mirth_match_Match__7E_cod (void);
 static void mw_mirth_match_Match__7E_token (void);
 static void mw_mirth_match_Match__7E_body (void);
+static void mw_mirth_match_Match__7E_home (void);
 static void mw_mirth_match_Match__7E_cases (void);
 static void mw_mirth_match_Case__7E_match (void);
 static void mw_mirth_match_Case__7E_token (void);
@@ -9187,6 +9207,19 @@ static VAL* fieldptr_mirth_match_Match__7E_body (size_t i) {
 
 static void mw_mirth_match_Match__7E_body (void){	size_t index = (size_t)pop_u64();
 	VAL *v = fieldptr_mirth_match_Match__7E_body(index);
+	push_ptr(v);
+}
+
+static VAL* fieldptr_mirth_match_Match__7E_home (size_t i) {
+	static struct VAL * p = 0;
+	size_t m = 65536;
+	if (! p) { p = calloc(m, sizeof *p); }
+	if (i>=m) { write(2,"table too big\n",14); exit(123); }
+	return p+i;
+}
+
+static void mw_mirth_match_Match__7E_home (void){	size_t index = (size_t)pop_u64();
+	VAL *v = fieldptr_mirth_match_Match__7E_home(index);
 	push_ptr(v);
 }
 
@@ -16496,6 +16529,10 @@ static void mw_mirth_data_Tag_qname (void) {
 	mw_mirth_data_Tag__7E_qname();
 	mw_std_prim_prim_mut_get();
 }
+static void mw_mirth_data_Tag_name (void) {
+	mw_mirth_data_Tag_qname();
+	mw_mirth_name_QName_name();
+}
 static void mw_mirth_data_Tag_value (void) {
 	mw_mirth_data_Tag__7E_value();
 	mw_std_prim_prim_mut_get();
@@ -16600,9 +16637,44 @@ static void mw_mirth_match_Match_body (void) {
 	mw_mirth_match_Match__7E_body();
 	mw_std_prim_prim_mut_get();
 }
+static void mw_mirth_match_Match_home (void) {
+	mw_mirth_match_Match__7E_home();
+	mw_std_prim_prim_mut_get();
+}
 static void mw_mirth_match_Match_cases (void) {
 	mw_mirth_match_Match__7E_cases();
 	mw_std_prim_prim_mut_get();
+}
+static void mw_mirth_match_Match_new_21_ (void) {
+	mw_mirth_match_Match_alloc_21_();
+	LPOP(lbl_ctx);
+	mw_std_prelude_over();
+	mw_mirth_match_Match__7E_ctx();
+	mw_std_prim_prim_mut_set();
+	LPOP(lbl_dom);
+	mw_std_prelude_over();
+	mw_mirth_match_Match__7E_dom();
+	mw_std_prim_prim_mut_set();
+	LPOP(lbl_cod);
+	mw_std_prelude_over();
+	mw_mirth_match_Match__7E_cod();
+	mw_std_prim_prim_mut_set();
+	LPOP(lbl_token);
+	mw_std_prelude_over();
+	mw_mirth_match_Match__7E_token();
+	mw_std_prim_prim_mut_set();
+	LPOP(lbl_home);
+	mw_std_prelude_over();
+	mw_mirth_match_Match__7E_home();
+	mw_std_prim_prim_mut_set();
+	LPOP(lbl_body);
+	mw_std_prelude_over();
+	mw_mirth_match_Match__7E_body();
+	mw_std_prim_prim_mut_set();
+	mw_std_list_List_L0();
+	mw_std_prelude_over();
+	mw_mirth_match_Match__7E_cases();
+	mw_std_prim_prim_mut_set();
 }
 static void mw_mirth_match_Case_alloc_21_ (void) {
 	mw_mirth_match_Case_NUM();
@@ -20520,6 +20592,10 @@ static void mw_mirth_type_ArrowType_unpack (void) {
 static void mw_mirth_type_ArrowType_dom (void) {
 	mw_mirth_type_ArrowType_unpack();
 	mw_std_prim_prim_drop();
+}
+static void mw_mirth_type_ArrowType_cod (void) {
+	mw_mirth_type_ArrowType_unpack();
+	mw_std_prelude_nip();
 }
 static void mw_mirth_type_ArrowType_unify_21_ (void) {
 	{
@@ -26732,7 +26808,7 @@ static void mw_mirth_elab_elab_simple_type_arg_21_ (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prelude_nip();
 }
-static void mw_mirth_elab__2F_MKAB (void) {
+static void mw_mirth_elab__2B_AB__2F_MKAB (void) {
 	switch (get_top_resource_data_tag()) {
 		case 0LL:
 			mp_mirth_elab__2B_AB_MKAB();
@@ -26808,7 +26884,7 @@ static void mw_mirth_elab_ab_build_21_ (void) {
 		mw_mirth_elab__2B_AB_MKAB();
 		incref(var_f);
 		run_value(var_f);
-		mw_mirth_elab__2F_MKAB();
+		mw_mirth_elab__2B_AB__2F_MKAB();
 		decref(var_f);
 	}
 }
@@ -28115,36 +28191,120 @@ static void mw_mirth_elab_elab_atom_lambda_21_ (void) {
 	mw_mirth_elab_ab_op_21_();
 }
 static void mw_mirth_elab_elab_match_at_21_ (void) {
-	mw_mirth_match_Match_alloc_21_();
 	mw_mirth_elab_ab_ctx_40_();
-	mw_std_prelude_over();
-	mw_mirth_match_Match__7E_ctx();
-	mw_std_prim_prim_mut_set();
+	LPUSH(lbl_ctx);
 	mw_mirth_elab_ab_type_40_();
-	mw_std_prelude_over();
-	mw_mirth_match_Match__7E_dom();
-	mw_std_prim_prim_mut_set();
+	LPUSH(lbl_dom);
 	mw_mirth_elab_ab_token_40_();
-	mw_std_prelude_over();
-	mw_mirth_match_Match__7E_token();
-	mw_std_prim_prim_mut_set();
-	mw_std_prelude_tuck();
-	mw_mirth_match_Match__7E_body();
-	mw_std_prim_prim_mut_set();
-	mw_std_prelude_tuck();
-	mw_mirth_match_Match__7E_cod();
-	mw_std_prim_prim_mut_set();
+	LPUSH(lbl_token);
+	mw_mirth_elab_ab_home_40_();
+	LPUSH(lbl_home);
+	mw_mirth_match_Match_new_21_();
 	mw_mirth_elab_elab_match_cases_21_();
 	mw_mirth_elab_elab_match_exhaustive_21_();
 	mw_mirth_arrow_Op_OP_5F_MATCH();
 	mw_mirth_elab_ab_op_21_();
 }
+static void mw_mirth_elab_ab_match_21_ (void) {
+	{
+		VAL var_f = pop_value();
+		mw_mirth_elab_ab_ctx_40_();
+		LPUSH(lbl_ctx);
+		mw_mirth_elab_ab_type_40_();
+		LPUSH(lbl_dom);
+		mw_mirth_elab_ab_token_40_();
+		LPUSH(lbl_token);
+		mw_mirth_elab_ab_home_40_();
+		LPUSH(lbl_home);
+		mw_mirth_match_Match_new_21_();
+		LPUSH(lbl_match);
+		{
+			VAL d3 = pop_resource();
+			incref(var_f);
+			run_value(var_f);
+			push_resource(d3);
+		}
+		LPOP(lbl_match);
+		mw_mirth_arrow_Op_OP_5F_MATCH();
+		mw_mirth_elab_ab_op_21_();
+		decref(var_f);
+	}
+}
+static void mw_mirth_elab_ab_case_21_ (void) {
+	{
+		VAL var_f = pop_value();
+		mw_mirth_match_Case_alloc_21_();
+		LPOP(lbl_match);
+		mw_std_prelude_over();
+		mw_mirth_match_Case__7E_match();
+		mw_std_prim_prim_mut_set();
+		mw_std_prelude_tuck();
+		mw_mirth_match_Case__7E_pattern();
+		mw_std_prim_prim_mut_set();
+		mw_std_prelude_tuck();
+		mw_mirth_match_Case__7E_token();
+		mw_std_prim_prim_mut_set();
+		mw_std_prim_prim_dup();
+		mw_mirth_match_Case_token();
+		mw_mirth_elab_determine_case_subst_and_mid_21_();
+		mw_std_prim_prim_drop();
+		{
+			VAL var_case = pop_value();
+			incref(var_case);
+			push_value(var_case);
+			mw_mirth_match_Case_match();
+			mw_mirth_match_Match_ctx();
+			incref(var_case);
+			push_value(var_case);
+			mw_mirth_match_Case_mid();
+			incref(var_case);
+			push_value(var_case);
+			mw_mirth_match_Case_match();
+			mw_mirth_match_Match_cod();
+			mw_mirth_type_T__3E_();
+			incref(var_case);
+			push_value(var_case);
+			mw_mirth_match_Case_token();
+			incref(var_case);
+			push_value(var_case);
+			mw_mirth_match_Case_match();
+			mw_mirth_match_Match_home();
+			push_u64(0);
+			incref(var_f);
+			push_value(var_f);
+			mw_std_prim_prim_pack_cons();
+			incref(var_case);
+			push_value(var_case);
+			mw_std_prim_prim_pack_cons();
+			push_fnptr(&mb_mirth_elab_ab_case_21__35);
+			mw_std_prim_prim_pack_cons();
+			mw_mirth_elab_ab_build_hom_21_();
+			incref(var_case);
+			push_value(var_case);
+			mw_mirth_match_Case__7E_body();
+			mw_std_prim_prim_mut_set();
+			incref(var_case);
+			push_value(var_case);
+			mw_std_prim_prim_dup();
+			mw_mirth_match_Case_match();
+			mw_mirth_match_Match_add_case_21_();
+			incref(var_case);
+			push_value(var_case);
+			mw_mirth_match_Case_match();
+			LPUSH(lbl_match);
+			decref(var_case);
+		}
+		decref(var_f);
+	}
+}
 static void mw_mirth_elab_elab_atom_match_21_ (void) {
 	mw_mirth_type_MetaVar_new_21_();
 	mw_mirth_type_StackType_STMeta();
+	LPUSH(lbl_cod);
 	mw_mirth_elab_ab_token_40_();
 	mw_mirth_token_Token_args_2B_();
 	mw_std_list_List_2B__first();
+	LPUSH(lbl_body);
 	mw_mirth_elab_elab_match_at_21_();
 }
 static void mw_mirth_elab_elab_lambda_21_ (void) {
@@ -28369,43 +28529,99 @@ static void mw_mirth_elab_elab_case_pattern_21_ (void) {
 	mw_std_prim_prim_dup();
 	mw_mirth_token_Token_pat_underscore_3F_();
 	if (pop_u64()) {
-		{
-			VAL d3 = pop_value();
-			mw_mirth_match_Pattern_PATTERN_5F_UNDERSCORE();
-			mw_std_prelude_over();
-			mw_mirth_match_Case__7E_pattern();
-			mw_std_prim_prim_mut_set();
-			push_value(d3);
-		}
-		{
-			VAL d3 = pop_value();
-			mw_std_prim_prim_dup();
-			mw_mirth_match_Case_match();
-			mw_mirth_match_Match_dom();
-			mw_mirth_type_StackType_STACK_5F_TYPE_5F_DONT_5F_CARE();
-			mw_mirth_type_Type_TYPE_5F_DONT_5F_CARE();
-			mw_mirth_type_T_2A_();
-			push_value(d3);
-		}
-		mw_mirth_elab_elab_stack_type_unify_21_();
-		{
-			VAL d3 = pop_value();
-			mw_std_prelude_over();
-			mw_mirth_match_Case__7E_mid();
-			mw_std_prim_prim_mut_set();
-			push_value(d3);
-		}
+		mw_mirth_match_Pattern_PATTERN_5F_UNDERSCORE();
+		mw_std_prelude_over2();
+		mw_mirth_match_Case__7E_pattern();
+		mw_std_prim_prim_mut_set();
+		mw_mirth_elab_determine_case_subst_and_mid_21_();
 		mw_mirth_token_Token_succ();
 	} else {
 		mw_std_prim_prim_dup();
 		mw_mirth_token_Token_name_3F_();
 		push_u64(0);
-		push_fnptr(&mb_mirth_elab_elab_case_pattern_21__33);
+		push_fnptr(&mb_mirth_elab_elab_case_pattern_21__15);
 		mw_std_prim_prim_pack_cons();
 		push_u64(0);
-		push_fnptr(&mb_mirth_elab_elab_case_pattern_21__103);
+		push_fnptr(&mb_mirth_elab_elab_case_pattern_21__38);
 		mw_std_prim_prim_pack_cons();
 		mw_std_maybe_Maybe_if_some();
+	}
+}
+static void mw_mirth_elab_determine_case_subst_and_mid_21_ (void) {
+	mw_std_prelude_over();
+	mw_mirth_match_Case_pattern();
+	switch (get_top_data_tag()) {
+		case 0LL:
+			mp_mirth_match_Pattern_PATTERN_5F_UNDERSCORE();
+			{
+				VAL d4 = pop_value();
+				mw_std_prim_prim_dup();
+				mw_mirth_match_Case_match();
+				mw_mirth_match_Match_dom();
+				mw_mirth_type_StackType_STACK_5F_TYPE_5F_DONT_5F_CARE();
+				mw_mirth_type_Type_TYPE_5F_DONT_5F_CARE();
+				mw_mirth_type_T_2A_();
+				push_value(d4);
+			}
+			mw_mirth_elab_elab_stack_type_unify_21_();
+			{
+				VAL d4 = pop_value();
+				mw_std_prelude_over();
+				mw_mirth_match_Case__7E_mid();
+				mw_std_prim_prim_mut_set();
+				mw_mirth_type_Subst_nil();
+				mw_std_prelude_over();
+				mw_mirth_match_Case__7E_subst();
+				mw_std_prim_prim_mut_set();
+				push_value(d4);
+			}
+			break;
+		case 1LL:
+			mp_mirth_match_Pattern_PATTERN_5F_TAG();
+			push_u64(0);
+			push_fnptr(&mb_mirth_elab_determine_case_subst_and_mid_21__31);
+			mw_std_prim_prim_pack_cons();
+			mw_std_prelude_dip2();
+			{
+				VAL d4 = pop_value();
+				mw_mirth_type_Subst_nil();
+				push_value(d4);
+			}
+			mw_mirth_data_Tag_type();
+			mw_mirth_type_ArrowType_freshen_sig();
+			mw_std_prelude_rotr();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mw_mirth_type_ArrowType_unpack();
+					push_value(d5);
+				}
+				push_u64(0);
+				push_fnptr(&mb_mirth_elab_determine_case_subst_and_mid_21__50);
+				mw_std_prim_prim_pack_cons();
+				mw_std_prelude_dip2();
+				mw_mirth_elab_elab_stack_type_unify_21_();
+				mw_std_prelude_nip();
+				{
+					VAL d5 = pop_value();
+					mw_std_prelude_over();
+					mw_mirth_match_Case__7E_mid();
+					mw_std_prim_prim_mut_set();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			mw_std_prim_prim_swap();
+			{
+				VAL d4 = pop_value();
+				mw_std_prelude_over();
+				mw_mirth_match_Case__7E_subst();
+				mw_std_prim_prim_mut_set();
+				push_value(d4);
+			}
+			break;
+		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
 	}
 }
 static void mw_mirth_elab_elab_case_body_21_ (void) {
@@ -28872,6 +29088,81 @@ static void mw_mirth_elab_elab_data_done_21_ (void) {
 		push_fnptr(&mb_mirth_elab_elab_data_done_21__8);
 		mw_std_prim_prim_pack_cons();
 		mw_std_prim_Bool_then();
+		incref(var_dat);
+		push_value(var_dat);
+		mw_mirth_data_Data_tags();
+		switch (get_top_data_tag()) {
+			case 1LL:
+				mp_std_list_List_L1();
+				{
+					VAL var_tag = pop_value();
+					incref(var_dat);
+					push_value(var_dat);
+					{
+						static bool vready = false;
+						static VAL v;
+						if (! vready) {
+							v = mkstr("/", 1);
+							vready = true;
+						}
+						push_value(v);
+						incref(v);
+					}
+					incref(var_tag);
+					push_value(var_tag);
+					mw_mirth_data_Tag_name();
+					mw_mirth_name_Name__3E_Str();
+					mw_std_prim_prim_str_cat();
+					mw_mirth_elab_data_word_new_21_();
+					{
+						VAL var_untag = pop_value();
+						incref(var_tag);
+						push_value(var_tag);
+						push_u64(0);
+						incref(var_dat);
+						push_value(var_dat);
+						mw_std_prim_prim_pack_cons();
+						incref(var_tag);
+						push_value(var_tag);
+						mw_std_prim_prim_pack_cons();
+						incref(var_untag);
+						push_value(var_untag);
+						mw_std_prim_prim_pack_cons();
+						push_fnptr(&mb_mirth_elab_elab_data_done_21__85);
+						mw_std_prim_prim_pack_cons();
+						mw_std_lazy_delay();
+						incref(var_untag);
+						push_value(var_untag);
+						mw_mirth_word_Word__7E_ctx_type();
+						mw_std_prim_prim_mut_set();
+						incref(var_untag);
+						push_value(var_untag);
+						push_u64(0);
+						incref(var_dat);
+						push_value(var_dat);
+						mw_std_prim_prim_pack_cons();
+						incref(var_tag);
+						push_value(var_tag);
+						mw_std_prim_prim_pack_cons();
+						incref(var_untag);
+						push_value(var_untag);
+						mw_std_prim_prim_pack_cons();
+						push_fnptr(&mb_mirth_elab_elab_data_done_21__97);
+						mw_std_prim_prim_pack_cons();
+						mw_std_lazy_delay();
+						incref(var_untag);
+						push_value(var_untag);
+						mw_mirth_word_Word__7E_arrow();
+						mw_std_prim_prim_mut_set();
+						decref(var_untag);
+					}
+					decref(var_tag);
+				}
+				break;
+			default:
+				mw_std_prim_prim_drop();
+				break;
+		}
 		decref(var_dat);
 	}
 }
@@ -29046,7 +29337,9 @@ static void mw_mirth_elab_elab_def_body_21_ (void) {
 	mw_mirth_token_Token_run_has_arrow_3F_();
 	if (pop_u64()) {
 		mw_std_prim_prim_dup();
+		LPUSH(lbl_cod);
 		mw_mirth_elab_ab_token_40_();
+		LPUSH(lbl_body);
 		mw_mirth_elab_elab_match_at_21_();
 	} else {
 		mw_mirth_elab_elab_atoms_21_();
@@ -30448,7 +30741,6 @@ static void mw_mirth_c99__2B_C99__2F_MKC99 (void) {
 	switch (get_top_resource_data_tag()) {
 		case 0LL:
 			mp_mirth_c99__2B_C99_MKC99();
-			mw_std_prim_prim_id();
 			break;
 		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
 	}
@@ -37210,6 +37502,31 @@ static void mb_mirth_elab_elab_match_exhaustive_21__4 (void) {
 	}
 	mw_mirth_token_emit_error_21_();
 }
+static void mb_mirth_elab_ab_case_21__35 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_case = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_f = pop_value();
+	mw_std_prim_prim_drop();
+	{
+		VAL d2 = pop_value();
+		incref(var_f);
+		run_value(var_f);
+		push_value(d2);
+	}
+	decref(var_case);
+	decref(var_f);
+}
+static void mb_mirth_elab_determine_case_subst_and_mid_21__31 (void) {
+	mw_std_prim_prim_drop();
+	mw_std_prim_prim_dup();
+	mw_mirth_match_Case_match();
+	mw_mirth_match_Match_dom();
+}
+static void mb_mirth_elab_determine_case_subst_and_mid_21__50 (void) {
+	mw_std_prim_prim_drop();
+	mw_std_prim_prim_swap();
+}
 static void mb_mirth_elab_elab_lambda_params_21__32 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prim_prim_dup();
@@ -37337,11 +37654,11 @@ static void mb_mirth_elab_elab_match_case_21__24 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_token_Token_succ();
 }
-static void mb_mirth_elab_elab_case_pattern_21__33 (void) {
+static void mb_mirth_elab_elab_case_pattern_21__15 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_name_Name_defs();
 	push_u64(0);
-	push_fnptr(&mb_mirth_elab_elab_case_pattern_21__36);
+	push_fnptr(&mb_mirth_elab_elab_case_pattern_21__18);
 	mw_std_prim_prim_pack_cons();
 	mw_std_list_List_find_some();
 	switch (get_top_data_tag()) {
@@ -37361,58 +37678,17 @@ static void mb_mirth_elab_elab_case_pattern_21__33 (void) {
 			break;
 		case 1LL:
 			mp_std_maybe_Maybe_SOME();
-			mw_std_prim_prim_dup();
 			mw_mirth_match_Pattern_PATTERN_5F_TAG();
-			mw_std_prelude_rotr();
-			push_u64(0);
-			push_fnptr(&mb_mirth_elab_elab_case_pattern_21__52);
-			mw_std_prim_prim_pack_cons();
-			mw_std_prelude_dip2();
-			push_u64(0);
-			push_fnptr(&mb_mirth_elab_elab_case_pattern_21__58);
-			mw_std_prim_prim_pack_cons();
-			mw_std_prelude_dip2();
-			mw_mirth_data_Tag_type();
-			mw_mirth_type_Subst_nil();
-			mw_std_prim_prim_swap();
-			mw_mirth_type_ArrowType_freshen_sig();
-			mw_std_prelude_rotr();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mw_mirth_type_ArrowType_unpack();
-					push_value(d5);
-				}
-				push_u64(0);
-				push_fnptr(&mb_mirth_elab_elab_case_pattern_21__81);
-				mw_std_prim_prim_pack_cons();
-				mw_std_prelude_dip2();
-				mw_mirth_elab_elab_stack_type_unify_21_();
-				mw_std_prelude_nip();
-				{
-					VAL d5 = pop_value();
-					mw_std_prelude_over();
-					mw_mirth_match_Case__7E_mid();
-					mw_std_prim_prim_mut_set();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			mw_std_prim_prim_swap();
-			{
-				VAL d4 = pop_value();
-				mw_std_prelude_over();
-				mw_mirth_match_Case__7E_subst();
-				mw_std_prim_prim_mut_set();
-				push_value(d4);
-			}
+			mw_std_prelude_over2();
+			mw_mirth_match_Case__7E_pattern();
+			mw_std_prim_prim_mut_set();
+			mw_mirth_elab_determine_case_subst_and_mid_21_();
 			mw_mirth_token_Token_succ();
 			break;
 		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
 	}
 }
-static void mb_mirth_elab_elab_case_pattern_21__103 (void) {
+static void mb_mirth_elab_elab_case_pattern_21__38 (void) {
 	mw_std_prim_prim_drop();
 	{
 		static bool vready = false;
@@ -37426,25 +37702,9 @@ static void mb_mirth_elab_elab_case_pattern_21__103 (void) {
 	}
 	mw_mirth_token_emit_fatal_error_21_();
 }
-static void mb_mirth_elab_elab_case_pattern_21__36 (void) {
+static void mb_mirth_elab_elab_case_pattern_21__18 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_def_Def_tag_3F_();
-}
-static void mb_mirth_elab_elab_case_pattern_21__52 (void) {
-	mw_std_prim_prim_drop();
-	mw_std_prelude_over();
-	mw_mirth_match_Case__7E_pattern();
-	mw_std_prim_prim_mut_set();
-}
-static void mb_mirth_elab_elab_case_pattern_21__58 (void) {
-	mw_std_prim_prim_drop();
-	mw_std_prim_prim_dup();
-	mw_mirth_match_Case_match();
-	mw_mirth_match_Match_dom();
-}
-static void mb_mirth_elab_elab_case_pattern_21__81 (void) {
-	mw_std_prim_prim_drop();
-	mw_std_prim_prim_swap();
 }
 static void mb_mirth_elab_elab_case_body_21__29 (void) {
 	mw_std_prim_prim_drop();
@@ -38332,6 +38592,128 @@ static void mb_mirth_elab_elab_data_done_21__55 (void) {
 	mw_mirth_arrow_Coerce_COERCE_5F_UNSAFE();
 	mw_mirth_elab_ab_coerce_21_();
 	decref(var_ftag);
+	decref(var_dat);
+}
+static void mb_mirth_elab_elab_data_done_21__85 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_untag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_dat = pop_value();
+	mw_std_prim_prim_drop();
+	mw_mirth_data_Tag_ctx_type();
+	mw_mirth_type_ArrowType_unpack();
+	mw_std_prim_prim_swap();
+	mw_mirth_type_T__3E_();
+	mw_std_prelude_pack2();
+	decref(var_untag);
+	decref(var_tag);
+	decref(var_dat);
+}
+static void mb_mirth_elab_elab_data_done_21__97 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_untag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_dat = pop_value();
+	mw_std_prim_prim_drop();
+	push_u64(0);
+	incref(var_dat);
+	push_value(var_dat);
+	mw_std_prim_prim_pack_cons();
+	incref(var_tag);
+	push_value(var_tag);
+	mw_std_prim_prim_pack_cons();
+	incref(var_untag);
+	push_value(var_untag);
+	mw_std_prim_prim_pack_cons();
+	push_fnptr(&mb_mirth_elab_elab_data_done_21__99);
+	mw_std_prim_prim_pack_cons();
+	mw_mirth_elab_ab_build_word_arrow_21_();
+	decref(var_untag);
+	decref(var_tag);
+	decref(var_dat);
+}
+static void mb_mirth_elab_elab_data_done_21__99 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_untag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_dat = pop_value();
+	mw_std_prim_prim_drop();
+	incref(var_untag);
+	push_value(var_untag);
+	mw_mirth_word_Word_type();
+	mw_mirth_type_ArrowType_cod();
+	LPUSH(lbl_cod);
+	incref(var_dat);
+	push_value(var_dat);
+	mw_mirth_data_Data_head_3F_();
+	mw_std_maybe_Maybe_unwrap();
+	LPUSH(lbl_body);
+	push_u64(0);
+	incref(var_dat);
+	push_value(var_dat);
+	mw_std_prim_prim_pack_cons();
+	incref(var_tag);
+	push_value(var_tag);
+	mw_std_prim_prim_pack_cons();
+	incref(var_untag);
+	push_value(var_untag);
+	mw_std_prim_prim_pack_cons();
+	push_fnptr(&mb_mirth_elab_elab_data_done_21__109);
+	mw_std_prim_prim_pack_cons();
+	mw_mirth_elab_ab_match_21_();
+	decref(var_untag);
+	decref(var_tag);
+	decref(var_dat);
+}
+static void mb_mirth_elab_elab_data_done_21__109 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_untag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_dat = pop_value();
+	mw_std_prim_prim_drop();
+	incref(var_dat);
+	push_value(var_dat);
+	mw_mirth_data_Data_head_3F_();
+	mw_std_maybe_Maybe_unwrap();
+	incref(var_tag);
+	push_value(var_tag);
+	mw_mirth_match_Pattern_PATTERN_5F_TAG();
+	push_u64(0);
+	incref(var_dat);
+	push_value(var_dat);
+	mw_std_prim_prim_pack_cons();
+	incref(var_tag);
+	push_value(var_tag);
+	mw_std_prim_prim_pack_cons();
+	incref(var_untag);
+	push_value(var_untag);
+	mw_std_prim_prim_pack_cons();
+	push_fnptr(&mb_mirth_elab_elab_data_done_21__116);
+	mw_std_prim_prim_pack_cons();
+	mw_mirth_elab_ab_case_21_();
+	decref(var_untag);
+	decref(var_tag);
+	decref(var_dat);
+}
+static void mb_mirth_elab_elab_data_done_21__116 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_untag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_dat = pop_value();
+	mw_std_prim_prim_drop();
+	mw_std_prim_prim_id();
+	decref(var_untag);
+	decref(var_tag);
 	decref(var_dat);
 }
 static void mb_mirth_elab_elab_def_qname_undefined_6 (void) {

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -8477,7 +8477,8 @@ static void mb_mirth_elab_create_projectors_21__37 (void);
 static void mb_mirth_elab_create_projectors_21__52 (void);
 static void mb_mirth_elab_create_projectors_21__68 (void);
 static void mb_mirth_elab_create_projectors_21__70 (void);
-static void mb_mirth_elab_create_projectors_21__84 (void);
+static void mb_mirth_elab_create_projectors_21__80 (void);
+static void mb_mirth_elab_create_projectors_21__86 (void);
 static void mb_mirth_elab_token_def_args_9 (void);
 static void mb_mirth_elab_elab_def_qname_4 (void);
 static void mb_mirth_elab_elab_def_params_21__13 (void);
@@ -39057,6 +39058,43 @@ static void mb_mirth_elab_create_projectors_21__70 (void) {
 	incref(var_lbl);
 	push_value(var_lbl);
 	mw_mirth_elab_ab_label_push_21_();
+	push_u64(0);
+	incref(var_untag);
+	push_value(var_untag);
+	mw_std_prim_prim_pack_cons();
+	incref(var_dat);
+	push_value(var_dat);
+	mw_std_prim_prim_pack_cons();
+	incref(var_tag);
+	push_value(var_tag);
+	mw_std_prim_prim_pack_cons();
+	incref(var_lbl);
+	push_value(var_lbl);
+	mw_std_prim_prim_pack_cons();
+	incref(var_lbl_5F_proj);
+	push_value(var_lbl_5F_proj);
+	mw_std_prim_prim_pack_cons();
+	push_fnptr(&mb_mirth_elab_create_projectors_21__80);
+	mw_std_prim_prim_pack_cons();
+	mw_mirth_elab_ab_dip_21_();
+	decref(var_lbl_5F_proj);
+	decref(var_lbl);
+	decref(var_tag);
+	decref(var_dat);
+	decref(var_untag);
+}
+static void mb_mirth_elab_create_projectors_21__80 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl_5F_proj = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_dat = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_untag = pop_value();
+	mw_std_prim_prim_drop();
 	incref(var_tag);
 	push_value(var_tag);
 	mw_mirth_elab_ab_tag_21_();
@@ -39079,7 +39117,7 @@ static void mb_mirth_elab_create_projectors_21__70 (void) {
 	incref(var_lbl_5F_proj);
 	push_value(var_lbl_5F_proj);
 	mw_std_prim_prim_pack_cons();
-	push_fnptr(&mb_mirth_elab_create_projectors_21__84);
+	push_fnptr(&mb_mirth_elab_create_projectors_21__86);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prim_Bool_else();
 	decref(var_lbl_5F_proj);
@@ -39088,7 +39126,7 @@ static void mb_mirth_elab_create_projectors_21__70 (void) {
 	decref(var_dat);
 	decref(var_untag);
 }
-static void mb_mirth_elab_create_projectors_21__84 (void) {
+static void mb_mirth_elab_create_projectors_21__86 (void) {
 	mw_std_prim_prim_pack_uncons();
 	VAL var_lbl_5F_proj = pop_value();
 	mw_std_prim_prim_pack_uncons();

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -1214,13 +1214,6 @@ static VAL lbl_output_file = {0};
 static VAL lbl_entry_point = {0};
 static VAL lbl_packages = {0};
 static VAL lbl_output_path = {0};
-static VAL lbl_ctx = {0};
-static VAL lbl_dom = {0};
-static VAL lbl_cod = {0};
-static VAL lbl_token = {0};
-static VAL lbl_body = {0};
-static VAL lbl_home = {0};
-static VAL lbl_match = {0};
 static VAL lbl_options = {0};
 static VAL lbl_parser = {0};
 static VAL lbl_args_doc = {0};
@@ -1235,6 +1228,13 @@ static VAL lbl_argv_info = {0};
 static VAL lbl_arg = {0};
 static VAL lbl_positional_index = {0};
 static VAL lbl_error = {0};
+static VAL lbl_ctx = {0};
+static VAL lbl_dom = {0};
+static VAL lbl_cod = {0};
+static VAL lbl_token = {0};
+static VAL lbl_body = {0};
+static VAL lbl_home = {0};
+static VAL lbl_match = {0};
 static void mw_std_prim_F (void) {
 	VAL tag = MKU64(0LL);
 	VAL car = (tag);
@@ -7064,31 +7064,35 @@ static void mw_posix_posix_line_print_21_ (void);
 static void mw_posix_posix_line_trace_21_ (void);
 static void mw_std_path_Path_trace_21_ (void);
 static void mw_std_prim_Int_trace_21_ (void);
+static void mw_args_state_ArgvInfo__2F_ARGV_5F_INFO (void);
 static void mw_args_state_ArgvInfo_program_name (void);
 static void mw_args_state_ArgvInfo_argv (void);
+static void mw_args_state_CurrentArg__2F_CURRENT_5F_ARG (void);
 static void mw_args_state_CurrentArg_option_option (void);
-static void mw_args_state_CurrentArg_option_option_21_ (void);
 static void mw_args_state_CurrentArg_parsing_3F_ (void);
+static void mw_args_state_CurrentArg_option_option_21_ (void);
 static void mw_args_state_CurrentArg_parsing_21_ (void);
+static void mw_args_state_State__2F_STATE (void);
+static void mw_args_state_State_error (void);
+static void mw_args_state_State_positional_index (void);
+static void mw_args_state_State_arg (void);
+static void mw_args_state_State_argv_info (void);
+static void mw_args_state_State_arguments (void);
 static void mw_args_state_State_init (void);
 static void mw_args_state_State_argv (void);
 static void mw_args_state_State_program_name (void);
-static void mw_args_state_State_argv_info (void);
 static void mw_args_state_State_parsing_3F_ (void);
 static void mw_args_state_State_parsing_21_ (void);
 static void mw_args_state_State_option_option (void);
 static void mw_args_state_State_option_option_21_ (void);
-static void mw_args_state_State_arg (void);
 static void mw_args_state_State_arg_21_ (void);
-static void mw_args_state_State_error (void);
 static void mw_args_state_State_error_21_ (void);
-static void mw_args_state_State_positional_index (void);
 static void mw_args_state_State_positional_index_21_ (void);
-static void mw_args_state_State_arguments (void);
 static void mw_args_state_State_arguments_21_ (void);
-static void mw_args_types_ArgumentParser_options (void);
-static void mw_args_types_ArgumentParser_parser (void);
+static void mw_args_types_ArgumentParser__2F_ARGUMENT_5F_PARSER (void);
 static void mw_args_types_ArgumentParser_args_doc (void);
+static void mw_args_types_ArgumentParser_parser (void);
+static void mw_args_types_ArgumentParser_options (void);
 static void mw_args_types_ArgumentParser_new (void);
 static void mw_args_types__ARGUMENTPARSER (void);
 static void mw_args_types__2B_ArgumentParser_rdrop (void);
@@ -14200,43 +14204,68 @@ static void mw_std_prim_Int_trace_21_ (void) {
 	mw_std_prim_Int_show();
 	mw_std_prim_Str_trace_21_();
 }
-static void mw_args_state_ArgvInfo_program_name (void) {
+static void mw_args_state_ArgvInfo__2F_ARGV_5F_INFO (void) {
 	switch (get_top_data_tag()) {
 		case 0LL:
 			mp_args_state_ArgvInfo_ARGV_5F_INFO();
-			LPOP(lbl_program_name);
-			mw_std_prim_prim_dup();
-			LPUSH(lbl_program_name);
-			mw_args_state_ArgvInfo_ARGV_5F_INFO();
-			mw_std_prim_prim_drop();
 			break;
 		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
 	}
 }
+static void mw_args_state_ArgvInfo_program_name (void) {
+	mw_args_state_ArgvInfo__2F_ARGV_5F_INFO();
+	LPOP(lbl_program_name);
+	mw_std_prim_prim_dup();
+	LPUSH(lbl_program_name);
+	{
+		VAL d2 = pop_value();
+		mw_args_state_ArgvInfo_ARGV_5F_INFO();
+		mw_std_prim_prim_drop();
+		push_value(d2);
+	}
+}
 static void mw_args_state_ArgvInfo_argv (void) {
+	mw_args_state_ArgvInfo__2F_ARGV_5F_INFO();
+	LPOP(lbl_argv);
+	mw_std_prim_prim_dup();
+	LPUSH(lbl_argv);
+	{
+		VAL d2 = pop_value();
+		mw_args_state_ArgvInfo_ARGV_5F_INFO();
+		mw_std_prim_prim_drop();
+		push_value(d2);
+	}
+}
+static void mw_args_state_CurrentArg__2F_CURRENT_5F_ARG (void) {
 	switch (get_top_data_tag()) {
 		case 0LL:
-			mp_args_state_ArgvInfo_ARGV_5F_INFO();
-			LPOP(lbl_argv);
-			mw_std_prim_prim_dup();
-			LPUSH(lbl_argv);
-			mw_args_state_ArgvInfo_ARGV_5F_INFO();
-			mw_std_prim_prim_drop();
+			mp_args_state_CurrentArg_CURRENT_5F_ARG();
 			break;
 		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
 	}
 }
 static void mw_args_state_CurrentArg_option_option (void) {
-	switch (get_top_data_tag()) {
-		case 0LL:
-			mp_args_state_CurrentArg_CURRENT_5F_ARG();
-			LPOP(lbl_option_option);
-			mw_std_prim_prim_dup();
-			LPUSH(lbl_option_option);
-			mw_args_state_CurrentArg_CURRENT_5F_ARG();
-			mw_std_prim_prim_drop();
-			break;
-		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
+	mw_args_state_CurrentArg__2F_CURRENT_5F_ARG();
+	LPOP(lbl_option_option);
+	mw_std_prim_prim_dup();
+	LPUSH(lbl_option_option);
+	{
+		VAL d2 = pop_value();
+		mw_args_state_CurrentArg_CURRENT_5F_ARG();
+		mw_std_prim_prim_drop();
+		push_value(d2);
+	}
+}
+static void mw_args_state_CurrentArg_parsing_3F_ (void) {
+	mw_args_state_CurrentArg__2F_CURRENT_5F_ARG();
+	LPOP(lbl_parsing_3F_);
+	mw_std_prim_prim_dup();
+	LPUSH(lbl_parsing_3F_);
+	{
+		VAL d2 = pop_value();
+		mw_args_state_CurrentArg_CURRENT_5F_ARG();
+		mw_std_prim_prim_drop();
+		push_value(d2);
 	}
 }
 static void mw_args_state_CurrentArg_option_option_21_ (void) {
@@ -14251,19 +14280,6 @@ static void mw_args_state_CurrentArg_option_option_21_ (void) {
 		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
 	}
 }
-static void mw_args_state_CurrentArg_parsing_3F_ (void) {
-	switch (get_top_data_tag()) {
-		case 0LL:
-			mp_args_state_CurrentArg_CURRENT_5F_ARG();
-			LPOP(lbl_parsing_3F_);
-			mw_std_prim_prim_dup();
-			LPUSH(lbl_parsing_3F_);
-			mw_args_state_CurrentArg_CURRENT_5F_ARG();
-			mw_std_prim_prim_drop();
-			break;
-		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
-	}
-}
 static void mw_args_state_CurrentArg_parsing_21_ (void) {
 	switch (get_top_data_tag()) {
 		case 0LL:
@@ -14274,6 +14290,74 @@ static void mw_args_state_CurrentArg_parsing_21_ (void) {
 			mw_args_state_CurrentArg_CURRENT_5F_ARG();
 			break;
 		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
+	}
+}
+static void mw_args_state_State__2F_STATE (void) {
+	switch (get_top_data_tag()) {
+		case 0LL:
+			mp_args_state_State_STATE();
+			break;
+		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
+	}
+}
+static void mw_args_state_State_error (void) {
+	mw_args_state_State__2F_STATE();
+	LPOP(lbl_error);
+	mw_std_prim_prim_dup();
+	LPUSH(lbl_error);
+	{
+		VAL d2 = pop_value();
+		mw_args_state_State_STATE();
+		mw_std_prim_prim_drop();
+		push_value(d2);
+	}
+}
+static void mw_args_state_State_positional_index (void) {
+	mw_args_state_State__2F_STATE();
+	LPOP(lbl_positional_index);
+	mw_std_prim_prim_dup();
+	LPUSH(lbl_positional_index);
+	{
+		VAL d2 = pop_value();
+		mw_args_state_State_STATE();
+		mw_std_prim_prim_drop();
+		push_value(d2);
+	}
+}
+static void mw_args_state_State_arg (void) {
+	mw_args_state_State__2F_STATE();
+	LPOP(lbl_arg);
+	mw_std_prim_prim_dup();
+	LPUSH(lbl_arg);
+	{
+		VAL d2 = pop_value();
+		mw_args_state_State_STATE();
+		mw_std_prim_prim_drop();
+		push_value(d2);
+	}
+}
+static void mw_args_state_State_argv_info (void) {
+	mw_args_state_State__2F_STATE();
+	LPOP(lbl_argv_info);
+	mw_std_prim_prim_dup();
+	LPUSH(lbl_argv_info);
+	{
+		VAL d2 = pop_value();
+		mw_args_state_State_STATE();
+		mw_std_prim_prim_drop();
+		push_value(d2);
+	}
+}
+static void mw_args_state_State_arguments (void) {
+	mw_args_state_State__2F_STATE();
+	LPOP(lbl_arguments);
+	mw_std_prim_prim_dup();
+	LPUSH(lbl_arguments);
+	{
+		VAL d2 = pop_value();
+		mw_args_state_State_STATE();
+		mw_std_prim_prim_drop();
+		push_value(d2);
 	}
 }
 static void mw_args_state_State_init (void) {
@@ -14310,19 +14394,6 @@ static void mw_args_state_State_program_name (void) {
 	mw_args_state_State_argv_info();
 	mw_args_state_ArgvInfo_program_name();
 }
-static void mw_args_state_State_argv_info (void) {
-	switch (get_top_data_tag()) {
-		case 0LL:
-			mp_args_state_State_STATE();
-			LPOP(lbl_argv_info);
-			mw_std_prim_prim_dup();
-			LPUSH(lbl_argv_info);
-			mw_args_state_State_STATE();
-			mw_std_prim_prim_drop();
-			break;
-		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
-	}
-}
 static void mw_args_state_State_parsing_3F_ (void) {
 	mw_args_state_State_arg();
 	mw_args_state_CurrentArg_parsing_3F_();
@@ -14351,19 +14422,6 @@ static void mw_args_state_State_option_option_21_ (void) {
 	}
 	mw_args_state_State_arg_21_();
 }
-static void mw_args_state_State_arg (void) {
-	switch (get_top_data_tag()) {
-		case 0LL:
-			mp_args_state_State_STATE();
-			LPOP(lbl_arg);
-			mw_std_prim_prim_dup();
-			LPUSH(lbl_arg);
-			mw_args_state_State_STATE();
-			mw_std_prim_prim_drop();
-			break;
-		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
-	}
-}
 static void mw_args_state_State_arg_21_ (void) {
 	switch (get_top_data_tag()) {
 		case 0LL:
@@ -14372,19 +14430,6 @@ static void mw_args_state_State_arg_21_ (void) {
 			mw_std_prim_prim_drop();
 			LPUSH(lbl_arg);
 			mw_args_state_State_STATE();
-			break;
-		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
-	}
-}
-static void mw_args_state_State_error (void) {
-	switch (get_top_data_tag()) {
-		case 0LL:
-			mp_args_state_State_STATE();
-			LPOP(lbl_error);
-			mw_std_prim_prim_dup();
-			LPUSH(lbl_error);
-			mw_args_state_State_STATE();
-			mw_std_prim_prim_drop();
 			break;
 		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
 	}
@@ -14401,19 +14446,6 @@ static void mw_args_state_State_error_21_ (void) {
 		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
 	}
 }
-static void mw_args_state_State_positional_index (void) {
-	switch (get_top_data_tag()) {
-		case 0LL:
-			mp_args_state_State_STATE();
-			LPOP(lbl_positional_index);
-			mw_std_prim_prim_dup();
-			LPUSH(lbl_positional_index);
-			mw_args_state_State_STATE();
-			mw_std_prim_prim_drop();
-			break;
-		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
-	}
-}
 static void mw_args_state_State_positional_index_21_ (void) {
 	switch (get_top_data_tag()) {
 		case 0LL:
@@ -14422,19 +14454,6 @@ static void mw_args_state_State_positional_index_21_ (void) {
 			mw_std_prim_prim_drop();
 			LPUSH(lbl_positional_index);
 			mw_args_state_State_STATE();
-			break;
-		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
-	}
-}
-static void mw_args_state_State_arguments (void) {
-	switch (get_top_data_tag()) {
-		case 0LL:
-			mp_args_state_State_STATE();
-			LPOP(lbl_arguments);
-			mw_std_prim_prim_dup();
-			LPUSH(lbl_arguments);
-			mw_args_state_State_STATE();
-			mw_std_prim_prim_drop();
 			break;
 		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
 	}
@@ -14451,43 +14470,48 @@ static void mw_args_state_State_arguments_21_ (void) {
 		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
 	}
 }
-static void mw_args_types_ArgumentParser_options (void) {
+static void mw_args_types_ArgumentParser__2F_ARGUMENT_5F_PARSER (void) {
 	switch (get_top_data_tag()) {
 		case 0LL:
 			mp_args_types_ArgumentParser_ARGUMENT_5F_PARSER();
-			LPOP(lbl_options);
-			mw_std_prim_prim_dup();
-			LPUSH(lbl_options);
-			mw_args_types_ArgumentParser_ARGUMENT_5F_PARSER();
-			mw_std_prim_prim_drop();
-			break;
-		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
-	}
-}
-static void mw_args_types_ArgumentParser_parser (void) {
-	switch (get_top_data_tag()) {
-		case 0LL:
-			mp_args_types_ArgumentParser_ARGUMENT_5F_PARSER();
-			LPOP(lbl_parser);
-			mw_std_prim_prim_dup();
-			LPUSH(lbl_parser);
-			mw_args_types_ArgumentParser_ARGUMENT_5F_PARSER();
-			mw_std_prim_prim_drop();
 			break;
 		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
 	}
 }
 static void mw_args_types_ArgumentParser_args_doc (void) {
-	switch (get_top_data_tag()) {
-		case 0LL:
-			mp_args_types_ArgumentParser_ARGUMENT_5F_PARSER();
-			LPOP(lbl_args_doc);
-			mw_std_prim_prim_dup();
-			LPUSH(lbl_args_doc);
-			mw_args_types_ArgumentParser_ARGUMENT_5F_PARSER();
-			mw_std_prim_prim_drop();
-			break;
-		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
+	mw_args_types_ArgumentParser__2F_ARGUMENT_5F_PARSER();
+	LPOP(lbl_args_doc);
+	mw_std_prim_prim_dup();
+	LPUSH(lbl_args_doc);
+	{
+		VAL d2 = pop_value();
+		mw_args_types_ArgumentParser_ARGUMENT_5F_PARSER();
+		mw_std_prim_prim_drop();
+		push_value(d2);
+	}
+}
+static void mw_args_types_ArgumentParser_parser (void) {
+	mw_args_types_ArgumentParser__2F_ARGUMENT_5F_PARSER();
+	LPOP(lbl_parser);
+	mw_std_prim_prim_dup();
+	LPUSH(lbl_parser);
+	{
+		VAL d2 = pop_value();
+		mw_args_types_ArgumentParser_ARGUMENT_5F_PARSER();
+		mw_std_prim_prim_drop();
+		push_value(d2);
+	}
+}
+static void mw_args_types_ArgumentParser_options (void) {
+	mw_args_types_ArgumentParser__2F_ARGUMENT_5F_PARSER();
+	LPOP(lbl_options);
+	mw_std_prim_prim_dup();
+	LPUSH(lbl_options);
+	{
+		VAL d2 = pop_value();
+		mw_args_types_ArgumentParser_ARGUMENT_5F_PARSER();
+		mw_std_prim_prim_drop();
+		push_value(d2);
 	}
 }
 static void mw_args_types_ArgumentParser_new (void) {

--- a/src/args/state.mth
+++ b/src/args/state.mth
@@ -11,29 +11,17 @@ data(ArgvInfo,
     program-name:Str
 )
 
-def(ArgvInfo.program-name, ArgvInfo -- Str, ARGV_INFO -> program-name> dup >program-name ARGV_INFO drop)
-def(ArgvInfo.argv, ArgvInfo -- List(Str), ARGV_INFO -> argv> dup >argv ARGV_INFO drop)
-
 data(CurrentArg,
   CURRENT_ARG ->
-    parsing?:Bool 
-    option:Maybe(ArgpOptionType) 
+    parsing?:Bool
+    option:Maybe(ArgpOptionType)
     option-option:Maybe(ArgpOption))
-
-def(CurrentArg.option-option, CurrentArg -- Maybe(ArgpOption),
-  CURRENT_ARG -> option-option> dup >option-option CURRENT_ARG drop)
 
 def(CurrentArg.option-option!, Maybe(ArgpOption) CurrentArg -- CurrentArg,
   CURRENT_ARG -> option-option> drop >option-option CURRENT_ARG)
 
-def(CurrentArg.option, CurrentArg -- Maybe(ArgpOptionType),
-  CURRENT_ARG ->  option> dup >option CURRENT_ARG drop)
-
 def(CurrentArg.option!, Maybe(ArgpOptionType) CurrentArg -- CurrentArg,
   CURRENT_ARG -> option> drop >option CURRENT_ARG)
-
-def(CurrentArg.parsing?, CurrentArg -- Bool,
-  CURRENT_ARG -> parsing?> dup >parsing? CURRENT_ARG drop)
 
 def(CurrentArg.parsing!, Bool CurrentArg -- CurrentArg,
   CURRENT_ARG -> parsing?> drop >parsing? CURRENT_ARG)
@@ -42,7 +30,7 @@ data(State(a),
   STATE ->
     arguments:a
     argv-info:ArgvInfo
-    arg:CurrentArg 
+    arg:CurrentArg
     positional-index:Int
     error:Maybe(ArgumentParsingError)
 )
@@ -67,9 +55,6 @@ def(State.argv, State(a) -- List(Str), argv-info ArgvInfo.argv)
 
 def(State.program-name, State(a) -- Str, argv-info program-name)
 
-def(State.argv-info, State(a) -- ArgvInfo,
-  STATE -> argv-info> dup >argv-info STATE drop)
-
 def(State.parsing?, State(a) -- Bool, arg parsing?)
 
 def(State.parsing!, Bool State(a) -- State(a),
@@ -87,26 +72,14 @@ def(State.option-option, State(a) -- Maybe(ArgpOption),
 def(State.option-option!, Maybe(ArgpOption) State(a) -- State(a),
   dup dip(arg option-option!) arg!)
 
-def(State.arg, State(a) -- CurrentArg,
-  STATE -> arg> dup >arg STATE drop)
-
 def(State.arg!, CurrentArg State(a) -- State(a),
   STATE -> arg> drop >arg STATE)
-
-def(State.error, State(a) -- Maybe(ArgumentParsingError),
-  STATE -> error> dup >error STATE drop)
 
 def(State.error!, Maybe(ArgumentParsingError) State(a) -- State(a),
   STATE -> error> drop >error STATE)
 
-def(State.positional-index, State(a) -- Int,
-  STATE -> positional-index> dup >positional-index STATE drop)
-
 def(State.positional-index!, Int State(a) -- State(a),
   STATE -> positional-index> drop >positional-index STATE)
-
-def(State.arguments, State(a) -- a,
-  STATE -> arguments> dup >arguments STATE drop)
 
 def(State.arguments!, a State(a) -- State(a),
   STATE -> arguments> drop >arguments STATE)

--- a/src/args/types.mth
+++ b/src/args/types.mth
@@ -13,29 +13,17 @@ data(ArgumentParser(a),
     args-doc:Maybe(Str)
     doc:Str)
 
-def(ArgumentParser.options, ArgumentParser(a) -- List(ArgpOption),
-  ARGUMENT_PARSER -> options> dup >options ARGUMENT_PARSER drop)
-
 def(ArgumentParser.options!, List(ArgpOption) ArgumentParser(a) -- ArgumentParser(a),
   ARGUMENT_PARSER -> options> drop >options ARGUMENT_PARSER)
-
-def(ArgumentParser.parser, ArgumentParser(a) -- Maybe([+ArgumentParser(a) a Maybe(Str) ArgpOptionType -- +ArgumentParser(a) a]),
-  ARGUMENT_PARSER -> parser> dup >parser ARGUMENT_PARSER drop)
 
 def(ArgumentParser.parser!,
   Maybe([+ArgumentParser(a) a Maybe(Str) ArgpOptionType -- +ArgumentParser(a) a]) ArgumentParser(a) -- ArgumentParser(a),
   ARGUMENT_PARSER -> parser> drop >parser ARGUMENT_PARSER)
 
-def(ArgumentParser.args-doc, ArgumentParser(a) -- Maybe(Str),
-  ARGUMENT_PARSER -> args-doc> dup >args-doc ARGUMENT_PARSER drop)
-
-def(ArgumentParser.doc, ArgumentParser(a) -- Str,
-  ARGUMENT_PARSER -> doc> dup >doc ARGUMENT_PARSER drop)
-
-def(ArgumentParser.new, 
-  options:List(ArgpOption) 
-  parser:Maybe([+ArgumentParser(a) a Maybe(Str) ArgpOptionType -- +ArgumentParser(a) a]) 
-  args-doc:Maybe(Str) 
+def(ArgumentParser.new,
+  options:List(ArgpOption)
+  parser:Maybe([+ArgumentParser(a) a Maybe(Str) ArgpOptionType -- +ArgumentParser(a) a])
+  args-doc:Maybe(Str)
   doc:Str -- ArgumentParser(a),
   ARGUMENT_PARSER
 )

--- a/src/mirth-tests/data-labels.mth
+++ b/src/mirth-tests/data-labels.mth
@@ -3,13 +3,36 @@ import(std.prelude)
 import(posix.posix)
 
 data(Person, PERSON -> age:Int name:Str)
+data(Mixed, MIXED -> msg:Str Str)
+data(+MyWorld, ENTER -> age:Int msg:Int name:Str +World)
 
-def(main, --,
+def(main, +World -- +World,
     "John" >name
     30 >age
     PERSON
     dup age trace-ln!
     dup name trace-ln!
-    drop)
+    drop
+
+    "Hello" >msg "Goodbye"
+    MIXED msg trace-ln!
+
+    99 >age 101 >msg "me" >name
+    ENTER
+    "<<<" trace-ln!
+    age trace-ln!
+    msg trace-ln!
+    name trace-ln!
+    ">>>" trace-ln!
+    /ENTER
+    age> drop
+    msg> drop
+    name> drop)
 # mirth-test # perr # 30
 # mirth-test # perr # John
+# mirth-test # perr # Hello
+# mirth-test # perr # <<<
+# mirth-test # perr # 99
+# mirth-test # perr # 101
+# mirth-test # perr # me
+# mirth-test # perr # >>>

--- a/src/mirth-tests/data-labels.mth
+++ b/src/mirth-tests/data-labels.mth
@@ -1,0 +1,17 @@
+module(mirth-tests.data-labels)
+import(std.prelude)
+import(posix.posix)
+
+data(Person, PERSON -> age:Int name:Str)
+def(Person.age, Person -- Int, PERSON -> age> dup >age PERSON drop)
+def(Person.name, Person -- Str, PERSON -> name> dup >name PERSON drop)
+
+def(main, --,
+    "John" >name
+    30 >age
+    PERSON
+    dup age trace-ln!
+    dup name trace-ln!
+    drop)
+# mirth-test # perr # 30
+# mirth-test # perr # John

--- a/src/mirth-tests/data-labels.mth
+++ b/src/mirth-tests/data-labels.mth
@@ -3,8 +3,6 @@ import(std.prelude)
 import(posix.posix)
 
 data(Person, PERSON -> age:Int name:Str)
-def(Person.age, Person -- Int, PERSON -> age> dup >age PERSON drop)
-def(Person.name, Person -- Str, PERSON -> name> dup >name PERSON drop)
 
 def(main, --,
     "John" >name

--- a/src/mirth/c99.mth
+++ b/src/mirth/c99.mth
@@ -147,6 +147,10 @@ def(c99-tag!, Tag +C99 -- +C99,
             "pop_resource());" put line
             "\tcar = mkcons(car, " put
         )
+        dup label-inputs reverse-for(
+            "lpop(&lbl_" put name mangled put "));" put line
+            "\tcar = mkcons(car, " put
+        )
         "tag);" put line
         dup outputs-resource? if(
             "\tpush_resource(car);",
@@ -161,10 +165,15 @@ def(c99-tag!, Tag +C99 -- +C99,
             "\tVAL car = pop_resource();",
             "\tVAL car = pop_value();"
         ) put line
-        dup num-resource-inputs over num-type-inputs + 0> then(
+        dup num-resource-inputs over num-type-inputs + over label-inputs len + 0> then(
             "\tVAL cdr;" put line
         )
         "\tdecref("
+        over label-inputs for(
+            "\tvalue_uncons_c(car, &car, &cdr);" put line
+            swap put "cdr);" put line
+            "\tlpush(&lbl_" swap name mangled cat ", " cat
+        )
         over num-resource-inputs repeat(
             "\tvalue_uncons_c(car, &car, &cdr);" put line
             put "cdr);" put line

--- a/src/mirth/c99.mth
+++ b/src/mirth/c99.mth
@@ -57,7 +57,6 @@ def(C99_Options.emit-debug-info, C99_Options -- EmitDebugInfo, C99_OPTIONS -> ni
 def(C99_Options.output-path, C99_Options -- OutputPath, C99_OPTIONS -> drop)
 
 data(+C99, MKC99 -> C99_Options Nat +Needs +Output)
-def(+C99./MKC99, +C99 -- C99_Options Nat +Needs +Output, MKC99 -> id)
 
 def(+C99.depth@, +C99 -- Nat +C99, /MKC99 dup dip(MKC99))
 def(+C99.depth!, Nat +C99 -- +C99, dip(/MKC99 drop) MKC99)

--- a/src/mirth/data.mth
+++ b/src/mirth/data.mth
@@ -68,6 +68,7 @@ def(make-prim-tag!, Str Int List(Type) Mut(Tag) --,
     dip(sip(len) TT)
     sip(CTX0 rotr .data TData T1 T-> pack2 LAZY_READY) sip(~ctx-type !)
     sip(~num-type-inputs !)
+    sip(L0 swap ~label-inputs !)
     sip(0 >Nat swap ~num-resource-inputs !)
     sip(dip(>Nat) ~value !)
     dip(QName.prim) tuck ~qname !
@@ -122,6 +123,7 @@ table(Tag)
 field(Tag.~data, Tag, Data)
 field(Tag.~qname, Tag, QName)
 field(Tag.~value, Tag, Nat)
+field(Tag.~label-inputs, Tag, List(Label))
 field(Tag.~num-type-inputs, Tag, Nat)
 field(Tag.~num-resource-inputs, Tag, Nat)
 field(Tag.~sig?, Tag, Maybe(Token))
@@ -130,6 +132,7 @@ field(Tag.~ctx-type, Tag, Lazy([Ctx ArrowType]))
 def(Tag.data, Tag -- Data, ~data @)
 def(Tag.qname, Tag -- QName, ~qname @)
 def(Tag.value, Tag -- Nat, ~value @)
+def(Tag.label-inputs, Tag -- List(Label), ~label-inputs @)
 def(Tag.num-type-inputs, Tag -- Nat, ~num-type-inputs @)
 def(Tag.num-resource-inputs, Tag -- Nat, ~num-resource-inputs @)
 def(Tag.sig?, Tag -- Maybe(Token), ~sig? @)
@@ -137,10 +140,14 @@ def(Tag.ctx-type, Tag -- Ctx ArrowType, ~ctx-type force! unpack2)
 def(Tag.ctx, Tag -- Ctx, ctx-type drop)
 def(Tag.type, Tag -- ArrowType, ctx-type nip)
 
+def(Tag.label-inputs-from-sig, Tag -- List(Label),
+    sig? if-some(run-tokens filter-some(label?), L0))
+
 def(Tag.num-type-inputs-from-sig, Tag -- Nat,
     dup sig? if-some(
         run-length
-        swap num-resource-inputs-from-sig -,
+        over num-resource-inputs-from-sig -
+        swap label-inputs-from-sig len 2* -,
         drop 0 >Nat
     ))
 

--- a/src/mirth/data.mth
+++ b/src/mirth/data.mth
@@ -128,6 +128,7 @@ field(Tag.~num-type-inputs, Tag, Nat)
 field(Tag.~num-resource-inputs, Tag, Nat)
 field(Tag.~sig?, Tag, Maybe(Token))
 field(Tag.~ctx-type, Tag, Lazy([Ctx ArrowType]))
+field(Tag.~untag, Tag, Maybe(Word))
 
 def(Tag.data, Tag -- Data, ~data @)
 def(Tag.qname, Tag -- QName, ~qname @)
@@ -140,6 +141,7 @@ def(Tag.sig?, Tag -- Maybe(Token), ~sig? @)
 def(Tag.ctx-type, Tag -- Ctx ArrowType, ~ctx-type force! unpack2)
 def(Tag.ctx, Tag -- Ctx, ctx-type drop)
 def(Tag.type, Tag -- ArrowType, ctx-type nip)
+def(Tag.untag, Tag -- Maybe(Word), ~untag @)
 
 def(Tag.label-inputs-from-sig, Tag -- List(Label),
     sig? if-some(run-tokens filter-some(label?), L0))

--- a/src/mirth/data.mth
+++ b/src/mirth/data.mth
@@ -131,6 +131,7 @@ field(Tag.~ctx-type, Tag, Lazy([Ctx ArrowType]))
 
 def(Tag.data, Tag -- Data, ~data @)
 def(Tag.qname, Tag -- QName, ~qname @)
+def(Tag.name, Tag -- Name, qname name)
 def(Tag.value, Tag -- Nat, ~value @)
 def(Tag.label-inputs, Tag -- List(Label), ~label-inputs @)
 def(Tag.num-type-inputs, Tag -- Nat, ~num-type-inputs @)

--- a/src/mirth/elab.mth
+++ b/src/mirth/elab.mth
@@ -1045,8 +1045,10 @@ def(create-projectors!, Tag --,
                 lbl ab-label-pop!
                 PRIM_CORE_DUP ab-prim!
                 lbl ab-label-push!
-                tag ab-tag!
-                dat is-resource? else(PRIM_CORE_DROP ab-prim!)
+                ab-dip!(
+                    tag ab-tag!
+                    dat is-resource? else(PRIM_CORE_DROP ab-prim!)
+                )
             )) lbl_proj ~arrow !
         )
     )))))

--- a/src/mirth/elab.mth
+++ b/src/mirth/elab.mth
@@ -36,6 +36,7 @@ import(mirth.package)
 import(mirth.alias)
 import(mirth.match)
 import(mirth.lexer)
+import(mirth.label)
 
 ####################
 # Type Elaboration #
@@ -945,6 +946,7 @@ def(elab-data-tag!, Data Token -- Data,
     dup2 name? unwrap-or(drop "Expected constructor name." emit-fatal-error!)
     data-qname
     Tag.alloc!
+    NONE over ~untag !
     tuck ~qname !
     dup DEF_TAG register
     { Data Token Tag }
@@ -1021,11 +1023,33 @@ def(elab-data-done!, Data --,
                             dat head? unwrap tag PATTERN_TAG ab-case!(id)
                         )
                     )) untag ~arrow !
+                    untag SOME tag ~untag !
+                    tag create-projectors!
                 )
             ),
             _ -> drop
         )
     ))
+
+def(create-projectors!, Tag --,
+    dup .data over .untag unwrap \(tag dat untag ->
+    tag label-inputs reverse-for(\(lbl -> dat lbl name data-qname undefined? then(
+        dat lbl >Str data-word-new! \(lbl_proj ->
+            tag delay (
+                ctx-type unpack lbl rotl force-cons-label?! unwrap
+                unpack2 dip(drop T0 dat is-resource? then(dat TData RESOURCE T+))
+                T* T-> pack2
+            ) lbl_proj ~ctx-type !
+            lbl_proj delay(ab-build-word-arrow!(
+                untag ab-word!
+                lbl ab-label-pop!
+                PRIM_CORE_DUP ab-prim!
+                lbl ab-label-push!
+                tag ab-tag!
+                dat is-resource? else(PRIM_CORE_DROP ab-prim!)
+            )) lbl_proj ~arrow !
+        )
+    )))))
 
 def(expect-token-arrow, Token -- Token,
     dup pat-arrow? else("Expected arrow." emit-fatal-error!))

--- a/src/mirth/elab.mth
+++ b/src/mirth/elab.mth
@@ -667,20 +667,42 @@ def(elab-atom-lambda!, +AB -- +AB,
 ||| Elaborate a match body within AB. Takes the output stack type,
 ||| and the token for the body of the match, from the stack. Takes
 ||| the rest from the AB environment.
-def(elab-match-at!, StackType Token +AB -- +AB,
-    Match.alloc!
-    ab-ctx@ over ~ctx !
-    ab-type@ over ~dom !
-    ab-token@ over ~token !
-    tuck ~body !
-    tuck ~cod !
+def(elab-match-at!, cod:StackType body:Token +AB -- +AB,
+    >body >cod
+    ab-ctx@ >ctx
+    ab-type@ >dom
+    ab-token@ >token
+    Match.new!
     elab-match-cases!
     elab-match-exhaustive!
     OP_MATCH ab-op!)
 
+def(ab-match!(f),
+        (*a match:Match +AB -- *b match:Match +AB)
+        *a cod:StackType body:Token +AB -- *b +AB,
+    ab-ctx@ >ctx
+    ab-type@ >dom
+    ab-token@ >token
+    Match.new! >match f match> OP_MATCH ab-op!)
+
+def(ab-case!(p),
+        (*a case:Case +AB -- *b case:Case +AB)
+        *a match:Match +AB Pattern -- *b match:Match +AB,
+    Case.alloc!
+    match> over ~match !
+    ab-token@ over ~token !
+    ab-pattern!
+    tuck ~pattern !
+    determine-case-mid
+
+
+         +AB
+
+
+
 def(elab-atom-match!, +AB -- +AB,
-    MetaVar.new! STMeta
-    ab-token@ args+ first
+    MetaVar.new! STMeta >cod
+    ab-token@ args+ first >body
     elab-match-at!)
 
 def(elab-lambda!, Lambda +AB -- Lambda +AB,
@@ -788,7 +810,7 @@ def(elab-case-pattern!, Case Token -- Case Token,
 
     dup name? if-some(
         # TODO type-directed tag resolution
-        # TODO defined tags
+        # TODO user-defined tags
         defs find-some(tag?) match(
             NONE -> "Unknown constructor." emit-fatal-error!,
             SOME ->
@@ -972,21 +994,35 @@ def(data-word-new!, Data Str -- Word,
     dip(dup head? unwrap dup rotl) data-word-qname Word.new!)
 
 def(elab-data-done!, Data --,
-    \(dat -> dat is-enum? then(
-        dat "tag" data-word-new! \(tag ->
-            CTX0 dat TData T1 TYPE_INT T1 T-> ready2 tag ~ctx-type !
-            tag ab-build-word!(
-                COERCE_UNSAFE ab-coerce!
-            ) drop
+    \(dat ->
+        dat is-enum? then(
+            dat "tag" data-word-new! \(tag ->
+                CTX0 dat TData T1 TYPE_INT T1 T-> ready2 tag ~ctx-type !
+                tag ab-build-word!(
+                    COERCE_UNSAFE ab-coerce!
+                ) drop
+            )
+
+            dat "from-tag-unsafe" data-word-new! \(ftag ->
+                CTX0 TYPE_INT T1 dat TData T1 T-> ready2 ftag ~ctx-type !
+                ftag ab-build-word!(
+                    COERCE_UNSAFE ab-coerce!
+                ) drop
+            )
         )
 
-        dat "from-tag-unsafe" data-word-new! \(ftag ->
-            CTX0 TYPE_INT T1 dat TData T1 T-> ready2 ftag ~ctx-type !
-            ftag ab-build-word!(
-                COERCE_UNSAFE ab-coerce!
-            ) drop
+        dat tags match(
+            L1 -> \(tag ->
+                dat "/" tag name >Str cat data-word-new! \(untag ->
+                    tag delay(ctx-type unpack swap T-> pack2) untag ~ctx-type !
+                    untag delay(ab-build-word-arrow!(
+                        ab-match!(ab-case!(tag PATTERN_TAG, id))
+                    )) ~arrow !
+                )
+            ),
+            _ -> drop
         )
-    )))
+    ))
 
 def(expect-token-arrow, Token -- Token,
     dup pat-arrow? else("Expected arrow." emit-fatal-error!))

--- a/src/mirth/elab.mth
+++ b/src/mirth/elab.mth
@@ -950,6 +950,7 @@ def(elab-data-tag!, Data Token -- Data,
     over ~ctx-type !
     sip(num-type-inputs-from-sig) sip(~num-type-inputs !)
     sip(num-resource-inputs-from-sig) sip(~num-resource-inputs !)
+    sip(label-inputs-from-sig) sip(~label-inputs !)
 
     dup outputs-resource? not
     over num-resource-inputs 0> && then(

--- a/src/mirth/elab.mth
+++ b/src/mirth/elab.mth
@@ -236,7 +236,6 @@ def(elab-simple-type-arg!, Token -- Type,
 ####################
 
 data(+AB, MKAB -> Arrow)
-def(/MKAB, +AB -- Arrow, MKAB ->  )
 def(ab-arrow@, +AB -- Arrow +AB, MKAB -> dup MKAB)
 def(ab-arrow!, Arrow +AB -- +AB, MKAB -> drop MKAB)
 def(ab-ctx@, +AB -- Ctx +AB, ab-arrow@ ~ctx @)
@@ -246,7 +245,6 @@ def(ab-token!, Token +AB -- +AB, ab-arrow@ ~token-end !)
 def(ab-type@, +AB -- StackType +AB, ab-arrow@ ~cod @)
 def(ab-type!, StackType +AB -- +AB, ab-arrow@ ~cod !)
 def(ab-home@, +AB -- Home +AB, ab-arrow@ home)
-
 
 def(ab-build!(f), (*a +AB -- *b +AB) *a Ctx StackType Token Home -- *b Arrow,
     Arrow.alloc!
@@ -668,37 +666,42 @@ def(elab-atom-lambda!, +AB -- +AB,
 ||| and the token for the body of the match, from the stack. Takes
 ||| the rest from the AB environment.
 def(elab-match-at!, cod:StackType body:Token +AB -- +AB,
-    >body >cod
     ab-ctx@ >ctx
     ab-type@ >dom
     ab-token@ >token
+    ab-home@ >home
     Match.new!
     elab-match-cases!
     elab-match-exhaustive!
     OP_MATCH ab-op!)
 
 def(ab-match!(f),
-        (*a match:Match +AB -- *b match:Match +AB)
+        (*a match:Match -- *b match:Match)
         *a cod:StackType body:Token +AB -- *b +AB,
     ab-ctx@ >ctx
     ab-type@ >dom
     ab-token@ >token
-    Match.new! >match f match> OP_MATCH ab-op!)
+    ab-home@ >home
+    Match.new! >match rdip(f) match> OP_MATCH ab-op!)
 
-def(ab-case!(p),
-        (*a case:Case +AB -- *b case:Case +AB)
-        *a match:Match +AB Pattern -- *b match:Match +AB,
+def(ab-case!(f),
+        (*a +AB -- *b +AB)
+        *a match:Match Token Pattern -- *b match:Match,
     Case.alloc!
     match> over ~match !
-    ab-token@ over ~token !
-    ab-pattern!
     tuck ~pattern !
-    determine-case-mid
-
-
-         +AB
-
-
+    tuck ~token !
+    dup token determine-case-subst-and-mid! drop
+    \(case ->
+        case .match ctx
+        case mid case .match cod T->
+        case token
+        case .match .home
+        ab-build-hom!(dip(f))
+        case ~body !
+        case dup .match add-case!
+        case .match >match
+    ))
 
 def(elab-atom-match!, +AB -- +AB,
     MetaVar.new! STMeta >cod
@@ -798,14 +801,8 @@ def(elab-match-case!, Match Token +AB -- Match Token +AB,
 ||| Elaborate case pattern.
 def(elab-case-pattern!, Case Token -- Case Token,
     dup pat-underscore? if(
-        # set case pattern
-        dip(PATTERN_UNDERSCORE over ~pattern !)
-
-        # set case mid
-        dip(dup .match dom STACK_TYPE_DONT_CARE TYPE_DONT_CARE T*)
-        elab-stack-type-unify! dip(over ~mid !)
-
-        # advance token
+        PATTERN_UNDERSCORE over2 ~pattern !
+        determine-case-subst-and-mid!
         succ,
 
     dup name? if-some(
@@ -814,27 +811,29 @@ def(elab-case-pattern!, Case Token -- Case Token,
         defs find-some(tag?) match(
             NONE -> "Unknown constructor." emit-fatal-error!,
             SOME ->
-
-                # set case pattern
-                dup PATTERN_TAG rotr
-                dip2(over ~pattern !)
-
-                # set case mid
-                dip2(dup .match dom) { Case StackType Token Tag }
-                type Subst.nil swap freshen-sig
-                rotr dip(
-                    dip(unpack)
-                    dip2(swap) elab-stack-type-unify! nip
-                    dip(over ~mid !)
-                )
-                swap dip(over ~subst !)
-
-                # advance token
+                PATTERN_TAG over2 ~pattern !
+                determine-case-subst-and-mid!
                 succ,
         ),
 
         "Expected constructor name." emit-fatal-error!
     )))
+
+def(determine-case-subst-and-mid!, Case Token -- Case Token,
+    over pattern match(
+        PATTERN_UNDERSCORE ->
+            dip(dup .match dom STACK_TYPE_DONT_CARE TYPE_DONT_CARE T*) elab-stack-type-unify!
+            dip(over ~mid ! Subst.nil over ~subst !),
+        PATTERN_TAG ->
+            dip2(dup .match dom)
+            dip(Subst.nil) type freshen-sig
+            rotr dip(
+                dip(unpack)
+                dip2(swap) elab-stack-type-unify! nip
+                dip(over ~mid !)
+            )
+            swap dip(over ~subst !)
+    ))
 
 ||| Elaborate case body.
 def(elab-case-body!, Case Token +AB -- Case Token +AB,
@@ -1016,8 +1015,12 @@ def(elab-data-done!, Data --,
                 dat "/" tag name >Str cat data-word-new! \(untag ->
                     tag delay(ctx-type unpack swap T-> pack2) untag ~ctx-type !
                     untag delay(ab-build-word-arrow!(
-                        ab-match!(ab-case!(tag PATTERN_TAG, id))
-                    )) ~arrow !
+                        untag type cod >cod
+                        dat head? unwrap >body
+                        ab-match!(
+                            dat head? unwrap tag PATTERN_TAG ab-case!(id)
+                        )
+                    )) untag ~arrow !
                 )
             ),
             _ -> drop
@@ -1120,7 +1123,7 @@ def(elab-def-params!, Word -- List(Param),
 ||| and the rest from the AB environment.
 def(elab-def-body!, StackType +AB -- StackType +AB,
     ab-token@ run-has-arrow? if(
-        dup ab-token@ elab-match-at!,
+        dup >cod ab-token@ >body elab-match-at!,
         elab-atoms!
     ))
 

--- a/src/mirth/match.mth
+++ b/src/mirth/match.mth
@@ -18,20 +18,23 @@ field(Match.~dom, Match, StackType)
 field(Match.~cod, Match, StackType)
 field(Match.~token, Match, Token) # where the diagnostics go
 field(Match.~body, Match, Token) # where the cases start
+field(Match.~home, Match, Home)
 field(Match.~cases, Match, List(Case))
 def(Match.ctx, Match -- Ctx, ~ctx @)
 def(Match.dom, Match -- StackType, ~dom @)
 def(Match.cod, Match -- StackType, ~cod @)
 def(Match.token, Match -- Token, ~token @)
 def(Match.body, Match -- Token, ~body @)
+def(Match.home, Match -- Home, ~home @)
 def(Match.cases, Match -- List(Case), ~cases @)
 
 def(Match.new!,
     ctx:Ctx dom:StackType cod:StackType
-    token:Token body:Token -- Match,
+    token:Token body:Token home:Home -- Match,
     Match.alloc!
     ctx> over ~ctx ! dom> over ~dom ! cod> over ~cod !
-    token> over ~token ! body> over ~body ! L0 over ~cases !)
+    token> over ~token ! home> over ~home !
+    body> over ~body ! L0 over ~cases !)
 
 table(Case)
 field(Case.~match, Case, Match)

--- a/src/mirth/match.mth
+++ b/src/mirth/match.mth
@@ -26,6 +26,13 @@ def(Match.token, Match -- Token, ~token @)
 def(Match.body, Match -- Token, ~body @)
 def(Match.cases, Match -- List(Case), ~cases @)
 
+def(Match.new!,
+    ctx:Ctx dom:StackType cod:StackType
+    token:Token body:Token -- Match,
+    Match.alloc!
+    ctx> over ~ctx ! dom> over ~dom ! cod> over ~cod !
+    token> over ~token ! body> over ~body ! L0 over ~cases !)
+
 table(Case)
 field(Case.~match, Case, Match)
 field(Case.~token, Case, Token)

--- a/src/mirth/mirth.h
+++ b/src/mirth/mirth.h
@@ -315,9 +315,6 @@ static VAL pop_value(void) {
 	return stack[stack_counter++];
 }
 
-#define LPOP(v) do { VAL lcar, lcdr; value_uncons_c((v), &lcar, &lcdr); push_value(lcdr); (v) = lcar; } while(0)
-#define LPUSH(v) do { (v) = mkcons((v), pop_value()); } while(0)
-
 static void push_resource(VAL x) {
 	ASSERT(rstack_counter > 0);
 	rstack[--rstack_counter] = x;
@@ -343,6 +340,14 @@ static VAL mkcons (VAL car, VAL cdr) {
 	cons->cdr = cdr;
 	return MKCONS(cons);
 }
+
+static VAL lpop(VAL* stk) {
+	VAL cons=*stk, lcar, lcdr; value_uncons(cons, &lcar, &lcdr);
+	*stk=lcar; incref(lcar); incref(lcdr); decref(cons); return lcdr;
+}
+static void lpush(VAL* stk, VAL cdr) { *stk = mkcons(*stk, cdr); }
+#define LPOP(v) push_value(lpop(&(v)))
+#define LPUSH(v) lpush(&(v),pop_value())
 
 static STR* str_alloc (USIZE cap) {
 	ASSERT(cap <= SIZE_MAX - sizeof(STR) - 4);


### PR DESCRIPTION
This PR changes `data` to make it generate a few functions in the case where the `data` type has a single constructor. Suppose we have a data type called `Foo` and it has a single constructor `FOO`. Then the compiler will generate:

- a method `Foo./FOO` that undoes the action of the constructor. It is defined as `match(FOO -> )`

- for each labelled input to the `FOO` constructor, for example `bar:Bar`, it generates a method `Foo.bar` of type `Foo -- Bar`  that fetches that field. This is defined as `/FOO bar> dup >bar dip(FOO drop)`

For the latter, if the data is actually a resource, it doesn't do the `drop`, so the method `+Foo.bar` will have type `+Foo -- +Foo Bar` and is defined as `/FOO bar> dup >bar dip(FOO)`.