### PR TITLE
Make colon a right-associative application operator -- lens syntax.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CCSAN=$(CC) -fsanitize=undefined -fsanitize=address
 
 SRCS=src/std/* src/args/* src/posix/* src/mirth/*
 
-.PHONY: default show showsan build buildsan update check checksan update-mirth install-vim install-code install profile play-snake test test-update
+.PHONY: default show showsan build buildsan debug update check checksan update-mirth install-vim install-code install profile play-snake test test-update
 
 default: show bin/snake.c
 
@@ -23,6 +23,7 @@ showsan: bin/mirth0.c bin/mirth1.c bin/mirth2.c bin/mirth3san.c
 
 build: bin/mirth0 bin/mirth1 bin/mirth2 bin/mirth1.c bin/mirth2.c bin/mirth3.c
 buildsan: bin/mirth0 bin/mirth1 bin/mirth2san bin/mirth1.c bin/mirth2.c bin/mirth3san.c
+debug: bin/mirth3debug
 
 update: bin/mirth0.c bin/mirth3.c
 	cp bin/mirth3.c bin/mirth0.c
@@ -104,11 +105,11 @@ bin/mirth3.c: bin/mirth2 $(SRCS)
 bin/mirth1debug.c: bin/mirth0 $(SRCS)
 	bin/mirth0 $(MIRTHFLAGS) --debug src/mirth/main.mth -o bin/mirth1debug.c
 
-bin/mirth2debug.c: bin/mirth1 $(SRCS)
-	bin/mirth1 $(MIRTHFLAGS) --debug src/mirth/main.mth -o bin/mirth2debug.c
+bin/mirth2debug.c: bin/mirth1debug $(SRCS)
+	bin/mirth1debug $(MIRTHFLAGS) --debug src/mirth/main.mth -o bin/mirth2debug.c
 
-bin/mirth3debug.c: bin/mirth2 $(SRCS)
-	bin/mirth2 $(MIRTHFLAGS) --debug mirth/main.mth -o bin/mirth3debug.c
+bin/mirth3debug.c: bin/mirth2debug $(SRCS)
+	bin/mirth2debug $(MIRTHFLAGS) --debug mirth/main.mth -o bin/mirth3debug.c
 
 bin/mirth3san.c: bin/mirth2san $(SRCS)
 	bin/mirth2san $(MIRTHFLAGS) src/mirth/main.mth -o bin/mirth3san.c

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -7505,6 +7505,7 @@ static void mw_mirth_token_TokenValue_name_3F_ (void);
 static void mw_mirth_token_TokenValue_dname_3F_ (void);
 static void mw_mirth_token_TokenValue_label_3F_ (void);
 static void mw_mirth_token_TokenValue_name_or_dname_3F_ (void);
+static void mw_mirth_token_TokenValue_name_or_dname_or_label_3F_ (void);
 static void mw_mirth_token_TokenValue_arg_end_3F_ (void);
 static void mw_mirth_token_TokenValue_left_enclosure_3F_ (void);
 static void mw_mirth_token_TokenValue_right_enclosure_3F_ (void);
@@ -7543,6 +7544,7 @@ static void mw_mirth_token_Token_name_3F_ (void);
 static void mw_mirth_token_Token_dname_3F_ (void);
 static void mw_mirth_token_Token_label_3F_ (void);
 static void mw_mirth_token_Token_name_or_dname_3F_ (void);
+static void mw_mirth_token_Token_name_or_dname_or_label_3F_ (void);
 static void mw_mirth_token_Token_arg_end_3F_ (void);
 static void mw_mirth_token_Token_left_enclosure_3F_ (void);
 static void mw_mirth_token_Token_right_enclosure_3F_ (void);
@@ -7562,6 +7564,7 @@ static void mw_mirth_token_Token_alloc_none_21_ (void);
 static void mw_mirth_token_Token_location (void);
 static void mw_mirth_token_Token_next (void);
 static void mw_mirth_token_Token_prev (void);
+static void mw_mirth_token_Token_in_lens_like_3F_ (void);
 static void mw_mirth_token_Token_next_arg_end (void);
 static void mw_mirth_token_Token_has_args_3F_ (void);
 static void mw_mirth_token_Token_args_start (void);
@@ -7580,6 +7583,7 @@ static void mw_mirth_token_Token_run_end_3F_ (void);
 static void mw_mirth_token_Token_run_tokens (void);
 static void mw_mirth_token_Token_run_length (void);
 static void mw_mirth_token_Token_run_has_arrow_3F_ (void);
+static void mw_mirth_token_Token_lens_like_3F_ (void);
 static void mw_mirth_token_Token_sig_stack_end_3F_ (void);
 static void mw_mirth_token_Token_sig_next_stack_end (void);
 static void mw_mirth_token_Token_sig_has_dashes_3F_ (void);
@@ -7652,6 +7656,7 @@ static void mw_mirth_name_Name_could_be_resource_var (void);
 static void mw_mirth_name_Name_could_be_resource_con (void);
 static void mw_mirth_name_Name_could_be_type_or_resource_con (void);
 static void mw_mirth_name_Name_mangle_compute_21_ (void);
+static void mw_mirth_name_Name_lens_like_3F_ (void);
 static void mw_mirth_name_Namespace__3D__3D_ (void);
 static void mw_mirth_name_Namespace_module_3F_ (void);
 static void mw_mirth_name_Namespace_prim (void);
@@ -7667,6 +7672,7 @@ static void mw_mirth_name_QName__3E_Str (void);
 static void mw_mirth_name_QName_to_module_path (void);
 static void mw_mirth_name_DName_root_3F_ (void);
 static void mw_mirth_name_DName_parts (void);
+static void mw_mirth_name_DName_lens_like_3F_ (void);
 static void mw_mirth_package_Package_index (void);
 static void mw_mirth_package_Package_alloc_21_ (void);
 static void mw_mirth_package_Package_name (void);
@@ -7803,7 +7809,6 @@ static void mw_mirth_elab_elab_label_pop_sig_21_ (void);
 static void mw_mirth_elab_elab_arrow_hom_21_ (void);
 static void mw_mirth_elab_elab_arrow_fwd_21_ (void);
 static void mw_mirth_elab_elab_atoms_21_ (void);
-static void mw_mirth_elab_elab_atoms_done_3F_ (void);
 static void mw_mirth_elab_elab_atom_21_ (void);
 static void mw_mirth_elab_elab_atom_block_21_ (void);
 static void mw_mirth_elab_elab_block_at_21_ (void);
@@ -8041,9 +8046,9 @@ static void mw_mirth_main_parse_package_def (void);
 static void mw_mirth_main_compiler_parse_args (void);
 static void mw_mirth_main_main (void);
 static void mb_mirth_module_Module_prim_3 (void);
-static void mb_mirth_token_Token_args_7 (void);
 static void mb_mirth_token_Token_args_11 (void);
-static void mb_mirth_token_Token_args_14 (void);
+static void mb_mirth_token_Token_args_15 (void);
+static void mb_mirth_token_Token_args_18 (void);
 static void mb_mirth_main_main_4 (void);
 static void mb_mirth_main_main_60 (void);
 static void mb_mirth_arrow_Arrow_type_2 (void);
@@ -8221,8 +8226,8 @@ static void mb_mirth_package_Package_find_or_new_21__4 (void);
 static void mb_mirth_name_hash_name_40__7 (void);
 static void mb_mirth_name_hash_name_21__12 (void);
 static void mb_std_prim_Str_hash_4 (void);
-static void mb_mirth_token_Token_next_27 (void);
-static void mb_mirth_token_Token_next_39 (void);
+static void mb_mirth_token_Token_next_34 (void);
+static void mb_mirth_token_Token_next_46 (void);
 static void mb_mirth_name_Name_mangle_compute_21__2 (void);
 static void mb_mirth_name_Name_mangle_compute_21__5 (void);
 static void mb_mirth_name_Name_could_be_type_or_resource_con_4 (void);
@@ -8244,18 +8249,16 @@ static void mb_mirth_token_TokenValue_sig_dashes_3F__3 (void);
 static void mb_mirth_token_TokenValue_pat_arrow_3F__3 (void);
 static void mb_mirth_token_TokenValue_pat_underscore_3F__3 (void);
 static void mb_mirth_token_TokenValue_module_header_3F__3 (void);
-static void mb_mirth_token_Token_prev_22 (void);
-static void mb_mirth_token_Token_prev_24 (void);
-static void mb_mirth_token_Token_has_args_3F__4 (void);
+static void mb_mirth_token_Token_has_args_3F__11 (void);
 static void mb_mirth_token_Token_args_start_4 (void);
-static void mb_mirth_token_Token_args_start_9 (void);
+static void mb_mirth_token_Token_args_start_11 (void);
 static void mb_mirth_token_Token_args_end_3F__4 (void);
 static void mb_mirth_token_Token_args_2B__5 (void);
 static void mb_mirth_error_emit_warning_at_21__10 (void);
 static void mb_mirth_error_emit_error_at_21__10 (void);
-static void mb_mirth_token_Token_run_tokens_2 (void);
-static void mb_mirth_token_Token_run_tokens_6 (void);
 static void mb_mirth_token_Token_run_tokens_8 (void);
+static void mb_mirth_token_Token_run_tokens_12 (void);
+static void mb_mirth_token_Token_run_tokens_14 (void);
 static void mb_mirth_token_Token_run_has_arrow_3F__3 (void);
 static void mb_mirth_token_Token_sig_stack_end_3F__4 (void);
 static void mb_mirth_token_Token_sig_count_types_13 (void);
@@ -8319,7 +8322,7 @@ static void mb_mirth_data_Tag_label_inputs_from_sig_3 (void);
 static void mb_mirth_data_Tag_label_inputs_from_sig_9 (void);
 static void mb_mirth_data_Tag_label_inputs_from_sig_6 (void);
 static void mb_mirth_data_Tag_num_type_inputs_from_sig_4 (void);
-static void mb_mirth_data_Tag_num_type_inputs_from_sig_14 (void);
+static void mb_mirth_data_Tag_num_type_inputs_from_sig_13 (void);
 static void mb_mirth_data_Tag_num_resource_inputs_from_sig_3 (void);
 static void mb_mirth_data_Tag_num_resource_inputs_from_sig_20 (void);
 static void mb_mirth_data_Tag_num_resource_inputs_from_sig_6 (void);
@@ -16657,7 +16660,7 @@ static void mw_mirth_data_Tag_num_type_inputs_from_sig (void) {
 	push_fnptr(&mb_mirth_data_Tag_num_type_inputs_from_sig_4);
 	mw_std_prim_prim_pack_cons();
 	push_u64(0);
-	push_fnptr(&mb_mirth_data_Tag_num_type_inputs_from_sig_14);
+	push_fnptr(&mb_mirth_data_Tag_num_type_inputs_from_sig_13);
 	mw_std_prim_prim_pack_cons();
 	mw_std_maybe_Maybe_if_some();
 }
@@ -23126,6 +23129,29 @@ static void mw_mirth_token_TokenValue_name_or_dname_3F_ (void) {
 			break;
 	}
 }
+static void mw_mirth_token_TokenValue_name_or_dname_or_label_3F_ (void) {
+	switch (get_top_data_tag()) {
+		case 13LL:
+			mp_mirth_token_TokenValue_TOKEN_5F_NAME();
+			mw_std_prim_prim_drop();
+			mw_std_prim_T();
+			break;
+		case 14LL:
+			mp_mirth_token_TokenValue_TOKEN_5F_DNAME();
+			mw_std_prim_prim_drop();
+			mw_std_prim_T();
+			break;
+		case 15LL:
+			mp_mirth_token_TokenValue_TOKEN_5F_LABEL();
+			mw_std_prim_prim_drop();
+			mw_std_prim_T();
+			break;
+		default:
+			mw_std_prim_prim_drop();
+			mw_std_prim_F();
+			break;
+	}
+}
 static void mw_mirth_token_TokenValue_arg_end_3F_ (void) {
 	switch (get_top_data_tag()) {
 		case 1LL:
@@ -23385,6 +23411,10 @@ static void mw_mirth_token_Token_name_or_dname_3F_ (void) {
 	mw_mirth_token_Token_value();
 	mw_mirth_token_TokenValue_name_or_dname_3F_();
 }
+static void mw_mirth_token_Token_name_or_dname_or_label_3F_ (void) {
+	mw_mirth_token_Token_value();
+	mw_mirth_token_TokenValue_name_or_dname_or_label_3F_();
+}
 static void mw_mirth_token_Token_arg_end_3F_ (void) {
 	mw_mirth_token_Token_value();
 	mw_mirth_token_TokenValue_arg_end_3F_();
@@ -23466,49 +23496,56 @@ static void mw_mirth_token_Token_location (void) {
 }
 static void mw_mirth_token_Token_next (void) {
 	mw_std_prim_prim_dup();
-	mw_mirth_token_Token_value();
-	switch (get_top_data_tag()) {
-		case 3LL:
-			mp_mirth_token_TokenValue_TOKEN_5F_LPAREN();
-			mw_std_prelude_nip();
-			mw_mirth_token_Token_succ();
-			break;
-		case 6LL:
-			mp_mirth_token_TokenValue_TOKEN_5F_LSQUARE();
-			mw_std_prelude_nip();
-			mw_mirth_token_Token_succ();
-			break;
-		case 9LL:
-			mp_mirth_token_TokenValue_TOKEN_5F_LCURLY();
-			mw_std_prelude_nip();
-			mw_mirth_token_Token_succ();
-			break;
-		case 13LL:
-			mp_mirth_token_TokenValue_TOKEN_5F_NAME();
-			mw_std_prim_prim_drop();
-			mw_mirth_token_Token_succ();
-			mw_std_prim_prim_dup();
-			mw_mirth_token_Token_lparen_3F_();
-			push_u64(0);
-			push_fnptr(&mb_mirth_token_Token_next_27);
-			mw_std_prim_prim_pack_cons();
-			mw_std_maybe_Maybe_for();
-			break;
-		case 14LL:
-			mp_mirth_token_TokenValue_TOKEN_5F_DNAME();
-			mw_std_prim_prim_drop();
-			mw_mirth_token_Token_succ();
-			mw_std_prim_prim_dup();
-			mw_mirth_token_Token_lparen_3F_();
-			push_u64(0);
-			push_fnptr(&mb_mirth_token_Token_next_39);
-			mw_std_prim_prim_pack_cons();
-			mw_std_maybe_Maybe_for();
-			break;
-		default:
-			mw_std_prim_prim_drop();
-			mw_mirth_token_Token_succ();
-			break;
+	mw_mirth_token_Token_lens_like_3F_();
+	if (pop_u64()) {
+		mw_mirth_token_Token_succ();
+		mw_mirth_token_Token_next();
+	} else {
+		mw_std_prim_prim_dup();
+		mw_mirth_token_Token_value();
+		switch (get_top_data_tag()) {
+			case 3LL:
+				mp_mirth_token_TokenValue_TOKEN_5F_LPAREN();
+				mw_std_prelude_nip();
+				mw_mirth_token_Token_succ();
+				break;
+			case 6LL:
+				mp_mirth_token_TokenValue_TOKEN_5F_LSQUARE();
+				mw_std_prelude_nip();
+				mw_mirth_token_Token_succ();
+				break;
+			case 9LL:
+				mp_mirth_token_TokenValue_TOKEN_5F_LCURLY();
+				mw_std_prelude_nip();
+				mw_mirth_token_Token_succ();
+				break;
+			case 13LL:
+				mp_mirth_token_TokenValue_TOKEN_5F_NAME();
+				mw_std_prim_prim_drop();
+				mw_mirth_token_Token_succ();
+				mw_std_prim_prim_dup();
+				mw_mirth_token_Token_lparen_3F_();
+				push_u64(0);
+				push_fnptr(&mb_mirth_token_Token_next_34);
+				mw_std_prim_prim_pack_cons();
+				mw_std_maybe_Maybe_for();
+				break;
+			case 14LL:
+				mp_mirth_token_TokenValue_TOKEN_5F_DNAME();
+				mw_std_prim_prim_drop();
+				mw_mirth_token_Token_succ();
+				mw_std_prim_prim_dup();
+				mw_mirth_token_Token_lparen_3F_();
+				push_u64(0);
+				push_fnptr(&mb_mirth_token_Token_next_46);
+				mw_std_prim_prim_pack_cons();
+				mw_std_maybe_Maybe_for();
+				break;
+			default:
+				mw_std_prim_prim_drop();
+				mw_mirth_token_Token_succ();
+				break;
+		}
 	}
 }
 static void mw_mirth_token_Token_prev (void) {
@@ -23530,46 +23567,82 @@ static void mw_mirth_token_Token_prev (void) {
 			mw_std_prim_prim_dup();
 			mw_mirth_token_Token_pred();
 			mw_std_prim_prim_dup();
-			mw_mirth_token_Token_name_or_dname_3F_();
-			push_u64(0);
-			push_fnptr(&mb_mirth_token_Token_prev_22);
-			mw_std_prim_prim_pack_cons();
-			push_u64(0);
-			push_fnptr(&mb_mirth_token_Token_prev_24);
-			mw_std_prim_prim_pack_cons();
-			mw_std_maybe_Maybe_if();
+			mw_mirth_token_Token_name_or_dname_or_label_3F_();
+			if (pop_u64()) {
+				mw_std_prelude_nip();
+			} else {
+				mw_std_prim_prim_drop();
+			}
 			break;
 		default:
 			mw_std_prim_prim_drop();
 			break;
 	}
-}
-static void mw_mirth_token_Token_next_arg_end (void) {
 	while(1) {
 		mw_std_prim_prim_dup();
-		mw_mirth_token_Token_arg_end_3F_();
-		mw_std_prim_Bool_not();
+		mw_mirth_token_Token_pred();
+		mw_mirth_token_Token_lens_like_3F_();
 		if (! pop_u64()) break;
-		mw_mirth_token_Token_next();
+		mw_mirth_token_Token_pred();
+	}
+}
+static void mw_mirth_token_Token_in_lens_like_3F_ (void) {
+	mw_mirth_token_Token_pred();
+	mw_mirth_token_Token_lens_like_3F_();
+}
+static void mw_mirth_token_Token_next_arg_end (void) {
+	mw_std_prim_prim_dup();
+	mw_mirth_token_Token_in_lens_like_3F_();
+	if (pop_u64()) {
+		{
+			static bool vready = false;
+			static VAL v;
+			if (! vready) {
+				v = mkstr("Token.next-arg-end called inside lens-like token", 48);
+				vready = true;
+			}
+			push_value(v);
+			incref(v);
+		}
+		mw_std_prim_prim_panic();
+	} else {
+		while(1) {
+			mw_std_prim_prim_dup();
+			mw_mirth_token_Token_arg_end_3F_();
+			mw_std_prim_Bool_not();
+			if (! pop_u64()) break;
+			mw_mirth_token_Token_next();
+		}
 	}
 }
 static void mw_mirth_token_Token_has_args_3F_ (void) {
 	mw_std_prim_prim_dup();
-	mw_mirth_token_Token_name_or_dname_3F_();
-	push_u64(0);
-	push_fnptr(&mb_mirth_token_Token_has_args_3F__4);
-	mw_std_prim_prim_pack_cons();
-	mw_std_maybe_Maybe_then();
-	mw_mirth_token_Token_lparen_3F_();
-	mw_std_maybe_Maybe__3E_Bool();
+	mw_mirth_token_Token_lens_like_3F_();
+	if (pop_u64()) {
+		mw_std_prim_prim_drop();
+		mw_std_prim_T();
+	} else {
+		mw_std_prim_prim_dup();
+		mw_mirth_token_Token_name_or_dname_3F_();
+		push_u64(0);
+		push_fnptr(&mb_mirth_token_Token_has_args_3F__11);
+		mw_std_prim_prim_pack_cons();
+		mw_std_maybe_Maybe_then();
+		mw_mirth_token_Token_lparen_3F_();
+		mw_std_maybe_Maybe__3E_Bool();
+	}
 }
 static void mw_mirth_token_Token_args_start (void) {
 	mw_std_prim_prim_dup();
-	mw_mirth_token_Token_name_or_dname_3F_();
+	mw_mirth_token_Token_name_or_dname_or_label_3F_();
 	push_u64(0);
 	push_fnptr(&mb_mirth_token_Token_args_start_4);
 	mw_std_prim_prim_pack_cons();
-	mw_std_maybe_Maybe_then();
+	mw_std_prim_Bool_and();
+	push_u64(0);
+	push_fnptr(&mb_mirth_token_Token_args_start_11);
+	mw_std_prim_prim_pack_cons();
+	mw_std_prim_Bool_then();
 }
 static void mw_mirth_token_Token_num_args (void) {
 	mw_mirth_token_Token_args_start();
@@ -23596,8 +23669,12 @@ static void mw_mirth_token_Token_num_args (void) {
 		}
 		mw_std_prim_prim_drop();
 	} else {
-		mw_std_prim_prim_drop();
-		push_i64(0LL);
+		mw_mirth_token_Token_lens_like_3F_();
+		if (pop_u64()) {
+			push_i64(1LL);
+		} else {
+			push_i64(0LL);
+		}
 	}
 }
 static void mw_mirth_token_Token_args_0 (void) {
@@ -23754,14 +23831,21 @@ static void mw_mirth_token_Token_args (void) {
 	mw_mirth_token_Token_has_args_3F_();
 	if (pop_u64()) {
 		mw_mirth_token_Token_args_start();
-		push_u64(0);
-		push_fnptr(&mb_mirth_token_Token_args_7);
-		mw_std_prim_prim_pack_cons();
-		push_u64(0);
-		push_fnptr(&mb_mirth_token_Token_args_11);
-		mw_std_prim_prim_pack_cons();
-		mw_std_list_collect_while();
-		mw_std_prelude_nip();
+		mw_std_prim_prim_dup();
+		mw_mirth_token_Token_left_enclosure_3F_();
+		if (pop_u64()) {
+			push_u64(0);
+			push_fnptr(&mb_mirth_token_Token_args_11);
+			mw_std_prim_prim_pack_cons();
+			push_u64(0);
+			push_fnptr(&mb_mirth_token_Token_args_15);
+			mw_std_prim_prim_pack_cons();
+			mw_std_list_collect_while();
+			mw_std_prelude_nip();
+		} else {
+			mw_mirth_token_Token_succ();
+			mw_std_list_List_L1();
+		}
 	} else {
 		mw_std_prim_prim_drop();
 		mw_std_list_List_L0();
@@ -23838,14 +23922,20 @@ static void mw_mirth_token_Token_run_end_3F_ (void) {
 	}
 }
 static void mw_mirth_token_Token_run_tokens (void) {
-	push_u64(0);
-	push_fnptr(&mb_mirth_token_Token_run_tokens_2);
-	mw_std_prim_prim_pack_cons();
-	push_u64(0);
-	push_fnptr(&mb_mirth_token_Token_run_tokens_6);
-	mw_std_prim_prim_pack_cons();
-	mw_std_list_collect_while();
-	mw_std_prelude_nip();
+	mw_std_prim_prim_dup();
+	mw_mirth_token_Token_in_lens_like_3F_();
+	if (pop_u64()) {
+		mw_std_list_List_L1();
+	} else {
+		push_u64(0);
+		push_fnptr(&mb_mirth_token_Token_run_tokens_8);
+		mw_std_prim_prim_pack_cons();
+		push_u64(0);
+		push_fnptr(&mb_mirth_token_Token_run_tokens_12);
+		mw_std_prim_prim_pack_cons();
+		mw_std_list_collect_while();
+		mw_std_prelude_nip();
+	}
 }
 static void mw_mirth_token_Token_run_length (void) {
 	{
@@ -23874,6 +23964,28 @@ static void mw_mirth_token_Token_run_has_arrow_3F_ (void) {
 	push_fnptr(&mb_mirth_token_Token_run_has_arrow_3F__3);
 	mw_std_prim_prim_pack_cons();
 	mw_std_list_List_any();
+}
+static void mw_mirth_token_Token_lens_like_3F_ (void) {
+	mw_mirth_token_Token_value();
+	switch (get_top_data_tag()) {
+		case 15LL:
+			mp_mirth_token_TokenValue_TOKEN_5F_LABEL();
+			mw_std_prim_prim_drop();
+			mw_std_prim_T();
+			break;
+		case 13LL:
+			mp_mirth_token_TokenValue_TOKEN_5F_NAME();
+			mw_mirth_name_Name_lens_like_3F_();
+			break;
+		case 14LL:
+			mp_mirth_token_TokenValue_TOKEN_5F_DNAME();
+			mw_mirth_name_DName_lens_like_3F_();
+			break;
+		default:
+			mw_std_prim_prim_drop();
+			mw_std_prim_F();
+			break;
+	}
 }
 static void mw_mirth_token_Token_sig_stack_end_3F_ (void) {
 	mw_std_prim_prim_dup();
@@ -24856,6 +24968,15 @@ static void mw_mirth_name_Name_mangle_compute_21_ (void) {
 	mw_std_prim_prim_pack_cons();
 	mw_std_str_build_str_21_();
 }
+static void mw_mirth_name_Name_lens_like_3F_ (void) {
+	mw_mirth_name_Name__3E_Str();
+	mw_std_prim_Str_thaw();
+	mw_std_str_str_buf_last_byte();
+	mw_std_byte_Byte_BCOLON();
+	mw_std_byte_Byte__3D__3D_();
+	mw_std_str__2B_Str_freeze();
+	mw_std_prim_prim_drop();
+}
 static void mw_mirth_name_Namespace__3D__3D_ (void) {
 	switch (get_top_data_tag()) {
 		case 0LL:
@@ -25134,6 +25255,11 @@ static void mw_mirth_name_DName_parts (void) {
 			break;
 		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
 	}
+}
+static void mw_mirth_name_DName_lens_like_3F_ (void) {
+	mw_mirth_name_DName_parts();
+	mw_std_list_List_2B__last();
+	mw_mirth_name_Name_lens_like_3F_();
 }
 static void mw_mirth_package_Package_index (void) {
 }
@@ -27722,19 +27848,22 @@ static void mw_mirth_elab_elab_arrow_fwd_21_ (void) {
 	mw_mirth_elab_ab_build_21_();
 }
 static void mw_mirth_elab_elab_atoms_21_ (void) {
-	while(1) {
-		mw_mirth_elab_elab_atoms_done_3F_();
-		mw_std_prim_Bool_not();
-		if (! pop_u64()) break;
-		mw_mirth_elab_elab_atom_21_();
-		mw_mirth_elab_ab_token_40_();
-		mw_mirth_token_Token_next();
-		mw_mirth_elab_ab_token_21_();
-	}
-}
-static void mw_mirth_elab_elab_atoms_done_3F_ (void) {
 	mw_mirth_elab_ab_token_40_();
-	mw_mirth_token_Token_run_end_3F_();
+	mw_mirth_token_Token_in_lens_like_3F_();
+	if (pop_u64()) {
+		mw_mirth_elab_elab_atom_21_();
+	} else {
+		while(1) {
+			mw_mirth_elab_ab_token_40_();
+			mw_mirth_token_Token_run_end_3F_();
+			mw_std_prim_Bool_not();
+			if (! pop_u64()) break;
+			mw_mirth_elab_elab_atom_21_();
+			mw_mirth_elab_ab_token_40_();
+			mw_mirth_token_Token_next();
+			mw_mirth_elab_ab_token_21_();
+		}
+	}
 }
 static void mw_mirth_elab_elab_atom_21_ (void) {
 	mw_mirth_elab_ab_token_40_();
@@ -34531,21 +34660,21 @@ static void mb_mirth_module_Module_prim_3 (void) {
 	mw_mirth_module_Module__7E_name();
 	mw_std_prim_prim_mut_set();
 }
-static void mb_mirth_token_Token_args_7 (void) {
+static void mb_mirth_token_Token_args_11 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prim_prim_dup();
 	mw_mirth_token_Token_args_end_3F_();
 	mw_std_prim_Bool_not();
 }
-static void mb_mirth_token_Token_args_11 (void) {
+static void mb_mirth_token_Token_args_15 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_token_Token_succ();
 	push_u64(0);
-	push_fnptr(&mb_mirth_token_Token_args_14);
+	push_fnptr(&mb_mirth_token_Token_args_18);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prelude_sip();
 }
-static void mb_mirth_token_Token_args_14 (void) {
+static void mb_mirth_token_Token_args_18 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_token_Token_next_arg_end();
 }
@@ -36218,12 +36347,12 @@ static void mb_std_prim_Str_hash_4 (void) {
 	mw_std_prim_prim_int_shr();
 	mw_std_prim_prim_int_xor();
 }
-static void mb_mirth_token_Token_next_27 (void) {
+static void mb_mirth_token_Token_next_34 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prelude_nip();
 	mw_mirth_token_Token_succ();
 }
-static void mb_mirth_token_Token_next_39 (void) {
+static void mb_mirth_token_Token_next_46 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prelude_nip();
 	mw_mirth_token_Token_succ();
@@ -36368,15 +36497,7 @@ static void mb_mirth_token_TokenValue_module_header_3F__3 (void) {
 	}
 	mw_std_prim_Str__3D__3D_();
 }
-static void mb_mirth_token_Token_prev_22 (void) {
-	mw_std_prim_prim_drop();
-	mw_std_prelude_nip();
-}
-static void mb_mirth_token_Token_prev_24 (void) {
-	mw_std_prim_prim_drop();
-	mw_std_prim_prim_drop();
-}
-static void mb_mirth_token_Token_has_args_3F__4 (void) {
+static void mb_mirth_token_Token_has_args_3F__11 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_token_Token_succ();
 }
@@ -36385,12 +36506,9 @@ static void mb_mirth_token_Token_args_start_4 (void) {
 	mw_std_prim_prim_dup();
 	mw_mirth_token_Token_succ();
 	mw_mirth_token_Token_lparen_3F_();
-	push_u64(0);
-	push_fnptr(&mb_mirth_token_Token_args_start_9);
-	mw_std_prim_prim_pack_cons();
-	mw_std_maybe_Maybe_then();
+	mw_std_maybe_Maybe_some_3F_();
 }
-static void mb_mirth_token_Token_args_start_9 (void) {
+static void mb_mirth_token_Token_args_start_11 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_token_Token_succ();
 }
@@ -36420,20 +36538,20 @@ static void mb_mirth_error_emit_error_at_21__10 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prelude_prim_int_succ();
 }
-static void mb_mirth_token_Token_run_tokens_2 (void) {
+static void mb_mirth_token_Token_run_tokens_8 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prim_prim_dup();
 	mw_mirth_token_Token_run_end_3F_();
 	mw_std_prim_Bool_not();
 }
-static void mb_mirth_token_Token_run_tokens_6 (void) {
+static void mb_mirth_token_Token_run_tokens_12 (void) {
 	mw_std_prim_prim_drop();
 	push_u64(0);
-	push_fnptr(&mb_mirth_token_Token_run_tokens_8);
+	push_fnptr(&mb_mirth_token_Token_run_tokens_14);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prelude_sip();
 }
-static void mb_mirth_token_Token_run_tokens_8 (void) {
+static void mb_mirth_token_Token_run_tokens_14 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_token_Token_next();
 }
@@ -36886,10 +37004,9 @@ static void mb_mirth_data_Tag_num_type_inputs_from_sig_4 (void) {
 	mw_std_prim_prim_swap();
 	mw_mirth_data_Tag_label_inputs_from_sig();
 	mw_std_list_List_len();
-	mw_std_prelude_Nat_2_2A_();
 	mw_std_prelude_Nat__();
 }
-static void mb_mirth_data_Tag_num_type_inputs_from_sig_14 (void) {
+static void mb_mirth_data_Tag_num_type_inputs_from_sig_13 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prim_prim_drop();
 	push_i64(0LL);

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -1208,11 +1208,11 @@ static void mw_std_prim_prim_mut_is_set (void) {
 
 /* GENERATED C99 */
 
-static VAL lbl_emit_debug_info = {0};
+static VAL lbl_packages = {0};
+static VAL lbl_entry_point = {0};
 static VAL lbl_input_file = {0};
 static VAL lbl_output_file = {0};
-static VAL lbl_entry_point = {0};
-static VAL lbl_packages = {0};
+static VAL lbl_emit_debug_info = {0};
 static VAL lbl_output_path = {0};
 static VAL lbl_options = {0};
 static VAL lbl_parser = {0};
@@ -1220,20 +1220,25 @@ static VAL lbl_args_doc = {0};
 static VAL lbl_doc = {0};
 static VAL lbl_argv = {0};
 static VAL lbl_program_name = {0};
+static VAL lbl_argv_info = {0};
 static VAL lbl_parsing_3F_ = {0};
 static VAL lbl_option = {0};
 static VAL lbl_option_option = {0};
-static VAL lbl_arguments = {0};
-static VAL lbl_argv_info = {0};
 static VAL lbl_arg = {0};
+static VAL lbl_arguments = {0};
 static VAL lbl_positional_index = {0};
 static VAL lbl_error = {0};
 static VAL lbl_ctx = {0};
 static VAL lbl_dom = {0};
 static VAL lbl_cod = {0};
 static VAL lbl_token = {0};
-static VAL lbl_body = {0};
 static VAL lbl_home = {0};
+static VAL lbl_body = {0};
+static VAL lbl_lexer_module = {0};
+static VAL lbl_lexer_row = {0};
+static VAL lbl_lexer_col = {0};
+static VAL lbl_lexer_stack = {0};
+static VAL lbl_lexer_last_token = {0};
 static VAL lbl_match = {0};
 static void mw_std_prim_F (void) {
 	VAL tag = MKU64(0LL);
@@ -5933,8 +5938,43 @@ static void mp_mirth_token_TokenValue_TOKEN_5F_RCURLY (void) {
 	decref(cdr);
 	push_value(car);
 }
-static void mw_mirth_token_TokenValue_TOKEN_5F_INT (void) {
+static void mw_mirth_token_TokenValue_TOKEN_5F_LCOLON_5F_OPEN (void) {
 	VAL tag = MKU64(11LL);
+	VAL car = (tag);
+	push_value(car);
+}
+static void mp_mirth_token_TokenValue_TOKEN_5F_LCOLON_5F_OPEN (void) {
+	VAL car = pop_value();
+	decref(car);
+}
+static void mw_mirth_token_TokenValue_TOKEN_5F_LCOLON (void) {
+	VAL tag = MKU64(12LL);
+	VAL car = (pop_value());
+	car = mkcons(car, tag);
+	push_value(car);
+}
+static void mp_mirth_token_TokenValue_TOKEN_5F_LCOLON (void) {
+	VAL car = pop_value();
+	VAL cdr;
+	value_uncons_c(car, &car, &cdr);
+	decref(cdr);
+	push_value(car);
+}
+static void mw_mirth_token_TokenValue_TOKEN_5F_RCOLON (void) {
+	VAL tag = MKU64(13LL);
+	VAL car = (pop_value());
+	car = mkcons(car, tag);
+	push_value(car);
+}
+static void mp_mirth_token_TokenValue_TOKEN_5F_RCOLON (void) {
+	VAL car = pop_value();
+	VAL cdr;
+	value_uncons_c(car, &car, &cdr);
+	decref(cdr);
+	push_value(car);
+}
+static void mw_mirth_token_TokenValue_TOKEN_5F_INT (void) {
+	VAL tag = MKU64(14LL);
 	VAL car = (pop_value());
 	car = mkcons(car, tag);
 	push_value(car);
@@ -5947,7 +5987,7 @@ static void mp_mirth_token_TokenValue_TOKEN_5F_INT (void) {
 	push_value(car);
 }
 static void mw_mirth_token_TokenValue_TOKEN_5F_STR (void) {
-	VAL tag = MKU64(12LL);
+	VAL tag = MKU64(15LL);
 	VAL car = (pop_value());
 	car = mkcons(car, tag);
 	push_value(car);
@@ -5960,7 +6000,7 @@ static void mp_mirth_token_TokenValue_TOKEN_5F_STR (void) {
 	push_value(car);
 }
 static void mw_mirth_token_TokenValue_TOKEN_5F_NAME (void) {
-	VAL tag = MKU64(13LL);
+	VAL tag = MKU64(16LL);
 	VAL car = (pop_value());
 	car = mkcons(car, tag);
 	push_value(car);
@@ -5973,7 +6013,7 @@ static void mp_mirth_token_TokenValue_TOKEN_5F_NAME (void) {
 	push_value(car);
 }
 static void mw_mirth_token_TokenValue_TOKEN_5F_DNAME (void) {
-	VAL tag = MKU64(14LL);
+	VAL tag = MKU64(17LL);
 	VAL car = (pop_value());
 	car = mkcons(car, tag);
 	push_value(car);
@@ -5985,21 +6025,8 @@ static void mp_mirth_token_TokenValue_TOKEN_5F_DNAME (void) {
 	decref(cdr);
 	push_value(car);
 }
-static void mw_mirth_token_TokenValue_TOKEN_5F_LABEL (void) {
-	VAL tag = MKU64(15LL);
-	VAL car = (pop_value());
-	car = mkcons(car, tag);
-	push_value(car);
-}
-static void mp_mirth_token_TokenValue_TOKEN_5F_LABEL (void) {
-	VAL car = pop_value();
-	VAL cdr;
-	value_uncons_c(car, &car, &cdr);
-	decref(cdr);
-	push_value(car);
-}
 static void mw_mirth_token_TokenValue_TOKEN_5F_LABEL_5F_PUSH (void) {
-	VAL tag = MKU64(16LL);
+	VAL tag = MKU64(18LL);
 	VAL car = (pop_value());
 	car = mkcons(car, tag);
 	push_value(car);
@@ -6012,7 +6039,7 @@ static void mp_mirth_token_TokenValue_TOKEN_5F_LABEL_5F_PUSH (void) {
 	push_value(car);
 }
 static void mw_mirth_token_TokenValue_TOKEN_5F_LABEL_5F_POP (void) {
-	VAL tag = MKU64(17LL);
+	VAL tag = MKU64(19LL);
 	VAL car = (pop_value());
 	car = mkcons(car, tag);
 	push_value(car);
@@ -6315,30 +6342,33 @@ static void mp_std_stack_Stack_STACK_5F_CONS (void) {
 	push_value(cdr);
 	push_value(car);
 }
-static void mw_mirth_lexer__2B_Lexer__2B_LEXER (void) {
+static void mw_mirth_lexer__2B_Lexer_LEXER (void) {
 	VAL tag = MKU64(0LL);
-	VAL car = (pop_value());
-	car = mkcons(car, pop_value());
-	car = mkcons(car, pop_value());
-	car = mkcons(car, pop_value());
-	car = mkcons(car, pop_resource());
+	VAL car = (pop_resource());
+	car = mkcons(car, lpop(&lbl_lexer_last_token));
+	car = mkcons(car, lpop(&lbl_lexer_stack));
+	car = mkcons(car, lpop(&lbl_lexer_col));
+	car = mkcons(car, lpop(&lbl_lexer_row));
+	car = mkcons(car, lpop(&lbl_lexer_module));
 	car = mkcons(car, tag);
 	push_resource(car);
 }
-static void mp_mirth_lexer__2B_Lexer__2B_LEXER (void) {
+static void mp_mirth_lexer__2B_Lexer_LEXER (void) {
 	VAL car = pop_resource();
 	VAL cdr;
 	value_uncons_c(car, &car, &cdr);
 	decref(cdr);
 	value_uncons_c(car, &car, &cdr);
-	push_resource(cdr);
+	lpush(&lbl_lexer_module, cdr);
 	value_uncons_c(car, &car, &cdr);
-	push_value(cdr);
+	lpush(&lbl_lexer_row, cdr);
 	value_uncons_c(car, &car, &cdr);
-	push_value(cdr);
+	lpush(&lbl_lexer_col, cdr);
 	value_uncons_c(car, &car, &cdr);
-	push_value(cdr);
-	push_value(car);
+	lpush(&lbl_lexer_stack, cdr);
+	value_uncons_c(car, &car, &cdr);
+	lpush(&lbl_lexer_last_token, cdr);
+	push_resource(car);
 }
 static void mw_mirth_elab_TypeElab_TYPE_5F_ELAB (void) {
 	VAL tag = MKU64(0LL);
@@ -6831,7 +6861,9 @@ static void mw_std_maybe_Maybe_if_some (void);
 static void mw_std_maybe_Maybe_then (void);
 static void mw_std_maybe_Maybe_else (void);
 static void mw_std_maybe_Maybe_not (void);
+static void mw_std_maybe_Maybe_and (void);
 static void mw_std_maybe_Maybe_and_some (void);
+static void mw_std_maybe_Maybe_guard (void);
 static void mw_std_maybe_Maybe_unwrap (void);
 static void mw_std_maybe_Maybe_unwrap_or (void);
 static void mw_std_maybe_Maybe_map (void);
@@ -6980,7 +7012,6 @@ static void mw_std_prim_U8__3E_Byte (void);
 static void mw_std_prim_Ptr__40_Byte (void);
 static void mw_std_byte_Byte__3D__3D_ (void);
 static void mw_std_byte_Byte__3E_ (void);
-static void mw_std_byte_Byte__3C__3E_ (void);
 static void mw_std_byte_Byte_in_range (void);
 static void mw_std_byte_Byte_is_upper (void);
 static void mw_std_byte_Byte_is_lower (void);
@@ -7499,13 +7530,14 @@ static void mw_mirth_token_TokenValue_lsquare_open_3F_ (void);
 static void mw_mirth_token_TokenValue_lsquare_3F_ (void);
 static void mw_mirth_token_TokenValue_rsquare_3F_ (void);
 static void mw_mirth_token_TokenValue_lcurly_open_3F_ (void);
+static void mw_mirth_token_TokenValue_lcolon_open_3F_ (void);
+static void mw_mirth_token_TokenValue_lcolon_3F_ (void);
+static void mw_mirth_token_TokenValue_lparen_or_lcolon_3F_ (void);
 static void mw_mirth_token_TokenValue_int_3F_ (void);
 static void mw_mirth_token_TokenValue_str_3F_ (void);
 static void mw_mirth_token_TokenValue_name_3F_ (void);
 static void mw_mirth_token_TokenValue_dname_3F_ (void);
-static void mw_mirth_token_TokenValue_label_3F_ (void);
 static void mw_mirth_token_TokenValue_name_or_dname_3F_ (void);
-static void mw_mirth_token_TokenValue_name_or_dname_or_label_3F_ (void);
 static void mw_mirth_token_TokenValue_arg_end_3F_ (void);
 static void mw_mirth_token_TokenValue_left_enclosure_3F_ (void);
 static void mw_mirth_token_TokenValue_right_enclosure_3F_ (void);
@@ -7538,13 +7570,14 @@ static void mw_mirth_token_Token_lsquare_open_3F_ (void);
 static void mw_mirth_token_Token_lsquare_3F_ (void);
 static void mw_mirth_token_Token_rsquare_3F_ (void);
 static void mw_mirth_token_Token_lcurly_open_3F_ (void);
+static void mw_mirth_token_Token_lcolon_open_3F_ (void);
+static void mw_mirth_token_Token_lcolon_3F_ (void);
+static void mw_mirth_token_Token_lparen_or_lcolon_3F_ (void);
 static void mw_mirth_token_Token_int_3F_ (void);
 static void mw_mirth_token_Token_str_3F_ (void);
 static void mw_mirth_token_Token_name_3F_ (void);
 static void mw_mirth_token_Token_dname_3F_ (void);
-static void mw_mirth_token_Token_label_3F_ (void);
 static void mw_mirth_token_Token_name_or_dname_3F_ (void);
-static void mw_mirth_token_Token_name_or_dname_or_label_3F_ (void);
 static void mw_mirth_token_Token_arg_end_3F_ (void);
 static void mw_mirth_token_Token_left_enclosure_3F_ (void);
 static void mw_mirth_token_Token_right_enclosure_3F_ (void);
@@ -7564,15 +7597,15 @@ static void mw_mirth_token_Token_alloc_none_21_ (void);
 static void mw_mirth_token_Token_location (void);
 static void mw_mirth_token_Token_next (void);
 static void mw_mirth_token_Token_prev (void);
-static void mw_mirth_token_Token_in_lens_like_3F_ (void);
 static void mw_mirth_token_Token_next_arg_end (void);
 static void mw_mirth_token_Token_has_args_3F_ (void);
 static void mw_mirth_token_Token_args_start (void);
-static void mw_mirth_token_Token_num_args (void);
+static void mw_mirth_token_Token_could_be_sig_label_3F_ (void);
 static void mw_mirth_token_Token_args_0 (void);
 static void mw_mirth_token_Token_args_1 (void);
 static void mw_mirth_token_Token_args_2 (void);
 static void mw_mirth_token_Token_args_3 (void);
+static void mw_mirth_token_Token_num_args (void);
 static void mw_mirth_token_Token_args (void);
 static void mw_mirth_token_Token_args_end_3F_ (void);
 static void mw_mirth_token_Token_args_2B_ (void);
@@ -7583,7 +7616,6 @@ static void mw_mirth_token_Token_run_end_3F_ (void);
 static void mw_mirth_token_Token_run_tokens (void);
 static void mw_mirth_token_Token_run_length (void);
 static void mw_mirth_token_Token_run_has_arrow_3F_ (void);
-static void mw_mirth_token_Token_lens_like_3F_ (void);
 static void mw_mirth_token_Token_sig_stack_end_3F_ (void);
 static void mw_mirth_token_Token_sig_next_stack_end (void);
 static void mw_mirth_token_Token_sig_has_dashes_3F_ (void);
@@ -7646,6 +7678,7 @@ static void mw_mirth_name_Name_trace_21_ (void);
 static void mw_mirth_name_Name_head (void);
 static void mw_mirth_name_Name_tail_head (void);
 static void mw_mirth_name_Name_can_be_relative_3F_ (void);
+static void mw_mirth_name_Name_could_be_label_name_3F_ (void);
 static void mw_mirth_name_Name_could_be_type (void);
 static void mw_mirth_name_Name_could_be_type_var (void);
 static void mw_mirth_name_Name_could_be_type_con (void);
@@ -7656,7 +7689,6 @@ static void mw_mirth_name_Name_could_be_resource_var (void);
 static void mw_mirth_name_Name_could_be_resource_con (void);
 static void mw_mirth_name_Name_could_be_type_or_resource_con (void);
 static void mw_mirth_name_Name_mangle_compute_21_ (void);
-static void mw_mirth_name_Name_lens_like_3F_ (void);
 static void mw_mirth_name_Namespace__3D__3D_ (void);
 static void mw_mirth_name_Namespace_module_3F_ (void);
 static void mw_mirth_name_Namespace_prim (void);
@@ -7672,7 +7704,6 @@ static void mw_mirth_name_QName__3E_Str (void);
 static void mw_mirth_name_QName_to_module_path (void);
 static void mw_mirth_name_DName_root_3F_ (void);
 static void mw_mirth_name_DName_parts (void);
-static void mw_mirth_name_DName_lens_like_3F_ (void);
 static void mw_mirth_package_Package_index (void);
 static void mw_mirth_package_Package_alloc_21_ (void);
 static void mw_mirth_package_Package_name (void);
@@ -7683,22 +7714,36 @@ static void mw_mirth_package_Package_new_or_set_path_21_ (void);
 static void mw_mirth_package_Package_find (void);
 static void mw_mirth_package_Package_find_or_new_21_ (void);
 static void mw_mirth_package_Package__3D__3D_ (void);
+static void mw_std_stack_Stack_head (void);
 static void mw_std_stack_Stack_cons (void);
 static void mw_std_stack_Stack_uncons (void);
-static void mw_mirth_lexer__LEXER (void);
-static void mw_mirth_lexer_lexer_module_40_ (void);
-static void mw_mirth_lexer_lexer_row_40_ (void);
-static void mw_mirth_lexer_lexer_col_40_ (void);
-static void mw_mirth_lexer_lexer_row_21_ (void);
-static void mw_mirth_lexer_lexer_col_21_ (void);
+static void mw_mirth_lexer__2B_Lexer__2F_LEXER (void);
+static void mw_mirth_lexer__2B_Lexer_lexer_last_token (void);
+static void mw_mirth_lexer__2B_Lexer_lexer_last_token_21_ (void);
+static void mw_mirth_lexer__2B_Lexer_lexer_stack (void);
+static void mw_mirth_lexer__2B_Lexer_lexer_stack_21_ (void);
+static void mw_mirth_lexer__2B_Lexer_lexer_col (void);
+static void mw_mirth_lexer__2B_Lexer_lexer_col_21_ (void);
+static void mw_mirth_lexer__2B_Lexer_lexer_row (void);
+static void mw_mirth_lexer__2B_Lexer_lexer_row_21_ (void);
+static void mw_mirth_lexer__2B_Lexer_lexer_module (void);
 static void mw_mirth_lexer_lexer_stack_push_21_ (void);
 static void mw_mirth_lexer_lexer_stack_pop_21_ (void);
+static void mw_mirth_lexer_lexer_stack_drop (void);
+static void mw_mirth_lexer_lexer_stack_peek (void);
+static void mw_mirth_lexer__2B_Lexer_lexer_col_40_ (void);
+static void mw_mirth_lexer__2B_Lexer_lexer_row_40_ (void);
+static void mw_mirth_lexer__2B_Lexer_lexer_module_40_ (void);
 static void mw_mirth_lexer_run_lexer_21_ (void);
 static void mw_mirth_lexer_lexer_done_3F_ (void);
 static void mw_mirth_lexer_lexer_make_21_ (void);
 static void mw_mirth_lexer_lexer_emit_21_ (void);
 static void mw_mirth_lexer_lexer_next_21_ (void);
 static void mw_mirth_lexer_lexer_newline_21_ (void);
+static void mw_mirth_lexer_lexer_emit_lcolon_21_ (void);
+static void mw_mirth_lexer_lexer_close_colons_21_ (void);
+static void mw_mirth_lexer_lexer_prepare_for_atom_21_ (void);
+static void mw_mirth_lexer_lexer_prepare_for_args_21_ (void);
 static void mw_mirth_lexer_lexer_emit_lparen_21_ (void);
 static void mw_mirth_lexer_lexer_emit_rparen_21_ (void);
 static void mw_mirth_lexer_lexer_emit_lsquare_21_ (void);
@@ -7707,6 +7752,7 @@ static void mw_mirth_lexer_lexer_emit_lcurly_21_ (void);
 static void mw_mirth_lexer_lexer_emit_rcurly_21_ (void);
 static void mw_mirth_lexer_lexer_emit_name_21_ (void);
 static void mw_mirth_lexer_str_buf_name_3F_ (void);
+static void mw_mirth_lexer_str_buf_drop_last_byte (void);
 static void mw_mirth_lexer_str_buf_label_token_3F_ (void);
 static void mw_mirth_lexer_str_buf_dname_3F_ (void);
 static void mw_mirth_lexer_str_buf_is_doc_start_3F_ (void);
@@ -7745,6 +7791,7 @@ static void mw_mirth_elab_elab_type_stack_rest_21_ (void);
 static void mw_mirth_elab_elab_type_arg_21_ (void);
 static void mw_mirth_elab_StackTypePart_cons (void);
 static void mw_mirth_elab_elab_type_atom_21_ (void);
+static void mw_mirth_elab_elab_stack_label_21_ (void);
 static void mw_mirth_elab_elab_stack_var_21_ (void);
 static void mw_mirth_elab_elab_type_var_21_ (void);
 static void mw_mirth_elab_elab_resource_var_21_ (void);
@@ -8046,9 +8093,9 @@ static void mw_mirth_main_parse_package_def (void);
 static void mw_mirth_main_compiler_parse_args (void);
 static void mw_mirth_main_main (void);
 static void mb_mirth_module_Module_prim_3 (void);
+static void mb_mirth_token_Token_args_7 (void);
 static void mb_mirth_token_Token_args_11 (void);
-static void mb_mirth_token_Token_args_15 (void);
-static void mb_mirth_token_Token_args_18 (void);
+static void mb_mirth_token_Token_args_14 (void);
 static void mb_mirth_main_main_4 (void);
 static void mb_mirth_main_main_60 (void);
 static void mb_mirth_arrow_Arrow_type_2 (void);
@@ -8070,7 +8117,7 @@ static void mb_mirth_type_StackType_trace_21__31 (void);
 static void mb_mirth_type_StackType_trace_21__40 (void);
 static void mb_mirth_type_StackType_trace_21__43 (void);
 static void mb_std_prim_Str__3E_Name_28 (void);
-static void mb_mirth_lexer_run_lexer_21__28 (void);
+static void mb_mirth_lexer_run_lexer_21__35 (void);
 static void mb_mirth_elab_typecheck_everything_21__2 (void);
 static void mb_mirth_elab_typecheck_everything_21__5 (void);
 static void mb_mirth_elab_typecheck_everything_21__10 (void);
@@ -8123,7 +8170,6 @@ static void mb_std_prelude_Offset__3E__3D__2 (void);
 static void mb_std_prelude_Nat__3C__3D__2 (void);
 static void mb_std_prelude_Size__3C__3D__2 (void);
 static void mb_std_prelude_Offset__3C__3D__2 (void);
-static void mb_std_byte_Byte__3C__3E__2 (void);
 static void mb_std_byte_Byte_in_range_4 (void);
 static void mb_std_buffer__2B_Buffer__40_U8_7 (void);
 static void mb_std_buffer__2B_Buffer__21_U8_7 (void);
@@ -8226,8 +8272,8 @@ static void mb_mirth_package_Package_find_or_new_21__4 (void);
 static void mb_mirth_name_hash_name_40__7 (void);
 static void mb_mirth_name_hash_name_21__12 (void);
 static void mb_std_prim_Str_hash_4 (void);
-static void mb_mirth_token_Token_next_34 (void);
-static void mb_mirth_token_Token_next_46 (void);
+static void mb_mirth_token_Token_next_32 (void);
+static void mb_mirth_token_Token_next_44 (void);
 static void mb_mirth_name_Name_mangle_compute_21__2 (void);
 static void mb_mirth_name_Name_mangle_compute_21__5 (void);
 static void mb_mirth_name_Name_could_be_type_or_resource_con_4 (void);
@@ -8249,16 +8295,21 @@ static void mb_mirth_token_TokenValue_sig_dashes_3F__3 (void);
 static void mb_mirth_token_TokenValue_pat_arrow_3F__3 (void);
 static void mb_mirth_token_TokenValue_pat_underscore_3F__3 (void);
 static void mb_mirth_token_TokenValue_module_header_3F__3 (void);
-static void mb_mirth_token_Token_has_args_3F__11 (void);
+static void mb_mirth_token_Token_prev_21 (void);
+static void mb_mirth_token_Token_prev_32 (void);
+static void mb_mirth_token_Token_has_args_3F__4 (void);
 static void mb_mirth_token_Token_args_start_4 (void);
 static void mb_mirth_token_Token_args_start_11 (void);
+static void mb_mirth_token_Token_could_be_sig_label_3F__4 (void);
+static void mb_mirth_token_Token_could_be_sig_label_3F__6 (void);
+static void mb_mirth_token_Token_could_be_sig_label_3F__10 (void);
 static void mb_mirth_token_Token_args_end_3F__4 (void);
 static void mb_mirth_token_Token_args_2B__5 (void);
 static void mb_mirth_error_emit_warning_at_21__10 (void);
 static void mb_mirth_error_emit_error_at_21__10 (void);
+static void mb_mirth_token_Token_run_tokens_2 (void);
+static void mb_mirth_token_Token_run_tokens_6 (void);
 static void mb_mirth_token_Token_run_tokens_8 (void);
-static void mb_mirth_token_Token_run_tokens_12 (void);
-static void mb_mirth_token_Token_run_tokens_14 (void);
 static void mb_mirth_token_Token_run_has_arrow_3F__3 (void);
 static void mb_mirth_token_Token_sig_stack_end_3F__4 (void);
 static void mb_mirth_token_Token_sig_count_types_13 (void);
@@ -8319,8 +8370,9 @@ static void mb_mirth_data_make_prim_tag_21__32 (void);
 static void mb_mirth_data_make_prim_tag_21__39 (void);
 static void mb_mirth_data_make_prim_tag_21__47 (void);
 static void mb_mirth_data_Tag_label_inputs_from_sig_3 (void);
-static void mb_mirth_data_Tag_label_inputs_from_sig_9 (void);
+static void mb_mirth_data_Tag_label_inputs_from_sig_16 (void);
 static void mb_mirth_data_Tag_label_inputs_from_sig_6 (void);
+static void mb_mirth_data_Tag_label_inputs_from_sig_11 (void);
 static void mb_mirth_data_Tag_num_type_inputs_from_sig_4 (void);
 static void mb_mirth_data_Tag_num_type_inputs_from_sig_13 (void);
 static void mb_mirth_data_Tag_num_resource_inputs_from_sig_3 (void);
@@ -8344,14 +8396,17 @@ static void mb_mirth_match_Case_covers_3F__2 (void);
 static void mb_mirth_match_Pattern_tag_3D__3 (void);
 static void mb_mirth_match_Pattern_tag_3D__5 (void);
 static void mb_mirth_lexer_lexer_skip_comment_21__12 (void);
-static void mb_mirth_lexer_lexer_emit_name_21__15 (void);
+static void mb_mirth_lexer_lexer_close_colons_21__2 (void);
+static void mb_mirth_lexer_lexer_close_colons_21__9 (void);
+static void mb_mirth_lexer_lexer_close_colons_21__5 (void);
+static void mb_mirth_lexer_lexer_prepare_for_args_21__4 (void);
+static void mb_mirth_lexer_lexer_prepare_for_atom_21__4 (void);
 static void mb_mirth_lexer_str_buf_is_int_3F__3 (void);
 static void mb_mirth_lexer_str_buf_is_int_3F__7 (void);
 static void mb_mirth_lexer_str_buf_dname_3F__28 (void);
-static void mb_mirth_lexer_str_buf_label_token_3F__15 (void);
-static void mb_mirth_lexer_str_buf_label_token_3F__28 (void);
-static void mb_mirth_lexer_str_buf_label_token_3F__48 (void);
-static void mb_mirth_lexer_str_buf_label_token_3F__59 (void);
+static void mb_mirth_lexer_str_buf_label_token_3F__13 (void);
+static void mb_mirth_lexer_str_buf_label_token_3F__33 (void);
+static void mb_mirth_lexer_str_buf_label_token_3F__44 (void);
 static void mb_mirth_lexer_str_buf_dec_int_3F__10 (void);
 static void mb_mirth_lexer_str_buf_hex_int_3F__12 (void);
 static void mb_mirth_lexer_str_buf_oct_int_3F__12 (void);
@@ -8361,11 +8416,11 @@ static void mb_mirth_elab_elab_type_sig_21__51 (void);
 static void mb_mirth_elab_elab_type_sig_params_21__4 (void);
 static void mb_mirth_elab_elab_type_sig_params_21__25 (void);
 static void mb_mirth_elab_elab_type_sig_params_21__13 (void);
-static void mb_mirth_elab_elab_type_atom_21__4 (void);
-static void mb_mirth_elab_elab_type_atom_21__36 (void);
-static void mb_mirth_elab_elab_type_atom_21__103 (void);
-static void mb_mirth_elab_elab_type_atom_21__109 (void);
+static void mb_mirth_elab_elab_type_atom_21__77 (void);
+static void mb_mirth_elab_elab_type_atom_21__83 (void);
 static void mb_mirth_elab_elab_type_arg_21__25 (void);
+static void mb_mirth_elab_elab_stack_label_21__2 (void);
+static void mb_mirth_elab_elab_stack_label_21__25 (void);
 static void mb_mirth_elab_elab_type_con_21__22 (void);
 static void mb_mirth_elab_elab_type_con_21__63 (void);
 static void mb_mirth_elab_elab_implicit_var_21__2 (void);
@@ -12044,6 +12099,25 @@ static void mw_std_maybe_Maybe_not (void) {
 	mw_std_maybe_Maybe__3E_Bool();
 	mw_std_prim_Bool_not();
 }
+static void mw_std_maybe_Maybe_and (void) {
+	{
+		VAL var_p = pop_value();
+		switch (get_top_data_tag()) {
+			case 0LL:
+				mp_std_maybe_Maybe_NONE();
+				mw_std_prim_F();
+				break;
+			case 1LL:
+				mp_std_maybe_Maybe_SOME();
+				mw_std_prim_prim_drop();
+				incref(var_p);
+				run_value(var_p);
+				break;
+			default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
+		}
+		decref(var_p);
+	}
+}
 static void mw_std_maybe_Maybe_and_some (void) {
 	{
 		VAL var_p = pop_value();
@@ -12056,6 +12130,30 @@ static void mw_std_maybe_Maybe_and_some (void) {
 				mp_std_maybe_Maybe_SOME();
 				incref(var_p);
 				run_value(var_p);
+				break;
+			default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
+		}
+		decref(var_p);
+	}
+}
+static void mw_std_maybe_Maybe_guard (void) {
+	{
+		VAL var_p = pop_value();
+		switch (get_top_data_tag()) {
+			case 0LL:
+				mp_std_maybe_Maybe_NONE();
+				mw_std_maybe_Maybe_NONE();
+				break;
+			case 1LL:
+				mp_std_maybe_Maybe_SOME();
+				incref(var_p);
+				run_value(var_p);
+				if (pop_u64()) {
+					mw_std_maybe_Maybe_SOME();
+				} else {
+					mw_std_prim_prim_drop();
+					mw_std_maybe_Maybe_NONE();
+				}
 				break;
 			default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
 		}
@@ -13257,13 +13355,6 @@ static void mw_std_byte_Byte__3E_ (void) {
 	mw_std_prelude_both();
 	mw_std_prim_Int__3E_();
 }
-static void mw_std_byte_Byte__3C__3E_ (void) {
-	push_u64(0);
-	push_fnptr(&mb_std_byte_Byte__3C__3E__2);
-	mw_std_prim_prim_pack_cons();
-	mw_std_prelude_both();
-	mw_std_prim_Int__3C__3E_();
-}
 static void mw_std_byte_Byte_in_range (void) {
 	{
 		VAL d2 = pop_value();
@@ -13480,6 +13571,10 @@ static void mw_std_byte_Byte_is_name_byte (void) {
 			break;
 		case 34LL:
 			mp_std_byte_Byte_BQUOTE();
+			mw_std_prim_F();
+			break;
+		case 58LL:
+			mp_std_byte_Byte_BCOLON();
 			mw_std_prim_F();
 			break;
 		case 127LL:
@@ -16649,7 +16744,7 @@ static void mw_mirth_data_Tag_label_inputs_from_sig (void) {
 	push_fnptr(&mb_mirth_data_Tag_label_inputs_from_sig_3);
 	mw_std_prim_prim_pack_cons();
 	push_u64(0);
-	push_fnptr(&mb_mirth_data_Tag_label_inputs_from_sig_9);
+	push_fnptr(&mb_mirth_data_Tag_label_inputs_from_sig_16);
 	mw_std_prim_prim_pack_cons();
 	mw_std_maybe_Maybe_if_some();
 }
@@ -23051,9 +23146,49 @@ static void mw_mirth_token_TokenValue_lcurly_open_3F_ (void) {
 			break;
 	}
 }
-static void mw_mirth_token_TokenValue_int_3F_ (void) {
+static void mw_mirth_token_TokenValue_lcolon_open_3F_ (void) {
 	switch (get_top_data_tag()) {
 		case 11LL:
+			mp_mirth_token_TokenValue_TOKEN_5F_LCOLON_5F_OPEN();
+			mw_std_prim_T();
+			break;
+		default:
+			mw_std_prim_prim_drop();
+			mw_std_prim_F();
+			break;
+	}
+}
+static void mw_mirth_token_TokenValue_lcolon_3F_ (void) {
+	switch (get_top_data_tag()) {
+		case 12LL:
+			mp_mirth_token_TokenValue_TOKEN_5F_LCOLON();
+			mw_std_maybe_Maybe_SOME();
+			break;
+		default:
+			mw_std_prim_prim_drop();
+			mw_std_maybe_Maybe_NONE();
+			break;
+	}
+}
+static void mw_mirth_token_TokenValue_lparen_or_lcolon_3F_ (void) {
+	switch (get_top_data_tag()) {
+		case 3LL:
+			mp_mirth_token_TokenValue_TOKEN_5F_LPAREN();
+			mw_std_maybe_Maybe_SOME();
+			break;
+		case 12LL:
+			mp_mirth_token_TokenValue_TOKEN_5F_LCOLON();
+			mw_std_maybe_Maybe_SOME();
+			break;
+		default:
+			mw_std_prim_prim_drop();
+			mw_std_maybe_Maybe_NONE();
+			break;
+	}
+}
+static void mw_mirth_token_TokenValue_int_3F_ (void) {
+	switch (get_top_data_tag()) {
+		case 14LL:
 			mp_mirth_token_TokenValue_TOKEN_5F_INT();
 			mw_std_maybe_Maybe_SOME();
 			break;
@@ -23065,7 +23200,7 @@ static void mw_mirth_token_TokenValue_int_3F_ (void) {
 }
 static void mw_mirth_token_TokenValue_str_3F_ (void) {
 	switch (get_top_data_tag()) {
-		case 12LL:
+		case 15LL:
 			mp_mirth_token_TokenValue_TOKEN_5F_STR();
 			mw_std_maybe_Maybe_SOME();
 			break;
@@ -23077,7 +23212,7 @@ static void mw_mirth_token_TokenValue_str_3F_ (void) {
 }
 static void mw_mirth_token_TokenValue_name_3F_ (void) {
 	switch (get_top_data_tag()) {
-		case 13LL:
+		case 16LL:
 			mp_mirth_token_TokenValue_TOKEN_5F_NAME();
 			mw_std_maybe_Maybe_SOME();
 			break;
@@ -23089,20 +23224,8 @@ static void mw_mirth_token_TokenValue_name_3F_ (void) {
 }
 static void mw_mirth_token_TokenValue_dname_3F_ (void) {
 	switch (get_top_data_tag()) {
-		case 14LL:
+		case 17LL:
 			mp_mirth_token_TokenValue_TOKEN_5F_DNAME();
-			mw_std_maybe_Maybe_SOME();
-			break;
-		default:
-			mw_std_prim_prim_drop();
-			mw_std_maybe_Maybe_NONE();
-			break;
-	}
-}
-static void mw_mirth_token_TokenValue_label_3F_ (void) {
-	switch (get_top_data_tag()) {
-		case 15LL:
-			mp_mirth_token_TokenValue_TOKEN_5F_LABEL();
 			mw_std_maybe_Maybe_SOME();
 			break;
 		default:
@@ -23113,12 +23236,12 @@ static void mw_mirth_token_TokenValue_label_3F_ (void) {
 }
 static void mw_mirth_token_TokenValue_name_or_dname_3F_ (void) {
 	switch (get_top_data_tag()) {
-		case 13LL:
+		case 16LL:
 			mp_mirth_token_TokenValue_TOKEN_5F_NAME();
 			mw_std_either_Either_LEFT();
 			mw_std_maybe_Maybe_SOME();
 			break;
-		case 14LL:
+		case 17LL:
 			mp_mirth_token_TokenValue_TOKEN_5F_DNAME();
 			mw_std_either_Either_RIGHT();
 			mw_std_maybe_Maybe_SOME();
@@ -23126,29 +23249,6 @@ static void mw_mirth_token_TokenValue_name_or_dname_3F_ (void) {
 		default:
 			mw_std_prim_prim_drop();
 			mw_std_maybe_Maybe_NONE();
-			break;
-	}
-}
-static void mw_mirth_token_TokenValue_name_or_dname_or_label_3F_ (void) {
-	switch (get_top_data_tag()) {
-		case 13LL:
-			mp_mirth_token_TokenValue_TOKEN_5F_NAME();
-			mw_std_prim_prim_drop();
-			mw_std_prim_T();
-			break;
-		case 14LL:
-			mp_mirth_token_TokenValue_TOKEN_5F_DNAME();
-			mw_std_prim_prim_drop();
-			mw_std_prim_T();
-			break;
-		case 15LL:
-			mp_mirth_token_TokenValue_TOKEN_5F_LABEL();
-			mw_std_prim_prim_drop();
-			mw_std_prim_T();
-			break;
-		default:
-			mw_std_prim_prim_drop();
-			mw_std_prim_F();
 			break;
 	}
 }
@@ -23170,6 +23270,11 @@ static void mw_mirth_token_TokenValue_arg_end_3F_ (void) {
 			break;
 		case 7LL:
 			mp_mirth_token_TokenValue_TOKEN_5F_RSQUARE();
+			mw_std_prim_prim_drop();
+			mw_std_prim_T();
+			break;
+		case 13LL:
+			mp_mirth_token_TokenValue_TOKEN_5F_RCOLON();
 			mw_std_prim_prim_drop();
 			mw_std_prim_T();
 			break;
@@ -23196,6 +23301,11 @@ static void mw_mirth_token_TokenValue_left_enclosure_3F_ (void) {
 			mw_std_prim_prim_drop();
 			mw_std_prim_T();
 			break;
+		case 12LL:
+			mp_mirth_token_TokenValue_TOKEN_5F_LCOLON();
+			mw_std_prim_prim_drop();
+			mw_std_prim_T();
+			break;
 		default:
 			mw_std_prim_prim_drop();
 			mw_std_prim_F();
@@ -23216,6 +23326,11 @@ static void mw_mirth_token_TokenValue_right_enclosure_3F_ (void) {
 			break;
 		case 10LL:
 			mp_mirth_token_TokenValue_TOKEN_5F_RCURLY();
+			mw_std_prim_prim_drop();
+			mw_std_prim_T();
+			break;
+		case 13LL:
+			mp_mirth_token_TokenValue_TOKEN_5F_RCOLON();
 			mw_std_prim_prim_drop();
 			mw_std_prim_T();
 			break;
@@ -23387,6 +23502,18 @@ static void mw_mirth_token_Token_lcurly_open_3F_ (void) {
 	mw_mirth_token_Token_value();
 	mw_mirth_token_TokenValue_lcurly_open_3F_();
 }
+static void mw_mirth_token_Token_lcolon_open_3F_ (void) {
+	mw_mirth_token_Token_value();
+	mw_mirth_token_TokenValue_lcolon_open_3F_();
+}
+static void mw_mirth_token_Token_lcolon_3F_ (void) {
+	mw_mirth_token_Token_value();
+	mw_mirth_token_TokenValue_lcolon_3F_();
+}
+static void mw_mirth_token_Token_lparen_or_lcolon_3F_ (void) {
+	mw_mirth_token_Token_value();
+	mw_mirth_token_TokenValue_lparen_or_lcolon_3F_();
+}
 static void mw_mirth_token_Token_int_3F_ (void) {
 	mw_mirth_token_Token_value();
 	mw_mirth_token_TokenValue_int_3F_();
@@ -23403,17 +23530,9 @@ static void mw_mirth_token_Token_dname_3F_ (void) {
 	mw_mirth_token_Token_value();
 	mw_mirth_token_TokenValue_dname_3F_();
 }
-static void mw_mirth_token_Token_label_3F_ (void) {
-	mw_mirth_token_Token_value();
-	mw_mirth_token_TokenValue_label_3F_();
-}
 static void mw_mirth_token_Token_name_or_dname_3F_ (void) {
 	mw_mirth_token_Token_value();
 	mw_mirth_token_TokenValue_name_or_dname_3F_();
-}
-static void mw_mirth_token_Token_name_or_dname_or_label_3F_ (void) {
-	mw_mirth_token_Token_value();
-	mw_mirth_token_TokenValue_name_or_dname_or_label_3F_();
 }
 static void mw_mirth_token_Token_arg_end_3F_ (void) {
 	mw_mirth_token_Token_value();
@@ -23496,56 +23615,54 @@ static void mw_mirth_token_Token_location (void) {
 }
 static void mw_mirth_token_Token_next (void) {
 	mw_std_prim_prim_dup();
-	mw_mirth_token_Token_lens_like_3F_();
-	if (pop_u64()) {
-		mw_mirth_token_Token_succ();
-		mw_mirth_token_Token_next();
-	} else {
-		mw_std_prim_prim_dup();
-		mw_mirth_token_Token_value();
-		switch (get_top_data_tag()) {
-			case 3LL:
-				mp_mirth_token_TokenValue_TOKEN_5F_LPAREN();
-				mw_std_prelude_nip();
-				mw_mirth_token_Token_succ();
-				break;
-			case 6LL:
-				mp_mirth_token_TokenValue_TOKEN_5F_LSQUARE();
-				mw_std_prelude_nip();
-				mw_mirth_token_Token_succ();
-				break;
-			case 9LL:
-				mp_mirth_token_TokenValue_TOKEN_5F_LCURLY();
-				mw_std_prelude_nip();
-				mw_mirth_token_Token_succ();
-				break;
-			case 13LL:
-				mp_mirth_token_TokenValue_TOKEN_5F_NAME();
-				mw_std_prim_prim_drop();
-				mw_mirth_token_Token_succ();
-				mw_std_prim_prim_dup();
-				mw_mirth_token_Token_lparen_3F_();
-				push_u64(0);
-				push_fnptr(&mb_mirth_token_Token_next_34);
-				mw_std_prim_prim_pack_cons();
-				mw_std_maybe_Maybe_for();
-				break;
-			case 14LL:
-				mp_mirth_token_TokenValue_TOKEN_5F_DNAME();
-				mw_std_prim_prim_drop();
-				mw_mirth_token_Token_succ();
-				mw_std_prim_prim_dup();
-				mw_mirth_token_Token_lparen_3F_();
-				push_u64(0);
-				push_fnptr(&mb_mirth_token_Token_next_46);
-				mw_std_prim_prim_pack_cons();
-				mw_std_maybe_Maybe_for();
-				break;
-			default:
-				mw_std_prim_prim_drop();
-				mw_mirth_token_Token_succ();
-				break;
-		}
+	mw_mirth_token_Token_value();
+	switch (get_top_data_tag()) {
+		case 3LL:
+			mp_mirth_token_TokenValue_TOKEN_5F_LPAREN();
+			mw_std_prelude_nip();
+			mw_mirth_token_Token_succ();
+			break;
+		case 6LL:
+			mp_mirth_token_TokenValue_TOKEN_5F_LSQUARE();
+			mw_std_prelude_nip();
+			mw_mirth_token_Token_succ();
+			break;
+		case 9LL:
+			mp_mirth_token_TokenValue_TOKEN_5F_LCURLY();
+			mw_std_prelude_nip();
+			mw_mirth_token_Token_succ();
+			break;
+		case 12LL:
+			mp_mirth_token_TokenValue_TOKEN_5F_LCOLON();
+			mw_std_prelude_nip();
+			mw_mirth_token_Token_succ();
+			break;
+		case 16LL:
+			mp_mirth_token_TokenValue_TOKEN_5F_NAME();
+			mw_std_prim_prim_drop();
+			mw_mirth_token_Token_succ();
+			mw_std_prim_prim_dup();
+			mw_mirth_token_Token_lparen_or_lcolon_3F_();
+			push_u64(0);
+			push_fnptr(&mb_mirth_token_Token_next_32);
+			mw_std_prim_prim_pack_cons();
+			mw_std_maybe_Maybe_for();
+			break;
+		case 17LL:
+			mp_mirth_token_TokenValue_TOKEN_5F_DNAME();
+			mw_std_prim_prim_drop();
+			mw_mirth_token_Token_succ();
+			mw_std_prim_prim_dup();
+			mw_mirth_token_Token_lparen_or_lcolon_3F_();
+			push_u64(0);
+			push_fnptr(&mb_mirth_token_Token_next_44);
+			mw_std_prim_prim_pack_cons();
+			mw_std_maybe_Maybe_for();
+			break;
+		default:
+			mw_std_prim_prim_drop();
+			mw_mirth_token_Token_succ();
+			break;
 	}
 }
 static void mw_mirth_token_Token_prev (void) {
@@ -23566,116 +23683,74 @@ static void mw_mirth_token_Token_prev (void) {
 			mw_std_prelude_nip();
 			mw_std_prim_prim_dup();
 			mw_mirth_token_Token_pred();
+			mw_mirth_token_Token_name_or_dname_3F_();
+			push_u64(0);
+			push_fnptr(&mb_mirth_token_Token_prev_21);
+			mw_std_prim_prim_pack_cons();
+			mw_std_maybe_Maybe_then();
+			break;
+		case 13LL:
+			mp_mirth_token_TokenValue_TOKEN_5F_RCOLON();
+			mw_std_prelude_nip();
 			mw_std_prim_prim_dup();
-			mw_mirth_token_Token_name_or_dname_or_label_3F_();
-			if (pop_u64()) {
-				mw_std_prelude_nip();
-			} else {
-				mw_std_prim_prim_drop();
-			}
+			mw_mirth_token_Token_pred();
+			mw_mirth_token_Token_name_or_dname_3F_();
+			push_u64(0);
+			push_fnptr(&mb_mirth_token_Token_prev_32);
+			mw_std_prim_prim_pack_cons();
+			mw_std_maybe_Maybe_then();
 			break;
 		default:
 			mw_std_prim_prim_drop();
 			break;
 	}
-	while(1) {
-		mw_std_prim_prim_dup();
-		mw_mirth_token_Token_pred();
-		mw_mirth_token_Token_lens_like_3F_();
-		if (! pop_u64()) break;
-		mw_mirth_token_Token_pred();
-	}
-}
-static void mw_mirth_token_Token_in_lens_like_3F_ (void) {
-	mw_mirth_token_Token_pred();
-	mw_mirth_token_Token_lens_like_3F_();
 }
 static void mw_mirth_token_Token_next_arg_end (void) {
-	mw_std_prim_prim_dup();
-	mw_mirth_token_Token_in_lens_like_3F_();
-	if (pop_u64()) {
-		{
-			static bool vready = false;
-			static VAL v;
-			if (! vready) {
-				v = mkstr("Token.next-arg-end called inside lens-like token", 48);
-				vready = true;
-			}
-			push_value(v);
-			incref(v);
-		}
-		mw_std_prim_prim_panic();
-	} else {
-		while(1) {
-			mw_std_prim_prim_dup();
-			mw_mirth_token_Token_arg_end_3F_();
-			mw_std_prim_Bool_not();
-			if (! pop_u64()) break;
-			mw_mirth_token_Token_next();
-		}
+	while(1) {
+		mw_std_prim_prim_dup();
+		mw_mirth_token_Token_arg_end_3F_();
+		mw_std_prim_Bool_not();
+		if (! pop_u64()) break;
+		mw_mirth_token_Token_next();
 	}
 }
 static void mw_mirth_token_Token_has_args_3F_ (void) {
 	mw_std_prim_prim_dup();
-	mw_mirth_token_Token_lens_like_3F_();
-	if (pop_u64()) {
-		mw_std_prim_prim_drop();
-		mw_std_prim_T();
-	} else {
-		mw_std_prim_prim_dup();
-		mw_mirth_token_Token_name_or_dname_3F_();
-		push_u64(0);
-		push_fnptr(&mb_mirth_token_Token_has_args_3F__11);
-		mw_std_prim_prim_pack_cons();
-		mw_std_maybe_Maybe_then();
-		mw_mirth_token_Token_lparen_3F_();
-		mw_std_maybe_Maybe__3E_Bool();
-	}
+	mw_mirth_token_Token_name_or_dname_3F_();
+	push_u64(0);
+	push_fnptr(&mb_mirth_token_Token_has_args_3F__4);
+	mw_std_prim_prim_pack_cons();
+	mw_std_maybe_Maybe_then();
+	mw_mirth_token_Token_lparen_or_lcolon_3F_();
+	mw_std_maybe_Maybe__3E_Bool();
 }
 static void mw_mirth_token_Token_args_start (void) {
 	mw_std_prim_prim_dup();
-	mw_mirth_token_Token_name_or_dname_or_label_3F_();
+	mw_mirth_token_Token_name_or_dname_3F_();
 	push_u64(0);
 	push_fnptr(&mb_mirth_token_Token_args_start_4);
 	mw_std_prim_prim_pack_cons();
-	mw_std_prim_Bool_and();
+	mw_std_maybe_Maybe_and();
 	push_u64(0);
 	push_fnptr(&mb_mirth_token_Token_args_start_11);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prim_Bool_then();
 }
-static void mw_mirth_token_Token_num_args (void) {
-	mw_mirth_token_Token_args_start();
+static void mw_mirth_token_Token_could_be_sig_label_3F_ (void) {
 	mw_std_prim_prim_dup();
-	mw_mirth_token_Token_left_enclosure_3F_();
-	if (pop_u64()) {
-		{
-			VAL d3 = pop_value();
-			push_i64(0LL);
-			push_value(d3);
-		}
-		while(1) {
-			mw_std_prim_prim_dup();
-			mw_mirth_token_Token_right_enclosure_3F_();
-			mw_std_prim_Bool_not();
-			if (! pop_u64()) break;
-			{
-				VAL d4 = pop_value();
-				mw_std_prelude_prim_int_succ();
-				push_value(d4);
-			}
-			mw_mirth_token_Token_succ();
-			mw_mirth_token_Token_next_arg_end();
-		}
-		mw_std_prim_prim_drop();
-	} else {
-		mw_mirth_token_Token_lens_like_3F_();
-		if (pop_u64()) {
-			push_i64(1LL);
-		} else {
-			push_i64(0LL);
-		}
-	}
+	mw_mirth_token_Token_name_3F_();
+	push_u64(0);
+	push_fnptr(&mb_mirth_token_Token_could_be_sig_label_3F__4);
+	mw_std_prim_prim_pack_cons();
+	push_u64(0);
+	push_fnptr(&mb_mirth_token_Token_could_be_sig_label_3F__6);
+	mw_std_prim_prim_pack_cons();
+	mw_std_maybe_Maybe_if_some();
+	push_u64(0);
+	push_fnptr(&mb_mirth_token_Token_could_be_sig_label_3F__10);
+	mw_std_prim_prim_pack_cons();
+	mw_std_prim_Bool_and();
+	mw_std_prelude_nip();
 }
 static void mw_mirth_token_Token_args_0 (void) {
 	mw_std_prim_prim_dup();
@@ -23826,26 +23901,48 @@ static void mw_mirth_token_Token_args_3 (void) {
 		}
 	}
 }
-static void mw_mirth_token_Token_args (void) {
+static void mw_mirth_token_Token_num_args (void) {
+	mw_mirth_token_Token_args_start();
 	mw_std_prim_prim_dup();
-	mw_mirth_token_Token_has_args_3F_();
+	mw_mirth_token_Token_left_enclosure_3F_();
 	if (pop_u64()) {
-		mw_mirth_token_Token_args_start();
-		mw_std_prim_prim_dup();
-		mw_mirth_token_Token_left_enclosure_3F_();
-		if (pop_u64()) {
-			push_u64(0);
-			push_fnptr(&mb_mirth_token_Token_args_11);
-			mw_std_prim_prim_pack_cons();
-			push_u64(0);
-			push_fnptr(&mb_mirth_token_Token_args_15);
-			mw_std_prim_prim_pack_cons();
-			mw_std_list_collect_while();
-			mw_std_prelude_nip();
-		} else {
-			mw_mirth_token_Token_succ();
-			mw_std_list_List_L1();
+		{
+			VAL d3 = pop_value();
+			push_i64(0LL);
+			push_value(d3);
 		}
+		while(1) {
+			mw_std_prim_prim_dup();
+			mw_mirth_token_Token_args_end_3F_();
+			mw_std_prim_Bool_not();
+			if (! pop_u64()) break;
+			{
+				VAL d4 = pop_value();
+				mw_std_prelude_prim_int_succ();
+				push_value(d4);
+			}
+			mw_mirth_token_Token_succ();
+			mw_mirth_token_Token_next_arg_end();
+		}
+		mw_std_prim_prim_drop();
+	} else {
+		mw_std_prim_prim_drop();
+		push_i64(0LL);
+	}
+}
+static void mw_mirth_token_Token_args (void) {
+	mw_mirth_token_Token_args_start();
+	mw_std_prim_prim_dup();
+	mw_mirth_token_Token_left_enclosure_3F_();
+	if (pop_u64()) {
+		push_u64(0);
+		push_fnptr(&mb_mirth_token_Token_args_7);
+		mw_std_prim_prim_pack_cons();
+		push_u64(0);
+		push_fnptr(&mb_mirth_token_Token_args_11);
+		mw_std_prim_prim_pack_cons();
+		mw_std_list_collect_while();
+		mw_std_prelude_nip();
 	} else {
 		mw_std_prim_prim_drop();
 		mw_std_list_List_L0();
@@ -23915,6 +24012,11 @@ static void mw_mirth_token_Token_run_end_3F_ (void) {
 			mw_std_prim_prim_drop();
 			mw_std_prim_T();
 			break;
+		case 13LL:
+			mp_mirth_token_TokenValue_TOKEN_5F_RCOLON();
+			mw_std_prim_prim_drop();
+			mw_std_prim_T();
+			break;
 		default:
 			mw_std_prim_prim_drop();
 			mw_std_prim_F();
@@ -23922,20 +24024,14 @@ static void mw_mirth_token_Token_run_end_3F_ (void) {
 	}
 }
 static void mw_mirth_token_Token_run_tokens (void) {
-	mw_std_prim_prim_dup();
-	mw_mirth_token_Token_in_lens_like_3F_();
-	if (pop_u64()) {
-		mw_std_list_List_L1();
-	} else {
-		push_u64(0);
-		push_fnptr(&mb_mirth_token_Token_run_tokens_8);
-		mw_std_prim_prim_pack_cons();
-		push_u64(0);
-		push_fnptr(&mb_mirth_token_Token_run_tokens_12);
-		mw_std_prim_prim_pack_cons();
-		mw_std_list_collect_while();
-		mw_std_prelude_nip();
-	}
+	push_u64(0);
+	push_fnptr(&mb_mirth_token_Token_run_tokens_2);
+	mw_std_prim_prim_pack_cons();
+	push_u64(0);
+	push_fnptr(&mb_mirth_token_Token_run_tokens_6);
+	mw_std_prim_prim_pack_cons();
+	mw_std_list_collect_while();
+	mw_std_prelude_nip();
 }
 static void mw_mirth_token_Token_run_length (void) {
 	{
@@ -23964,28 +24060,6 @@ static void mw_mirth_token_Token_run_has_arrow_3F_ (void) {
 	push_fnptr(&mb_mirth_token_Token_run_has_arrow_3F__3);
 	mw_std_prim_prim_pack_cons();
 	mw_std_list_List_any();
-}
-static void mw_mirth_token_Token_lens_like_3F_ (void) {
-	mw_mirth_token_Token_value();
-	switch (get_top_data_tag()) {
-		case 15LL:
-			mp_mirth_token_TokenValue_TOKEN_5F_LABEL();
-			mw_std_prim_prim_drop();
-			mw_std_prim_T();
-			break;
-		case 13LL:
-			mp_mirth_token_TokenValue_TOKEN_5F_NAME();
-			mw_mirth_name_Name_lens_like_3F_();
-			break;
-		case 14LL:
-			mp_mirth_token_TokenValue_TOKEN_5F_DNAME();
-			mw_mirth_name_DName_lens_like_3F_();
-			break;
-		default:
-			mw_std_prim_prim_drop();
-			mw_std_prim_F();
-			break;
-	}
 }
 static void mw_mirth_token_Token_sig_stack_end_3F_ (void) {
 	mw_std_prim_prim_dup();
@@ -24885,6 +24959,10 @@ static void mw_mirth_name_Name_can_be_relative_3F_ (void) {
 	mw_std_byte_Byte_is_upper();
 	mw_std_prim_Bool_not();
 }
+static void mw_mirth_name_Name_could_be_label_name_3F_ (void) {
+	mw_mirth_name_Name_head();
+	mw_std_byte_Byte_is_lower();
+}
 static void mw_mirth_name_Name_could_be_type (void) {
 	mw_mirth_name_Name_head();
 	mw_std_byte_Byte_is_alpha();
@@ -24967,15 +25045,6 @@ static void mw_mirth_name_Name_mangle_compute_21_ (void) {
 	push_fnptr(&mb_mirth_name_Name_mangle_compute_21__2);
 	mw_std_prim_prim_pack_cons();
 	mw_std_str_build_str_21_();
-}
-static void mw_mirth_name_Name_lens_like_3F_ (void) {
-	mw_mirth_name_Name__3E_Str();
-	mw_std_prim_Str_thaw();
-	mw_std_str_str_buf_last_byte();
-	mw_std_byte_Byte_BCOLON();
-	mw_std_byte_Byte__3D__3D_();
-	mw_std_str__2B_Str_freeze();
-	mw_std_prim_prim_drop();
 }
 static void mw_mirth_name_Namespace__3D__3D_ (void) {
 	switch (get_top_data_tag()) {
@@ -25256,11 +25325,6 @@ static void mw_mirth_name_DName_parts (void) {
 		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
 	}
 }
-static void mw_mirth_name_DName_lens_like_3F_ (void) {
-	mw_mirth_name_DName_parts();
-	mw_std_list_List_2B__last();
-	mw_mirth_name_Name_lens_like_3F_();
-}
 static void mw_mirth_package_Package_index (void) {
 }
 static void mw_mirth_package_Package_alloc_21_ (void) {
@@ -25382,6 +25446,20 @@ static void mw_mirth_package_Package__3D__3D_ (void) {
 	mw_std_prelude_both();
 	mw_std_prim_prim_int_eq();
 }
+static void mw_std_stack_Stack_head (void) {
+	switch (get_top_data_tag()) {
+		case 0LL:
+			mp_std_stack_Stack_STACK_5F_NIL();
+			mw_std_maybe_Maybe_NONE();
+			break;
+		case 1LL:
+			mp_std_stack_Stack_STACK_5F_CONS();
+			mw_std_prim_prim_drop();
+			mw_std_maybe_Maybe_SOME();
+			break;
+		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
+	}
+}
 static void mw_std_stack_Stack_cons (void) {
 	mw_std_stack_Stack_STACK_5F_CONS();
 }
@@ -25403,97 +25481,143 @@ static void mw_std_stack_Stack_uncons (void) {
 		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
 	}
 }
-static void mw_mirth_lexer__LEXER (void) {
+static void mw_mirth_lexer__2B_Lexer__2F_LEXER (void) {
 	switch (get_top_resource_data_tag()) {
 		case 0LL:
-			mp_mirth_lexer__2B_Lexer__2B_LEXER();
-			mw_std_prim_prim_id();
+			mp_mirth_lexer__2B_Lexer_LEXER();
 			break;
 		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
 	}
 }
-static void mw_mirth_lexer_lexer_module_40_ (void) {
-	mw_mirth_lexer__LEXER();
-	mw_std_prelude_over3();
+static void mw_mirth_lexer__2B_Lexer_lexer_last_token (void) {
+	mw_mirth_lexer__2B_Lexer__2F_LEXER();
+	LPOP(lbl_lexer_last_token);
+	mw_std_prim_prim_dup();
+	LPUSH(lbl_lexer_last_token);
 	{
 		VAL d2 = pop_value();
-		mw_mirth_lexer__2B_Lexer__2B_LEXER();
+		mw_mirth_lexer__2B_Lexer_LEXER();
 		push_value(d2);
 	}
 }
-static void mw_mirth_lexer_lexer_row_40_ (void) {
-	mw_mirth_lexer__LEXER();
-	mw_std_prelude_over2();
+static void mw_mirth_lexer__2B_Lexer_lexer_last_token_21_ (void) {
+	LPUSH(lbl_lexer_last_token);
+	mw_mirth_lexer__2B_Lexer__2F_LEXER();
+	LPOP(lbl_lexer_last_token);
+	mw_std_prim_prim_drop();
+	mw_mirth_lexer__2B_Lexer_LEXER();
+}
+static void mw_mirth_lexer__2B_Lexer_lexer_stack (void) {
+	mw_mirth_lexer__2B_Lexer__2F_LEXER();
+	LPOP(lbl_lexer_stack);
+	mw_std_prim_prim_dup();
+	LPUSH(lbl_lexer_stack);
 	{
 		VAL d2 = pop_value();
-		mw_mirth_lexer__2B_Lexer__2B_LEXER();
+		mw_mirth_lexer__2B_Lexer_LEXER();
 		push_value(d2);
 	}
 }
-static void mw_mirth_lexer_lexer_col_40_ (void) {
-	mw_mirth_lexer__LEXER();
-	mw_std_prelude_over();
+static void mw_mirth_lexer__2B_Lexer_lexer_stack_21_ (void) {
+	LPUSH(lbl_lexer_stack);
+	mw_mirth_lexer__2B_Lexer__2F_LEXER();
+	LPOP(lbl_lexer_stack);
+	mw_std_prim_prim_drop();
+	mw_mirth_lexer__2B_Lexer_LEXER();
+}
+static void mw_mirth_lexer__2B_Lexer_lexer_col (void) {
+	mw_mirth_lexer__2B_Lexer__2F_LEXER();
+	LPOP(lbl_lexer_col);
+	mw_std_prim_prim_dup();
+	LPUSH(lbl_lexer_col);
 	{
 		VAL d2 = pop_value();
-		mw_mirth_lexer__2B_Lexer__2B_LEXER();
+		mw_mirth_lexer__2B_Lexer_LEXER();
 		push_value(d2);
 	}
 }
-static void mw_mirth_lexer_lexer_row_21_ (void) {
-	{
-		VAL d2 = pop_value();
-		mw_mirth_lexer__LEXER();
-		mw_std_prelude_rotl();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
-	mw_std_prelude_rotr();
-	mw_mirth_lexer__2B_Lexer__2B_LEXER();
+static void mw_mirth_lexer__2B_Lexer_lexer_col_21_ (void) {
+	LPUSH(lbl_lexer_col);
+	mw_mirth_lexer__2B_Lexer__2F_LEXER();
+	LPOP(lbl_lexer_col);
+	mw_std_prim_prim_drop();
+	mw_mirth_lexer__2B_Lexer_LEXER();
 }
-static void mw_mirth_lexer_lexer_col_21_ (void) {
+static void mw_mirth_lexer__2B_Lexer_lexer_row (void) {
+	mw_mirth_lexer__2B_Lexer__2F_LEXER();
+	LPOP(lbl_lexer_row);
+	mw_std_prim_prim_dup();
+	LPUSH(lbl_lexer_row);
 	{
 		VAL d2 = pop_value();
-		mw_mirth_lexer__LEXER();
-		mw_std_prim_prim_swap();
-		mw_std_prim_prim_drop();
+		mw_mirth_lexer__2B_Lexer_LEXER();
 		push_value(d2);
 	}
-	mw_std_prim_prim_swap();
-	mw_mirth_lexer__2B_Lexer__2B_LEXER();
+}
+static void mw_mirth_lexer__2B_Lexer_lexer_row_21_ (void) {
+	LPUSH(lbl_lexer_row);
+	mw_mirth_lexer__2B_Lexer__2F_LEXER();
+	LPOP(lbl_lexer_row);
+	mw_std_prim_prim_drop();
+	mw_mirth_lexer__2B_Lexer_LEXER();
+}
+static void mw_mirth_lexer__2B_Lexer_lexer_module (void) {
+	mw_mirth_lexer__2B_Lexer__2F_LEXER();
+	LPOP(lbl_lexer_module);
+	mw_std_prim_prim_dup();
+	LPUSH(lbl_lexer_module);
+	{
+		VAL d2 = pop_value();
+		mw_mirth_lexer__2B_Lexer_LEXER();
+		push_value(d2);
+	}
 }
 static void mw_mirth_lexer_lexer_stack_push_21_ (void) {
-	{
-		VAL d2 = pop_value();
-		mw_mirth_lexer__LEXER();
-		push_value(d2);
-	}
-	mw_std_prim_prim_swap();
+	mw_mirth_lexer__2B_Lexer_lexer_stack();
 	mw_std_stack_Stack_cons();
-	mw_mirth_lexer__2B_Lexer__2B_LEXER();
+	mw_mirth_lexer__2B_Lexer_lexer_stack_21_();
 }
 static void mw_mirth_lexer_lexer_stack_pop_21_ (void) {
-	mw_mirth_lexer__LEXER();
+	mw_mirth_lexer__2B_Lexer_lexer_stack();
 	mw_std_stack_Stack_uncons();
-	mw_std_prim_prim_swap();
-	{
-		VAL d2 = pop_value();
-		mw_mirth_lexer__2B_Lexer__2B_LEXER();
-		push_value(d2);
-	}
+	mw_mirth_lexer__2B_Lexer_lexer_stack_21_();
+}
+static void mw_mirth_lexer_lexer_stack_drop (void) {
+	mw_mirth_lexer_lexer_stack_pop_21_();
+	mw_std_prim_prim_drop();
+}
+static void mw_mirth_lexer_lexer_stack_peek (void) {
+	mw_mirth_lexer__2B_Lexer_lexer_stack();
+	mw_std_stack_Stack_head();
+}
+static void mw_mirth_lexer__2B_Lexer_lexer_col_40_ (void) {
+	mw_mirth_lexer__2B_Lexer_lexer_col();
+}
+static void mw_mirth_lexer__2B_Lexer_lexer_row_40_ (void) {
+	mw_mirth_lexer__2B_Lexer_lexer_row();
+}
+static void mw_mirth_lexer__2B_Lexer_lexer_module_40_ (void) {
+	mw_mirth_lexer__2B_Lexer_lexer_module();
 }
 static void mw_mirth_lexer_run_lexer_21_ (void) {
 	mw_mirth_module_Module_new_21_();
 	mw_std_prim_prim_dup();
+	LPUSH(lbl_lexer_module);
 	mw_mirth_module_Module_source_path();
 	mw_std_prim__2B_World_open_file_21_();
 	mw_posix_input_input_start_21_();
 	push_i64(1LL);
 	mw_std_prim_Int__3E_Row();
+	LPUSH(lbl_lexer_row);
 	push_i64(1LL);
 	mw_std_prim_Int__3E_Col();
+	LPUSH(lbl_lexer_col);
 	mw_std_stack_Stack_STACK_5F_NIL();
-	mw_mirth_lexer__2B_Lexer__2B_LEXER();
+	LPUSH(lbl_lexer_stack);
 	mw_mirth_token_Token_alloc_none_21_();
+	mw_std_prim_prim_dup();
+	LPUSH(lbl_lexer_last_token);
+	mw_mirth_lexer__2B_Lexer_LEXER();
 	while(1) {
 		mw_mirth_lexer_lexer_done_3F_();
 		mw_std_prim_Bool_not();
@@ -25502,16 +25626,21 @@ static void mw_mirth_lexer_run_lexer_21_ (void) {
 	}
 	mw_mirth_token_TokenValue_TOKEN_5F_NONE();
 	mw_mirth_lexer_lexer_emit_21_();
-	mw_mirth_lexer__LEXER();
+	mw_mirth_lexer__2B_Lexer__2F_LEXER();
 	mw_posix_input_input_end_21_();
 	mw_posix_file__2B_File_close_file_21_();
+	LPOP(lbl_lexer_stack);
 	mw_std_stack_Stack_uncons();
 	mw_std_prim_prim_drop();
 	push_u64(0);
-	push_fnptr(&mb_mirth_lexer_run_lexer_21__28);
+	push_fnptr(&mb_mirth_lexer_run_lexer_21__35);
 	mw_std_prim_prim_pack_cons();
 	mw_std_maybe_Maybe_for();
-	mw_std_prelude_drop2();
+	LPOP(lbl_lexer_row);
+	LPOP(lbl_lexer_col);
+	LPOP(lbl_lexer_last_token);
+	mw_std_prelude_drop3();
+	LPOP(lbl_lexer_module);
 	mw_mirth_token_Token_alloc_none_21_();
 	mw_std_prelude_over();
 	mw_mirth_module_Module__7E_end();
@@ -25523,31 +25652,29 @@ static void mw_mirth_lexer_run_lexer_21_ (void) {
 	mw_std_prim_prim_mut_set();
 }
 static void mw_mirth_lexer_lexer_done_3F_ (void) {
-	mw_mirth_lexer__LEXER();
+	mw_mirth_lexer__2B_Lexer__2F_LEXER();
 	mw_posix_input_input_done_3F_();
-	{
-		VAL d2 = pop_value();
-		mw_mirth_lexer__2B_Lexer__2B_LEXER();
-		push_value(d2);
-	}
+	mw_mirth_lexer__2B_Lexer_LEXER();
 }
 static void mw_mirth_lexer_lexer_make_21_ (void) {
 	mw_mirth_token_Token_alloc_21_();
 	mw_std_prelude_tuck();
 	mw_mirth_token_Token__7E_value();
 	mw_std_prim_prim_mut_set();
-	mw_mirth_lexer_lexer_module_40_();
+	mw_mirth_lexer__2B_Lexer_lexer_module();
 	mw_std_prelude_over();
 	mw_mirth_token_Token__7E_module();
 	mw_std_prim_prim_mut_set();
-	mw_mirth_lexer_lexer_row_40_();
+	mw_mirth_lexer__2B_Lexer_lexer_row();
 	mw_std_prelude_over();
 	mw_mirth_token_Token__7E_row();
 	mw_std_prim_prim_mut_set();
-	mw_mirth_lexer_lexer_col_40_();
+	mw_mirth_lexer__2B_Lexer_lexer_col();
 	mw_std_prelude_over();
 	mw_mirth_token_Token__7E_col();
 	mw_std_prim_prim_mut_set();
+	mw_std_prim_prim_dup();
+	mw_mirth_lexer__2B_Lexer_lexer_last_token_21_();
 }
 static void mw_mirth_lexer_lexer_emit_21_ (void) {
 	mw_mirth_lexer_lexer_make_21_();
@@ -25584,48 +25711,63 @@ static void mw_mirth_lexer_lexer_next_21_ (void) {
 			break;
 		case 44LL:
 			mp_std_byte_Byte_BCOMMA();
+			mw_mirth_lexer_lexer_close_colons_21_();
 			mw_mirth_token_TokenValue_TOKEN_5F_COMMA();
 			mw_mirth_lexer_lexer_emit_21_();
 			mw_mirth_lexer_lexer_move_21_();
 			break;
-		case 40LL:
-			mp_std_byte_Byte_BLPAREN();
-			mw_mirth_lexer_lexer_emit_lparen_21_();
-			mw_mirth_lexer_lexer_move_21_();
-			break;
 		case 41LL:
 			mp_std_byte_Byte_BRPAREN();
+			mw_mirth_lexer_lexer_close_colons_21_();
 			mw_mirth_lexer_lexer_emit_rparen_21_();
-			mw_mirth_lexer_lexer_move_21_();
-			break;
-		case 91LL:
-			mp_std_byte_Byte_BLSQUARE();
-			mw_mirth_lexer_lexer_emit_lsquare_21_();
 			mw_mirth_lexer_lexer_move_21_();
 			break;
 		case 93LL:
 			mp_std_byte_Byte_BRSQUARE();
+			mw_mirth_lexer_lexer_close_colons_21_();
 			mw_mirth_lexer_lexer_emit_rsquare_21_();
-			mw_mirth_lexer_lexer_move_21_();
-			break;
-		case 123LL:
-			mp_std_byte_Byte_BLCURLY();
-			mw_mirth_lexer_lexer_emit_lcurly_21_();
 			mw_mirth_lexer_lexer_move_21_();
 			break;
 		case 125LL:
 			mp_std_byte_Byte_BRCURLY();
+			mw_mirth_lexer_lexer_close_colons_21_();
 			mw_mirth_lexer_lexer_emit_rcurly_21_();
+			mw_mirth_lexer_lexer_move_21_();
+			break;
+		case 58LL:
+			mp_std_byte_Byte_BCOLON();
+			mw_mirth_lexer_lexer_prepare_for_args_21_();
+			mw_mirth_lexer_lexer_emit_lcolon_21_();
+			mw_mirth_lexer_lexer_move_21_();
+			break;
+		case 40LL:
+			mp_std_byte_Byte_BLPAREN();
+			mw_mirth_lexer_lexer_prepare_for_args_21_();
+			mw_mirth_lexer_lexer_emit_lparen_21_();
+			mw_mirth_lexer_lexer_move_21_();
+			break;
+		case 91LL:
+			mp_std_byte_Byte_BLSQUARE();
+			mw_mirth_lexer_lexer_prepare_for_atom_21_();
+			mw_mirth_lexer_lexer_emit_lsquare_21_();
+			mw_mirth_lexer_lexer_move_21_();
+			break;
+		case 123LL:
+			mp_std_byte_Byte_BLCURLY();
+			mw_mirth_lexer_lexer_prepare_for_atom_21_();
+			mw_mirth_lexer_lexer_emit_lcurly_21_();
 			mw_mirth_lexer_lexer_move_21_();
 			break;
 		case 34LL:
 			mp_std_byte_Byte_BQUOTE();
+			mw_mirth_lexer_lexer_prepare_for_atom_21_();
 			mw_mirth_lexer_lexer_emit_string_21_();
 			mw_mirth_lexer_lexer_move_21_();
 			break;
 		default:
 			mw_std_byte_Byte_is_name_byte();
 			if (pop_u64()) {
+				mw_mirth_lexer_lexer_prepare_for_atom_21_();
 				mw_mirth_lexer_lexer_emit_name_21_();
 			} else {
 				{
@@ -25644,14 +25786,44 @@ static void mw_mirth_lexer_lexer_next_21_ (void) {
 	}
 }
 static void mw_mirth_lexer_lexer_newline_21_ (void) {
-	mw_mirth_lexer_lexer_row_40_();
+	mw_mirth_lexer__2B_Lexer_lexer_row_40_();
 	mw_mirth_location_Row__3E_Int();
 	mw_std_prelude_prim_int_succ();
 	mw_std_prim_Int__3E_Row();
-	mw_mirth_lexer_lexer_row_21_();
+	mw_mirth_lexer__2B_Lexer_lexer_row_21_();
 	push_i64(0LL);
 	mw_std_prim_Int__3E_Col();
-	mw_mirth_lexer_lexer_col_21_();
+	mw_mirth_lexer__2B_Lexer_lexer_col_21_();
+}
+static void mw_mirth_lexer_lexer_emit_lcolon_21_ (void) {
+	mw_mirth_token_TokenValue_TOKEN_5F_LCOLON_5F_OPEN();
+	mw_mirth_lexer_lexer_make_21_();
+	mw_mirth_lexer_lexer_stack_push_21_();
+}
+static void mw_mirth_lexer_lexer_close_colons_21_ (void) {
+	push_u64(0);
+	push_fnptr(&mb_mirth_lexer_lexer_close_colons_21__2);
+	mw_std_prim_prim_pack_cons();
+	push_u64(0);
+	push_fnptr(&mb_mirth_lexer_lexer_close_colons_21__9);
+	mw_std_prim_prim_pack_cons();
+	mw_std_maybe_while_some();
+}
+static void mw_mirth_lexer_lexer_prepare_for_atom_21_ (void) {
+	mw_mirth_lexer__2B_Lexer_lexer_last_token();
+	mw_mirth_token_Token_lcolon_open_3F_();
+	push_u64(0);
+	push_fnptr(&mb_mirth_lexer_lexer_prepare_for_atom_21__4);
+	mw_std_prim_prim_pack_cons();
+	mw_std_prim_Bool_else();
+}
+static void mw_mirth_lexer_lexer_prepare_for_args_21_ (void) {
+	mw_mirth_lexer__2B_Lexer_lexer_last_token();
+	mw_mirth_token_Token_name_or_dname_3F_();
+	push_u64(0);
+	push_fnptr(&mb_mirth_lexer_lexer_prepare_for_args_21__4);
+	mw_std_prim_prim_pack_cons();
+	mw_std_maybe_Maybe_else();
 }
 static void mw_mirth_lexer_lexer_emit_lparen_21_ (void) {
 	mw_mirth_token_TokenValue_TOKEN_5F_LPAREN_5F_OPEN();
@@ -25822,17 +25994,13 @@ static void mw_mirth_lexer_lexer_emit_name_21_ (void) {
 		mw_std_prim_Str_thaw();
 		push_resource(d2);
 	}
-	mw_mirth_lexer_lexer_module_40_();
-	mw_mirth_lexer_lexer_row_40_();
-	mw_mirth_lexer_lexer_col_40_();
+	mw_mirth_lexer__2B_Lexer_lexer_module_40_();
+	mw_mirth_lexer__2B_Lexer_lexer_row_40_();
+	mw_mirth_lexer__2B_Lexer_lexer_col_40_();
 	mw_mirth_lexer_lexer_peek();
 	while(1) {
 		mw_std_prim_prim_dup();
 		mw_std_byte_Byte_is_name_byte();
-		push_u64(0);
-		push_fnptr(&mb_mirth_lexer_lexer_emit_name_21__15);
-		mw_std_prim_prim_pack_cons();
-		mw_std_prim_Bool_and();
 		if (! pop_u64()) break;
 		{
 			VAL d3 = pop_resource();
@@ -25896,8 +26064,10 @@ static void mw_mirth_lexer_lexer_emit_name_21_ (void) {
 		mw_std_prelude_tuck();
 		mw_mirth_token_Token__7E_row();
 		mw_std_prim_prim_mut_set();
+		mw_std_prelude_tuck();
 		mw_mirth_token_Token__7E_module();
 		mw_std_prim_prim_mut_set();
+		mw_mirth_lexer__2B_Lexer_lexer_last_token_21_();
 	}
 	{
 		VAL d2 = pop_resource();
@@ -25910,6 +26080,15 @@ static void mw_mirth_lexer_str_buf_name_3F_ (void) {
 	mw_std_str_str_buf_dup_21_();
 	mw_std_prim_Str__3E_Name();
 }
+static void mw_mirth_lexer_str_buf_drop_last_byte (void) {
+	{
+		VAL d2 = pop_resource();
+		mw_std_str_str_buf_num_bytes_3F_();
+		push_resource(d2);
+	}
+	mw_std_prelude_Size_1_();
+	mw_std_str_str_buf_take_slice();
+}
 static void mw_mirth_lexer_str_buf_label_token_3F_ (void) {
 	push_i64(0LL);
 	mw_std_prim_Int__3E_Offset();
@@ -25918,25 +26097,10 @@ static void mw_mirth_lexer_str_buf_label_token_3F_ (void) {
 	if (pop_u64()) {
 		mw_std_str_str_buf_last_byte();
 		switch (get_top_data_tag()) {
-			case 58LL:
-				mp_std_byte_Byte_BCOLON();
-				mw_std_str_str_buf_num_bytes_3F_();
-				mw_std_prelude_Size_1_();
-				push_u64(0);
-				push_fnptr(&mb_mirth_lexer_str_buf_label_token_3F__15);
-				mw_std_prim_prim_pack_cons();
-				mw_std_prelude_unsafe();
-				mw_std_prim_Str__3E_Name();
-				mw_mirth_label_Label_new_21_();
-				mw_mirth_token_TokenValue_TOKEN_5F_LABEL();
-				mw_std_maybe_Maybe_SOME();
-				break;
 			case 62LL:
 				mp_std_byte_Byte_B_27__3E__27_();
-				mw_std_str_str_buf_num_bytes_3F_();
-				mw_std_prelude_Size_1_();
 				push_u64(0);
-				push_fnptr(&mb_mirth_lexer_str_buf_label_token_3F__28);
+				push_fnptr(&mb_mirth_lexer_str_buf_label_token_3F__13);
 				mw_std_prim_prim_pack_cons();
 				mw_std_prelude_unsafe();
 				mw_std_prim_Str__3E_Name();
@@ -25956,14 +26120,14 @@ static void mw_mirth_lexer_str_buf_label_token_3F_ (void) {
 		mw_std_byte_Byte_B_27__3E__27_();
 		mw_std_byte_Byte__3D__3D_();
 		push_u64(0);
-		push_fnptr(&mb_mirth_lexer_str_buf_label_token_3F__48);
+		push_fnptr(&mb_mirth_lexer_str_buf_label_token_3F__33);
 		mw_std_prim_prim_pack_cons();
 		mw_std_prim_Bool_and();
 		if (pop_u64()) {
 			push_i64(1LL);
 			mw_std_prim_Int__3E_Offset();
 			push_u64(0);
-			push_fnptr(&mb_mirth_lexer_str_buf_label_token_3F__59);
+			push_fnptr(&mb_mirth_lexer_str_buf_label_token_3F__44);
 			mw_std_prim_prim_pack_cons();
 			mw_std_prelude_unsafe();
 			mw_std_prim_Str__3E_Name();
@@ -26462,28 +26626,24 @@ static void mw_mirth_lexer_lexer_comment_end_3F_ (void) {
 	}
 }
 static void mw_mirth_lexer_lexer_peek (void) {
-	mw_mirth_lexer__LEXER();
+	mw_mirth_lexer__2B_Lexer__2F_LEXER();
 	mw_posix_input_input_peek();
-	{
-		VAL d2 = pop_value();
-		mw_mirth_lexer__2B_Lexer__2B_LEXER();
-		push_value(d2);
-	}
+	mw_mirth_lexer__2B_Lexer_LEXER();
 }
 static void mw_mirth_lexer_lexer_move_21_ (void) {
-	mw_mirth_lexer__LEXER();
+	mw_mirth_lexer__2B_Lexer__2F_LEXER();
 	mw_posix_input_input_move_21_();
-	mw_mirth_lexer__2B_Lexer__2B_LEXER();
-	mw_mirth_lexer_lexer_col_40_();
+	mw_mirth_lexer__2B_Lexer_LEXER();
+	mw_mirth_lexer__2B_Lexer_lexer_col_40_();
 	mw_mirth_location_Col__3E_Int();
 	mw_std_prelude_prim_int_succ();
 	mw_std_prim_Int__3E_Col();
-	mw_mirth_lexer_lexer_col_21_();
+	mw_mirth_lexer__2B_Lexer_lexer_col_21_();
 }
 static void mw_mirth_lexer_lexer_location (void) {
-	mw_mirth_lexer_lexer_module_40_();
-	mw_mirth_lexer_lexer_row_40_();
-	mw_mirth_lexer_lexer_col_40_();
+	mw_mirth_lexer__2B_Lexer_lexer_module_40_();
+	mw_mirth_lexer__2B_Lexer_lexer_row_40_();
+	mw_mirth_lexer__2B_Lexer_lexer_col_40_();
 	mw_mirth_location_Location_LOCATION();
 }
 static void mw_mirth_lexer_lexer_emit_warning_21_ (void) {
@@ -26725,14 +26885,130 @@ static void mw_mirth_elab_StackTypePart_cons (void) {
 }
 static void mw_mirth_elab_elab_type_atom_21_ (void) {
 	mw_std_prim_prim_dup();
-	mw_mirth_token_Token_label_3F_();
+	mw_mirth_token_Token_could_be_sig_label_3F_();
+	if (pop_u64()) {
+		mw_mirth_elab_elab_stack_label_21_();
+		{
+			VAL d3 = pop_value();
+			mw_mirth_elab_StackTypePart_STPConsLabel();
+			push_value(d3);
+		}
+	} else {
+		mw_std_prim_prim_dup();
+		mw_mirth_token_Token_sig_type_var_3F_();
+		if (pop_u64()) {
+			mw_mirth_elab_elab_type_var_21_();
+			{
+				VAL d4 = pop_value();
+				mw_mirth_type_Type_TVar();
+				mw_mirth_elab_StackTypePart_STPCons();
+				push_value(d4);
+			}
+		} else {
+			mw_std_prim_prim_dup();
+			mw_mirth_token_Token_sig_type_con_3F_();
+			if (pop_u64()) {
+				mw_mirth_elab_elab_type_con_21_();
+				{
+					VAL d5 = pop_value();
+					mw_mirth_elab_StackTypePart_STPCons();
+					push_value(d5);
+				}
+			} else {
+				mw_std_prim_prim_dup();
+				mw_mirth_token_Token_sig_resource_var_3F_();
+				if (pop_u64()) {
+					mw_mirth_elab_elab_resource_var_21_();
+					{
+						VAL d6 = pop_value();
+						mw_mirth_type_Type_TVar();
+						mw_mirth_type_Resource_RESOURCE();
+						mw_mirth_elab_StackTypePart_STPWith();
+						push_value(d6);
+					}
+				} else {
+					mw_std_prim_prim_dup();
+					mw_mirth_token_Token_sig_resource_con_3F_();
+					if (pop_u64()) {
+						mw_mirth_elab_elab_resource_con_21_();
+						{
+							VAL d7 = pop_value();
+							mw_mirth_elab_StackTypePart_STPWith();
+							push_value(d7);
+						}
+					} else {
+						mw_std_prim_prim_dup();
+						mw_mirth_token_Token_pat_underscore_3F_();
+						if (pop_u64()) {
+							mw_mirth_elab_elab_type_dont_care_21_();
+							{
+								VAL d8 = pop_value();
+								mw_mirth_elab_StackTypePart_STPCons();
+								push_value(d8);
+							}
+						} else {
+							mw_std_prim_prim_dup();
+							mw_mirth_token_Token_sig_type_hole_3F_();
+							if (pop_u64()) {
+								mw_mirth_elab_elab_type_hole_21_();
+								{
+									VAL d9 = pop_value();
+									mw_mirth_elab_StackTypePart_STPCons();
+									push_value(d9);
+								}
+							} else {
+								mw_std_prim_prim_dup();
+								mw_mirth_token_Token_lsquare_3F_();
+								push_u64(0);
+								push_fnptr(&mb_mirth_elab_elab_type_atom_21__77);
+								mw_std_prim_prim_pack_cons();
+								push_u64(0);
+								push_fnptr(&mb_mirth_elab_elab_type_atom_21__83);
+								mw_std_prim_prim_pack_cons();
+								mw_std_maybe_Maybe_if();
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+static void mw_mirth_elab_elab_stack_label_21_ (void) {
 	push_u64(0);
-	push_fnptr(&mb_mirth_elab_elab_type_atom_21__4);
+	push_fnptr(&mb_mirth_elab_elab_stack_label_21__2);
 	mw_std_prim_prim_pack_cons();
+	mw_std_prelude_sip();
+	mw_std_prim_prim_swap();
+	switch (get_top_data_tag()) {
+		case 0LL:
+			mp_mirth_elab_StackTypePart_STPCons();
+			mw_std_prim_prim_id();
+			break;
+		default:
+			mw_std_prim_prim_drop();
+			mw_std_prim_prim_dup();
+			mw_mirth_token_Token_args_1();
+			{
+				static bool vready = false;
+				static VAL v;
+				if (! vready) {
+					v = mkstr("Expected type", 13);
+					vready = true;
+				}
+				push_value(v);
+				incref(v);
+			}
+			mw_mirth_token_emit_error_21_();
+			mw_mirth_type_Type_TYPE_5F_ERROR();
+			break;
+	}
+	mw_std_prim_prim_swap();
 	push_u64(0);
-	push_fnptr(&mb_mirth_elab_elab_type_atom_21__36);
+	push_fnptr(&mb_mirth_elab_elab_stack_label_21__25);
 	mw_std_prim_prim_pack_cons();
-	mw_std_maybe_Maybe_if_some();
+	mw_std_prelude_sip();
+	mw_mirth_token_Token_next();
 }
 static void mw_mirth_elab_elab_stack_var_21_ (void) {
 	mw_mirth_type_TYPE_5F_STACK();
@@ -27848,40 +28124,34 @@ static void mw_mirth_elab_elab_arrow_fwd_21_ (void) {
 	mw_mirth_elab_ab_build_21_();
 }
 static void mw_mirth_elab_elab_atoms_21_ (void) {
-	mw_mirth_elab_ab_token_40_();
-	mw_mirth_token_Token_in_lens_like_3F_();
-	if (pop_u64()) {
+	while(1) {
+		mw_mirth_elab_ab_token_40_();
+		mw_mirth_token_Token_run_end_3F_();
+		mw_std_prim_Bool_not();
+		if (! pop_u64()) break;
 		mw_mirth_elab_elab_atom_21_();
-	} else {
-		while(1) {
-			mw_mirth_elab_ab_token_40_();
-			mw_mirth_token_Token_run_end_3F_();
-			mw_std_prim_Bool_not();
-			if (! pop_u64()) break;
-			mw_mirth_elab_elab_atom_21_();
-			mw_mirth_elab_ab_token_40_();
-			mw_mirth_token_Token_next();
-			mw_mirth_elab_ab_token_21_();
-		}
+		mw_mirth_elab_ab_token_40_();
+		mw_mirth_token_Token_next();
+		mw_mirth_elab_ab_token_21_();
 	}
 }
 static void mw_mirth_elab_elab_atom_21_ (void) {
 	mw_mirth_elab_ab_token_40_();
 	mw_mirth_token_Token_value();
 	switch (get_top_data_tag()) {
-		case 13LL:
+		case 16LL:
 			mp_mirth_token_TokenValue_TOKEN_5F_NAME();
 			mw_mirth_elab_elab_atom_name_21_();
 			break;
-		case 14LL:
+		case 17LL:
 			mp_mirth_token_TokenValue_TOKEN_5F_DNAME();
 			mw_mirth_elab_elab_atom_dname_21_();
 			break;
-		case 11LL:
+		case 14LL:
 			mp_mirth_token_TokenValue_TOKEN_5F_INT();
 			mw_mirth_elab_ab_int_21_();
 			break;
-		case 12LL:
+		case 15LL:
 			mp_mirth_token_TokenValue_TOKEN_5F_STR();
 			mw_mirth_elab_ab_str_21_();
 			break;
@@ -27895,11 +28165,11 @@ static void mw_mirth_elab_elab_atom_21_ (void) {
 			mw_std_prim_prim_drop();
 			mw_mirth_elab_elab_atom_assert_21_();
 			break;
-		case 16LL:
+		case 18LL:
 			mp_mirth_token_TokenValue_TOKEN_5F_LABEL_5F_PUSH();
 			mw_mirth_elab_ab_label_push_21_();
 			break;
-		case 17LL:
+		case 19LL:
 			mp_mirth_token_TokenValue_TOKEN_5F_LABEL_5F_POP();
 			mw_mirth_elab_ab_label_pop_21_();
 			break;
@@ -34660,21 +34930,21 @@ static void mb_mirth_module_Module_prim_3 (void) {
 	mw_mirth_module_Module__7E_name();
 	mw_std_prim_prim_mut_set();
 }
-static void mb_mirth_token_Token_args_11 (void) {
+static void mb_mirth_token_Token_args_7 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prim_prim_dup();
 	mw_mirth_token_Token_args_end_3F_();
 	mw_std_prim_Bool_not();
 }
-static void mb_mirth_token_Token_args_15 (void) {
+static void mb_mirth_token_Token_args_11 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_token_Token_succ();
 	push_u64(0);
-	push_fnptr(&mb_mirth_token_Token_args_18);
+	push_fnptr(&mb_mirth_token_Token_args_14);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prelude_sip();
 }
-static void mb_mirth_token_Token_args_18 (void) {
+static void mb_mirth_token_Token_args_14 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_token_Token_next_arg_end();
 }
@@ -35061,7 +35331,7 @@ static void mb_std_prim_Str__3E_Name_28 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_name_Name_mangle_compute_21_();
 }
-static void mb_mirth_lexer_run_lexer_21__28 (void) {
+static void mb_mirth_lexer_run_lexer_21__35 (void) {
 	mw_std_prim_prim_drop();
 	{
 		static bool vready = false;
@@ -35475,10 +35745,6 @@ static void mb_std_prelude_Size__3C__3D__2 (void) {
 static void mb_std_prelude_Offset__3C__3D__2 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prelude_Offset__3E_Int();
-}
-static void mb_std_byte_Byte__3C__3E__2 (void) {
-	mw_std_prim_prim_drop();
-	mw_std_byte_Byte__3E_Int();
 }
 static void mb_std_byte_Byte_in_range_4 (void) {
 	mw_std_prim_prim_drop();
@@ -36347,12 +36613,12 @@ static void mb_std_prim_Str_hash_4 (void) {
 	mw_std_prim_prim_int_shr();
 	mw_std_prim_prim_int_xor();
 }
-static void mb_mirth_token_Token_next_34 (void) {
+static void mb_mirth_token_Token_next_32 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prelude_nip();
 	mw_mirth_token_Token_succ();
 }
-static void mb_mirth_token_Token_next_46 (void) {
+static void mb_mirth_token_Token_next_44 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prelude_nip();
 	mw_mirth_token_Token_succ();
@@ -36497,7 +36763,15 @@ static void mb_mirth_token_TokenValue_module_header_3F__3 (void) {
 	}
 	mw_std_prim_Str__3D__3D_();
 }
-static void mb_mirth_token_Token_has_args_3F__11 (void) {
+static void mb_mirth_token_Token_prev_21 (void) {
+	mw_std_prim_prim_drop();
+	mw_mirth_token_Token_pred();
+}
+static void mb_mirth_token_Token_prev_32 (void) {
+	mw_std_prim_prim_drop();
+	mw_mirth_token_Token_pred();
+}
+static void mb_mirth_token_Token_has_args_3F__4 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_token_Token_succ();
 }
@@ -36505,12 +36779,27 @@ static void mb_mirth_token_Token_args_start_4 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prim_prim_dup();
 	mw_mirth_token_Token_succ();
-	mw_mirth_token_Token_lparen_3F_();
-	mw_std_maybe_Maybe_some_3F_();
+	mw_mirth_token_Token_lparen_or_lcolon_3F_();
+	mw_std_maybe_Maybe__3E_Bool();
 }
 static void mb_mirth_token_Token_args_start_11 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_token_Token_succ();
+}
+static void mb_mirth_token_Token_could_be_sig_label_3F__4 (void) {
+	mw_std_prim_prim_drop();
+	mw_mirth_name_Name_could_be_label_name_3F_();
+}
+static void mb_mirth_token_Token_could_be_sig_label_3F__6 (void) {
+	mw_std_prim_prim_drop();
+	mw_std_prim_F();
+}
+static void mb_mirth_token_Token_could_be_sig_label_3F__10 (void) {
+	mw_std_prim_prim_drop();
+	mw_std_prim_prim_dup();
+	mw_mirth_token_Token_succ();
+	mw_mirth_token_Token_lcolon_3F_();
+	mw_std_maybe_Maybe__3E_Bool();
 }
 static void mb_mirth_token_Token_args_end_3F__4 (void) {
 	mw_std_prim_prim_drop();
@@ -36538,20 +36827,20 @@ static void mb_mirth_error_emit_error_at_21__10 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prelude_prim_int_succ();
 }
-static void mb_mirth_token_Token_run_tokens_8 (void) {
+static void mb_mirth_token_Token_run_tokens_2 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prim_prim_dup();
 	mw_mirth_token_Token_run_end_3F_();
 	mw_std_prim_Bool_not();
 }
-static void mb_mirth_token_Token_run_tokens_12 (void) {
+static void mb_mirth_token_Token_run_tokens_6 (void) {
 	mw_std_prim_prim_drop();
 	push_u64(0);
-	push_fnptr(&mb_mirth_token_Token_run_tokens_14);
+	push_fnptr(&mb_mirth_token_Token_run_tokens_8);
 	mw_std_prim_prim_pack_cons();
 	mw_std_prelude_sip();
 }
-static void mb_mirth_token_Token_run_tokens_14 (void) {
+static void mb_mirth_token_Token_run_tokens_8 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_token_Token_next();
 }
@@ -36985,15 +37274,26 @@ static void mb_mirth_data_Tag_label_inputs_from_sig_3 (void) {
 	push_u64(0);
 	push_fnptr(&mb_mirth_data_Tag_label_inputs_from_sig_6);
 	mw_std_prim_prim_pack_cons();
-	mw_std_list_List_filter_some();
+	mw_std_list_List_filter();
+	push_u64(0);
+	push_fnptr(&mb_mirth_data_Tag_label_inputs_from_sig_11);
+	mw_std_prim_prim_pack_cons();
+	mw_std_list_List_map();
 }
-static void mb_mirth_data_Tag_label_inputs_from_sig_9 (void) {
+static void mb_mirth_data_Tag_label_inputs_from_sig_16 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_list_List_L0();
 }
 static void mb_mirth_data_Tag_label_inputs_from_sig_6 (void) {
 	mw_std_prim_prim_drop();
-	mw_mirth_token_Token_label_3F_();
+	mw_std_prim_prim_dup();
+	mw_mirth_token_Token_could_be_sig_label_3F_();
+}
+static void mb_mirth_data_Tag_label_inputs_from_sig_11 (void) {
+	mw_std_prim_prim_drop();
+	mw_mirth_token_Token_name_3F_();
+	mw_std_maybe_Maybe_unwrap();
+	mw_mirth_label_Label_new_21_();
 }
 static void mb_mirth_data_Tag_num_type_inputs_from_sig_4 (void) {
 	mw_std_prim_prim_drop();
@@ -37165,15 +37465,37 @@ static void mb_mirth_lexer_lexer_skip_comment_21__12 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_lexer_lexer_newline_21_();
 }
-static void mb_mirth_lexer_lexer_emit_name_21__15 (void) {
+static void mb_mirth_lexer_lexer_close_colons_21__2 (void) {
 	mw_std_prim_prim_drop();
-	{
-		VAL d2 = pop_resource();
-		mw_std_str_str_buf_last_byte();
-		push_resource(d2);
-	}
-	mw_std_byte_Byte_BCOLON();
-	mw_std_byte_Byte__3C__3E_();
+	mw_mirth_lexer_lexer_stack_peek();
+	push_u64(0);
+	push_fnptr(&mb_mirth_lexer_lexer_close_colons_21__5);
+	mw_std_prim_prim_pack_cons();
+	mw_std_maybe_Maybe_guard();
+}
+static void mb_mirth_lexer_lexer_close_colons_21__9 (void) {
+	mw_std_prim_prim_drop();
+	mw_mirth_lexer_lexer_stack_drop();
+	mw_std_prim_prim_dup();
+	mw_mirth_token_TokenValue_TOKEN_5F_RCOLON();
+	mw_mirth_lexer_lexer_make_21_();
+	mw_mirth_token_TokenValue_TOKEN_5F_LCOLON();
+	mw_std_prim_prim_swap();
+	mw_mirth_token_Token__7E_value();
+	mw_std_prim_prim_mut_set();
+}
+static void mb_mirth_lexer_lexer_close_colons_21__5 (void) {
+	mw_std_prim_prim_drop();
+	mw_std_prim_prim_dup();
+	mw_mirth_token_Token_lcolon_open_3F_();
+}
+static void mb_mirth_lexer_lexer_prepare_for_args_21__4 (void) {
+	mw_std_prim_prim_drop();
+	mw_mirth_lexer_lexer_close_colons_21_();
+}
+static void mb_mirth_lexer_lexer_prepare_for_atom_21__4 (void) {
+	mw_std_prim_prim_drop();
+	mw_mirth_lexer_lexer_close_colons_21_();
 }
 static void mb_mirth_lexer_str_buf_is_int_3F__3 (void) {
 	mw_std_prim_prim_drop();
@@ -37187,22 +37509,18 @@ static void mb_mirth_lexer_str_buf_dname_3F__28 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prim_Str__3E_Name();
 }
-static void mb_mirth_lexer_str_buf_label_token_3F__15 (void) {
+static void mb_mirth_lexer_str_buf_label_token_3F__13 (void) {
 	mw_std_prim_prim_drop();
-	mw_std_str_str_buf_take_slice();
+	mw_mirth_lexer_str_buf_drop_last_byte();
 }
-static void mb_mirth_lexer_str_buf_label_token_3F__28 (void) {
-	mw_std_prim_prim_drop();
-	mw_std_str_str_buf_take_slice();
-}
-static void mb_mirth_lexer_str_buf_label_token_3F__48 (void) {
+static void mb_mirth_lexer_str_buf_label_token_3F__33 (void) {
 	mw_std_prim_prim_drop();
 	push_i64(1LL);
 	mw_std_prim_Int__3E_Offset();
 	mw_std_str_str_buf_byte_40_();
 	mw_std_byte_Byte_is_lower();
 }
-static void mb_mirth_lexer_str_buf_label_token_3F__59 (void) {
+static void mb_mirth_lexer_str_buf_label_token_3F__44 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_str_str_buf_drop_slice();
 }
@@ -37314,133 +37632,7 @@ static void mb_mirth_elab_elab_type_sig_params_21__13 (void) {
 		push_value(d2);
 	}
 }
-static void mb_mirth_elab_elab_type_atom_21__4 (void) {
-	mw_std_prim_prim_drop();
-	{
-		VAL d2 = pop_value();
-		mw_mirth_token_Token_succ();
-		mw_std_prim_prim_dup();
-		{
-			VAL d3 = pop_value();
-			mw_mirth_elab_elab_type_atom_21_();
-			push_value(d3);
-		}
-		push_value(d2);
-	}
-	mw_std_prelude_rot4l();
-	switch (get_top_data_tag()) {
-		case 0LL:
-			mp_mirth_elab_StackTypePart_STPCons();
-			mw_std_prim_prim_swap();
-			mw_mirth_elab_StackTypePart_STPConsLabel();
-			mw_std_prelude_nip();
-			mw_std_prim_prim_swap();
-			break;
-		default:
-			mw_std_prim_prim_drop();
-			{
-				VAL d4 = pop_value();
-				{
-					static bool vready = false;
-					static VAL v;
-					if (! vready) {
-						v = mkstr("Expected type", 13);
-						vready = true;
-					}
-					push_value(v);
-					incref(v);
-				}
-				mw_mirth_token_emit_error_21_();
-				mw_mirth_type_Type_TYPE_5F_ERROR();
-				push_value(d4);
-			}
-			mw_mirth_elab_StackTypePart_STPConsLabel();
-			mw_std_prim_prim_swap();
-			break;
-	}
-}
-static void mb_mirth_elab_elab_type_atom_21__36 (void) {
-	mw_std_prim_prim_drop();
-	mw_std_prim_prim_dup();
-	mw_mirth_token_Token_sig_type_var_3F_();
-	if (pop_u64()) {
-		mw_mirth_elab_elab_type_var_21_();
-		{
-			VAL d3 = pop_value();
-			mw_mirth_type_Type_TVar();
-			mw_mirth_elab_StackTypePart_STPCons();
-			push_value(d3);
-		}
-	} else {
-		mw_std_prim_prim_dup();
-		mw_mirth_token_Token_sig_type_con_3F_();
-		if (pop_u64()) {
-			mw_mirth_elab_elab_type_con_21_();
-			{
-				VAL d4 = pop_value();
-				mw_mirth_elab_StackTypePart_STPCons();
-				push_value(d4);
-			}
-		} else {
-			mw_std_prim_prim_dup();
-			mw_mirth_token_Token_sig_resource_var_3F_();
-			if (pop_u64()) {
-				mw_mirth_elab_elab_resource_var_21_();
-				{
-					VAL d5 = pop_value();
-					mw_mirth_type_Type_TVar();
-					mw_mirth_type_Resource_RESOURCE();
-					mw_mirth_elab_StackTypePart_STPWith();
-					push_value(d5);
-				}
-			} else {
-				mw_std_prim_prim_dup();
-				mw_mirth_token_Token_sig_resource_con_3F_();
-				if (pop_u64()) {
-					mw_mirth_elab_elab_resource_con_21_();
-					{
-						VAL d6 = pop_value();
-						mw_mirth_elab_StackTypePart_STPWith();
-						push_value(d6);
-					}
-				} else {
-					mw_std_prim_prim_dup();
-					mw_mirth_token_Token_pat_underscore_3F_();
-					if (pop_u64()) {
-						mw_mirth_elab_elab_type_dont_care_21_();
-						{
-							VAL d7 = pop_value();
-							mw_mirth_elab_StackTypePart_STPCons();
-							push_value(d7);
-						}
-					} else {
-						mw_std_prim_prim_dup();
-						mw_mirth_token_Token_sig_type_hole_3F_();
-						if (pop_u64()) {
-							mw_mirth_elab_elab_type_hole_21_();
-							{
-								VAL d8 = pop_value();
-								mw_mirth_elab_StackTypePart_STPCons();
-								push_value(d8);
-							}
-						} else {
-							mw_std_prim_prim_dup();
-							mw_mirth_token_Token_lsquare_3F_();
-							push_u64(0);
-							push_fnptr(&mb_mirth_elab_elab_type_atom_21__103);
-							mw_std_prim_prim_pack_cons();
-							push_u64(0);
-							push_fnptr(&mb_mirth_elab_elab_type_atom_21__109);
-							mw_std_prim_prim_pack_cons();
-							mw_std_maybe_Maybe_if();
-						}
-					}
-				}
-			}
-		}
-	}
-}
-static void mb_mirth_elab_elab_type_atom_21__103 (void) {
+static void mb_mirth_elab_elab_type_atom_21__77 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_elab_elab_type_quote_21_();
 	{
@@ -37449,7 +37641,7 @@ static void mb_mirth_elab_elab_type_atom_21__103 (void) {
 		push_value(d2);
 	}
 }
-static void mb_mirth_elab_elab_type_atom_21__109 (void) {
+static void mb_mirth_elab_elab_type_atom_21__83 (void) {
 	mw_std_prim_prim_drop();
 	mw_std_prim_prim_dup();
 	{
@@ -37484,6 +37676,18 @@ static void mb_mirth_elab_elab_type_arg_21__25 (void) {
 		incref(v);
 	}
 	mw_mirth_token_emit_fatal_error_21_();
+}
+static void mb_mirth_elab_elab_stack_label_21__2 (void) {
+	mw_std_prim_prim_drop();
+	mw_mirth_token_Token_args_1();
+	mw_mirth_elab_elab_type_atom_21_();
+	mw_std_prim_prim_drop();
+}
+static void mb_mirth_elab_elab_stack_label_21__25 (void) {
+	mw_std_prim_prim_drop();
+	mw_mirth_token_Token_name_3F_();
+	mw_std_maybe_Maybe_unwrap();
+	mw_mirth_label_Label_new_21_();
 }
 static void mb_mirth_elab_elab_type_con_21__22 (void) {
 	mw_std_prim_prim_drop();

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -uo pipefail
+make bin/mirth2 && bin/mirth2 -p std:src/std -p posix:src/posix -p mirth:src/mirth -p args:src/args -p snake:src/snake -p mirth-tests:src/mirth-tests --debug -o bin/test.c $1 && gcc -o bin/test bin/test.c && bin/test

--- a/src/mirth-tests/lens-syntax.mth
+++ b/src/mirth-tests/lens-syntax.mth
@@ -1,0 +1,39 @@
+module(mirth-tests.lens-syntax)
+import(std.prelude)
+import(posix.posix)
+
+data(Foo, FOO -> bar:Int)
+data(Boom, BOOM -> foo:Foo)
+
+def(Foo.bar:f, (*a Int -- *b Int) *a Foo -- *b Foo, dup dip(bar f) bar!)
+def(Boom.foo:f, (*a Foo -- *b Foo) *a Boom -- *b Boom, dup dip(foo f) foo!)
+def(Foo.print, Foo +World -- Foo +World, dup bar print! " FOO" print!)
+def(Boom.print, Boom +World -- Boom +World, .foo:print " BOOM" print!)
+def(+World.line, +World -- +World, "\n" print!)
+
+def(main, +World -- +World,
+    10 >bar FOO print line
+    .bar:(1+) print line
+    1 dip(.bar:1+) drop print line
+    .bar:1+ print line
+    Foo.bar:30 print line
+    Foo.bar:drop print line
+    >foo BOOM print line
+    .foo:print " . " print! print line
+    .foo:.bar:1+ print line
+    .foo:.bar:1+ print line
+    .foo:.bar:99 print line
+    .foo:bar! print line
+    drop)
+# mirth-test # pout # 10 FOO
+# mirth-test # pout # 11 FOO
+# mirth-test # pout # 12 FOO
+# mirth-test # pout # 13 FOO
+# mirth-test # pout # 30 FOO
+# mirth-test # pout # 13 FOO
+# mirth-test # pout # 13 FOO BOOM
+# mirth-test # pout # 13 FOO . 13 FOO BOOM
+# mirth-test # pout # 14 FOO BOOM
+# mirth-test # pout # 15 FOO BOOM
+# mirth-test # pout # 99 FOO BOOM
+# mirth-test # pout # 15 FOO BOOM

--- a/src/mirth-tests/lens-syntax.mth
+++ b/src/mirth-tests/lens-syntax.mth
@@ -5,25 +5,25 @@ import(posix.posix)
 data(Foo, FOO -> bar:Int)
 data(Boom, BOOM -> foo:Foo)
 
-def(Foo.bar:f, (*a Int -- *b Int) *a Foo -- *b Foo, dup dip(bar f) bar!)
-def(Boom.foo:f, (*a Foo -- *b Foo) *a Boom -- *b Boom, dup dip(foo f) foo!)
+def(Foo.bar~:f, (*a Int -- *b Int) *a Foo -- *b Foo, dup dip(bar f) bar!)
+def(Boom.foo~:f, (*a Foo -- *b Foo) *a Boom -- *b Boom, dup dip(foo f) foo!)
 def(Foo.print, Foo +World -- Foo +World, dup bar print! " FOO" print!)
-def(Boom.print, Boom +World -- Boom +World, .foo:print " BOOM" print!)
+def(Boom.print, Boom +World -- Boom +World, .foo~:print " BOOM" print!)
 def(+World.line, +World -- +World, "\n" print!)
 
 def(main, +World -- +World,
     10 >bar FOO print line
-    .bar:(1+) print line
-    1 dip(.bar:1+) drop print line
-    .bar:1+ print line
-    Foo.bar:30 print line
-    Foo.bar:drop print line
+    bar~(1+) print line
+    1 dip:bar~:1+ drop print line
+    bar~:1+ print line
+    Foo.bar~:30 print line
+    Foo.bar~:drop print line
     >foo BOOM print line
-    .foo:print " . " print! print line
-    .foo:.bar:1+ print line
-    .foo:.bar:1+ print line
-    .foo:.bar:99 print line
-    .foo:bar! print line
+    foo~:print " . " print! print line
+    foo~:bar~:1+ print line
+    foo~:bar~:1+ print line
+    foo~:bar~:99 print line
+    foo~:bar! print line
     drop)
 # mirth-test # pout # 10 FOO
 # mirth-test # pout # 11 FOO

--- a/src/mirth/data.mth
+++ b/src/mirth/data.mth
@@ -10,6 +10,7 @@ import(mirth.type)
 import(mirth.token)
 import(mirth.name)
 import(mirth.def)
+import(mirth.label)
 
 table(Data)
 field(Data.~head?, Data, Maybe(Token))
@@ -144,7 +145,7 @@ def(Tag.type, Tag -- ArrowType, ctx-type nip)
 def(Tag.untag, Tag -- Maybe(Word), ~untag @)
 
 def(Tag.label-inputs-from-sig, Tag -- List(Label),
-    sig? if-some(run-tokens filter-some(label?), L0))
+    sig? if-some(run-tokens filter(dup could-be-sig-label?) map(name? unwrap Label.new!), L0))
 
 def(Tag.num-type-inputs-from-sig, Tag -- Nat,
     dup sig? if-some(

--- a/src/mirth/data.mth
+++ b/src/mirth/data.mth
@@ -150,7 +150,7 @@ def(Tag.num-type-inputs-from-sig, Tag -- Nat,
     dup sig? if-some(
         run-length
         over num-resource-inputs-from-sig -
-        swap label-inputs-from-sig len 2* -,
+        swap label-inputs-from-sig len -,
         drop 0 >Nat
     ))
 

--- a/src/mirth/elab.mth
+++ b/src/mirth/elab.mth
@@ -475,13 +475,13 @@ def(elab-arrow-fwd!, Ctx StackType Token Home -- Arrow,
     ab-build!(elab-atoms!))
 
 def(elab-atoms!, +AB -- +AB,
-    while(
-        elab-atoms-done? not,
-        elab-atom! ab-token@ next ab-token!
+    ab-token@ in-lens-like? if(
+        elab-atom!,
+        while(
+            ab-token@ run-end? not,
+            elab-atom! ab-token@ next ab-token!
+        )
     ))
-
-def(elab-atoms-done?, +AB -- Bool +AB,
-    ab-token@ run-end?)
 
 def(elab-atom!, +AB -- +AB,
     ab-token@ value match(

--- a/src/mirth/elab.mth
+++ b/src/mirth/elab.mth
@@ -106,11 +106,8 @@ def(StackTypePart.cons, StackType StackTypePart -- StackType,
     STPWith -> STWith)
 
 def(elab-type-atom!, TypeElab Token -- TypeElab StackTypePart Token,
-    dup label? if-some(
-        dip(succ dup dip(elab-type-atom!)) rot4l match(
-            STPCons -> swap STPConsLabel nip swap,
-            _ -> drop dip("Expected type" emit-error! TYPE_ERROR) STPConsLabel swap
-        ),
+    dup could-be-sig-label? if(
+        elab-stack-label! dip(STPConsLabel),
 
     dup sig-type-var? if(
         elab-type-var! dip(TVar STPCons),
@@ -136,6 +133,11 @@ def(elab-type-atom!, TypeElab Token -- TypeElab StackTypePart Token,
         dup "Expected type, got unknown token." emit-error!
         dip(TYPE_ERROR STPCons) next
     )))))))))
+
+def(elab-stack-label!, TypeElab Token -- TypeElab Type Label Token,
+    sip(args-1 elab-type-atom! drop) swap
+    match(STPCons -> id, _ -> drop dup args-1 "Expected type" emit-error! TYPE_ERROR)
+    swap sip(name? unwrap Label.new!) next)
 
 def(elab-stack-var!, TypeElab Token -- TypeElab Var Token,
     TYPE_STACK elab-implicit-var!)
@@ -475,12 +477,9 @@ def(elab-arrow-fwd!, Ctx StackType Token Home -- Arrow,
     ab-build!(elab-atoms!))
 
 def(elab-atoms!, +AB -- +AB,
-    ab-token@ in-lens-like? if(
-        elab-atom!,
-        while(
-            ab-token@ run-end? not,
-            elab-atom! ab-token@ next ab-token!
-        )
+    while(
+        ab-token@ run-end? not,
+        elab-atom! ab-token@ next ab-token!
     ))
 
 def(elab-atom!, +AB -- +AB,

--- a/src/mirth/lexer.mth
+++ b/src/mirth/lexer.mth
@@ -24,51 +24,58 @@ import(mirth.module)
 # LEXER #
 #########
 
-data(+Lexer, +LEXER -> Module Row Col Stack(Token) +Input)
-def(-LEXER, +Lexer -- Module Row Col Stack(Token) +Input, +LEXER -> id)
+data(+Lexer, LEXER ->
+    lexer-module:Module
+    lexer-row:Row
+    lexer-col:Col
+    lexer-stack:Stack(Token)
+    lexer-last-token:Token
+    +Input)
 
-def(lexer-module@, +Lexer -- Module +Lexer, -LEXER over3 dip(+LEXER))
-def(lexer-row@, +Lexer -- Row +Lexer, -LEXER over2 dip(+LEXER))
-def(lexer-col@, +Lexer -- Col +Lexer, -LEXER over dip(+LEXER))
-def(lexer-stack@, +Lexer -- Stack(Token) +Lexer, -LEXER dup dip(+LEXER))
-
-def(lexer-module!, Module +Lexer -- +Lexer, -LEXER rot4l drop +LEXER)
-def(lexer-row!, Row +Lexer -- +Lexer, dip(-LEXER rotl drop) rotr +LEXER)
-def(lexer-col!, Col +Lexer -- +Lexer, dip(-LEXER swap drop) swap +LEXER)
-def(lexer-stack!, Stack(Token) +Lexer -- +Lexer, dip(-LEXER drop) +LEXER)
 def(lexer-stack-push!, Token +Lexer -- +Lexer,
-    dip(-LEXER) swap cons +LEXER)
+    lexer-stack cons lexer-stack!)
 def(lexer-stack-pop!, +Lexer -- Maybe(Token) +Lexer,
-    -LEXER uncons swap dip(+LEXER))
+    lexer-stack uncons lexer-stack!)
+def(lexer-stack-drop, +Lexer -- +Lexer,
+    lexer-stack-pop! drop)
+def(lexer-stack-peek, +Lexer -- Maybe(Token) +Lexer,
+    lexer-stack head)
+
+def-missing(+Lexer.lexer-col@, +Lexer -- +Lexer Col, lexer-col)
+def-missing(+Lexer.lexer-row@, +Lexer -- +Lexer Row, lexer-row)
+def-missing(+Lexer.lexer-module@, +Lexer -- +Lexer Module, lexer-module)
+def-missing(+Lexer.lexer-stack@, +Lexer -- +Lexer Stack(Token), lexer-stack)
+def-missing(+Lexer.lexer-last-token@, +Lexer -- +Lexer Token, lexer-last-token)
 
 def(run-lexer!, Path +World -- Module +World,
-    Module.new! dup source-path open-file! input-start!
-    1 >Row
-    1 >Col
-    STACK_NIL
-    +LEXER
-
-    Token.alloc-none!
+    Module.new! dup >lexer-module
+    source-path open-file! input-start!
+    1 >Row >lexer-row
+    1 >Col >lexer-col
+    STACK_NIL >lexer-stack
+    Token.alloc-none! dup >lexer-last-token
+    LEXER
 
     while(lexer-done? not, lexer-next!)
     TOKEN_NONE lexer-emit!
-    -LEXER input-end! +File.close-file!
-    uncons drop for("Mismatched left parenthesis." emit-fatal-error!) drop2
-
-    Token.alloc-none! over ~end !
+    /LEXER input-end! +File.close-file!
+    lexer-stack> uncons drop for("Mismatched left parenthesis." emit-fatal-error!)
+    lexer-row> lexer-col> lexer-last-token> drop3
+    lexer-module> Token.alloc-none! over ~end !
     swap succ over ~start !)
 
 # Is the lexer done?
-def(lexer-done?, +Lexer -- Bool +Lexer, -LEXER input-done? dip(+LEXER))
+def(lexer-done?, +Lexer -- Bool +Lexer, /LEXER input-done? LEXER)
 
 # Create a token, and add it to the token buffer,
 # returning the new token.
 def(lexer-make!, TokenValue +Lexer -- Token +Lexer,
     Token.alloc!
     tuck ~value !
-    lexer-module@ over ~module !
-    lexer-row@ over ~row !
-    lexer-col@ over ~col !)
+    lexer-module over ~module !
+    lexer-row over ~row !
+    lexer-col over ~col !
+    dup lexer-last-token!)
 
 # Create a token, and add it to the token buffer.
 def(lexer-emit!, TokenValue +Lexer -- +Lexer, lexer-make! drop)
@@ -81,22 +88,39 @@ def(lexer-next!, +Lexer -- +Lexer, lexer-peek match(
     BVT -> lexer-move!,
     BCR -> lexer-move!,
     BHASH -> lexer-skip-comment! lexer-move!,
-    BCOMMA -> TOKEN_COMMA lexer-emit! lexer-move!,
-    BLPAREN -> lexer-emit-lparen! lexer-move!,
-    BRPAREN -> lexer-emit-rparen! lexer-move!,
-    BLSQUARE -> lexer-emit-lsquare! lexer-move!,
-    BRSQUARE -> lexer-emit-rsquare! lexer-move!,
-    BLCURLY -> lexer-emit-lcurly! lexer-move!,
-    BRCURLY -> lexer-emit-rcurly! lexer-move!,
-    BQUOTE -> lexer-emit-string! lexer-move!,
+    BCOMMA -> lexer-close-colons! TOKEN_COMMA lexer-emit! lexer-move!,
+    BRPAREN -> lexer-close-colons! lexer-emit-rparen! lexer-move!,
+    BRSQUARE -> lexer-close-colons! lexer-emit-rsquare! lexer-move!,
+    BRCURLY -> lexer-close-colons! lexer-emit-rcurly! lexer-move!,
+    BCOLON -> lexer-prepare-for-args! lexer-emit-lcolon! lexer-move!,
+    BLPAREN -> lexer-prepare-for-args! lexer-emit-lparen! lexer-move!,
+    BLSQUARE -> lexer-prepare-for-atom! lexer-emit-lsquare! lexer-move!,
+    BLCURLY -> lexer-prepare-for-atom! lexer-emit-lcurly! lexer-move!,
+    BQUOTE -> lexer-prepare-for-atom! lexer-emit-string! lexer-move!,
     _ -> is-name-byte if(
-        lexer-emit-name!,
+        lexer-prepare-for-atom! lexer-emit-name!,
         "Unrecognized byte." lexer-emit-fatal-error!
     )))
 
 def(lexer-newline!, +Lexer -- +Lexer,
     lexer-row@ >Int 1+ >Row lexer-row!
     0 >Col lexer-col!)
+
+def(lexer-emit-lcolon!, +Lexer -- +Lexer,
+    TOKEN_LCOLON_OPEN lexer-make!
+    lexer-stack-push!)
+
+def(lexer-close-colons!, +Lexer -- +Lexer,
+    while-some(
+        lexer-stack-peek guard(dup lcolon-open?),
+        lexer-stack-drop
+        dup TOKEN_RCOLON lexer-make!
+        TOKEN_LCOLON swap ~value !
+    ))
+def(lexer-prepare-for-atom!, +Lexer -- +Lexer,
+    lexer-last-token lcolon-open? else(lexer-close-colons!))
+def(lexer-prepare-for-args!, +Lexer -- +Lexer,
+    lexer-last-token name-or-dname? else(lexer-close-colons!))
 
 def(lexer-emit-lparen!, +Lexer -- +Lexer,
     TOKEN_LPAREN_OPEN lexer-make!
@@ -143,7 +167,7 @@ def(lexer-emit-name!, +Lexer -- +Lexer,
     lexer-row@
     lexer-col@
 
-    lexer-peek while(dup is-name-byte and(rdip(str-buf-last-byte) BCOLON <>),
+    lexer-peek while(dup is-name-byte,
         rdip(str-buf-push-byte-unsafe!)
         lexer-move!
         lexer-peek)
@@ -170,20 +194,22 @@ def(lexer-emit-name!, +Lexer -- +Lexer,
         tuck ~value !
         tuck ~col !
         tuck ~row !
-        ~module !
+        tuck ~module !
+        lexer-last-token!
     )
     rdip(freeze drop))
 
 def(str-buf-name?, +Str -- Name +Str, str-buf-dup! >Name)
 
+def(str-buf-drop-last-byte, +Str +Unsafe -- Str +Str +Unsafe,
+    rdip(str-buf-num-bytes?) 1- str-buf-take-slice)
+
 def(str-buf-label-token?, +Str -- Maybe(TokenValue) +Str,
     0 >Offset str-buf-byte@ is-lower if(
         str-buf-last-byte match(
-            BCOLON -> str-buf-num-bytes? 1- unsafe(str-buf-take-slice) >Name Label.new! TOKEN_LABEL SOME,
-            B'>' -> str-buf-num-bytes? 1- unsafe(str-buf-take-slice) >Name Label.new! TOKEN_LABEL_POP SOME,
+            B'>' -> unsafe(str-buf-drop-last-byte) >Name Label.new! TOKEN_LABEL_POP SOME,
             _ -> drop NONE
         ),
-
         0 >Offset str-buf-byte@ B'>' == and(1 >Offset str-buf-byte@ is-lower) if(
             1 >Offset unsafe(str-buf-drop-slice) >Name Label.new! TOKEN_LABEL_PUSH SOME,
             NONE
@@ -217,7 +243,7 @@ def(str-buf-is-dec-int?, +Str -- Bool +Str,
     dup str-buf-byte@ is-sign if(1+, id)
     while(dup str-buf-byte@ is-digit, dip(1+) 1+)
     swap 0> if(str-buf-num-bytes? >Offset ==, drop F))
-   
+
 def(str-buf-is-hex-int?, +Str -- Bool +Str,
     0 >Size # number of digits
     0 >Offset # current index
@@ -312,7 +338,7 @@ def(str-buf-oct-int?, +Str -- Int +Str,
     str-buf-int-sign 1+ 1+ # skip 0x prefix
     while(dup str-buf-num-bytes? >Offset <,
         sip(
-            str-buf-byte@ >Int 
+            str-buf-byte@ >Int
             dip(8 *) 48 - +
         )
         1+)
@@ -365,8 +391,9 @@ def(lexer-comment-end?, +Lexer -- Bool +Lexer,
         lexer-peek dup BLF == nip
     ))
 
-def(lexer-peek, +Lexer -- Byte +Lexer, -LEXER input-peek dip(+LEXER))
-def(lexer-move!, +Lexer -- +Lexer, -LEXER input-move! +LEXER
+def(lexer-peek, +Lexer -- Byte +Lexer, /LEXER input-peek LEXER)
+def(lexer-move!, +Lexer -- +Lexer,
+    /LEXER input-move! LEXER
     lexer-col@ >Int 1+ >Col lexer-col!)
 
 def(lexer-location, +Lexer -- Location +Lexer,

--- a/src/mirth/name.mth
+++ b/src/mirth/name.mth
@@ -91,6 +91,7 @@ def(Name.tail, Name -- Name,
     ) >Name)
 
 def(Name.can-be-relative?, Name -- Bool, head is-upper not)
+def(Name.could-be-label-name?, Name -- Bool, head is-lower)
 def(Name.could-be-type, Name -- Bool, head is-alpha)
 def(Name.could-be-type-var, Name -- Bool, head is-lower)
 def(Name.could-be-type-con, Name -- Bool, head is-upper)

--- a/src/mirth/name.mth
+++ b/src/mirth/name.mth
@@ -113,14 +113,8 @@ def(Name.mangle-compute!, Name -- Str,
         )
     )))
 
-def(Name.could-be-relative, Name -- Bool,
-    head is-overload-trigger)
-
-def(Name.to-overload-suffix, Name -- Str,
-    dup head is-alpha if(
-        "." swap >Str cat,
-        >Str
-    ))
+def(Name.lens-like?, Name -- Bool,
+    >Str thaw str-buf-last-byte BCOLON == freeze drop)
 
 #############
 # Namespace #
@@ -200,3 +194,4 @@ data(DName, DNAME -> Maybe(Name) List+(Name))
 def(DName/DNAME, DName -- Maybe(Name) List+(Name), DNAME -> id)
 def(DName.root?, DName -- Maybe(Name), DNAME -> drop)
 def(DName.parts, DName -- List+(Name), DNAME -> nip)
+def(DName.lens-like?, DName -- Bool, parts last lens-like?)

--- a/src/mirth/token.mth
+++ b/src/mirth/token.mth
@@ -55,6 +55,11 @@ def(TokenValue.name-or-dname?, TokenValue -- Maybe(Either(Name,DName)),
     TOKEN_NAME -> LEFT SOME,
     TOKEN_DNAME -> RIGHT SOME,
     _ -> drop NONE)
+def(TokenValue.name-or-dname-or-label?, TokenValue -- Bool,
+    TOKEN_NAME -> drop T,
+    TOKEN_DNAME -> drop T,
+    TOKEN_LABEL -> drop T,
+    _ -> drop F)
 def(TokenValue.arg-end?, TokenValue -- Bool,
     TOKEN_COMMA -> T,
     TOKEN_RPAREN -> drop T,
@@ -113,6 +118,7 @@ def(Token.name?, Token -- Maybe(Name), value name?)
 def(Token.dname?, Token -- Maybe(DName), value dname?)
 def(Token.label?, Token -- Maybe(Label), value label?)
 def(Token.name-or-dname?, Token -- Maybe(Either(Name,DName)), value name-or-dname?)
+def(Token.name-or-dname-or-label?, Token -- Bool, value name-or-dname-or-label?)
 def(Token.arg-end?, Token -- Bool, value arg-end?)
 def(Token.left-enclosure?, Token -- Bool, value left-enclosure?)
 def(Token.right-enclosure?, Token -- Bool, value right-enclosure?)
@@ -138,13 +144,16 @@ def(Token.location, Token -- Location,
 
 ||| Get next token, respecting nesting of tokens and arguments.
 def(Token.next, Token -- Token,
-    dup value match(
-        TOKEN_LPAREN -> nip succ,
-        TOKEN_LSQUARE -> nip succ,
-        TOKEN_LCURLY -> nip succ,
-        TOKEN_NAME -> drop succ dup lparen? for(nip succ),
-        TOKEN_DNAME -> drop succ dup lparen? for(nip succ),
-        _ -> drop succ
+    dup lens-like? if(
+        succ next,
+        dup value match(
+            TOKEN_LPAREN -> nip succ,
+            TOKEN_LSQUARE -> nip succ,
+            TOKEN_LCURLY -> nip succ,
+            TOKEN_NAME -> drop succ dup lparen? for(nip succ),
+            TOKEN_DNAME -> drop succ dup lparen? for(nip succ),
+            _ -> drop succ
+        )
     ))
 
 ||| Get previous token, respecting nesting of tokens and arguments.
@@ -152,23 +161,32 @@ def(Token.prev, Token -- Token,
     pred dup value match(
         TOKEN_RSQUARE -> nip,
         TOKEN_RCURLY -> nip,
-        TOKEN_RPAREN -> nip dup pred dup name-or-dname? .if(nip, drop),
+        TOKEN_RPAREN -> nip dup pred dup name-or-dname-or-label? if(nip, drop),
         _ -> drop
-    ))
+    )
+    while(dup pred lens-like?, pred))
+
+def(Token.in-lens-like?, Token -- Bool,
+    pred lens-like?)
 
 ||| Get closest arg ending (see `TokenValue.arg-end?`) while respecting the
 ||| nesting of tokens.
 def(Token.next-arg-end, Token -- Token,
-    while(dup arg-end? not, next))
+    dup in-lens-like? if(
+        "Token.next-arg-end called inside lens-like token" panic!,
+        while(dup arg-end? not, next)
+    ))
 
 def(Token.has-args?, Token -- Bool,
-    dup name-or-dname? then(succ)
-    lparen? >Bool)
+    dup lens-like? if(
+        drop T,
+        dup name-or-dname? then(succ)
+        lparen? >Bool
+    ))
 
 def(Token.args-start, Token -- Token,
-    dup name-or-dname? then(
-        dup succ lparen? then(succ)
-    ))
+    dup name-or-dname-or-label?
+    and(dup succ lparen? some?) then(succ))
 
 ||| Get number of arguments or number of components in enclosed token.
 def(Token.num-args, Token -- Int,
@@ -177,7 +195,7 @@ def(Token.num-args, Token -- Int,
         while(dup right-enclosure? not,
             dip(1+) succ next-arg-end)
         drop,
-        drop 0
+        lens-like? if(1, 0)
     ))
 
 ||| Verify that token has 0 args, and return them.
@@ -227,9 +245,11 @@ def(Token.args-3, Token -- Token Token Token,
 ||| Get List of token args.
 def(Token.args, Token -- List(Token),
     dup has-args? if(
-        args-start
-        collect-while(dup args-end? not, succ sip(next-arg-end))
-        nip,
+        args-start dup left-enclosure? if(
+            collect-while(dup args-end? not, succ sip(next-arg-end))
+            nip,
+            succ L1
+        ),
         drop L0
     ))
 
@@ -270,13 +290,24 @@ def(Token.run-end?, Token -- Bool,
     ))
 
 def(Token.run-tokens, Token -- List(Token),
-    collect-while(dup run-end? not, sip(next)) nip)
+    dup in-lens-like? if(
+        L1,
+        collect-while(dup run-end? not, sip(next)) nip
+    ))
 
 def(Token.run-length, Token -- Nat,
     dip(0 >Nat) while(dup run-end? not, next dip(1+)) drop )
 
 def(Token.run-has-arrow?, Token -- Bool,
     run-tokens any(dup pat-arrow?))
+
+def(Token.lens-like?, Token -- Bool,
+    value match(
+        TOKEN_LABEL -> drop T,
+        TOKEN_NAME -> lens-like?,
+        TOKEN_DNAME -> lens-like?,
+        _ -> drop F
+    ))
 
 ###################
 # Type Signatures #

--- a/src/mirth/token.mth
+++ b/src/mirth/token.mth
@@ -27,11 +27,13 @@ data(TokenValue,
     TOKEN_LCURLY_OPEN,
     TOKEN_LCURLY -> Token,
     TOKEN_RCURLY -> Token,
+    TOKEN_LCOLON_OPEN,
+    TOKEN_LCOLON -> Token,
+    TOKEN_RCOLON -> Token,
     TOKEN_INT -> Int,
     TOKEN_STR -> Str,
     TOKEN_NAME -> Name,
     TOKEN_DNAME -> DName,
-    TOKEN_LABEL -> Label,
     TOKEN_LABEL_PUSH -> Label,
     TOKEN_LABEL_POP -> Label)
 
@@ -46,35 +48,37 @@ def(TokenValue.rsquare?, TokenValue -- Maybe(Token), TOKEN_RSQUARE -> SOME, _ ->
 def(TokenValue.lcurly-open?, TokenValue -- Bool, TOKEN_LCURLY_OPEN -> T, _ -> drop F)
 def(TokenValue.lcurly?, TokenValue -- Maybe(Token), TOKEN_LCURLY -> SOME, _ -> drop NONE)
 def(TokenValue.rcurly?, TokenValue -- Maybe(Token), TOKEN_RCURLY -> SOME, _ -> drop NONE)
+def(TokenValue.lcolon-open?, TokenValue -- Bool, TOKEN_LCOLON_OPEN -> T, _ -> drop F)
+def(TokenValue.lcolon?, TokenValue -- Maybe(Token), TOKEN_LCOLON -> SOME, _ -> drop NONE)
+def(TokenValue.rcolon?, TokenValue -- Maybe(Token), TOKEN_RCOLON -> SOME, _ -> drop NONE)
+def(TokenValue.lparen-or-lcolon?, TokenValue -- Maybe(Token), TOKEN_LPAREN -> SOME, TOKEN_LCOLON -> SOME, _ -> drop NONE)
+
 def(TokenValue.int?, TokenValue -- Maybe(Int), TOKEN_INT -> SOME, _ -> drop NONE)
 def(TokenValue.str?, TokenValue -- Maybe(Str), TOKEN_STR -> SOME, _ -> drop NONE)
 def(TokenValue.name?, TokenValue -- Maybe(Name), TOKEN_NAME -> SOME, _ -> drop NONE)
 def(TokenValue.dname?, TokenValue -- Maybe(DName), TOKEN_DNAME -> SOME, _ -> drop NONE)
-def(TokenValue.label?, TokenValue -- Maybe(Label), TOKEN_LABEL -> SOME, _ -> drop NONE)
 def(TokenValue.name-or-dname?, TokenValue -- Maybe(Either(Name,DName)),
     TOKEN_NAME -> LEFT SOME,
     TOKEN_DNAME -> RIGHT SOME,
     _ -> drop NONE)
-def(TokenValue.name-or-dname-or-label?, TokenValue -- Bool,
-    TOKEN_NAME -> drop T,
-    TOKEN_DNAME -> drop T,
-    TOKEN_LABEL -> drop T,
-    _ -> drop F)
 def(TokenValue.arg-end?, TokenValue -- Bool,
     TOKEN_COMMA -> T,
     TOKEN_RPAREN -> drop T,
     TOKEN_RCURLY -> drop T,
     TOKEN_RSQUARE -> drop T,
+    TOKEN_RCOLON -> drop T,
     _ -> drop F)
 def(TokenValue.left-enclosure?, TokenValue -- Bool,
     TOKEN_LPAREN -> drop T,
     TOKEN_LSQUARE -> drop T,
-    TOKEN_LCURLY  -> drop T,
+    TOKEN_LCURLY -> drop T,
+    TOKEN_LCOLON -> drop T,
     _ -> drop F)
 def(TokenValue.right-enclosure?, TokenValue -- Bool,
     TOKEN_RPAREN -> drop T,
     TOKEN_RSQUARE -> drop T,
-    TOKEN_RCURLY  -> drop T,
+    TOKEN_RCURLY -> drop T,
+    TOKEN_RCOLON -> drop T,
     _ -> drop F)
 
 def(TokenValue.sig-type?, TokenValue -- Bool, name? and-some(could-be-type))
@@ -112,13 +116,15 @@ def(Token.rsquare?, Token -- Maybe(Token), value rsquare?)
 def(Token.lcurly-open?, Token -- Bool, value lcurly-open?)
 def(Token.lcurly?, Token -- Maybe(Token), value lcurly?)
 def(Token.rcurly?, Token -- Maybe(Token), value rcurly?)
+def(Token.lcolon-open?, Token -- Bool, value lcolon-open?)
+def(Token.lcolon?, Token -- Maybe(Token), value lcolon?)
+def(Token.rcolon?, Token -- Maybe(Token), value rcolon?)
+def(Token.lparen-or-lcolon?, Token -- Maybe(Token), value lparen-or-lcolon?)
 def(Token.int?, Token -- Maybe(Int), value int?)
 def(Token.str?, Token -- Maybe(Str), value str?)
 def(Token.name?, Token -- Maybe(Name), value name?)
 def(Token.dname?, Token -- Maybe(DName), value dname?)
-def(Token.label?, Token -- Maybe(Label), value label?)
 def(Token.name-or-dname?, Token -- Maybe(Either(Name,DName)), value name-or-dname?)
-def(Token.name-or-dname-or-label?, Token -- Bool, value name-or-dname-or-label?)
 def(Token.arg-end?, Token -- Bool, value arg-end?)
 def(Token.left-enclosure?, Token -- Bool, value left-enclosure?)
 def(Token.right-enclosure?, Token -- Bool, value right-enclosure?)
@@ -144,16 +150,14 @@ def(Token.location, Token -- Location,
 
 ||| Get next token, respecting nesting of tokens and arguments.
 def(Token.next, Token -- Token,
-    dup lens-like? if(
-        succ next,
-        dup value match(
-            TOKEN_LPAREN -> nip succ,
-            TOKEN_LSQUARE -> nip succ,
-            TOKEN_LCURLY -> nip succ,
-            TOKEN_NAME -> drop succ dup lparen? for(nip succ),
-            TOKEN_DNAME -> drop succ dup lparen? for(nip succ),
-            _ -> drop succ
-        )
+    dup value match(
+        TOKEN_LPAREN -> nip succ,
+        TOKEN_LSQUARE -> nip succ,
+        TOKEN_LCURLY -> nip succ,
+        TOKEN_LCOLON -> nip succ,
+        TOKEN_NAME -> drop succ dup lparen-or-lcolon? for(nip succ),
+        TOKEN_DNAME -> drop succ dup lparen-or-lcolon? for(nip succ),
+        _ -> drop succ
     ))
 
 ||| Get previous token, respecting nesting of tokens and arguments.
@@ -161,42 +165,27 @@ def(Token.prev, Token -- Token,
     pred dup value match(
         TOKEN_RSQUARE -> nip,
         TOKEN_RCURLY -> nip,
-        TOKEN_RPAREN -> nip dup pred dup name-or-dname-or-label? if(nip, drop),
+        TOKEN_RPAREN -> nip dup pred name-or-dname? then(pred),
+        TOKEN_RCOLON -> nip dup pred name-or-dname? then(pred),
         _ -> drop
-    )
-    while(dup pred lens-like?, pred))
-
-def(Token.in-lens-like?, Token -- Bool,
-    pred lens-like?)
+    ))
 
 ||| Get closest arg ending (see `TokenValue.arg-end?`) while respecting the
 ||| nesting of tokens.
 def(Token.next-arg-end, Token -- Token,
-    dup in-lens-like? if(
-        "Token.next-arg-end called inside lens-like token" panic!,
-        while(dup arg-end? not, next)
-    ))
+    while(dup arg-end? not, next))
 
 def(Token.has-args?, Token -- Bool,
-    dup lens-like? if(
-        drop T,
-        dup name-or-dname? then(succ)
-        lparen? >Bool
-    ))
+    dup name-or-dname? then(succ)
+    lparen-or-lcolon? >Bool)
 
 def(Token.args-start, Token -- Token,
-    dup name-or-dname-or-label?
-    and(dup succ lparen? some?) then(succ))
+    dup name-or-dname?
+    and(dup succ lparen-or-lcolon? >Bool) then(succ))
 
-||| Get number of arguments or number of components in enclosed token.
-def(Token.num-args, Token -- Int,
-    args-start dup left-enclosure? if(
-        dip(0)
-        while(dup right-enclosure? not,
-            dip(1+) succ next-arg-end)
-        drop,
-        lens-like? if(1, 0)
-    ))
+def(Token.could-be-sig-label?, Token -- Bool,
+    dup name? if-some(could-be-label-name?, F)
+    and(dup succ lcolon? >Bool) nip)
 
 ||| Verify that token has 0 args, and return them.
 ||| Emits a fatal error if arity is wrong.
@@ -242,14 +231,20 @@ def(Token.args-3, Token -- Token Token Token,
         )
     ))
 
+||| Get number of arguments or number of components in enclosed token.
+def(Token.num-args, Token -- Int,
+    args-start dup left-enclosure? if(
+        dip(0)
+        while(dup args-end? not,
+            dip(1+) succ next-arg-end)
+        drop,
+        drop 0
+    ))
+
 ||| Get List of token args.
 def(Token.args, Token -- List(Token),
-    dup has-args? if(
-        args-start dup left-enclosure? if(
-            collect-while(dup args-end? not, succ sip(next-arg-end))
-            nip,
-            succ L1
-        ),
+    args-start dup left-enclosure? if(
+        collect-while(dup args-end? not, succ sip(next-arg-end)) nip,
         drop L0
     ))
 
@@ -286,28 +281,18 @@ def(Token.run-end?, Token -- Bool,
         TOKEN_RPAREN -> drop T,
         TOKEN_RSQUARE -> drop T,
         TOKEN_RCURLY -> drop T,
+        TOKEN_RCOLON -> drop T,
         _ -> drop F
     ))
 
 def(Token.run-tokens, Token -- List(Token),
-    dup in-lens-like? if(
-        L1,
-        collect-while(dup run-end? not, sip(next)) nip
-    ))
+    collect-while(dup run-end? not, sip(next)) nip)
 
 def(Token.run-length, Token -- Nat,
-    dip(0 >Nat) while(dup run-end? not, next dip(1+)) drop )
+    dip(0 >Nat) while(dup run-end? not, next dip(1+)) drop)
 
 def(Token.run-has-arrow?, Token -- Bool,
     run-tokens any(dup pat-arrow?))
-
-def(Token.lens-like?, Token -- Bool,
-    value match(
-        TOKEN_LABEL -> drop T,
-        TOKEN_NAME -> lens-like?,
-        TOKEN_DNAME -> lens-like?,
-        _ -> drop F
-    ))
 
 ###################
 # Type Signatures #

--- a/src/std/byte.mth
+++ b/src/std/byte.mth
@@ -105,6 +105,7 @@ def(Byte.is-name-byte, Byte -- Bool,
     BRCURLY -> F,
     BCOMMA -> F,
     BQUOTE -> F,
+    BCOLON -> F,
     BDEL -> F,
     _ -> BSPACE >)
 

--- a/src/std/maybe.mth
+++ b/src/std/maybe.mth
@@ -40,6 +40,9 @@ def(Maybe.and(p), (*c -- *c Bool) *c Maybe(a) -- *c Bool,
 def(Maybe.and-some(p), (*c a -- *c Bool) *c Maybe(a) -- *c Bool,
     NONE -> F,
     SOME -> p)
+def(Maybe.guard(p), (*c a -- *c a Bool) *c Maybe(a) -- *c Maybe(a),
+    NONE -> NONE,
+    SOME -> p if(SOME, drop NONE))
 
 def(Maybe.unwrap, Maybe(t) -- t,
     NONE -> "tried to unwrap NONE" panic!,

--- a/src/std/stack.mth
+++ b/src/std/stack.mth
@@ -10,6 +10,9 @@ def(Stack.push!, t Mut(Stack(t)) --,
     modify(STACK_CONS))
 def(Stack.pop!, Mut(Stack(t)) -- Maybe(t),
     modify(uncons))
+def(Stack.head, Stack(t) -- Maybe(t),
+    STACK_NIL -> NONE,
+    STACK_CONS -> drop SOME)
 def(Stack.cons, t Stack(t) -- Stack(t),
     STACK_CONS)
 def(Stack.uncons, Stack(t) -- Maybe(t) Stack(t),


### PR DESCRIPTION
This PR implements reserves colon (`:`) as a special token, and turns it into a right-associative application operator, as an alternative for parentheses in many situations.

This new syntax can be used in place of unary application, whenever the argument consists of a single atom (including the atom's arguments). For example `foo(bar)` can be replaced with `foo:bar`. The syntax is right-associative, so `foo(bar(baz))` can be replaced with `foo:bar:baz`.

The primary motivation for this syntax is to be able to compose multiple higher-order words without creating a mess of parentheses. In particular, this syntax should be useful for defining and using functions to access deeply nested fields. Hence calling it "lens syntax".

Examples of the syntax:
- `foo:bar` is equivalent to `foo(bar)`
- `foo:bar(10)` is equivalent to `foo(bar(10))`
- `foo:bar:10` is equivalent to `foo(bar(10))`
- `foo:bar:baz` is equivalent to `foo(bar(baz))`
- `foo:bar:baz(1 2 3)` is equivalent to `foo(bar(baz(1 2 3)))`

That said, there is one place where these two are not equivalent, and it's in type signatures. A `foo:Int` in a type signature indicates a stack label (see #210). It is not a type variable application* `foo(Int)`. Internally the `:` syntax and the traditional `()` syntax are stored as different kinds of application syntax, so a distinction can be made as needed.

Implementation detail: The `:` syntax introduces two new token types: one for opening the colon application (called `TOKEN_LCOLON`) and one for closing the colon application (called `TOKEN_RCOLON`). These are placed before and after the argument respectively, where the equivalent `TOKEN_LPAREN` and `TOKEN_RPAREN` would have been if the traditional application syntax had been used instead. While `TOKEN_LCOLON` tokens correspond to the colon character `:` in the source code, the `TOKEN_RCOLON` tokens don't correspond to any lexical token in the source code. They are generated by the lexer as virtual tokens. These make the next stages of the compiler easier and more uniform, by making `:` application more similar to `()` application. The tokenized language remains visibly pushdown.

(*-type variable application is not currently supported)