### PR TITLE
runtime: Use flat tuples rather than linked lists.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 C99FLAGS=-std=c99 -Wall -Wextra -Wno-unused-variable -Wno-unused-function -Wno-unused-parameter \
- -Wno-unused-value -Wno-missing-braces -Wno-overlength-strings -Werror -pedantic -O1 -g
+ -Wno-unused-value -Wno-missing-braces -Wno-overlength-strings -Wno-infinite-recursion \
+ -Werror -pedantic -O1 -g
 
 MIRTHFLAGS=-p std:src/std -p args:src/args -p mirth:src/mirth -p posix:src/posix -p snake:src/snake
 

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -4569,6 +4569,50 @@ static void mp_mirth_arrow_Op_OP_5F_LABEL_5F_POP (void) {
 		free(tup);
 	}
 }
+static void mw_mirth_arrow_Op_OP_5F_DATA_5F_GET_5F_LABEL (void) {
+	TUP* tup = tup_new(3);
+	tup->size = 3;
+	tup->cells[0] = MKU64(17LL);
+	tup->cells[2] = pop_value();
+	tup->cells[1] = pop_value();
+	push_value(MKTUP(tup, 3));
+}
+static void mp_mirth_arrow_Op_OP_5F_DATA_5F_GET_5F_LABEL (void) {
+	VAL val = pop_value();
+	ASSERT1(IS_TUP(val),val);
+	TUP* tup = VTUP(val);
+	push_value(tup->cells[1]);
+	push_value(tup->cells[2]);
+	if (tup->refs > 1) {
+		incref(tup->cells[1]);
+		incref(tup->cells[2]);
+		decref(val);
+	} else {
+		free(tup);
+	}
+}
+static void mw_mirth_arrow_Op_OP_5F_DATA_5F_SET_5F_LABEL (void) {
+	TUP* tup = tup_new(3);
+	tup->size = 3;
+	tup->cells[0] = MKU64(18LL);
+	tup->cells[2] = pop_value();
+	tup->cells[1] = pop_value();
+	push_value(MKTUP(tup, 3));
+}
+static void mp_mirth_arrow_Op_OP_5F_DATA_5F_SET_5F_LABEL (void) {
+	VAL val = pop_value();
+	ASSERT1(IS_TUP(val),val);
+	TUP* tup = VTUP(val);
+	push_value(tup->cells[1]);
+	push_value(tup->cells[2]);
+	if (tup->refs > 1) {
+		incref(tup->cells[1]);
+		incref(tup->cells[2]);
+		decref(val);
+	} else {
+		free(tup);
+	}
+}
 static void mw_mirth_arrow_Coerce_COERCE_5F_UNSAFE (void) {
 	push_value(MKU64(0LL));
 }
@@ -7394,15 +7438,12 @@ static void mw_posix_posix_line_print_21_ (void);
 static void mw_posix_posix_line_trace_21_ (void);
 static void mw_std_path_Path_trace_21_ (void);
 static void mw_std_prim_Int_trace_21_ (void);
-static void mw_args_state_ArgvInfo__2F_ARGV_5F_INFO (void);
 static void mw_args_state_ArgvInfo_program_name (void);
 static void mw_args_state_ArgvInfo_argv (void);
-static void mw_args_state_CurrentArg__2F_CURRENT_5F_ARG (void);
 static void mw_args_state_CurrentArg_option_option (void);
 static void mw_args_state_CurrentArg_option_option_21_ (void);
 static void mw_args_state_CurrentArg_parsing_3F_ (void);
 static void mw_args_state_CurrentArg_parsing_3F__21_ (void);
-static void mw_args_state_State_1__2F_STATE (void);
 static void mw_args_state_State_1_error (void);
 static void mw_args_state_State_1_error_21_ (void);
 static void mw_args_state_State_1_positional_index (void);
@@ -7420,7 +7461,6 @@ static void mw_args_state_State_1_parsing_3F_ (void);
 static void mw_args_state_State_1_parsing_3F__21_ (void);
 static void mw_args_state_State_1_option_option (void);
 static void mw_args_state_State_1_option_option_21_ (void);
-static void mw_args_types_ArgumentParser_1__2F_ARGUMENT_5F_PARSER (void);
 static void mw_args_types_ArgumentParser_1_args_doc (void);
 static void mw_args_types_ArgumentParser_1_parser (void);
 static void mw_args_types_ArgumentParser_1_options (void);
@@ -7623,12 +7663,10 @@ static void mw_mirth_data_Tag_num_total_inputs (void);
 static void mw_mirth_data_Tag_is_transparent_3F_ (void);
 static void mw_mirth_data_Tag_outputs_resource_3F_ (void);
 static void mw_mirth_data_Tag__3D__3D_ (void);
-static void mw_mirth_match_Match__2F_MATCH (void);
 static void mw_mirth_match_Match_cases (void);
 static void mw_mirth_match_Match_cod (void);
 static void mw_mirth_match_Match_dom (void);
 static void mw_mirth_match_Match_token (void);
-static void mw_mirth_match__2B_Match__2F__2B_MATCH (void);
 static void mw_mirth_match__2B_Match_cases (void);
 static void mw_mirth_match__2B_Match_cases_21_ (void);
 static void mw_mirth_match__2B_Match_cases_1 (void);
@@ -7639,7 +7677,6 @@ static void mw_mirth_match__2B_Match_body (void);
 static void mw_mirth_match__2B_Match_home (void);
 static void mw_mirth_match_Match_thaw (void);
 static void mw_mirth_match__2B_Match_freeze (void);
-static void mw_mirth_match_Case__2F_CASE (void);
 static void mw_mirth_match_Case_body (void);
 static void mw_mirth_match_Case_pattern (void);
 static void mw_mirth_match_Match_is_exhaustive_3F_ (void);
@@ -7650,7 +7687,6 @@ static void mw_mirth_match__2B_Match_add_case (void);
 static void mw_mirth_match__2B_Match_case_redundant_3F_ (void);
 static void mw_mirth_match_Case_covers_3F_ (void);
 static void mw_mirth_match_Case_is_default_case_3F_ (void);
-static void mw_mirth_match_Pattern__2F_PATTERN (void);
 static void mw_mirth_match_Pattern_atoms (void);
 static void mw_mirth_match_Pattern_atoms_21_ (void);
 static void mw_mirth_match_Pattern_atoms_1 (void);
@@ -7670,7 +7706,6 @@ static void mw_mirth_match__2B_Pattern_pattern (void);
 static void mw_mirth_match__2B_Pattern_pattern_21_ (void);
 static void mw_mirth_match__2B_Pattern_pattern_1 (void);
 static void mw_mirth_match__2B_Pattern_freeze (void);
-static void mw_mirth_match_PatternAtom__2F_PATATOM (void);
 static void mw_mirth_match_PatternAtom_op (void);
 static void mw_mirth_match__2B_Pattern_underscore_21_ (void);
 static void mw_mirth_match__2B_Pattern_tag_21_ (void);
@@ -7682,7 +7717,6 @@ static void mw_mirth_arrow_Block_for_1 (void);
 static void mw_mirth_arrow_Block_alloc_21_ (void);
 static void mw_mirth_var_Var__3E_Param (void);
 static void mw_mirth_arrow_Param__3E_Var (void);
-static void mw_mirth_arrow_Arrow__2F_ARROW (void);
 static void mw_mirth_arrow_Arrow_atoms (void);
 static void mw_mirth_arrow_Arrow_atoms_21_ (void);
 static void mw_mirth_arrow_Arrow_atoms_1 (void);
@@ -7695,7 +7729,6 @@ static void mw_mirth_arrow_Arrow_token_end_21_ (void);
 static void mw_mirth_arrow_Arrow_token_start (void);
 static void mw_mirth_arrow_Arrow_home (void);
 static void mw_mirth_arrow_Arrow_type (void);
-static void mw_mirth_arrow_Atom__2F_ATOM (void);
 static void mw_mirth_arrow_Atom_cod (void);
 static void mw_mirth_arrow_Atom_dom_21_ (void);
 static void mw_mirth_arrow_Atom_args (void);
@@ -7703,7 +7736,6 @@ static void mw_mirth_arrow_Atom_args_21_ (void);
 static void mw_mirth_arrow_Atom_args_1 (void);
 static void mw_mirth_arrow_Atom_op (void);
 static void mw_mirth_arrow_Atom_token (void);
-static void mw_mirth_arrow_Lambda__2F_LAMBDA (void);
 static void mw_mirth_arrow_Lambda_body (void);
 static void mw_mirth_arrow_Lambda_params (void);
 static void mw_mirth_arrow_Lambda_dom (void);
@@ -8246,6 +8278,8 @@ static void mw_mirth_elab_data_word_new_21_ (void);
 static void mw_mirth_elab_elab_data_done_21_ (void);
 static void mw_mirth_data_Tag_output_type (void);
 static void mw_mirth_data_Tag_project_input_label (void);
+static void mw_mirth_elab_data_get_label_type (void);
+static void mw_mirth_elab_data_set_label_type (void);
 static void mw_mirth_elab_create_projectors_21_ (void);
 static void mw_mirth_elab_expect_token_arrow (void);
 static void mw_mirth_elab_token_def_args (void);
@@ -8360,6 +8394,9 @@ static void mw_mirth_c99_c99_variables_21_ (void);
 static void mw_mirth_c99_c99_variable_21_ (void);
 static void mw_mirth_c99_c99_tags_21_ (void);
 static void mw_mirth_c99_c99_tag_21_ (void);
+static void mw_mirth_c99_c99_tag_label_index (void);
+static void mw_mirth_c99_c99_tag_get_label_21_ (void);
+static void mw_mirth_c99_c99_tag_set_label_21_ (void);
 static void mw_mirth_c99_c99_externals_21_ (void);
 static void mw_mirth_c99_c99_external_21_ (void);
 static void mw_mirth_c99_c99_nest_1 (void);
@@ -8797,6 +8834,7 @@ static void mb_mirth_elab_atoms_turn_last_block_to_arg_43 (void);
 static void mb_mirth_elab_ab_lambda_at_21__1_10 (void);
 static void mb_mirth_elab_elab_match_sig_21__2 (void);
 static void mb_mirth_elab_elab_lambda_sig_21__2 (void);
+static void mb_mirth_elab_data_get_label_type_19 (void);
 static void mb_mirth_elab_elab_arrow_fwd_21__2 (void);
 static void mb_mirth_elab_elab_atom_name_21__20 (void);
 static void mb_mirth_elab_elab_atom_name_21__24 (void);
@@ -8916,20 +8954,16 @@ static void mb_mirth_elab_data_word_new_21__4 (void);
 static void mb_mirth_elab_create_projectors_21__15 (void);
 static void mb_mirth_elab_create_projectors_21__27 (void);
 static void mb_mirth_elab_create_projectors_21__52 (void);
+static void mb_mirth_elab_create_projectors_21__65 (void);
 static void mb_mirth_elab_create_projectors_21__67 (void);
-static void mb_mirth_elab_create_projectors_21__80 (void);
-static void mb_mirth_elab_create_projectors_21__82 (void);
-static void mb_mirth_elab_create_projectors_21__92 (void);
-static void mb_mirth_elab_create_projectors_21__98 (void);
-static void mb_mirth_elab_create_projectors_21__109 (void);
-static void mb_mirth_elab_create_projectors_21__132 (void);
-static void mb_mirth_elab_create_projectors_21__134 (void);
-static void mb_mirth_elab_create_projectors_21__143 (void);
+static void mb_mirth_elab_create_projectors_21__78 (void);
+static void mb_mirth_elab_create_projectors_21__91 (void);
+static void mb_mirth_elab_create_projectors_21__93 (void);
+static void mb_mirth_elab_create_projectors_21__104 (void);
 static void mb_mirth_elab_create_projectors_21__162 (void);
-static void mb_mirth_elab_create_projectors_21__220 (void);
-static void mb_mirth_elab_create_projectors_21__222 (void);
-static void mb_mirth_elab_create_projectors_21__230 (void);
-static void mb_mirth_elab_create_projectors_21__244 (void);
+static void mb_mirth_elab_create_projectors_21__164 (void);
+static void mb_mirth_elab_create_projectors_21__172 (void);
+static void mb_mirth_elab_create_projectors_21__186 (void);
 static void mb_mirth_data_Tag_project_input_label_5 (void);
 static void mb_mirth_elab_token_def_args_9 (void);
 static void mb_mirth_elab_elab_def_qname_4 (void);
@@ -8997,6 +9031,37 @@ static void mb_mirth_c99_c99_tag_21__177 (void);
 static void mb_mirth_c99_c99_tag_21__191 (void);
 static void mb_mirth_c99_c99_tag_21__205 (void);
 static void mb_mirth_c99_c99_tag_21__229 (void);
+static void mb_mirth_c99_c99_tag_label_index_7 (void);
+static void mb_mirth_c99_c99_tag_get_label_21__6 (void);
+static void mb_mirth_c99_c99_tag_get_label_21__12 (void);
+static void mb_mirth_c99_c99_tag_get_label_21__18 (void);
+static void mb_mirth_c99_c99_tag_get_label_21__23 (void);
+static void mb_mirth_c99_c99_tag_get_label_21__35 (void);
+static void mb_mirth_c99_c99_tag_get_label_21__46 (void);
+static void mb_mirth_c99_c99_tag_get_label_21__53 (void);
+static void mb_mirth_c99_c99_tag_get_label_21__55 (void);
+static void mb_mirth_c99_c99_tag_get_label_21__61 (void);
+static void mb_mirth_c99_c99_tag_set_label_21__11 (void);
+static void mb_mirth_c99_c99_tag_set_label_21__17 (void);
+static void mb_mirth_c99_c99_tag_set_label_21__23 (void);
+static void mb_mirth_c99_c99_tag_set_label_21__28 (void);
+static void mb_mirth_c99_c99_tag_set_label_21__33 (void);
+static void mb_mirth_c99_c99_tag_set_label_21__49 (void);
+static void mb_mirth_c99_c99_tag_set_label_21__61 (void);
+static void mb_mirth_c99_c99_tag_set_label_21__67 (void);
+static void mb_mirth_c99_c99_tag_set_label_21__72 (void);
+static void mb_mirth_c99_c99_tag_set_label_21__74 (void);
+static void mb_mirth_c99_c99_tag_set_label_21__86 (void);
+static void mb_mirth_c99_c99_tag_set_label_21__91 (void);
+static void mb_mirth_c99_c99_tag_set_label_21__97 (void);
+static void mb_mirth_c99_c99_tag_set_label_21__102 (void);
+static void mb_mirth_c99_c99_tag_set_label_21__104 (void);
+static void mb_mirth_c99_c99_tag_set_label_21__116 (void);
+static void mb_mirth_c99_c99_tag_set_label_21__144 (void);
+static void mb_mirth_c99_c99_tag_set_label_21__155 (void);
+static void mb_mirth_c99_c99_tag_set_label_21__179 (void);
+static void mb_mirth_c99_c99_tag_set_label_21__184 (void);
+static void mb_mirth_c99_c99_tag_set_label_21__197 (void);
 static void mb_mirth_c99_c99_external_21__26 (void);
 static void mb_mirth_c99_c99_external_21__42 (void);
 static void mb_mirth_c99_c99_external_21__55 (void);
@@ -14245,168 +14310,174 @@ static void mw_std_prim_Int_trace_21_ (void) {
 	mw_std_prim_Int_show();
 	mw_std_prim_Str_trace_21_();
 }
-static void mw_args_state_ArgvInfo__2F_ARGV_5F_INFO (void) {
-	switch (get_top_data_tag()) {
-		case 0LL:
-			mp_args_state_ArgvInfo_ARGV_5F_INFO();
-			break;
-		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
-	}
-}
 static void mw_args_state_ArgvInfo_program_name (void) {
-	mw_args_state_ArgvInfo__2F_ARGV_5F_INFO();
-	LPOP(lbl_program_name);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_program_name);
-	{
-		VAL d2 = pop_value();
-		mw_args_state_ArgvInfo_ARGV_5F_INFO();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 3, v);
+	VAL u = VTUP(v)->cells[2];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_args_state_ArgvInfo_argv (void) {
-	mw_args_state_ArgvInfo__2F_ARGV_5F_INFO();
-	LPOP(lbl_argv);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_argv);
-	{
-		VAL d2 = pop_value();
-		mw_args_state_ArgvInfo_ARGV_5F_INFO();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
-}
-static void mw_args_state_CurrentArg__2F_CURRENT_5F_ARG (void) {
-	switch (get_top_data_tag()) {
-		case 0LL:
-			mp_args_state_CurrentArg_CURRENT_5F_ARG();
-			break;
-		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 3, v);
+	VAL u = VTUP(v)->cells[1];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_args_state_CurrentArg_option_option (void) {
-	mw_args_state_CurrentArg__2F_CURRENT_5F_ARG();
-	LPOP(lbl_option_option);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_option_option);
-	{
-		VAL d2 = pop_value();
-		mw_args_state_CurrentArg_CURRENT_5F_ARG();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 4, v);
+	VAL u = VTUP(v)->cells[3];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_args_state_CurrentArg_option_option_21_ (void) {
-	{
-		VAL d2 = pop_value();
-		LPUSH(lbl_option_option);
-		push_value(d2);
+	VAL v = pop_value();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 4, v);
+	if (VTUP(v)->refs == 1) {
+		VAL* p = &VTUP(v)->cells[3];
+		VAL t = *p; *p = u; decref(t);
+		push_value(v);
+	} else {
+		TUP *tup = tup_new(4);
+		tup->size = 4;
+		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
+		tup->cells[1] = VTUP(v)->cells[1]; incref(tup->cells[1]);
+		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
+		tup->cells[3] = u;
+		decref(v);
+		push_value(MKTUP(tup,4));
 	}
-	mw_args_state_CurrentArg__2F_CURRENT_5F_ARG();
-	LPOP(lbl_option_option);
-	mw_std_prim_prim_drop();
-	mw_args_state_CurrentArg_CURRENT_5F_ARG();
 }
 static void mw_args_state_CurrentArg_parsing_3F_ (void) {
-	mw_args_state_CurrentArg__2F_CURRENT_5F_ARG();
-	LPOP(lbl_parsing_3F_);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_parsing_3F_);
-	{
-		VAL d2 = pop_value();
-		mw_args_state_CurrentArg_CURRENT_5F_ARG();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 4, v);
+	VAL u = VTUP(v)->cells[1];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_args_state_CurrentArg_parsing_3F__21_ (void) {
-	{
-		VAL d2 = pop_value();
-		LPUSH(lbl_parsing_3F_);
-		push_value(d2);
-	}
-	mw_args_state_CurrentArg__2F_CURRENT_5F_ARG();
-	LPOP(lbl_parsing_3F_);
-	mw_std_prim_prim_drop();
-	mw_args_state_CurrentArg_CURRENT_5F_ARG();
-}
-static void mw_args_state_State_1__2F_STATE (void) {
-	switch (get_top_data_tag()) {
-		case 0LL:
-			mp_args_state_State_1_STATE();
-			break;
-		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
+	VAL v = pop_value();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 4, v);
+	if (VTUP(v)->refs == 1) {
+		VAL* p = &VTUP(v)->cells[1];
+		VAL t = *p; *p = u; decref(t);
+		push_value(v);
+	} else {
+		TUP *tup = tup_new(4);
+		tup->size = 4;
+		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
+		tup->cells[1] = u;
+		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
+		tup->cells[3] = VTUP(v)->cells[3]; incref(tup->cells[3]);
+		decref(v);
+		push_value(MKTUP(tup,4));
 	}
 }
 static void mw_args_state_State_1_error (void) {
-	mw_args_state_State_1__2F_STATE();
-	LPOP(lbl_error);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_error);
-	{
-		VAL d2 = pop_value();
-		mw_args_state_State_1_STATE();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 6, v);
+	VAL u = VTUP(v)->cells[5];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_args_state_State_1_error_21_ (void) {
-	{
-		VAL d2 = pop_value();
-		LPUSH(lbl_error);
-		push_value(d2);
+	VAL v = pop_value();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 6, v);
+	if (VTUP(v)->refs == 1) {
+		VAL* p = &VTUP(v)->cells[5];
+		VAL t = *p; *p = u; decref(t);
+		push_value(v);
+	} else {
+		TUP *tup = tup_new(6);
+		tup->size = 6;
+		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
+		tup->cells[1] = VTUP(v)->cells[1]; incref(tup->cells[1]);
+		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
+		tup->cells[3] = VTUP(v)->cells[3]; incref(tup->cells[3]);
+		tup->cells[4] = VTUP(v)->cells[4]; incref(tup->cells[4]);
+		tup->cells[5] = u;
+		decref(v);
+		push_value(MKTUP(tup,6));
 	}
-	mw_args_state_State_1__2F_STATE();
-	LPOP(lbl_error);
-	mw_std_prim_prim_drop();
-	mw_args_state_State_1_STATE();
 }
 static void mw_args_state_State_1_positional_index (void) {
-	mw_args_state_State_1__2F_STATE();
-	LPOP(lbl_positional_index);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_positional_index);
-	{
-		VAL d2 = pop_value();
-		mw_args_state_State_1_STATE();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 6, v);
+	VAL u = VTUP(v)->cells[4];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_args_state_State_1_positional_index_21_ (void) {
-	{
-		VAL d2 = pop_value();
-		LPUSH(lbl_positional_index);
-		push_value(d2);
+	VAL v = pop_value();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 6, v);
+	if (VTUP(v)->refs == 1) {
+		VAL* p = &VTUP(v)->cells[4];
+		VAL t = *p; *p = u; decref(t);
+		push_value(v);
+	} else {
+		TUP *tup = tup_new(6);
+		tup->size = 6;
+		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
+		tup->cells[1] = VTUP(v)->cells[1]; incref(tup->cells[1]);
+		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
+		tup->cells[3] = VTUP(v)->cells[3]; incref(tup->cells[3]);
+		tup->cells[4] = u;
+		tup->cells[5] = VTUP(v)->cells[5]; incref(tup->cells[5]);
+		decref(v);
+		push_value(MKTUP(tup,6));
 	}
-	mw_args_state_State_1__2F_STATE();
-	LPOP(lbl_positional_index);
-	mw_std_prim_prim_drop();
-	mw_args_state_State_1_STATE();
 }
 static void mw_args_state_State_1_arg (void) {
-	mw_args_state_State_1__2F_STATE();
-	LPOP(lbl_arg);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_arg);
-	{
-		VAL d2 = pop_value();
-		mw_args_state_State_1_STATE();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 6, v);
+	VAL u = VTUP(v)->cells[3];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_args_state_State_1_arg_21_ (void) {
-	{
-		VAL d2 = pop_value();
-		LPUSH(lbl_arg);
-		push_value(d2);
+	VAL v = pop_value();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 6, v);
+	if (VTUP(v)->refs == 1) {
+		VAL* p = &VTUP(v)->cells[3];
+		VAL t = *p; *p = u; decref(t);
+		push_value(v);
+	} else {
+		TUP *tup = tup_new(6);
+		tup->size = 6;
+		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
+		tup->cells[1] = VTUP(v)->cells[1]; incref(tup->cells[1]);
+		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
+		tup->cells[3] = u;
+		tup->cells[4] = VTUP(v)->cells[4]; incref(tup->cells[4]);
+		tup->cells[5] = VTUP(v)->cells[5]; incref(tup->cells[5]);
+		decref(v);
+		push_value(MKTUP(tup,6));
 	}
-	mw_args_state_State_1__2F_STATE();
-	LPOP(lbl_arg);
-	mw_std_prim_prim_drop();
-	mw_args_state_State_1_STATE();
 }
 static void mw_args_state_State_1_arg_1 (void) {
 	mw_std_prim_prim_swap();
@@ -14421,39 +14492,44 @@ static void mw_args_state_State_1_arg_1 (void) {
 	mw_args_state_State_1_arg_21_();
 }
 static void mw_args_state_State_1_argv_info (void) {
-	mw_args_state_State_1__2F_STATE();
-	LPOP(lbl_argv_info);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_argv_info);
-	{
-		VAL d2 = pop_value();
-		mw_args_state_State_1_STATE();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 6, v);
+	VAL u = VTUP(v)->cells[2];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_args_state_State_1_arguments (void) {
-	mw_args_state_State_1__2F_STATE();
-	LPOP(lbl_arguments);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_arguments);
-	{
-		VAL d2 = pop_value();
-		mw_args_state_State_1_STATE();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 6, v);
+	VAL u = VTUP(v)->cells[1];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_args_state_State_1_arguments_21_ (void) {
-	{
-		VAL d2 = pop_value();
-		LPUSH(lbl_arguments);
-		push_value(d2);
+	VAL v = pop_value();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 6, v);
+	if (VTUP(v)->refs == 1) {
+		VAL* p = &VTUP(v)->cells[1];
+		VAL t = *p; *p = u; decref(t);
+		push_value(v);
+	} else {
+		TUP *tup = tup_new(6);
+		tup->size = 6;
+		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
+		tup->cells[1] = u;
+		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
+		tup->cells[3] = VTUP(v)->cells[3]; incref(tup->cells[3]);
+		tup->cells[4] = VTUP(v)->cells[4]; incref(tup->cells[4]);
+		tup->cells[5] = VTUP(v)->cells[5]; incref(tup->cells[5]);
+		decref(v);
+		push_value(MKTUP(tup,6));
 	}
-	mw_args_state_State_1__2F_STATE();
-	LPOP(lbl_arguments);
-	mw_std_prim_prim_drop();
-	mw_args_state_State_1_STATE();
 }
 static void mw_args_state_State_1_init (void) {
 	mw_args_parse_argv_to_str();
@@ -14509,49 +14585,32 @@ static void mw_args_state_State_1_option_option_21_ (void) {
 	mw_std_prim_prim_pack_cons();
 	mw_args_state_State_1_arg_1();
 }
-static void mw_args_types_ArgumentParser_1__2F_ARGUMENT_5F_PARSER (void) {
-	switch (get_top_data_tag()) {
-		case 0LL:
-			mp_args_types_ArgumentParser_1_ARGUMENT_5F_PARSER();
-			break;
-		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
-	}
-}
 static void mw_args_types_ArgumentParser_1_args_doc (void) {
-	mw_args_types_ArgumentParser_1__2F_ARGUMENT_5F_PARSER();
-	LPOP(lbl_args_doc);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_args_doc);
-	{
-		VAL d2 = pop_value();
-		mw_args_types_ArgumentParser_1_ARGUMENT_5F_PARSER();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 5, v);
+	VAL u = VTUP(v)->cells[3];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_args_types_ArgumentParser_1_parser (void) {
-	mw_args_types_ArgumentParser_1__2F_ARGUMENT_5F_PARSER();
-	LPOP(lbl_parser);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_parser);
-	{
-		VAL d2 = pop_value();
-		mw_args_types_ArgumentParser_1_ARGUMENT_5F_PARSER();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 5, v);
+	VAL u = VTUP(v)->cells[2];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_args_types_ArgumentParser_1_options (void) {
-	mw_args_types_ArgumentParser_1__2F_ARGUMENT_5F_PARSER();
-	LPOP(lbl_options);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_options);
-	{
-		VAL d2 = pop_value();
-		mw_args_types_ArgumentParser_1_ARGUMENT_5F_PARSER();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 5, v);
+	VAL u = VTUP(v)->cells[1];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_args_types_ArgumentParser_1_new (void) {
 	mw_args_types_ArgumentParser_1_ARGUMENT_5F_PARSER();
@@ -17099,87 +17158,57 @@ static void mw_mirth_data_Tag__3D__3D_ (void) {
 	mw_std_prelude_both_1();
 	mw_std_prim_prim_int_eq();
 }
-static void mw_mirth_match_Match__2F_MATCH (void) {
-	switch (get_top_data_tag()) {
-		case 0LL:
-			mp_mirth_match_Match_MATCH();
-			break;
-		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
-	}
-}
 static void mw_mirth_match_Match_cases (void) {
-	mw_mirth_match_Match__2F_MATCH();
-	LPOP(lbl_cases);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_cases);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_match_Match_MATCH();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[7];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_match_Match_cod (void) {
-	mw_mirth_match_Match__2F_MATCH();
-	LPOP(lbl_cod);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_cod);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_match_Match_MATCH();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[6];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_match_Match_dom (void) {
-	mw_mirth_match_Match__2F_MATCH();
-	LPOP(lbl_dom);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_dom);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_match_Match_MATCH();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[5];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_match_Match_token (void) {
-	mw_mirth_match_Match__2F_MATCH();
-	LPOP(lbl_token);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_token);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_match_Match_MATCH();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
-}
-static void mw_mirth_match__2B_Match__2F__2B_MATCH (void) {
-	switch (get_top_resource_data_tag()) {
-		case 0LL:
-			mp_mirth_match__2B_Match__2B_MATCH();
-			break;
-		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[2];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_match__2B_Match_cases (void) {
-	mw_mirth_match__2B_Match__2F__2B_MATCH();
-	LPOP(lbl_cases);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_cases);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_match__2B_Match__2B_MATCH();
-		push_value(d2);
-	}
+	VAL v = top_resource();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[7];
+	incref(u);
+	push_value(u);
 }
 static void mw_mirth_match__2B_Match_cases_21_ (void) {
-	LPUSH(lbl_cases);
-	mw_mirth_match__2B_Match__2F__2B_MATCH();
-	LPOP(lbl_cases);
-	mw_std_prim_prim_drop();
-	mw_mirth_match__2B_Match__2B_MATCH();
+	VAL v = top_resource();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL* p = &VTUP(v)->cells[7];
+	VAL t = *p; *p = u; decref(t);
 }
 static void mw_mirth_match__2B_Match_cases_1 (void) {
 	mw_mirth_match__2B_Match_cases();
@@ -17192,59 +17221,44 @@ static void mw_mirth_match__2B_Match_cases_1 (void) {
 	mw_mirth_match__2B_Match_cases_21_();
 }
 static void mw_mirth_match__2B_Match_cod (void) {
-	mw_mirth_match__2B_Match__2F__2B_MATCH();
-	LPOP(lbl_cod);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_cod);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_match__2B_Match__2B_MATCH();
-		push_value(d2);
-	}
+	VAL v = top_resource();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[6];
+	incref(u);
+	push_value(u);
 }
 static void mw_mirth_match__2B_Match_dom (void) {
-	mw_mirth_match__2B_Match__2F__2B_MATCH();
-	LPOP(lbl_dom);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_dom);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_match__2B_Match__2B_MATCH();
-		push_value(d2);
-	}
+	VAL v = top_resource();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[5];
+	incref(u);
+	push_value(u);
 }
 static void mw_mirth_match__2B_Match_ctx (void) {
-	mw_mirth_match__2B_Match__2F__2B_MATCH();
-	LPOP(lbl_ctx);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_ctx);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_match__2B_Match__2B_MATCH();
-		push_value(d2);
-	}
+	VAL v = top_resource();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[4];
+	incref(u);
+	push_value(u);
 }
 static void mw_mirth_match__2B_Match_body (void) {
-	mw_mirth_match__2B_Match__2F__2B_MATCH();
-	LPOP(lbl_body);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_body);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_match__2B_Match__2B_MATCH();
-		push_value(d2);
-	}
+	VAL v = top_resource();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[3];
+	incref(u);
+	push_value(u);
 }
 static void mw_mirth_match__2B_Match_home (void) {
-	mw_mirth_match__2B_Match__2F__2B_MATCH();
-	LPOP(lbl_home);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_home);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_match__2B_Match__2B_MATCH();
-		push_value(d2);
-	}
+	VAL v = top_resource();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[1];
+	incref(u);
+	push_value(u);
 }
 static void mw_mirth_match_Match_thaw (void) {
 	switch (get_top_data_tag()) {
@@ -17264,37 +17278,23 @@ static void mw_mirth_match__2B_Match_freeze (void) {
 		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
 	}
 }
-static void mw_mirth_match_Case__2F_CASE (void) {
-	switch (get_top_data_tag()) {
-		case 0LL:
-			mp_mirth_match_Case_CASE();
-			break;
-		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
-	}
-}
 static void mw_mirth_match_Case_body (void) {
-	mw_mirth_match_Case__2F_CASE();
-	LPOP(lbl_body);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_body);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_match_Case_CASE();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 3, v);
+	VAL u = VTUP(v)->cells[2];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_match_Case_pattern (void) {
-	mw_mirth_match_Case__2F_CASE();
-	LPOP(lbl_pattern);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_pattern);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_match_Case_CASE();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 3, v);
+	VAL u = VTUP(v)->cells[1];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_match_Match_is_exhaustive_3F_ (void) {
 	mw_std_prim_prim_dup();
@@ -17391,36 +17391,40 @@ static void mw_mirth_match_Case_is_default_case_3F_ (void) {
 	mw_mirth_match_Case_pattern();
 	mw_mirth_match_Pattern_is_default_3F_();
 }
-static void mw_mirth_match_Pattern__2F_PATTERN (void) {
-	switch (get_top_data_tag()) {
-		case 0LL:
-			mp_mirth_match_Pattern_PATTERN();
-			break;
-		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
-	}
-}
 static void mw_mirth_match_Pattern_atoms (void) {
-	mw_mirth_match_Pattern__2F_PATTERN();
-	LPOP(lbl_atoms);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_atoms);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_match_Pattern_PATTERN();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 10, v);
+	VAL u = VTUP(v)->cells[9];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_match_Pattern_atoms_21_ (void) {
-	{
-		VAL d2 = pop_value();
-		LPUSH(lbl_atoms);
-		push_value(d2);
+	VAL v = pop_value();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 10, v);
+	if (VTUP(v)->refs == 1) {
+		VAL* p = &VTUP(v)->cells[9];
+		VAL t = *p; *p = u; decref(t);
+		push_value(v);
+	} else {
+		TUP *tup = tup_new(10);
+		tup->size = 10;
+		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
+		tup->cells[1] = VTUP(v)->cells[1]; incref(tup->cells[1]);
+		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
+		tup->cells[3] = VTUP(v)->cells[3]; incref(tup->cells[3]);
+		tup->cells[4] = VTUP(v)->cells[4]; incref(tup->cells[4]);
+		tup->cells[5] = VTUP(v)->cells[5]; incref(tup->cells[5]);
+		tup->cells[6] = VTUP(v)->cells[6]; incref(tup->cells[6]);
+		tup->cells[7] = VTUP(v)->cells[7]; incref(tup->cells[7]);
+		tup->cells[8] = VTUP(v)->cells[8]; incref(tup->cells[8]);
+		tup->cells[9] = u;
+		decref(v);
+		push_value(MKTUP(tup,10));
 	}
-	mw_mirth_match_Pattern__2F_PATTERN();
-	LPOP(lbl_atoms);
-	mw_std_prim_prim_drop();
-	mw_mirth_match_Pattern_PATTERN();
 }
 static void mw_mirth_match_Pattern_atoms_1 (void) {
 	mw_std_prim_prim_swap();
@@ -17435,50 +17439,74 @@ static void mw_mirth_match_Pattern_atoms_1 (void) {
 	mw_mirth_match_Pattern_atoms_21_();
 }
 static void mw_mirth_match_Pattern_mid (void) {
-	mw_mirth_match_Pattern__2F_PATTERN();
-	LPOP(lbl_mid);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_mid);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_match_Pattern_PATTERN();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 10, v);
+	VAL u = VTUP(v)->cells[7];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_match_Pattern_mid_21_ (void) {
-	{
-		VAL d2 = pop_value();
-		LPUSH(lbl_mid);
-		push_value(d2);
+	VAL v = pop_value();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 10, v);
+	if (VTUP(v)->refs == 1) {
+		VAL* p = &VTUP(v)->cells[7];
+		VAL t = *p; *p = u; decref(t);
+		push_value(v);
+	} else {
+		TUP *tup = tup_new(10);
+		tup->size = 10;
+		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
+		tup->cells[1] = VTUP(v)->cells[1]; incref(tup->cells[1]);
+		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
+		tup->cells[3] = VTUP(v)->cells[3]; incref(tup->cells[3]);
+		tup->cells[4] = VTUP(v)->cells[4]; incref(tup->cells[4]);
+		tup->cells[5] = VTUP(v)->cells[5]; incref(tup->cells[5]);
+		tup->cells[6] = VTUP(v)->cells[6]; incref(tup->cells[6]);
+		tup->cells[7] = u;
+		tup->cells[8] = VTUP(v)->cells[8]; incref(tup->cells[8]);
+		tup->cells[9] = VTUP(v)->cells[9]; incref(tup->cells[9]);
+		decref(v);
+		push_value(MKTUP(tup,10));
 	}
-	mw_mirth_match_Pattern__2F_PATTERN();
-	LPOP(lbl_mid);
-	mw_std_prim_prim_drop();
-	mw_mirth_match_Pattern_PATTERN();
 }
 static void mw_mirth_match_Pattern_saved (void) {
-	mw_mirth_match_Pattern__2F_PATTERN();
-	LPOP(lbl_saved);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_saved);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_match_Pattern_PATTERN();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 10, v);
+	VAL u = VTUP(v)->cells[6];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_match_Pattern_saved_21_ (void) {
-	{
-		VAL d2 = pop_value();
-		LPUSH(lbl_saved);
-		push_value(d2);
+	VAL v = pop_value();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 10, v);
+	if (VTUP(v)->refs == 1) {
+		VAL* p = &VTUP(v)->cells[6];
+		VAL t = *p; *p = u; decref(t);
+		push_value(v);
+	} else {
+		TUP *tup = tup_new(10);
+		tup->size = 10;
+		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
+		tup->cells[1] = VTUP(v)->cells[1]; incref(tup->cells[1]);
+		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
+		tup->cells[3] = VTUP(v)->cells[3]; incref(tup->cells[3]);
+		tup->cells[4] = VTUP(v)->cells[4]; incref(tup->cells[4]);
+		tup->cells[5] = VTUP(v)->cells[5]; incref(tup->cells[5]);
+		tup->cells[6] = u;
+		tup->cells[7] = VTUP(v)->cells[7]; incref(tup->cells[7]);
+		tup->cells[8] = VTUP(v)->cells[8]; incref(tup->cells[8]);
+		tup->cells[9] = VTUP(v)->cells[9]; incref(tup->cells[9]);
+		decref(v);
+		push_value(MKTUP(tup,10));
 	}
-	mw_mirth_match_Pattern__2F_PATTERN();
-	LPOP(lbl_saved);
-	mw_std_prim_prim_drop();
-	mw_mirth_match_Pattern_PATTERN();
 }
 static void mw_mirth_match_Pattern_saved_1 (void) {
 	mw_std_prim_prim_swap();
@@ -17493,28 +17521,22 @@ static void mw_mirth_match_Pattern_saved_1 (void) {
 	mw_mirth_match_Pattern_saved_21_();
 }
 static void mw_mirth_match_Pattern_inner_ctx (void) {
-	mw_mirth_match_Pattern__2F_PATTERN();
-	LPOP(lbl_inner_ctx);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_inner_ctx);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_match_Pattern_PATTERN();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 10, v);
+	VAL u = VTUP(v)->cells[5];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_match_Pattern_token_start (void) {
-	mw_mirth_match_Pattern__2F_PATTERN();
-	LPOP(lbl_token_start);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_token_start);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_match_Pattern_PATTERN();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 10, v);
+	VAL u = VTUP(v)->cells[2];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_match_Pattern_dom (void) {
 	push_value(MKNIL);
@@ -17555,22 +17577,20 @@ static void mw_mirth_match__2B_Pattern__2F__2B_PATTERN (void) {
 	}
 }
 static void mw_mirth_match__2B_Pattern_pattern (void) {
-	mw_mirth_match__2B_Pattern__2F__2B_PATTERN();
-	LPOP(lbl_pattern);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_pattern);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_match__2B_Pattern__2B_PATTERN();
-		push_value(d2);
-	}
+	VAL v = top_resource();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 2, v);
+	VAL u = VTUP(v)->cells[1];
+	incref(u);
+	push_value(u);
 }
 static void mw_mirth_match__2B_Pattern_pattern_21_ (void) {
-	LPUSH(lbl_pattern);
-	mw_mirth_match__2B_Pattern__2F__2B_PATTERN();
-	LPOP(lbl_pattern);
-	mw_std_prim_prim_drop();
-	mw_mirth_match__2B_Pattern__2B_PATTERN();
+	VAL v = top_resource();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 2, v);
+	VAL* p = &VTUP(v)->cells[1];
+	VAL t = *p; *p = u; decref(t);
 }
 static void mw_mirth_match__2B_Pattern_pattern_1 (void) {
 	mw_mirth_match__2B_Pattern_pattern();
@@ -17586,25 +17606,14 @@ static void mw_mirth_match__2B_Pattern_freeze (void) {
 	mw_mirth_match__2B_Pattern__2F__2B_PATTERN();
 	LPOP(lbl_pattern);
 }
-static void mw_mirth_match_PatternAtom__2F_PATATOM (void) {
-	switch (get_top_data_tag()) {
-		case 0LL:
-			mp_mirth_match_PatternAtom_PATATOM();
-			break;
-		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
-	}
-}
 static void mw_mirth_match_PatternAtom_op (void) {
-	mw_mirth_match_PatternAtom__2F_PATATOM();
-	LPOP(lbl_op);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_op);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_match_PatternAtom_PATATOM();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[7];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_match__2B_Pattern_underscore_21_ (void) {
 	mw_mirth_match__2B_Pattern_pattern();
@@ -17822,36 +17831,38 @@ static void mw_mirth_var_Var__3E_Param (void) {
 }
 static void mw_mirth_arrow_Param__3E_Var (void) {
 }
-static void mw_mirth_arrow_Arrow__2F_ARROW (void) {
-	switch (get_top_data_tag()) {
-		case 0LL:
-			mp_mirth_arrow_Arrow_ARROW();
-			break;
-		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
-	}
-}
 static void mw_mirth_arrow_Arrow_atoms (void) {
-	mw_mirth_arrow_Arrow__2F_ARROW();
-	LPOP(lbl_atoms);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_atoms);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_arrow_Arrow_ARROW();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[7];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_arrow_Arrow_atoms_21_ (void) {
-	{
-		VAL d2 = pop_value();
-		LPUSH(lbl_atoms);
-		push_value(d2);
+	VAL v = pop_value();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	if (VTUP(v)->refs == 1) {
+		VAL* p = &VTUP(v)->cells[7];
+		VAL t = *p; *p = u; decref(t);
+		push_value(v);
+	} else {
+		TUP *tup = tup_new(8);
+		tup->size = 8;
+		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
+		tup->cells[1] = VTUP(v)->cells[1]; incref(tup->cells[1]);
+		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
+		tup->cells[3] = VTUP(v)->cells[3]; incref(tup->cells[3]);
+		tup->cells[4] = VTUP(v)->cells[4]; incref(tup->cells[4]);
+		tup->cells[5] = VTUP(v)->cells[5]; incref(tup->cells[5]);
+		tup->cells[6] = VTUP(v)->cells[6]; incref(tup->cells[6]);
+		tup->cells[7] = u;
+		decref(v);
+		push_value(MKTUP(tup,8));
 	}
-	mw_mirth_arrow_Arrow__2F_ARROW();
-	LPOP(lbl_atoms);
-	mw_std_prim_prim_drop();
-	mw_mirth_arrow_Arrow_ARROW();
 }
 static void mw_mirth_arrow_Arrow_atoms_1 (void) {
 	mw_std_prim_prim_swap();
@@ -17866,98 +17877,106 @@ static void mw_mirth_arrow_Arrow_atoms_1 (void) {
 	mw_mirth_arrow_Arrow_atoms_21_();
 }
 static void mw_mirth_arrow_Arrow_cod (void) {
-	mw_mirth_arrow_Arrow__2F_ARROW();
-	LPOP(lbl_cod);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_cod);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_arrow_Arrow_ARROW();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[6];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_arrow_Arrow_cod_21_ (void) {
-	{
-		VAL d2 = pop_value();
-		LPUSH(lbl_cod);
-		push_value(d2);
+	VAL v = pop_value();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	if (VTUP(v)->refs == 1) {
+		VAL* p = &VTUP(v)->cells[6];
+		VAL t = *p; *p = u; decref(t);
+		push_value(v);
+	} else {
+		TUP *tup = tup_new(8);
+		tup->size = 8;
+		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
+		tup->cells[1] = VTUP(v)->cells[1]; incref(tup->cells[1]);
+		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
+		tup->cells[3] = VTUP(v)->cells[3]; incref(tup->cells[3]);
+		tup->cells[4] = VTUP(v)->cells[4]; incref(tup->cells[4]);
+		tup->cells[5] = VTUP(v)->cells[5]; incref(tup->cells[5]);
+		tup->cells[6] = u;
+		tup->cells[7] = VTUP(v)->cells[7]; incref(tup->cells[7]);
+		decref(v);
+		push_value(MKTUP(tup,8));
 	}
-	mw_mirth_arrow_Arrow__2F_ARROW();
-	LPOP(lbl_cod);
-	mw_std_prim_prim_drop();
-	mw_mirth_arrow_Arrow_ARROW();
 }
 static void mw_mirth_arrow_Arrow_dom (void) {
-	mw_mirth_arrow_Arrow__2F_ARROW();
-	LPOP(lbl_dom);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_dom);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_arrow_Arrow_ARROW();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[5];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_arrow_Arrow_ctx (void) {
-	mw_mirth_arrow_Arrow__2F_ARROW();
-	LPOP(lbl_ctx);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_ctx);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_arrow_Arrow_ARROW();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[4];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_arrow_Arrow_token_end (void) {
-	mw_mirth_arrow_Arrow__2F_ARROW();
-	LPOP(lbl_token_end);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_token_end);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_arrow_Arrow_ARROW();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[3];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_arrow_Arrow_token_end_21_ (void) {
-	{
-		VAL d2 = pop_value();
-		LPUSH(lbl_token_end);
-		push_value(d2);
+	VAL v = pop_value();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	if (VTUP(v)->refs == 1) {
+		VAL* p = &VTUP(v)->cells[3];
+		VAL t = *p; *p = u; decref(t);
+		push_value(v);
+	} else {
+		TUP *tup = tup_new(8);
+		tup->size = 8;
+		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
+		tup->cells[1] = VTUP(v)->cells[1]; incref(tup->cells[1]);
+		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
+		tup->cells[3] = u;
+		tup->cells[4] = VTUP(v)->cells[4]; incref(tup->cells[4]);
+		tup->cells[5] = VTUP(v)->cells[5]; incref(tup->cells[5]);
+		tup->cells[6] = VTUP(v)->cells[6]; incref(tup->cells[6]);
+		tup->cells[7] = VTUP(v)->cells[7]; incref(tup->cells[7]);
+		decref(v);
+		push_value(MKTUP(tup,8));
 	}
-	mw_mirth_arrow_Arrow__2F_ARROW();
-	LPOP(lbl_token_end);
-	mw_std_prim_prim_drop();
-	mw_mirth_arrow_Arrow_ARROW();
 }
 static void mw_mirth_arrow_Arrow_token_start (void) {
-	mw_mirth_arrow_Arrow__2F_ARROW();
-	LPOP(lbl_token_start);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_token_start);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_arrow_Arrow_ARROW();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[2];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_arrow_Arrow_home (void) {
-	mw_mirth_arrow_Arrow__2F_ARROW();
-	LPOP(lbl_home);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_home);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_arrow_Arrow_ARROW();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[1];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_arrow_Arrow_type (void) {
 	push_value(MKNIL);
@@ -17967,59 +17986,71 @@ static void mw_mirth_arrow_Arrow_type (void) {
 	mw_mirth_arrow_Arrow_cod();
 	mw_mirth_type_T__3E_();
 }
-static void mw_mirth_arrow_Atom__2F_ATOM (void) {
-	switch (get_top_data_tag()) {
-		case 0LL:
-			mp_mirth_arrow_Atom_ATOM();
-			break;
-		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
-	}
-}
 static void mw_mirth_arrow_Atom_cod (void) {
-	mw_mirth_arrow_Atom__2F_ATOM();
-	LPOP(lbl_cod);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_cod);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_arrow_Atom_ATOM();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[6];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_arrow_Atom_dom_21_ (void) {
-	{
-		VAL d2 = pop_value();
-		LPUSH(lbl_dom);
-		push_value(d2);
+	VAL v = pop_value();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	if (VTUP(v)->refs == 1) {
+		VAL* p = &VTUP(v)->cells[5];
+		VAL t = *p; *p = u; decref(t);
+		push_value(v);
+	} else {
+		TUP *tup = tup_new(8);
+		tup->size = 8;
+		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
+		tup->cells[1] = VTUP(v)->cells[1]; incref(tup->cells[1]);
+		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
+		tup->cells[3] = VTUP(v)->cells[3]; incref(tup->cells[3]);
+		tup->cells[4] = VTUP(v)->cells[4]; incref(tup->cells[4]);
+		tup->cells[5] = u;
+		tup->cells[6] = VTUP(v)->cells[6]; incref(tup->cells[6]);
+		tup->cells[7] = VTUP(v)->cells[7]; incref(tup->cells[7]);
+		decref(v);
+		push_value(MKTUP(tup,8));
 	}
-	mw_mirth_arrow_Atom__2F_ATOM();
-	LPOP(lbl_dom);
-	mw_std_prim_prim_drop();
-	mw_mirth_arrow_Atom_ATOM();
 }
 static void mw_mirth_arrow_Atom_args (void) {
-	mw_mirth_arrow_Atom__2F_ATOM();
-	LPOP(lbl_args);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_args);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_arrow_Atom_ATOM();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[4];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_arrow_Atom_args_21_ (void) {
-	{
-		VAL d2 = pop_value();
-		LPUSH(lbl_args);
-		push_value(d2);
+	VAL v = pop_value();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	if (VTUP(v)->refs == 1) {
+		VAL* p = &VTUP(v)->cells[4];
+		VAL t = *p; *p = u; decref(t);
+		push_value(v);
+	} else {
+		TUP *tup = tup_new(8);
+		tup->size = 8;
+		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
+		tup->cells[1] = VTUP(v)->cells[1]; incref(tup->cells[1]);
+		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
+		tup->cells[3] = VTUP(v)->cells[3]; incref(tup->cells[3]);
+		tup->cells[4] = u;
+		tup->cells[5] = VTUP(v)->cells[5]; incref(tup->cells[5]);
+		tup->cells[6] = VTUP(v)->cells[6]; incref(tup->cells[6]);
+		tup->cells[7] = VTUP(v)->cells[7]; incref(tup->cells[7]);
+		decref(v);
+		push_value(MKTUP(tup,8));
 	}
-	mw_mirth_arrow_Atom__2F_ATOM();
-	LPOP(lbl_args);
-	mw_std_prim_prim_drop();
-	mw_mirth_arrow_Atom_ATOM();
 }
 static void mw_mirth_arrow_Atom_args_1 (void) {
 	mw_std_prim_prim_swap();
@@ -18034,72 +18065,49 @@ static void mw_mirth_arrow_Atom_args_1 (void) {
 	mw_mirth_arrow_Atom_args_21_();
 }
 static void mw_mirth_arrow_Atom_op (void) {
-	mw_mirth_arrow_Atom__2F_ATOM();
-	LPOP(lbl_op);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_op);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_arrow_Atom_ATOM();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[3];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_arrow_Atom_token (void) {
-	mw_mirth_arrow_Atom__2F_ATOM();
-	LPOP(lbl_token);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_token);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_arrow_Atom_ATOM();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
-}
-static void mw_mirth_arrow_Lambda__2F_LAMBDA (void) {
-	switch (get_top_data_tag()) {
-		case 0LL:
-			mp_mirth_arrow_Lambda_LAMBDA();
-			break;
-		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	VAL u = VTUP(v)->cells[1];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_arrow_Lambda_body (void) {
-	mw_mirth_arrow_Lambda__2F_LAMBDA();
-	LPOP(lbl_body);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_body);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_arrow_Lambda_LAMBDA();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 6, v);
+	VAL u = VTUP(v)->cells[5];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_arrow_Lambda_params (void) {
-	mw_mirth_arrow_Lambda__2F_LAMBDA();
-	LPOP(lbl_params);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_params);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_arrow_Lambda_LAMBDA();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 6, v);
+	VAL u = VTUP(v)->cells[4];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_arrow_Lambda_dom (void) {
-	mw_mirth_arrow_Lambda__2F_LAMBDA();
-	LPOP(lbl_dom);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_dom);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_arrow_Lambda_LAMBDA();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 6, v);
+	VAL u = VTUP(v)->cells[3];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_arrow_Lambda_cod (void) {
 	mw_mirth_arrow_Lambda_body();
@@ -25736,62 +25744,71 @@ static void mw_mirth_name_QName__2F_MKQNAME (void) {
 	}
 }
 static void mw_mirth_name_QName_arity (void) {
-	mw_mirth_name_QName__2F_MKQNAME();
-	LPOP(lbl_arity);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_arity);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_name_QName_MKQNAME();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 4, v);
+	VAL u = VTUP(v)->cells[3];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_name_QName_arity_21_ (void) {
-	{
-		VAL d2 = pop_value();
-		LPUSH(lbl_arity);
-		push_value(d2);
+	VAL v = pop_value();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 4, v);
+	if (VTUP(v)->refs == 1) {
+		VAL* p = &VTUP(v)->cells[3];
+		VAL t = *p; *p = u; decref(t);
+		push_value(v);
+	} else {
+		TUP *tup = tup_new(4);
+		tup->size = 4;
+		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
+		tup->cells[1] = VTUP(v)->cells[1]; incref(tup->cells[1]);
+		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
+		tup->cells[3] = u;
+		decref(v);
+		push_value(MKTUP(tup,4));
 	}
-	mw_mirth_name_QName__2F_MKQNAME();
-	LPOP(lbl_arity);
-	mw_std_prim_prim_drop();
-	mw_mirth_name_QName_MKQNAME();
 }
 static void mw_mirth_name_QName_name (void) {
-	mw_mirth_name_QName__2F_MKQNAME();
-	LPOP(lbl_name);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_name);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_name_QName_MKQNAME();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 4, v);
+	VAL u = VTUP(v)->cells[2];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_name_QName_namespace (void) {
-	mw_mirth_name_QName__2F_MKQNAME();
-	LPOP(lbl_namespace);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_namespace);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_name_QName_MKQNAME();
-		mw_std_prim_prim_drop();
-		push_value(d2);
-	}
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 4, v);
+	VAL u = VTUP(v)->cells[1];
+	incref(u);
+	decref(v);
+	push_value(u);
 }
 static void mw_mirth_name_QName_namespace_21_ (void) {
-	{
-		VAL d2 = pop_value();
-		LPUSH(lbl_namespace);
-		push_value(d2);
+	VAL v = pop_value();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 4, v);
+	if (VTUP(v)->refs == 1) {
+		VAL* p = &VTUP(v)->cells[1];
+		VAL t = *p; *p = u; decref(t);
+		push_value(v);
+	} else {
+		TUP *tup = tup_new(4);
+		tup->size = 4;
+		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
+		tup->cells[1] = u;
+		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
+		tup->cells[3] = VTUP(v)->cells[3]; incref(tup->cells[3]);
+		decref(v);
+		push_value(MKTUP(tup,4));
 	}
-	mw_mirth_name_QName__2F_MKQNAME();
-	LPOP(lbl_namespace);
-	mw_std_prim_prim_drop();
-	mw_mirth_name_QName_MKQNAME();
 }
 static void mw_mirth_name_QNAME0 (void) {
 	LPUSH(lbl_name);
@@ -26116,87 +26133,76 @@ static void mw_mirth_lexer__2B_Lexer__2F_LEXER (void) {
 	}
 }
 static void mw_mirth_lexer__2B_Lexer_lexer_last_token (void) {
-	mw_mirth_lexer__2B_Lexer__2F_LEXER();
-	LPOP(lbl_lexer_last_token);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_lexer_last_token);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_lexer__2B_Lexer_LEXER();
-		push_value(d2);
-	}
+	VAL v = top_resource();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 7, v);
+	VAL u = VTUP(v)->cells[6];
+	incref(u);
+	push_value(u);
 }
 static void mw_mirth_lexer__2B_Lexer_lexer_last_token_21_ (void) {
-	LPUSH(lbl_lexer_last_token);
-	mw_mirth_lexer__2B_Lexer__2F_LEXER();
-	LPOP(lbl_lexer_last_token);
-	mw_std_prim_prim_drop();
-	mw_mirth_lexer__2B_Lexer_LEXER();
+	VAL v = top_resource();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 7, v);
+	VAL* p = &VTUP(v)->cells[6];
+	VAL t = *p; *p = u; decref(t);
 }
 static void mw_mirth_lexer__2B_Lexer_lexer_stack (void) {
-	mw_mirth_lexer__2B_Lexer__2F_LEXER();
-	LPOP(lbl_lexer_stack);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_lexer_stack);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_lexer__2B_Lexer_LEXER();
-		push_value(d2);
-	}
+	VAL v = top_resource();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 7, v);
+	VAL u = VTUP(v)->cells[5];
+	incref(u);
+	push_value(u);
 }
 static void mw_mirth_lexer__2B_Lexer_lexer_stack_21_ (void) {
-	LPUSH(lbl_lexer_stack);
-	mw_mirth_lexer__2B_Lexer__2F_LEXER();
-	LPOP(lbl_lexer_stack);
-	mw_std_prim_prim_drop();
-	mw_mirth_lexer__2B_Lexer_LEXER();
+	VAL v = top_resource();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 7, v);
+	VAL* p = &VTUP(v)->cells[5];
+	VAL t = *p; *p = u; decref(t);
 }
 static void mw_mirth_lexer__2B_Lexer_lexer_col (void) {
-	mw_mirth_lexer__2B_Lexer__2F_LEXER();
-	LPOP(lbl_lexer_col);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_lexer_col);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_lexer__2B_Lexer_LEXER();
-		push_value(d2);
-	}
+	VAL v = top_resource();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 7, v);
+	VAL u = VTUP(v)->cells[4];
+	incref(u);
+	push_value(u);
 }
 static void mw_mirth_lexer__2B_Lexer_lexer_col_21_ (void) {
-	LPUSH(lbl_lexer_col);
-	mw_mirth_lexer__2B_Lexer__2F_LEXER();
-	LPOP(lbl_lexer_col);
-	mw_std_prim_prim_drop();
-	mw_mirth_lexer__2B_Lexer_LEXER();
+	VAL v = top_resource();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 7, v);
+	VAL* p = &VTUP(v)->cells[4];
+	VAL t = *p; *p = u; decref(t);
 }
 static void mw_mirth_lexer__2B_Lexer_lexer_row (void) {
-	mw_mirth_lexer__2B_Lexer__2F_LEXER();
-	LPOP(lbl_lexer_row);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_lexer_row);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_lexer__2B_Lexer_LEXER();
-		push_value(d2);
-	}
+	VAL v = top_resource();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 7, v);
+	VAL u = VTUP(v)->cells[3];
+	incref(u);
+	push_value(u);
 }
 static void mw_mirth_lexer__2B_Lexer_lexer_row_21_ (void) {
-	LPUSH(lbl_lexer_row);
-	mw_mirth_lexer__2B_Lexer__2F_LEXER();
-	LPOP(lbl_lexer_row);
-	mw_std_prim_prim_drop();
-	mw_mirth_lexer__2B_Lexer_LEXER();
+	VAL v = top_resource();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 7, v);
+	VAL* p = &VTUP(v)->cells[3];
+	VAL t = *p; *p = u; decref(t);
 }
 static void mw_mirth_lexer__2B_Lexer_lexer_module (void) {
-	mw_mirth_lexer__2B_Lexer__2F_LEXER();
-	LPOP(lbl_lexer_module);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_lexer_module);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_lexer__2B_Lexer_LEXER();
-		push_value(d2);
-	}
+	VAL v = top_resource();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 7, v);
+	VAL u = VTUP(v)->cells[2];
+	incref(u);
+	push_value(u);
 }
 static void mw_mirth_lexer_lexer_stack_push_21_ (void) {
 	mw_mirth_lexer__2B_Lexer_lexer_stack();
@@ -27936,22 +27942,20 @@ static void mw_mirth_elab__2B_AB__2F_MKAB (void) {
 	}
 }
 static void mw_mirth_elab__2B_AB_arrow (void) {
-	mw_mirth_elab__2B_AB__2F_MKAB();
-	LPOP(lbl_arrow);
-	mw_std_prim_prim_dup();
-	LPUSH(lbl_arrow);
-	{
-		VAL d2 = pop_value();
-		mw_mirth_elab__2B_AB_MKAB();
-		push_value(d2);
-	}
+	VAL v = top_resource();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 2, v);
+	VAL u = VTUP(v)->cells[1];
+	incref(u);
+	push_value(u);
 }
 static void mw_mirth_elab__2B_AB_arrow_21_ (void) {
-	LPUSH(lbl_arrow);
-	mw_mirth_elab__2B_AB__2F_MKAB();
-	LPOP(lbl_arrow);
-	mw_std_prim_prim_drop();
-	mw_mirth_elab__2B_AB_MKAB();
+	VAL v = top_resource();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 2, v);
+	VAL* p = &VTUP(v)->cells[1];
+	VAL t = *p; *p = u; decref(t);
 }
 static void mw_mirth_elab__2B_AB_arrow_1 (void) {
 	mw_mirth_elab__2B_AB_arrow();
@@ -28607,6 +28611,18 @@ static void mw_mirth_elab_elab_op_fresh_sig_21_ (void) {
 		case 16LL:
 			mp_mirth_arrow_Op_OP_5F_LABEL_5F_POP();
 			mw_mirth_elab_elab_label_pop_sig_21_();
+			break;
+		case 17LL:
+			mp_mirth_arrow_Op_OP_5F_DATA_5F_GET_5F_LABEL();
+			mw_mirth_elab_data_get_label_type();
+			mw_mirth_type_ArrowType_freshen_sig();
+			mw_mirth_elab_OpSig_OPSIG_5F_APPLY();
+			break;
+		case 18LL:
+			mp_mirth_arrow_Op_OP_5F_DATA_5F_SET_5F_LABEL();
+			mw_mirth_elab_data_set_label_type();
+			mw_mirth_type_ArrowType_freshen_sig();
+			mw_mirth_elab_OpSig_OPSIG_5F_APPLY();
 			break;
 		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
 	}
@@ -30202,6 +30218,66 @@ static void mw_mirth_data_Tag_project_input_label (void) {
 	mw_std_prim_prim_pack_cons();
 	mw_std_maybe_Maybe_1_map_1();
 }
+static void mw_mirth_elab_data_get_label_type (void) {
+	{
+		VAL var_lbl = pop_value();
+		VAL var_tag = pop_value();
+		mw_mirth_type_T0();
+		incref(var_tag);
+		push_value(var_tag);
+		mw_mirth_data_Tag_output_type();
+		mw_mirth_type_T_2A__2B_();
+		incref(var_lbl);
+		push_value(var_lbl);
+		incref(var_tag);
+		push_value(var_tag);
+		mw_mirth_data_Tag_project_input_label();
+		mw_std_maybe_Maybe_1_unwrap();
+		mw_mirth_type_T1();
+		incref(var_tag);
+		push_value(var_tag);
+		mw_mirth_data_Tag_data();
+		mw_mirth_data_Data_is_resource_3F_();
+		push_value(MKNIL);
+		incref(var_lbl);
+		push_value(var_lbl);
+		mw_std_prim_prim_pack_cons();
+		incref(var_tag);
+		push_value(var_tag);
+		mw_std_prim_prim_pack_cons();
+		push_fnptr(&mb_mirth_elab_data_get_label_type_19);
+		mw_std_prim_prim_pack_cons();
+		mw_std_prim_Bool_then_1();
+		mw_mirth_type_T__3E_();
+		decref(var_lbl);
+		decref(var_tag);
+	}
+}
+static void mw_mirth_elab_data_set_label_type (void) {
+	{
+		VAL var_lbl = pop_value();
+		VAL var_tag = pop_value();
+		incref(var_lbl);
+		push_value(var_lbl);
+		incref(var_tag);
+		push_value(var_tag);
+		mw_mirth_data_Tag_project_input_label();
+		mw_std_maybe_Maybe_1_unwrap();
+		mw_mirth_type_T1();
+		incref(var_tag);
+		push_value(var_tag);
+		mw_mirth_data_Tag_output_type();
+		mw_mirth_type_T_2A__2B_();
+		mw_mirth_type_T0();
+		incref(var_tag);
+		push_value(var_tag);
+		mw_mirth_data_Tag_output_type();
+		mw_mirth_type_T_2A__2B_();
+		mw_mirth_type_T__3E_();
+		decref(var_lbl);
+		decref(var_tag);
+	}
+}
 static void mw_mirth_elab_create_projectors_21_ (void) {
 	mw_std_prim_prim_dup();
 	mw_mirth_data_Tag_data();
@@ -31706,6 +31782,14 @@ static void mw_mirth_need__2B_Needs_run_op_21_ (void) {
 		case 16LL:
 			mp_mirth_arrow_Op_OP_5F_LABEL_5F_POP();
 			mw_std_prelude_drop2();
+			break;
+		case 17LL:
+			mp_mirth_arrow_Op_OP_5F_DATA_5F_GET_5F_LABEL();
+			mw_std_prelude_drop3();
+			break;
+		case 18LL:
+			mp_mirth_arrow_Op_OP_5F_DATA_5F_SET_5F_LABEL();
+			mw_std_prelude_drop3();
 			break;
 		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
 	}
@@ -33697,6 +33781,205 @@ static void mw_mirth_c99_c99_tag_21_ (void) {
 		decref(var_tag);
 	}
 }
+static void mw_mirth_c99_c99_tag_label_index (void) {
+	mw_std_prelude_over();
+	mw_mirth_data_Tag_num_total_inputs();
+	mw_std_prelude_Nat_1_2B_();
+	mw_std_prelude_over2();
+	mw_mirth_data_Tag_label_inputs();
+	push_value(MKNIL);
+	push_fnptr(&mb_mirth_c99_c99_tag_label_index_7);
+	mw_std_prim_prim_pack_cons();
+	mw_std_list_List_1_reverse_find_1();
+	mw_std_prim_prim_drop();
+	{
+		VAL d2 = pop_value();
+		mw_std_prelude_drop2();
+		push_value(d2);
+	}
+}
+static void mw_mirth_c99_c99_tag_get_label_21_ (void) {
+	mw_std_prelude_over();
+	mw_mirth_data_Tag_outputs_resource_3F_();
+	if (pop_u64()) {
+		push_value(MKNIL);
+		push_fnptr(&mb_mirth_c99_c99_tag_get_label_21__6);
+		mw_std_prim_prim_pack_cons();
+		mw_mirth_c99_c99_line_1();
+	} else {
+		push_value(MKNIL);
+		push_fnptr(&mb_mirth_c99_c99_tag_get_label_21__12);
+		mw_std_prim_prim_pack_cons();
+		mw_mirth_c99_c99_line_1();
+	}
+	push_value(MKNIL);
+	push_fnptr(&mb_mirth_c99_c99_tag_get_label_21__18);
+	mw_std_prim_prim_pack_cons();
+	mw_mirth_c99_c99_line_1();
+	push_value(MKNIL);
+	push_fnptr(&mb_mirth_c99_c99_tag_get_label_21__23);
+	mw_std_prim_prim_pack_cons();
+	mw_mirth_c99_c99_line_1();
+	push_value(MKNIL);
+	push_fnptr(&mb_mirth_c99_c99_tag_get_label_21__35);
+	mw_std_prim_prim_pack_cons();
+	mw_mirth_c99_c99_line_1();
+	push_value(MKNIL);
+	push_fnptr(&mb_mirth_c99_c99_tag_get_label_21__46);
+	mw_std_prim_prim_pack_cons();
+	mw_mirth_c99_c99_line_1();
+	mw_std_prelude_over();
+	mw_mirth_data_Tag_outputs_resource_3F_();
+	push_value(MKNIL);
+	push_fnptr(&mb_mirth_c99_c99_tag_get_label_21__53);
+	mw_std_prim_prim_pack_cons();
+	mw_std_prim_Bool_else_1();
+	push_value(MKNIL);
+	push_fnptr(&mb_mirth_c99_c99_tag_get_label_21__61);
+	mw_std_prim_prim_pack_cons();
+	mw_mirth_c99_c99_line_1();
+	mw_std_prelude_drop2();
+}
+static void mw_mirth_c99_c99_tag_set_label_21_ (void) {
+	{
+		VAL var_lbl = pop_value();
+		VAL var_tag = pop_value();
+		incref(var_tag);
+		push_value(var_tag);
+		mw_mirth_data_Tag_outputs_resource_3F_();
+		if (pop_u64()) {
+			push_value(MKNIL);
+			incref(var_lbl);
+			push_value(var_lbl);
+			mw_std_prim_prim_pack_cons();
+			incref(var_tag);
+			push_value(var_tag);
+			mw_std_prim_prim_pack_cons();
+			push_fnptr(&mb_mirth_c99_c99_tag_set_label_21__11);
+			mw_std_prim_prim_pack_cons();
+			mw_mirth_c99_c99_line_1();
+		} else {
+			push_value(MKNIL);
+			incref(var_lbl);
+			push_value(var_lbl);
+			mw_std_prim_prim_pack_cons();
+			incref(var_tag);
+			push_value(var_tag);
+			mw_std_prim_prim_pack_cons();
+			push_fnptr(&mb_mirth_c99_c99_tag_set_label_21__17);
+			mw_std_prim_prim_pack_cons();
+			mw_mirth_c99_c99_line_1();
+		}
+		push_value(MKNIL);
+		incref(var_lbl);
+		push_value(var_lbl);
+		mw_std_prim_prim_pack_cons();
+		incref(var_tag);
+		push_value(var_tag);
+		mw_std_prim_prim_pack_cons();
+		push_fnptr(&mb_mirth_c99_c99_tag_set_label_21__23);
+		mw_std_prim_prim_pack_cons();
+		mw_mirth_c99_c99_line_1();
+		push_value(MKNIL);
+		incref(var_lbl);
+		push_value(var_lbl);
+		mw_std_prim_prim_pack_cons();
+		incref(var_tag);
+		push_value(var_tag);
+		mw_std_prim_prim_pack_cons();
+		push_fnptr(&mb_mirth_c99_c99_tag_set_label_21__28);
+		mw_std_prim_prim_pack_cons();
+		mw_mirth_c99_c99_line_1();
+		push_value(MKNIL);
+		incref(var_lbl);
+		push_value(var_lbl);
+		mw_std_prim_prim_pack_cons();
+		incref(var_tag);
+		push_value(var_tag);
+		mw_std_prim_prim_pack_cons();
+		push_fnptr(&mb_mirth_c99_c99_tag_set_label_21__33);
+		mw_std_prim_prim_pack_cons();
+		mw_mirth_c99_c99_line_1();
+		incref(var_tag);
+		push_value(var_tag);
+		mw_mirth_data_Tag_outputs_resource_3F_();
+		if (pop_u64()) {
+			push_value(MKNIL);
+			incref(var_lbl);
+			push_value(var_lbl);
+			mw_std_prim_prim_pack_cons();
+			incref(var_tag);
+			push_value(var_tag);
+			mw_std_prim_prim_pack_cons();
+			push_fnptr(&mb_mirth_c99_c99_tag_set_label_21__49);
+			mw_std_prim_prim_pack_cons();
+			mw_mirth_c99_c99_line_1();
+			push_value(MKNIL);
+			incref(var_lbl);
+			push_value(var_lbl);
+			mw_std_prim_prim_pack_cons();
+			incref(var_tag);
+			push_value(var_tag);
+			mw_std_prim_prim_pack_cons();
+			push_fnptr(&mb_mirth_c99_c99_tag_set_label_21__61);
+			mw_std_prim_prim_pack_cons();
+			mw_mirth_c99_c99_line_1();
+		} else {
+			push_value(MKNIL);
+			incref(var_lbl);
+			push_value(var_lbl);
+			mw_std_prim_prim_pack_cons();
+			incref(var_tag);
+			push_value(var_tag);
+			mw_std_prim_prim_pack_cons();
+			push_fnptr(&mb_mirth_c99_c99_tag_set_label_21__67);
+			mw_std_prim_prim_pack_cons();
+			mw_mirth_c99_c99_line_1();
+			push_value(MKNIL);
+			incref(var_lbl);
+			push_value(var_lbl);
+			mw_std_prim_prim_pack_cons();
+			incref(var_tag);
+			push_value(var_tag);
+			mw_std_prim_prim_pack_cons();
+			push_fnptr(&mb_mirth_c99_c99_tag_set_label_21__72);
+			mw_std_prim_prim_pack_cons();
+			mw_mirth_c99_c99_nest_1();
+			push_value(MKNIL);
+			incref(var_lbl);
+			push_value(var_lbl);
+			mw_std_prim_prim_pack_cons();
+			incref(var_tag);
+			push_value(var_tag);
+			mw_std_prim_prim_pack_cons();
+			push_fnptr(&mb_mirth_c99_c99_tag_set_label_21__97);
+			mw_std_prim_prim_pack_cons();
+			mw_mirth_c99_c99_line_1();
+			push_value(MKNIL);
+			incref(var_lbl);
+			push_value(var_lbl);
+			mw_std_prim_prim_pack_cons();
+			incref(var_tag);
+			push_value(var_tag);
+			mw_std_prim_prim_pack_cons();
+			push_fnptr(&mb_mirth_c99_c99_tag_set_label_21__102);
+			mw_std_prim_prim_pack_cons();
+			mw_mirth_c99_c99_nest_1();
+			push_value(MKNIL);
+			incref(var_lbl);
+			push_value(var_lbl);
+			mw_std_prim_prim_pack_cons();
+			incref(var_tag);
+			push_value(var_tag);
+			mw_std_prim_prim_pack_cons();
+			push_fnptr(&mb_mirth_c99_c99_tag_set_label_21__197);
+			mw_std_prim_prim_pack_cons();
+			mw_mirth_c99_c99_line_1();
+		}
+		decref(var_lbl);
+		decref(var_tag);
+	}
+}
 static void mw_mirth_c99_c99_externals_21_ (void) {
 	push_value(MKNIL);
 	push_fnptr(&mb_mirth_c99_c99_externals_21__2);
@@ -34103,6 +34386,16 @@ static void mw_mirth_c99_c99_args_op_21_ (void) {
 			mp_mirth_arrow_Op_OP_5F_LABEL_5F_POP();
 			mw_std_prelude_nip();
 			mw_mirth_c99_c99_label_pop_21_();
+			break;
+		case 17LL:
+			mp_mirth_arrow_Op_OP_5F_DATA_5F_GET_5F_LABEL();
+			mw_mirth_c99_c99_tag_get_label_21_();
+			mw_std_prim_prim_drop();
+			break;
+		case 18LL:
+			mp_mirth_arrow_Op_OP_5F_DATA_5F_SET_5F_LABEL();
+			mw_mirth_c99_c99_tag_set_label_21_();
+			mw_std_prim_prim_drop();
 			break;
 		default: write(2, "unexpected fallthrough in match\n", 32); mw_std_prim_prim_debug(); exit(99);
 	}
@@ -38613,6 +38906,19 @@ static void mb_mirth_elab_elab_lambda_sig_21__2 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_arrow_Lambda_dom();
 }
+static void mb_mirth_elab_data_get_label_type_19 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	incref(var_tag);
+	push_value(var_tag);
+	mw_mirth_data_Tag_output_type();
+	mw_mirth_type_T_2A__2B_();
+	decref(var_tag);
+	decref(var_lbl);
+}
 static void mb_mirth_elab_elab_arrow_fwd_21__2 (void) {
 	mw_std_prim_prim_drop();
 	mw_mirth_elab_elab_atoms_21_();
@@ -40214,7 +40520,7 @@ static void mb_mirth_elab_create_projectors_21__27 (void) {
 		incref(var_lbl_5F_get);
 		push_value(var_lbl_5F_get);
 		mw_std_prim_prim_pack_cons();
-		push_fnptr(&mb_mirth_elab_create_projectors_21__80);
+		push_fnptr(&mb_mirth_elab_create_projectors_21__65);
 		mw_std_prim_prim_pack_cons();
 		mw_std_lazy_delay_1();
 		incref(var_lbl_5F_get);
@@ -40243,7 +40549,7 @@ static void mb_mirth_elab_create_projectors_21__27 (void) {
 		incref(var_lbl_5F_get);
 		push_value(var_lbl_5F_get);
 		mw_std_prim_prim_pack_cons();
-		push_fnptr(&mb_mirth_elab_create_projectors_21__109);
+		push_fnptr(&mb_mirth_elab_create_projectors_21__78);
 		mw_std_prim_prim_pack_cons();
 		mw_std_lazy_delay0_1();
 		incref(var_lbl_5F_set);
@@ -40274,13 +40580,44 @@ static void mb_mirth_elab_create_projectors_21__27 (void) {
 		incref(var_lbl_5F_get);
 		push_value(var_lbl_5F_get);
 		mw_std_prim_prim_pack_cons();
-		push_fnptr(&mb_mirth_elab_create_projectors_21__132);
+		push_fnptr(&mb_mirth_elab_create_projectors_21__91);
 		mw_std_prim_prim_pack_cons();
 		mw_std_lazy_delay_1();
 		incref(var_lbl_5F_set);
 		push_value(var_lbl_5F_set);
 		mw_mirth_word_Word__7E_arrow();
 		mw_std_prim_prim_mut_set();
+		push_value(MKNIL);
+		incref(var_untag);
+		push_value(var_untag);
+		mw_std_prim_prim_pack_cons();
+		incref(var_dat);
+		push_value(var_dat);
+		mw_std_prim_prim_pack_cons();
+		incref(var_tag);
+		push_value(var_tag);
+		mw_std_prim_prim_pack_cons();
+		incref(var_lbl);
+		push_value(var_lbl);
+		mw_std_prim_prim_pack_cons();
+		incref(var_lbl_5F_lens);
+		push_value(var_lbl_5F_lens);
+		mw_std_prim_prim_pack_cons();
+		incref(var_lbl_5F_set);
+		push_value(var_lbl_5F_set);
+		mw_std_prim_prim_pack_cons();
+		incref(var_lbl_5F_get);
+		push_value(var_lbl_5F_get);
+		mw_std_prim_prim_pack_cons();
+		push_fnptr(&mb_mirth_elab_create_projectors_21__104);
+		mw_std_prim_prim_pack_cons();
+		mw_std_lazy_delay0_1();
+		incref(var_lbl_5F_lens);
+		push_value(var_lbl_5F_lens);
+		mw_mirth_word_Word__7E_ctx_type();
+		mw_std_prim_prim_mut_set();
+		incref(var_lbl_5F_lens);
+		push_value(var_lbl_5F_lens);
 		push_value(MKNIL);
 		incref(var_untag);
 		push_value(var_untag);
@@ -40304,37 +40641,6 @@ static void mb_mirth_elab_create_projectors_21__27 (void) {
 		push_value(var_lbl_5F_get);
 		mw_std_prim_prim_pack_cons();
 		push_fnptr(&mb_mirth_elab_create_projectors_21__162);
-		mw_std_prim_prim_pack_cons();
-		mw_std_lazy_delay0_1();
-		incref(var_lbl_5F_lens);
-		push_value(var_lbl_5F_lens);
-		mw_mirth_word_Word__7E_ctx_type();
-		mw_std_prim_prim_mut_set();
-		incref(var_lbl_5F_lens);
-		push_value(var_lbl_5F_lens);
-		push_value(MKNIL);
-		incref(var_untag);
-		push_value(var_untag);
-		mw_std_prim_prim_pack_cons();
-		incref(var_dat);
-		push_value(var_dat);
-		mw_std_prim_prim_pack_cons();
-		incref(var_tag);
-		push_value(var_tag);
-		mw_std_prim_prim_pack_cons();
-		incref(var_lbl);
-		push_value(var_lbl);
-		mw_std_prim_prim_pack_cons();
-		incref(var_lbl_5F_lens);
-		push_value(var_lbl_5F_lens);
-		mw_std_prim_prim_pack_cons();
-		incref(var_lbl_5F_set);
-		push_value(var_lbl_5F_set);
-		mw_std_prim_prim_pack_cons();
-		incref(var_lbl_5F_get);
-		push_value(var_lbl_5F_get);
-		mw_std_prim_prim_pack_cons();
-		push_fnptr(&mb_mirth_elab_create_projectors_21__220);
 		mw_std_prim_prim_pack_cons();
 		mw_std_lazy_delay_1();
 		incref(var_lbl_5F_lens);
@@ -40369,21 +40675,36 @@ static void mb_mirth_elab_create_projectors_21__52 (void) {
 	incref(var_tag);
 	push_value(var_tag);
 	mw_mirth_data_Tag_ctx();
-	mw_mirth_type_T0();
 	incref(var_tag);
 	push_value(var_tag);
-	mw_mirth_data_Tag_output_type();
-	mw_mirth_type_T_2A__2B_();
 	incref(var_lbl);
 	push_value(var_lbl);
-	incref(var_tag);
-	push_value(var_tag);
-	mw_mirth_data_Tag_project_input_label();
-	mw_std_maybe_Maybe_1_unwrap();
-	mw_mirth_type_T1();
-	incref(var_dat);
-	push_value(var_dat);
-	mw_mirth_data_Data_is_resource_3F_();
+	mw_mirth_elab_data_get_label_type();
+	mw_std_prelude_pack2();
+	decref(var_lbl_5F_get);
+	decref(var_lbl_5F_set);
+	decref(var_lbl_5F_lens);
+	decref(var_lbl);
+	decref(var_tag);
+	decref(var_dat);
+	decref(var_untag);
+}
+static void mb_mirth_elab_create_projectors_21__65 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl_5F_get = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl_5F_set = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl_5F_lens = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_dat = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_untag = pop_value();
+	mw_std_prim_prim_drop();
 	push_value(MKNIL);
 	incref(var_untag);
 	push_value(var_untag);
@@ -40408,9 +40729,7 @@ static void mb_mirth_elab_create_projectors_21__52 (void) {
 	mw_std_prim_prim_pack_cons();
 	push_fnptr(&mb_mirth_elab_create_projectors_21__67);
 	mw_std_prim_prim_pack_cons();
-	mw_std_prim_Bool_then_1();
-	mw_mirth_type_T__3E_();
-	mw_std_prelude_pack2();
+	mw_mirth_elab_ab_build_word_arrow_21__1();
 	decref(var_lbl_5F_get);
 	decref(var_lbl_5F_set);
 	decref(var_lbl_5F_lens);
@@ -40437,8 +40756,10 @@ static void mb_mirth_elab_create_projectors_21__67 (void) {
 	mw_std_prim_prim_drop();
 	incref(var_tag);
 	push_value(var_tag);
-	mw_mirth_data_Tag_output_type();
-	mw_mirth_type_T_2A__2B_();
+	incref(var_lbl);
+	push_value(var_lbl);
+	mw_mirth_arrow_Op_OP_5F_DATA_5F_GET_5F_LABEL();
+	mw_mirth_elab_ab_op_21_();
 	decref(var_lbl_5F_get);
 	decref(var_lbl_5F_set);
 	decref(var_lbl_5F_lens);
@@ -40447,197 +40768,7 @@ static void mb_mirth_elab_create_projectors_21__67 (void) {
 	decref(var_dat);
 	decref(var_untag);
 }
-static void mb_mirth_elab_create_projectors_21__80 (void) {
-	mw_std_prim_prim_pack_uncons();
-	VAL var_lbl_5F_get = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_lbl_5F_set = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_lbl_5F_lens = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_lbl = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_tag = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_dat = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_untag = pop_value();
-	mw_std_prim_prim_drop();
-	push_value(MKNIL);
-	incref(var_untag);
-	push_value(var_untag);
-	mw_std_prim_prim_pack_cons();
-	incref(var_dat);
-	push_value(var_dat);
-	mw_std_prim_prim_pack_cons();
-	incref(var_tag);
-	push_value(var_tag);
-	mw_std_prim_prim_pack_cons();
-	incref(var_lbl);
-	push_value(var_lbl);
-	mw_std_prim_prim_pack_cons();
-	incref(var_lbl_5F_lens);
-	push_value(var_lbl_5F_lens);
-	mw_std_prim_prim_pack_cons();
-	incref(var_lbl_5F_set);
-	push_value(var_lbl_5F_set);
-	mw_std_prim_prim_pack_cons();
-	incref(var_lbl_5F_get);
-	push_value(var_lbl_5F_get);
-	mw_std_prim_prim_pack_cons();
-	push_fnptr(&mb_mirth_elab_create_projectors_21__82);
-	mw_std_prim_prim_pack_cons();
-	mw_mirth_elab_ab_build_word_arrow_21__1();
-	decref(var_lbl_5F_get);
-	decref(var_lbl_5F_set);
-	decref(var_lbl_5F_lens);
-	decref(var_lbl);
-	decref(var_tag);
-	decref(var_dat);
-	decref(var_untag);
-}
-static void mb_mirth_elab_create_projectors_21__82 (void) {
-	mw_std_prim_prim_pack_uncons();
-	VAL var_lbl_5F_get = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_lbl_5F_set = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_lbl_5F_lens = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_lbl = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_tag = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_dat = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_untag = pop_value();
-	mw_std_prim_prim_drop();
-	incref(var_untag);
-	push_value(var_untag);
-	mw_mirth_elab_ab_word_21_();
-	incref(var_lbl);
-	push_value(var_lbl);
-	mw_mirth_elab_ab_label_pop_21_();
-	mw_mirth_prim_Prim_PRIM_5F_CORE_5F_DUP();
-	mw_mirth_elab_ab_prim_21_();
-	incref(var_lbl);
-	push_value(var_lbl);
-	mw_mirth_elab_ab_label_push_21_();
-	push_value(MKNIL);
-	incref(var_untag);
-	push_value(var_untag);
-	mw_std_prim_prim_pack_cons();
-	incref(var_dat);
-	push_value(var_dat);
-	mw_std_prim_prim_pack_cons();
-	incref(var_tag);
-	push_value(var_tag);
-	mw_std_prim_prim_pack_cons();
-	incref(var_lbl);
-	push_value(var_lbl);
-	mw_std_prim_prim_pack_cons();
-	incref(var_lbl_5F_lens);
-	push_value(var_lbl_5F_lens);
-	mw_std_prim_prim_pack_cons();
-	incref(var_lbl_5F_set);
-	push_value(var_lbl_5F_set);
-	mw_std_prim_prim_pack_cons();
-	incref(var_lbl_5F_get);
-	push_value(var_lbl_5F_get);
-	mw_std_prim_prim_pack_cons();
-	push_fnptr(&mb_mirth_elab_create_projectors_21__92);
-	mw_std_prim_prim_pack_cons();
-	mw_mirth_elab_ab_dip_21__1();
-	decref(var_lbl_5F_get);
-	decref(var_lbl_5F_set);
-	decref(var_lbl_5F_lens);
-	decref(var_lbl);
-	decref(var_tag);
-	decref(var_dat);
-	decref(var_untag);
-}
-static void mb_mirth_elab_create_projectors_21__92 (void) {
-	mw_std_prim_prim_pack_uncons();
-	VAL var_lbl_5F_get = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_lbl_5F_set = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_lbl_5F_lens = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_lbl = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_tag = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_dat = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_untag = pop_value();
-	mw_std_prim_prim_drop();
-	incref(var_tag);
-	push_value(var_tag);
-	mw_mirth_elab_ab_tag_21_();
-	incref(var_dat);
-	push_value(var_dat);
-	mw_mirth_data_Data_is_resource_3F_();
-	push_value(MKNIL);
-	incref(var_untag);
-	push_value(var_untag);
-	mw_std_prim_prim_pack_cons();
-	incref(var_dat);
-	push_value(var_dat);
-	mw_std_prim_prim_pack_cons();
-	incref(var_tag);
-	push_value(var_tag);
-	mw_std_prim_prim_pack_cons();
-	incref(var_lbl);
-	push_value(var_lbl);
-	mw_std_prim_prim_pack_cons();
-	incref(var_lbl_5F_lens);
-	push_value(var_lbl_5F_lens);
-	mw_std_prim_prim_pack_cons();
-	incref(var_lbl_5F_set);
-	push_value(var_lbl_5F_set);
-	mw_std_prim_prim_pack_cons();
-	incref(var_lbl_5F_get);
-	push_value(var_lbl_5F_get);
-	mw_std_prim_prim_pack_cons();
-	push_fnptr(&mb_mirth_elab_create_projectors_21__98);
-	mw_std_prim_prim_pack_cons();
-	mw_std_prim_Bool_else_1();
-	decref(var_lbl_5F_get);
-	decref(var_lbl_5F_set);
-	decref(var_lbl_5F_lens);
-	decref(var_lbl);
-	decref(var_tag);
-	decref(var_dat);
-	decref(var_untag);
-}
-static void mb_mirth_elab_create_projectors_21__98 (void) {
-	mw_std_prim_prim_pack_uncons();
-	VAL var_lbl_5F_get = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_lbl_5F_set = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_lbl_5F_lens = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_lbl = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_tag = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_dat = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_untag = pop_value();
-	mw_std_prim_prim_drop();
-	mw_mirth_prim_Prim_PRIM_5F_CORE_5F_DROP();
-	mw_mirth_elab_ab_prim_21_();
-	decref(var_lbl_5F_get);
-	decref(var_lbl_5F_set);
-	decref(var_lbl_5F_lens);
-	decref(var_lbl);
-	decref(var_tag);
-	decref(var_dat);
-	decref(var_untag);
-}
-static void mb_mirth_elab_create_projectors_21__109 (void) {
+static void mb_mirth_elab_create_projectors_21__78 (void) {
 	mw_std_prim_prim_pack_uncons();
 	VAL var_lbl_5F_get = pop_value();
 	mw_std_prim_prim_pack_uncons();
@@ -40656,23 +40787,11 @@ static void mb_mirth_elab_create_projectors_21__109 (void) {
 	incref(var_tag);
 	push_value(var_tag);
 	mw_mirth_data_Tag_ctx();
+	incref(var_tag);
+	push_value(var_tag);
 	incref(var_lbl);
 	push_value(var_lbl);
-	incref(var_tag);
-	push_value(var_tag);
-	mw_mirth_data_Tag_project_input_label();
-	mw_std_maybe_Maybe_1_unwrap();
-	mw_mirth_type_T1();
-	incref(var_tag);
-	push_value(var_tag);
-	mw_mirth_data_Tag_output_type();
-	mw_mirth_type_T_2A__2B_();
-	mw_mirth_type_T0();
-	incref(var_tag);
-	push_value(var_tag);
-	mw_mirth_data_Tag_output_type();
-	mw_mirth_type_T_2A__2B_();
-	mw_mirth_type_T__3E_();
+	mw_mirth_elab_data_set_label_type();
 	mw_std_prelude_pack2();
 	decref(var_lbl_5F_get);
 	decref(var_lbl_5F_set);
@@ -40682,7 +40801,7 @@ static void mb_mirth_elab_create_projectors_21__109 (void) {
 	decref(var_dat);
 	decref(var_untag);
 }
-static void mb_mirth_elab_create_projectors_21__132 (void) {
+static void mb_mirth_elab_create_projectors_21__91 (void) {
 	mw_std_prim_prim_pack_uncons();
 	VAL var_lbl_5F_get = pop_value();
 	mw_std_prim_prim_pack_uncons();
@@ -40720,7 +40839,7 @@ static void mb_mirth_elab_create_projectors_21__132 (void) {
 	incref(var_lbl_5F_get);
 	push_value(var_lbl_5F_get);
 	mw_std_prim_prim_pack_cons();
-	push_fnptr(&mb_mirth_elab_create_projectors_21__134);
+	push_fnptr(&mb_mirth_elab_create_projectors_21__93);
 	mw_std_prim_prim_pack_cons();
 	mw_mirth_elab_ab_build_word_arrow_21__1();
 	decref(var_lbl_5F_get);
@@ -40731,7 +40850,7 @@ static void mb_mirth_elab_create_projectors_21__132 (void) {
 	decref(var_dat);
 	decref(var_untag);
 }
-static void mb_mirth_elab_create_projectors_21__134 (void) {
+static void mb_mirth_elab_create_projectors_21__93 (void) {
 	mw_std_prim_prim_pack_uncons();
 	VAL var_lbl_5F_get = pop_value();
 	mw_std_prim_prim_pack_uncons();
@@ -40747,78 +40866,12 @@ static void mb_mirth_elab_create_projectors_21__134 (void) {
 	mw_std_prim_prim_pack_uncons();
 	VAL var_untag = pop_value();
 	mw_std_prim_prim_drop();
-	incref(var_dat);
-	push_value(var_dat);
-	mw_mirth_data_Data_is_resource_3F_();
-	if (pop_u64()) {
-		incref(var_lbl);
-		push_value(var_lbl);
-		mw_mirth_elab_ab_label_push_21_();
-	} else {
-		push_value(MKNIL);
-		incref(var_untag);
-		push_value(var_untag);
-		mw_std_prim_prim_pack_cons();
-		incref(var_dat);
-		push_value(var_dat);
-		mw_std_prim_prim_pack_cons();
-		incref(var_tag);
-		push_value(var_tag);
-		mw_std_prim_prim_pack_cons();
-		incref(var_lbl);
-		push_value(var_lbl);
-		mw_std_prim_prim_pack_cons();
-		incref(var_lbl_5F_lens);
-		push_value(var_lbl_5F_lens);
-		mw_std_prim_prim_pack_cons();
-		incref(var_lbl_5F_set);
-		push_value(var_lbl_5F_set);
-		mw_std_prim_prim_pack_cons();
-		incref(var_lbl_5F_get);
-		push_value(var_lbl_5F_get);
-		mw_std_prim_prim_pack_cons();
-		push_fnptr(&mb_mirth_elab_create_projectors_21__143);
-		mw_std_prim_prim_pack_cons();
-		mw_mirth_elab_ab_dip_21__1();
-	}
-	incref(var_untag);
-	push_value(var_untag);
-	mw_mirth_elab_ab_word_21_();
-	incref(var_lbl);
-	push_value(var_lbl);
-	mw_mirth_elab_ab_label_pop_21_();
-	mw_mirth_prim_Prim_PRIM_5F_CORE_5F_DROP();
-	mw_mirth_elab_ab_prim_21_();
 	incref(var_tag);
 	push_value(var_tag);
-	mw_mirth_elab_ab_tag_21_();
-	decref(var_lbl_5F_get);
-	decref(var_lbl_5F_set);
-	decref(var_lbl_5F_lens);
-	decref(var_lbl);
-	decref(var_tag);
-	decref(var_dat);
-	decref(var_untag);
-}
-static void mb_mirth_elab_create_projectors_21__143 (void) {
-	mw_std_prim_prim_pack_uncons();
-	VAL var_lbl_5F_get = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_lbl_5F_set = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_lbl_5F_lens = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_lbl = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_tag = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_dat = pop_value();
-	mw_std_prim_prim_pack_uncons();
-	VAL var_untag = pop_value();
-	mw_std_prim_prim_drop();
 	incref(var_lbl);
 	push_value(var_lbl);
-	mw_mirth_elab_ab_label_push_21_();
+	mw_mirth_arrow_Op_OP_5F_DATA_5F_SET_5F_LABEL();
+	mw_mirth_elab_ab_op_21_();
 	decref(var_lbl_5F_get);
 	decref(var_lbl_5F_set);
 	decref(var_lbl_5F_lens);
@@ -40827,7 +40880,7 @@ static void mb_mirth_elab_create_projectors_21__143 (void) {
 	decref(var_dat);
 	decref(var_untag);
 }
-static void mb_mirth_elab_create_projectors_21__162 (void) {
+static void mb_mirth_elab_create_projectors_21__104 (void) {
 	mw_std_prim_prim_pack_uncons();
 	VAL var_lbl_5F_get = pop_value();
 	mw_std_prim_prim_pack_uncons();
@@ -40936,7 +40989,7 @@ static void mb_mirth_elab_create_projectors_21__162 (void) {
 	decref(var_dat);
 	decref(var_untag);
 }
-static void mb_mirth_elab_create_projectors_21__220 (void) {
+static void mb_mirth_elab_create_projectors_21__162 (void) {
 	mw_std_prim_prim_pack_uncons();
 	VAL var_lbl_5F_get = pop_value();
 	mw_std_prim_prim_pack_uncons();
@@ -40974,7 +41027,7 @@ static void mb_mirth_elab_create_projectors_21__220 (void) {
 	incref(var_lbl_5F_get);
 	push_value(var_lbl_5F_get);
 	mw_std_prim_prim_pack_cons();
-	push_fnptr(&mb_mirth_elab_create_projectors_21__222);
+	push_fnptr(&mb_mirth_elab_create_projectors_21__164);
 	mw_std_prim_prim_pack_cons();
 	mw_mirth_elab_ab_build_word_arrow_21__1();
 	decref(var_lbl_5F_get);
@@ -40985,7 +41038,7 @@ static void mb_mirth_elab_create_projectors_21__220 (void) {
 	decref(var_dat);
 	decref(var_untag);
 }
-static void mb_mirth_elab_create_projectors_21__222 (void) {
+static void mb_mirth_elab_create_projectors_21__164 (void) {
 	mw_std_prim_prim_pack_uncons();
 	VAL var_lbl_5F_get = pop_value();
 	mw_std_prim_prim_pack_uncons();
@@ -41030,7 +41083,7 @@ static void mb_mirth_elab_create_projectors_21__222 (void) {
 		incref(var_lbl_5F_get);
 		push_value(var_lbl_5F_get);
 		mw_std_prim_prim_pack_cons();
-		push_fnptr(&mb_mirth_elab_create_projectors_21__230);
+		push_fnptr(&mb_mirth_elab_create_projectors_21__172);
 		mw_std_prim_prim_pack_cons();
 		mw_mirth_elab_ab_rdip_21__1();
 		incref(var_lbl_5F_set);
@@ -41063,7 +41116,7 @@ static void mb_mirth_elab_create_projectors_21__222 (void) {
 		incref(var_lbl_5F_get);
 		push_value(var_lbl_5F_get);
 		mw_std_prim_prim_pack_cons();
-		push_fnptr(&mb_mirth_elab_create_projectors_21__244);
+		push_fnptr(&mb_mirth_elab_create_projectors_21__186);
 		mw_std_prim_prim_pack_cons();
 		mw_mirth_elab_ab_dip_21__1();
 		incref(var_lbl_5F_set);
@@ -41078,7 +41131,7 @@ static void mb_mirth_elab_create_projectors_21__222 (void) {
 	decref(var_dat);
 	decref(var_untag);
 }
-static void mb_mirth_elab_create_projectors_21__230 (void) {
+static void mb_mirth_elab_create_projectors_21__172 (void) {
 	mw_std_prim_prim_pack_uncons();
 	VAL var_lbl_5F_get = pop_value();
 	mw_std_prim_prim_pack_uncons();
@@ -41106,7 +41159,7 @@ static void mb_mirth_elab_create_projectors_21__230 (void) {
 	decref(var_dat);
 	decref(var_untag);
 }
-static void mb_mirth_elab_create_projectors_21__244 (void) {
+static void mb_mirth_elab_create_projectors_21__186 (void) {
 	mw_std_prim_prim_pack_uncons();
 	VAL var_lbl_5F_get = pop_value();
 	mw_std_prim_prim_pack_uncons();
@@ -42681,6 +42734,837 @@ static void mb_mirth_c99_c99_tag_21__229 (void) {
 	mw_mirth_c99__2B_C99_line();
 	mw_std_prelude_prim_int_succ();
 	decref(var_tag);
+}
+static void mb_mirth_c99_c99_tag_label_index_7 (void) {
+	mw_std_prim_prim_drop();
+	{
+		VAL d2 = pop_value();
+		mw_std_prelude_Nat_1_();
+		push_value(d2);
+	}
+	mw_std_prelude_over2();
+	mw_std_prelude_over();
+	mw_mirth_label_Label__3D__3D_();
+}
+static void mb_mirth_c99_c99_tag_get_label_21__6 (void) {
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("VAL v = top_resource();", 23);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+}
+static void mb_mirth_c99_c99_tag_get_label_21__12 (void) {
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("VAL v = pop_value();", 20);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+}
+static void mb_mirth_c99_c99_tag_get_label_21__18 (void) {
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("ASSERT1(IS_TUP(v), v);", 22);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+}
+static void mb_mirth_c99_c99_tag_get_label_21__23 (void) {
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("ASSERT1(VTUPLEN(v) == ", 22);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	mw_std_prelude_over();
+	mw_mirth_data_Tag_num_total_inputs();
+	mw_std_prelude_Nat_1_2B_();
+	mw_std_prelude_Nat_show();
+	mw_mirth_c99__2B_C99_put();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr(", v);", 5);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+}
+static void mb_mirth_c99_c99_tag_get_label_21__35 (void) {
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("VAL u = VTUP(v)->cells[", 23);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	mw_std_prelude_dup2();
+	mw_mirth_c99_c99_tag_label_index();
+	mw_std_prelude_Nat_show();
+	mw_mirth_c99__2B_C99_put();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("];", 2);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+}
+static void mb_mirth_c99_c99_tag_get_label_21__46 (void) {
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("incref(u);", 10);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+}
+static void mb_mirth_c99_c99_tag_get_label_21__53 (void) {
+	mw_std_prim_prim_drop();
+	push_value(MKNIL);
+	push_fnptr(&mb_mirth_c99_c99_tag_get_label_21__55);
+	mw_std_prim_prim_pack_cons();
+	mw_mirth_c99_c99_line_1();
+}
+static void mb_mirth_c99_c99_tag_get_label_21__55 (void) {
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("decref(v);", 10);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+}
+static void mb_mirth_c99_c99_tag_get_label_21__61 (void) {
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("push_value(u);", 14);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+}
+static void mb_mirth_c99_c99_tag_set_label_21__11 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("VAL v = top_resource();", 23);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	decref(var_tag);
+	decref(var_lbl);
+}
+static void mb_mirth_c99_c99_tag_set_label_21__17 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("VAL v = pop_value();", 20);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	decref(var_tag);
+	decref(var_lbl);
+}
+static void mb_mirth_c99_c99_tag_set_label_21__23 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("VAL u = pop_value();", 20);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	decref(var_tag);
+	decref(var_lbl);
+}
+static void mb_mirth_c99_c99_tag_set_label_21__28 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("ASSERT1(IS_TUP(v), v);", 22);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	decref(var_tag);
+	decref(var_lbl);
+}
+static void mb_mirth_c99_c99_tag_set_label_21__33 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("ASSERT1(VTUPLEN(v) == ", 22);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	incref(var_tag);
+	push_value(var_tag);
+	mw_mirth_data_Tag_num_total_inputs();
+	mw_std_prelude_Nat_1_2B_();
+	mw_std_prelude_Nat_show();
+	mw_mirth_c99__2B_C99_put();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr(", v);", 5);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	decref(var_tag);
+	decref(var_lbl);
+}
+static void mb_mirth_c99_c99_tag_set_label_21__49 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("VAL* p = &VTUP(v)->cells[", 25);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	incref(var_tag);
+	push_value(var_tag);
+	incref(var_lbl);
+	push_value(var_lbl);
+	mw_mirth_c99_c99_tag_label_index();
+	mw_std_prelude_Nat_show();
+	mw_mirth_c99__2B_C99_put();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("];", 2);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	decref(var_tag);
+	decref(var_lbl);
+}
+static void mb_mirth_c99_c99_tag_set_label_21__61 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("VAL t = *p; *p = u; decref(t);", 30);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	decref(var_tag);
+	decref(var_lbl);
+}
+static void mb_mirth_c99_c99_tag_set_label_21__67 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("if (VTUP(v)->refs == 1) {", 25);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	decref(var_tag);
+	decref(var_lbl);
+}
+static void mb_mirth_c99_c99_tag_set_label_21__72 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	push_value(MKNIL);
+	incref(var_lbl);
+	push_value(var_lbl);
+	mw_std_prim_prim_pack_cons();
+	incref(var_tag);
+	push_value(var_tag);
+	mw_std_prim_prim_pack_cons();
+	push_fnptr(&mb_mirth_c99_c99_tag_set_label_21__74);
+	mw_std_prim_prim_pack_cons();
+	mw_mirth_c99_c99_line_1();
+	push_value(MKNIL);
+	incref(var_lbl);
+	push_value(var_lbl);
+	mw_std_prim_prim_pack_cons();
+	incref(var_tag);
+	push_value(var_tag);
+	mw_std_prim_prim_pack_cons();
+	push_fnptr(&mb_mirth_c99_c99_tag_set_label_21__86);
+	mw_std_prim_prim_pack_cons();
+	mw_mirth_c99_c99_line_1();
+	push_value(MKNIL);
+	incref(var_lbl);
+	push_value(var_lbl);
+	mw_std_prim_prim_pack_cons();
+	incref(var_tag);
+	push_value(var_tag);
+	mw_std_prim_prim_pack_cons();
+	push_fnptr(&mb_mirth_c99_c99_tag_set_label_21__91);
+	mw_std_prim_prim_pack_cons();
+	mw_mirth_c99_c99_line_1();
+	decref(var_tag);
+	decref(var_lbl);
+}
+static void mb_mirth_c99_c99_tag_set_label_21__74 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("VAL* p = &VTUP(v)->cells[", 25);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	incref(var_tag);
+	push_value(var_tag);
+	incref(var_lbl);
+	push_value(var_lbl);
+	mw_mirth_c99_c99_tag_label_index();
+	mw_std_prelude_Nat_show();
+	mw_mirth_c99__2B_C99_put();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("];", 2);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	decref(var_tag);
+	decref(var_lbl);
+}
+static void mb_mirth_c99_c99_tag_set_label_21__86 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("VAL t = *p; *p = u; decref(t);", 30);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	decref(var_tag);
+	decref(var_lbl);
+}
+static void mb_mirth_c99_c99_tag_set_label_21__91 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("push_value(v);", 14);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	decref(var_tag);
+	decref(var_lbl);
+}
+static void mb_mirth_c99_c99_tag_set_label_21__97 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("} else {", 8);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	decref(var_tag);
+	decref(var_lbl);
+}
+static void mb_mirth_c99_c99_tag_set_label_21__102 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	push_value(MKNIL);
+	incref(var_lbl);
+	push_value(var_lbl);
+	mw_std_prim_prim_pack_cons();
+	incref(var_tag);
+	push_value(var_tag);
+	mw_std_prim_prim_pack_cons();
+	push_fnptr(&mb_mirth_c99_c99_tag_set_label_21__104);
+	mw_std_prim_prim_pack_cons();
+	mw_mirth_c99_c99_line_1();
+	push_value(MKNIL);
+	incref(var_lbl);
+	push_value(var_lbl);
+	mw_std_prim_prim_pack_cons();
+	incref(var_tag);
+	push_value(var_tag);
+	mw_std_prim_prim_pack_cons();
+	push_fnptr(&mb_mirth_c99_c99_tag_set_label_21__116);
+	mw_std_prim_prim_pack_cons();
+	mw_mirth_c99_c99_line_1();
+	push_i64(0LL);
+	mw_std_prim_Int__3E_Nat();
+	while(1) {
+		mw_std_prim_prim_dup();
+		incref(var_tag);
+		push_value(var_tag);
+		mw_mirth_data_Tag_num_total_inputs();
+		mw_std_prelude_Nat__3C__3D_();
+		if (! pop_u64()) break;
+		mw_std_prim_prim_dup();
+		incref(var_tag);
+		push_value(var_tag);
+		incref(var_lbl);
+		push_value(var_lbl);
+		mw_mirth_c99_c99_tag_label_index();
+		mw_std_prelude_Nat__3D__3D_();
+		if (pop_u64()) {
+			push_value(MKNIL);
+			incref(var_lbl);
+			push_value(var_lbl);
+			mw_std_prim_prim_pack_cons();
+			incref(var_tag);
+			push_value(var_tag);
+			mw_std_prim_prim_pack_cons();
+			push_fnptr(&mb_mirth_c99_c99_tag_set_label_21__144);
+			mw_std_prim_prim_pack_cons();
+			mw_mirth_c99_c99_line_1();
+		} else {
+			push_value(MKNIL);
+			incref(var_lbl);
+			push_value(var_lbl);
+			mw_std_prim_prim_pack_cons();
+			incref(var_tag);
+			push_value(var_tag);
+			mw_std_prim_prim_pack_cons();
+			push_fnptr(&mb_mirth_c99_c99_tag_set_label_21__155);
+			mw_std_prim_prim_pack_cons();
+			mw_mirth_c99_c99_line_1();
+		}
+		mw_std_prelude_Nat_1_2B_();
+	}
+	mw_std_prim_prim_drop();
+	push_value(MKNIL);
+	incref(var_lbl);
+	push_value(var_lbl);
+	mw_std_prim_prim_pack_cons();
+	incref(var_tag);
+	push_value(var_tag);
+	mw_std_prim_prim_pack_cons();
+	push_fnptr(&mb_mirth_c99_c99_tag_set_label_21__179);
+	mw_std_prim_prim_pack_cons();
+	mw_mirth_c99_c99_line_1();
+	push_value(MKNIL);
+	incref(var_lbl);
+	push_value(var_lbl);
+	mw_std_prim_prim_pack_cons();
+	incref(var_tag);
+	push_value(var_tag);
+	mw_std_prim_prim_pack_cons();
+	push_fnptr(&mb_mirth_c99_c99_tag_set_label_21__184);
+	mw_std_prim_prim_pack_cons();
+	mw_mirth_c99_c99_line_1();
+	decref(var_tag);
+	decref(var_lbl);
+}
+static void mb_mirth_c99_c99_tag_set_label_21__104 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("TUP *tup = tup_new(", 19);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	incref(var_tag);
+	push_value(var_tag);
+	mw_mirth_data_Tag_num_total_inputs();
+	mw_std_prelude_Nat_1_2B_();
+	mw_std_prelude_Nat_show();
+	mw_mirth_c99__2B_C99_put();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr(");", 2);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	decref(var_tag);
+	decref(var_lbl);
+}
+static void mb_mirth_c99_c99_tag_set_label_21__116 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("tup->size = ", 12);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	incref(var_tag);
+	push_value(var_tag);
+	mw_mirth_data_Tag_num_total_inputs();
+	mw_std_prelude_Nat_1_2B_();
+	mw_std_prelude_Nat_show();
+	mw_mirth_c99__2B_C99_put();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr(";", 1);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	decref(var_tag);
+	decref(var_lbl);
+}
+static void mb_mirth_c99_c99_tag_set_label_21__144 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("tup->cells[", 11);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	mw_std_prim_prim_dup();
+	mw_std_prelude_Nat_show();
+	mw_mirth_c99__2B_C99_put();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("] = u;", 6);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	decref(var_tag);
+	decref(var_lbl);
+}
+static void mb_mirth_c99_c99_tag_set_label_21__155 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("tup->cells[", 11);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	mw_std_prim_prim_dup();
+	mw_std_prelude_Nat_show();
+	mw_mirth_c99__2B_C99_put();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("] = VTUP(v)->cells[", 19);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	mw_std_prim_prim_dup();
+	mw_std_prelude_Nat_show();
+	mw_mirth_c99__2B_C99_put();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("]; incref(tup->cells[", 21);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	mw_std_prim_prim_dup();
+	mw_std_prelude_Nat_show();
+	mw_mirth_c99__2B_C99_put();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("]);", 3);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	decref(var_tag);
+	decref(var_lbl);
+}
+static void mb_mirth_c99_c99_tag_set_label_21__179 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("decref(v);", 10);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	decref(var_tag);
+	decref(var_lbl);
+}
+static void mb_mirth_c99_c99_tag_set_label_21__184 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("push_value(MKTUP(tup,", 21);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	incref(var_tag);
+	push_value(var_tag);
+	mw_mirth_data_Tag_num_total_inputs();
+	mw_std_prelude_Nat_1_2B_();
+	mw_std_prelude_Nat_show();
+	mw_mirth_c99__2B_C99_put();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("));", 3);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	decref(var_tag);
+	decref(var_lbl);
+}
+static void mb_mirth_c99_c99_tag_set_label_21__197 (void) {
+	mw_std_prim_prim_pack_uncons();
+	VAL var_tag = pop_value();
+	mw_std_prim_prim_pack_uncons();
+	VAL var_lbl = pop_value();
+	mw_std_prim_prim_drop();
+	{
+		static bool vready = false;
+		static VAL v;
+		if (! vready) {
+			v = mkstr("}", 1);
+			vready = true;
+		}
+		push_value(v);
+		incref(v);
+	}
+	mw_mirth_c99__2B_C99_put();
+	decref(var_tag);
+	decref(var_lbl);
 }
 static void mb_mirth_c99_c99_external_21__26 (void) {
 	mw_std_prim_prim_drop();

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -1,6 +1,6 @@
 #define MIRTH_DEBUG 0
 /* MIRTH HEADER */
-#line 3 "src/mirth/mirth.h"
+// #line 3 "src/mirth/mirth.h"
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
 #define MIRTH_WINDOWS 1
@@ -17000,8 +17000,10 @@ static void mw_mirth_data_Data_is_transparent_3F_ (void) {
 				mw_std_prim_Int__3E_Nat();
 				mw_std_prelude_Nat__3D__3D_();
 				mw_std_prim_prim_swap();
-				mw_mirth_data_Tag_num_resource_inputs();
-				mw_std_prelude_Nat_0_3D_();
+				mw_mirth_data_Tag_num_total_inputs();
+				push_i64(1LL);
+				mw_std_prim_Int__3E_Nat();
+				mw_std_prelude_Nat__3D__3D_();
 				mw_std_prim_Bool__26__26_();
 				break;
 			default:
@@ -32220,7 +32222,7 @@ static void mw_mirth_c99_c99_header_str (void) {
 		if (! vready) {
 			v = mkstr(
 				"/* MIRTH HEADER */\n"
-				"#line 3 \"src/mirth/mirth.h\"\n"
+				"// #line 3 \"src/mirth/mirth.h\"\n"
 				"\n"
 				"#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)\n"
 				"#define MIRTH_WINDOWS 1\n"
@@ -33510,7 +33512,7 @@ static void mw_mirth_c99_c99_header_str (void) {
 				"}\n"
 				"\n"
 				"/* GENERATED C99 */\n",
-				34109
+				34112
 			);
 			vready = true;
 		}

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -38,9 +38,9 @@ typedef uint16_t TAG;
 #define TUP_LEN_MAX  0x3FFF
 
 #define TAG_INT 1
+#define TAG_PTR 1
 #define TAG_STR (2 | REFS_FLAG)
-#define TAG_PTR 3
-#define TAG_FNPTR 4
+#define TAG_FNPTR 3
 #define TAG_TUP_NIL TUP_FLAG
 #define TAG_TUP_LEN(t) ((t) & TUP_LEN_MASK)
 #define TAG_TUP(n) (TUP_FLAG | REFS_FLAG | (n))
@@ -826,8 +826,6 @@ void value_trace_(VAL val, int fd) {
 		int_trace_(VINT(val), fd);
 	} else if (IS_STR(val)) {
 		str_trace_(VSTR(val), fd);
-	} else if (IS_PTR(val)) {
-		write(fd, "<ptr>", 5);
 	} else if (IS_FNPTR(val)) {
 		write(fd, "<fnptr>", 7);
 	} else if (IS_TUP(val)) {
@@ -836,12 +834,12 @@ void value_trace_(VAL val, int fd) {
 		if (VTUPLEN(val) == 0) {
 			write(fd, "[]", 2);
 		} else {
-			write(fd, "[", 2);
+			write(fd, "[ ", 2);
 			for(TUPLEN i = 0; i < len; i++) {
 				if (i > 0) write(fd, " ", 1);
 				value_trace_(tup->cells[i], fd);
 			}
-			write(fd, "]", 1);
+			write(fd, " ]", 2);
 		}
 	} else {
 		TRACE("value cannot be traced");
@@ -1238,7 +1236,7 @@ static void mw_std_prim_prim_str_num_bytes (void) {
 
 static void mw_std_prim_prim_pack_nil (void) {
 	PRIM_ENTER(mw_std_prim_prim_pack_nil,"prim-pack-nil");
-	push_u64(0);
+	push_value(MKNIL);
 	PRIM_EXIT(mw_std_prim_prim_pack_nil);
 }
 
@@ -32260,9 +32258,9 @@ static void mw_mirth_c99_c99_header_str (void) {
 				"#define TUP_LEN_MAX  0x3FFF\n"
 				"\n"
 				"#define TAG_INT 1\n"
+				"#define TAG_PTR 1\n"
 				"#define TAG_STR (2 | REFS_FLAG)\n"
-				"#define TAG_PTR 3\n"
-				"#define TAG_FNPTR 4\n"
+				"#define TAG_FNPTR 3\n"
 				"#define TAG_TUP_NIL TUP_FLAG\n"
 				"#define TAG_TUP_LEN(t) ((t) & TUP_LEN_MASK)\n"
 				"#define TAG_TUP(n) (TUP_FLAG | REFS_FLAG | (n))\n"
@@ -33048,8 +33046,6 @@ static void mw_mirth_c99_c99_header_str (void) {
 				"\t\tint_trace_(VINT(val), fd);\n"
 				"\t} else if (IS_STR(val)) {\n"
 				"\t\tstr_trace_(VSTR(val), fd);\n"
-				"\t} else if (IS_PTR(val)) {\n"
-				"\t\twrite(fd, \"<ptr>\", 5);\n"
 				"\t} else if (IS_FNPTR(val)) {\n"
 				"\t\twrite(fd, \"<fnptr>\", 7);\n"
 				"\t} else if (IS_TUP(val)) {\n"
@@ -33058,12 +33054,12 @@ static void mw_mirth_c99_c99_header_str (void) {
 				"\t\tif (VTUPLEN(val) == 0) {\n"
 				"\t\t\twrite(fd, \"[]\", 2);\n"
 				"\t\t} else {\n"
-				"\t\t\twrite(fd, \"[\", 2);\n"
+				"\t\t\twrite(fd, \"[ \", 2);\n"
 				"\t\t\tfor(TUPLEN i = 0; i < len; i++) {\n"
 				"\t\t\t\tif (i > 0) write(fd, \" \", 1);\n"
 				"\t\t\t\tvalue_trace_(tup->cells[i], fd);\n"
 				"\t\t\t}\n"
-				"\t\t\twrite(fd, \"]\", 1);\n"
+				"\t\t\twrite(fd, \" ]\", 2);\n"
 				"\t\t}\n"
 				"\t} else {\n"
 				"\t\tTRACE(\"value cannot be traced\");\n"
@@ -33460,7 +33456,7 @@ static void mw_mirth_c99_c99_header_str (void) {
 				"\n"
 				"static void mw_std_prim_prim_pack_nil (void) {\n"
 				"\tPRIM_ENTER(mw_std_prim_prim_pack_nil,\"prim-pack-nil\");\n"
-				"\tpush_u64(0);\n"
+				"\tpush_value(MKNIL);\n"
 				"\tPRIM_EXIT(mw_std_prim_prim_pack_nil);\n"
 				"}\n"
 				"\n"
@@ -33512,7 +33508,7 @@ static void mw_mirth_c99_c99_header_str (void) {
 				"}\n"
 				"\n"
 				"/* GENERATED C99 */\n",
-				34112
+				34068
 			);
 			vready = true;
 		}

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -258,19 +258,25 @@ static void value_uncons_c(VAL val, VAL* tail, VAL* head) {
 		ASSERT1((len > 0) && tup, val);
 		VAL tailval = MKTUP(tup, len-1);
 		VAL headval = tup->cells[len-1];
-		if (tup->refs == 1) {
-			for (TUPLEN i=len; i < tup->size; i++) { decref(tup->cells[i]); }
-			memset(tup->cells + (len-1), 0, sizeof(VAL)*(tup->size - (len-1)));
-			tup->size = len-1;
-		} else {
+		if (len == 1) {
 			incref(headval);
-		}
-		if (len == 2) {
-			VAL ptval = tup->cells[0];
-			if (!IS_TUP(ptval)) {
-				incref(ptval);
-				decref(tailval);
-				tailval = ptval;
+			decref(val);
+			tailval = MKNIL;
+		} else {
+			if (tup->refs == 1) {
+				for (TUPLEN i=len; i < tup->size; i++) { decref(tup->cells[i]); }
+				memset(tup->cells + (len-1), 0, sizeof(VAL)*(tup->size - (len-1)));
+				tup->size = len-1;
+			} else {
+				incref(headval);
+			}
+			if (len == 2) {
+				VAL ptval = tup->cells[0];
+				if (!IS_TUP(ptval)) {
+					incref(ptval);
+					decref(tailval);
+					tailval = ptval;
+				}
 			}
 		}
 		*tail = tailval;
@@ -32386,19 +32392,25 @@ static void mw_mirth_c99_c99_header_str (void) {
 				"\t\tASSERT1((len > 0) && tup, val);\n"
 				"\t\tVAL tailval = MKTUP(tup, len-1);\n"
 				"\t\tVAL headval = tup->cells[len-1];\n"
-				"\t\tif (tup->refs == 1) {\n"
-				"\t\t\tfor (TUPLEN i=len; i < tup->size; i++) { decref(tup->cells[i]); }\n"
-				"\t\t\tmemset(tup->cells + (len-1), 0, sizeof(VAL)*(tup->size - (len-1)));\n"
-				"\t\t\ttup->size = len-1;\n"
-				"\t\t} else {\n"
+				"\t\tif (len == 1) {\n"
 				"\t\t\tincref(headval);\n"
-				"\t\t}\n"
-				"\t\tif (len == 2) {\n"
-				"\t\t\tVAL ptval = tup->cells[0];\n"
-				"\t\t\tif (!IS_TUP(ptval)) {\n"
-				"\t\t\t\tincref(ptval);\n"
-				"\t\t\t\tdecref(tailval);\n"
-				"\t\t\t\ttailval = ptval;\n"
+				"\t\t\tdecref(val);\n"
+				"\t\t\ttailval = MKNIL;\n"
+				"\t\t} else {\n"
+				"\t\t\tif (tup->refs == 1) {\n"
+				"\t\t\t\tfor (TUPLEN i=len; i < tup->size; i++) { decref(tup->cells[i]); }\n"
+				"\t\t\t\tmemset(tup->cells + (len-1), 0, sizeof(VAL)*(tup->size - (len-1)));\n"
+				"\t\t\t\ttup->size = len-1;\n"
+				"\t\t\t} else {\n"
+				"\t\t\t\tincref(headval);\n"
+				"\t\t\t}\n"
+				"\t\t\tif (len == 2) {\n"
+				"\t\t\t\tVAL ptval = tup->cells[0];\n"
+				"\t\t\t\tif (!IS_TUP(ptval)) {\n"
+				"\t\t\t\t\tincref(ptval);\n"
+				"\t\t\t\t\tdecref(tailval);\n"
+				"\t\t\t\t\ttailval = ptval;\n"
+				"\t\t\t\t}\n"
 				"\t\t\t}\n"
 				"\t\t}\n"
 				"\t\t*tail = tailval;\n"
@@ -33414,7 +33426,7 @@ static void mw_mirth_c99_c99_header_str (void) {
 				"}\n"
 				"\n"
 				"/* GENERATED C99 */\n",
-				34126
+				34230
 			);
 			vready = true;
 		}

--- a/src/mirth/arrow.mth
+++ b/src/mirth/arrow.mth
@@ -55,7 +55,9 @@ data(Op,
     OP_BLOCK -> Block,
     OP_COERCE -> Coerce,
     OP_LABEL_PUSH -> Label,
-    OP_LABEL_POP -> Label)
+    OP_LABEL_POP -> Label,
+    OP_DATA_GET_LABEL -> Tag Label,
+    OP_DATA_SET_LABEL -> Tag Label)
 
 data(Coerce,
     COERCE_UNSAFE)

--- a/src/mirth/c99.mth
+++ b/src/mirth/c99.mth
@@ -136,61 +136,105 @@ def(c99-variable!, Variable +C99 -- +C99,
     "}" put line)
 
 def(c99-tags!, +C99 -- +C99, Tag.for(c99-tag!))
-def(c99-tag!, Tag +C99 -- +C99,
-    dup qname sig-put " {" put line
-    dup is-transparent? else(
-        "\tVAL tag = MKU64(" put dup value show put "LL);" put line
-        "\tVAL car = (" put
-        dup num-type-inputs repeat(
-            "pop_value());" put line
-            "\tcar = mkcons(car, " put
+def(c99-tag!, Tag +C99 -- +C99, \(tag ->
+    tag qname sig-put " {" put line
+    tag is-transparent? else(
+        tag num-total-inputs 0= if(
+            tag outputs-resource? if(
+                "\tpush_resource(MKU64(",
+                "\tpush_value(MKU64("
+            ) put
+                tag value show put
+                "LL));" put line
+            ,
+
+            "\tTUP* tup = tup_new(" put
+                tag num-total-inputs 1+ show put
+                ");" put line
+            "\ttup->size = " put
+                tag num-total-inputs 1+ show put
+                ";" put line
+            "\ttup->cells[0] = MKU64(" put
+                tag value show put
+                "LL);" put line
+            tag num-total-inputs
+            tag label-inputs reverse-for(
+                "\ttup->cells[" put
+                    over show put
+                    "] = lpop(&lbl_" put
+                    name mangled put
+                    ");" put line
+                1-
+            )
+            tag num-resource-inputs repeat(
+                "\ttup->cells[" put
+                    dup show put
+                    "] = pop_resource();" put line
+                1-
+            )
+            tag num-type-inputs repeat(
+                "\ttup->cells[" put
+                    dup show put
+                    "] = pop_value();" put line
+                1-
+            )
+            drop
+            tag outputs-resource? if(
+                "\tpush_resource(MKTUP(tup, ",
+                "\tpush_value(MKTUP(tup, "
+            ) put
+                tag num-total-inputs 1+ show put
+                "));" put line
         )
-        dup num-resource-inputs repeat(
-            "pop_resource());" put line
-            "\tcar = mkcons(car, " put
-        )
-        dup label-inputs reverse-for(
-            "lpop(&lbl_" put name mangled put "));" put line
-            "\tcar = mkcons(car, " put
-        )
-        "tag);" put line
-        dup outputs-resource? if(
-            "\tpush_resource(car);",
-            "\tpush_value(car);"
-        ) put line
     )
     "}" put line
 
-    dup qname cosig-put " {" put line
-    dup is-transparent? else(
-        dup outputs-resource? if(
-            "\tVAL car = pop_resource();",
-            "\tVAL car = pop_value();"
+    tag qname cosig-put " {" put line
+    tag is-transparent? else(
+        tag outputs-resource? if(
+            "\tVAL val = pop_resource();",
+            "\tVAL val = pop_value();"
         ) put line
-        dup num-resource-inputs over num-type-inputs + over label-inputs len + 0> then(
-            "\tVAL cdr;" put line
+        tag num-total-inputs 0= if(
+            "\t(void)val;" put line,
+            "\tASSERT1(IS_TUP(val),val);" put line
+            "\tTUP* tup = VTUP(val);" put line
+            1
+            tag num-type-inputs repeat(
+                "\tpush_value(tup->cells[" put
+                    dup show put
+                    "]);" put line
+                1+
+            )
+            tag num-resource-inputs repeat(
+                "\tpush_resource(tup->cells[" put
+                    dup show put
+                    "]);" put line
+                1+
+            )
+            tag label-inputs for(
+                "\tlpush(&lbl_" put
+                    name mangled put
+                    ", tup->cells[" put
+                    dup show put
+                    "]);" put line
+                1+
+            )
+            drop
+            "\tif (tup->refs > 1) {" put line
+            1 tag num-total-inputs repeat(
+                "\t\tincref(tup->cells[" put
+                    dup show put
+                    "]);" put line
+                1+
+            ) drop
+            "\t\tdecref(val);" put line
+            "\t} else {" put line
+            "\t\tfree(tup);" put line
+            "\t}" put line
         )
-        "\tdecref("
-        over label-inputs for(
-            "\tvalue_uncons_c(car, &car, &cdr);" put line
-            swap put "cdr);" put line
-            "\tlpush(&lbl_" swap name mangled cat ", " cat
-        )
-        over num-resource-inputs repeat(
-            "\tvalue_uncons_c(car, &car, &cdr);" put line
-            put "cdr);" put line
-            "\tpush_resource("
-        )
-        over num-type-inputs repeat(
-            "\tvalue_uncons_c(car, &car, &cdr);" put line
-            put "cdr);" put line
-            "\tpush_value("
-        )
-        put "car);" put line
     )
-    "}" put line
-
-    drop)
+    "}" put line))
 
 def(c99-externals!, +C99 -- +C99,
     External.for(c99-external!))

--- a/src/mirth/c99.mth
+++ b/src/mirth/c99.mth
@@ -271,7 +271,7 @@ def(c99-args-op!, List(Arg) Op +C99 -- +C99,
     OP_LABEL_POP  -> nip c99-label-pop!)
 
 def(c99-label-defs!, +C99 -- +C99, Label.for(c99-label-def!))
-def(c99-label-def!, Label +C99 -- +C99, "static VAL lbl_" put name mangled put " = {0};" put line)
+def(c99-label-def!, Label +C99 -- +C99, "static VAL lbl_" put name mangled put " = MKNIL_C;" put line)
 def(c99-label-push!, Label +C99 -- +C99, c99-line("LPUSH(lbl_" put name mangled put ");" put))
 def(c99-label-pop!, Label +C99 -- +C99, c99-line("LPOP(lbl_" put name mangled put ");" put))
 
@@ -410,7 +410,7 @@ def(+C99.var-put, Var +C99 -- +C99, "var_" put name mangled put)
 def(+C99.param-put, Param +C99 -- +C99, >Var var-put)
 
 def(c99-pack-ctx!, Ctx +C99 -- +C99,
-    c99-line("push_u64(0);" put)
+    c99-line("push_value(MKNIL);" put)
     physical-vars for(
         c99-var-push!
         c99-line("mw_std_prim_prim_pack_cons();" put)
@@ -593,7 +593,7 @@ def(c99-field-def!, Field +C99 -- +C99,
     "\tstatic struct VAL * p = 0;" put line
     "\tsize_t m = " put TABLE_MAX_COUNT show put ";" put line
     "\tif (! p) { p = calloc(m, sizeof *p); }" put line
-    "\tif (i>=m) { write(2,\"table too big\\n\",14); exit(123); }" put line
+    "\tEXPECT(i<m, \"table grew too big\");" put line
     "\treturn p+i;" put line
     "}" put line line
         # TODO make this more flexible wrt table size

--- a/src/mirth/c99.mth
+++ b/src/mirth/c99.mth
@@ -236,6 +236,85 @@ def(c99-tag!, Tag +C99 -- +C99, \(tag ->
     )
     "}" put line))
 
+def(c99-tag-label-index, Tag Label +C99 -- Nat +C99,
+    over num-total-inputs 1+
+    over2 label-inputs reverse-find(dip(1-) over2 over ==) drop
+    dip:drop2)
+
+def(c99-tag-get-label!, Tag Label +C99 -- +C99,
+    over outputs-resource? if(
+        c99-line("VAL v = top_resource();" put),
+        c99-line("VAL v = pop_value();" put)
+    )
+    c99-line("ASSERT1(IS_TUP(v), v);" put)
+    c99-line("ASSERT1(VTUPLEN(v) == " put
+        over num-total-inputs 1+ show put
+        ", v);" put)
+    c99-line("VAL u = VTUP(v)->cells[" put
+        dup2 c99-tag-label-index show put
+        "];" put)
+    c99-line("incref(u);" put)
+    over outputs-resource? else(
+        c99-line("decref(v);" put)
+    )
+    c99-line("push_value(u);" put)
+    drop2)
+
+def(c99-tag-set-label!, Tag Label +C99 -- +C99, \(tag lbl ->
+    tag outputs-resource? if(
+        c99-line("VAL v = top_resource();" put),
+        c99-line("VAL v = pop_value();" put)
+    )
+    c99-line("VAL u = pop_value();" put)
+    c99-line("ASSERT1(IS_TUP(v), v);" put)
+    c99-line("ASSERT1(VTUPLEN(v) == " put
+        tag num-total-inputs 1+ show put
+        ", v);" put)
+    tag outputs-resource? if(
+        c99-line("VAL* p = &VTUP(v)->cells[" put
+            tag lbl c99-tag-label-index show put
+            "];" put)
+        c99-line("VAL t = *p; *p = u; decref(t);" put),
+
+        c99-line("if (VTUP(v)->refs == 1) {" put)
+        c99-nest(
+            c99-line("VAL* p = &VTUP(v)->cells[" put
+                tag lbl c99-tag-label-index show put
+                "];" put)
+            c99-line("VAL t = *p; *p = u; decref(t);" put)
+            c99-line("push_value(v);" put)
+        )
+        c99-line("} else {" put)
+        c99-nest(
+            c99-line("TUP *tup = tup_new(" put
+                tag num-total-inputs 1+ show put
+                ");" put)
+            c99-line("tup->size = " put
+                tag num-total-inputs 1+ show put
+                ";" put)
+            0 >Nat while(dup tag num-total-inputs <=,
+                dup tag lbl c99-tag-label-index == if(
+                    c99-line("tup->cells[" put
+                        dup show put
+                        "] = u;" put),
+                    c99-line("tup->cells[" put
+                        dup show put
+                        "] = VTUP(v)->cells[" put
+                        dup show put
+                        "]; incref(tup->cells[" put
+                        dup show put
+                        "]);" put)
+                )
+                1+)
+            drop
+            c99-line("decref(v);" put)
+            c99-line("push_value(MKTUP(tup," put
+                tag num-total-inputs 1+ show put
+                "));" put)
+        )
+        c99-line("}" put)
+    )))
+
 def(c99-externals!, +C99 -- +C99,
     External.for(c99-external!))
 
@@ -312,7 +391,9 @@ def(c99-args-op!, List(Arg) Op +C99 -- +C99,
     OP_BLOCK    -> nip c99-block-push!,
     OP_COERCE   -> drop2,
     OP_LABEL_PUSH -> nip c99-label-push!,
-    OP_LABEL_POP  -> nip c99-label-pop!)
+    OP_LABEL_POP  -> nip c99-label-pop!,
+    OP_DATA_GET_LABEL -> c99-tag-get-label! drop,
+    OP_DATA_SET_LABEL -> c99-tag-set-label! drop)
 
 def(c99-label-defs!, +C99 -- +C99, Label.for(c99-label-def!))
 def(c99-label-def!, Label +C99 -- +C99, "static VAL lbl_" put name mangled put " = MKNIL_C;" put line)

--- a/src/mirth/data.mth
+++ b/src/mirth/data.mth
@@ -116,7 +116,7 @@ def(Data.is-transparent?, Data -- Bool,
     dup is-resource? if(
         drop F,
         tags match(
-            L1 -> dup num-type-inputs 1 >Nat == swap num-resource-inputs 0= &&,
+            L1 -> dup num-type-inputs 1 >Nat == swap num-total-inputs 1 >Nat == &&,
             _ -> drop F
         )
     ))

--- a/src/mirth/data.mth
+++ b/src/mirth/data.mth
@@ -171,6 +171,11 @@ def(Tag.num-resource-inputs-from-sig, Tag -- Nat,
         0 >Nat
     ))
 
+def(Tag.num-total-inputs, Tag -- Nat,
+    dup label-inputs len
+    over num-type-inputs +
+    swap num-resource-inputs +)
+
 def(Tag.is-transparent?, Tag -- Bool,
     .data is-transparent?)
 

--- a/src/mirth/elab.mth
+++ b/src/mirth/elab.mth
@@ -415,6 +415,8 @@ def(elab-op-fresh-sig!, Op -- Subst OpSig,
         OP_COERCE -> elab-coerce-sig!,
         OP_LABEL_PUSH -> elab-label-push-sig!,
         OP_LABEL_POP -> elab-label-pop-sig!,
+        OP_DATA_GET_LABEL -> data-get-label-type freshen-sig OPSIG_APPLY,
+        OP_DATA_SET_LABEL -> data-set-label-type freshen-sig OPSIG_APPLY,
     ))
 
 def(elab-coerce-sig!, Coerce -- OpSig,
@@ -439,10 +441,12 @@ def(elab-var-sig!, Var -- OpSig,
     ))
 
 def(elab-label-push-sig!, Label -- OpSig,
-    dip(MetaVar.new! STMeta MetaVar.new! TMeta dup2) STConsLabel dip(STCons) T-> OPSIG_APPLY)
+    dip(MetaVar.new! STMeta MetaVar.new! TMeta dup2)
+    STConsLabel dip(STCons) T-> OPSIG_APPLY)
 
 def(elab-label-pop-sig!, Label -- OpSig,
-    dip(MetaVar.new! STMeta MetaVar.new! TMeta dup2) STConsLabel dip(STCons) swap T-> OPSIG_APPLY)
+    dip(MetaVar.new! STMeta MetaVar.new! TMeta dup2)
+    STConsLabel dip(STCons) swap T-> OPSIG_APPLY)
 
 def(elab-arrow!, Ctx ArrowType Token Home -- Arrow,
     dip2(unpack) elab-arrow-hom!)
@@ -952,6 +956,21 @@ def(Tag.output-type, Tag -- Either(Type,Resource),
 def(Tag.project-input-label, Label Tag -- Maybe(Type),
     type dom force-cons-label?! map(unpack2 nip))
 
+def(data-get-label-type, Tag Label -- ArrowType,
+    \(tag lbl ->
+        T0 tag output-type T*+
+        lbl tag project-input-label unwrap T1
+        tag .data is-resource? then(tag output-type T*+)
+        T->
+    ))
+
+def(data-set-label-type, Tag Label -- ArrowType,
+    \(tag lbl ->
+        lbl tag project-input-label unwrap T1 tag output-type T*+
+        T0 tag output-type T*+
+        T->
+    ))
+
 def(create-projectors!, Tag --,
     dup .data over .untag unwrap \(tag dat untag ->
     tag label-inputs reverse-for(\(lbl -> dat lbl name 0 data-qname undefined? then(
@@ -960,37 +979,20 @@ def(create-projectors!, Tag --,
         dat lbl >Str 1 data-word-new! \(lbl_get lbl_set lbl_lens ->
             delay0(
                 tag ctx
-                T0 tag output-type T*+
-                lbl tag project-input-label unwrap T1
-                dat is-resource? then(tag output-type T*+)
-                T-> pack2
+                tag lbl data-get-label-type
+                pack2
             ) lbl_get ~ctx-type !
             lbl_get delay(ab-build-word-arrow!(
-                untag ab-word!
-                lbl ab-label-pop!
-                PRIM_CORE_DUP ab-prim!
-                lbl ab-label-push!
-                ab-dip!(
-                    tag ab-tag!
-                    dat is-resource? else(PRIM_CORE_DROP ab-prim!)
-                )
+                tag lbl OP_DATA_GET_LABEL ab-op!
             )) lbl_get ~arrow !
 
             delay0(
                 tag ctx
-                lbl tag project-input-label unwrap T1 tag output-type T*+
-                T0 tag output-type T*+
-                T-> pack2
+                tag lbl data-set-label-type
+                pack2
             ) lbl_set ~ctx-type !
             lbl_set delay(ab-build-word-arrow!(
-                dat is-resource? if(
-                    lbl ab-label-push!,
-                    ab-dip!(lbl ab-label-push!)
-                )
-                untag ab-word!
-                lbl ab-label-pop!
-                PRIM_CORE_DROP ab-prim!
-                tag ab-tag!
+                tag lbl OP_DATA_SET_LABEL ab-op!
             )) lbl_set ~arrow !
 
             delay0(

--- a/src/mirth/mirth.h
+++ b/src/mirth/mirth.h
@@ -1,5 +1,5 @@
 /* MIRTH HEADER */
-#line 3 "src/mirth/mirth.h"
+// #line 3 "src/mirth/mirth.h"
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
 #define MIRTH_WINDOWS 1

--- a/src/mirth/mirth.h
+++ b/src/mirth/mirth.h
@@ -248,7 +248,7 @@ static void free_value(VAL v) {
 	}
 }
 
-static void value_uncons_c(VAL val, VAL* tail, VAL* head) {
+static void value_uncons(VAL val, VAL* tail, VAL* head) {
 	if (IS_TUP(val)) {
 		TUPLEN len = VTUPLEN(val);
 		TUP* tup = VTUP(val);
@@ -471,7 +471,7 @@ static VAL mkcons(VAL tail, VAL head) {
 }
 
 static VAL lpop(VAL* stk) {
-	VAL cons=*stk, lcar, lcdr; value_uncons_c(cons, &lcar, &lcdr);
+	VAL cons=*stk, lcar, lcdr; value_uncons(cons, &lcar, &lcdr);
 	*stk=lcar; return lcdr;
 }
 static void lpush(VAL* stk, VAL cdr) { *stk = mkcons(*stk, cdr); }
@@ -499,7 +499,7 @@ static VAL mkstr (const char* data, USIZE size) {
 static void do_uncons(void) {
 	VAL val, tail, head;
 	val = pop_value();
-	value_uncons_c(val, &tail, &head);
+	value_uncons(val, &tail, &head);
 	push_value(tail);
 	push_value(head);
 }
@@ -507,7 +507,7 @@ static void do_uncons(void) {
 static USIZE get_data_tag(VAL v) {
 	if (IS_TUP(v)) {
 		ASSERT(VTUPLEN(v) > 0);
-		return VU64(VTUP(v)->cells[VTUPLEN(v)-1]);
+		return VU64(VTUP(v)->cells[0]);
 	} else {
 		return VU64(v);
 	}
@@ -538,7 +538,7 @@ static void run_value(VAL v) {
 	// TODO Make a closure tag or something.
 	// As it is, this feels kinda wrong.
 	VAL car, cdr;
-	value_uncons_c(v, &car, &cdr);
+	value_uncons(v, &car, &cdr);
 	push_value(car);
 	ASSERT(IS_FNPTR(cdr) && VFNPTR(cdr));
 	VFNPTR(cdr)();

--- a/src/mirth/mirth.h
+++ b/src/mirth/mirth.h
@@ -37,9 +37,9 @@ typedef uint16_t TAG;
 #define TUP_LEN_MAX  0x3FFF
 
 #define TAG_INT 1
+#define TAG_PTR 1
 #define TAG_STR (2 | REFS_FLAG)
-#define TAG_PTR 3
-#define TAG_FNPTR 4
+#define TAG_FNPTR 3
 #define TAG_TUP_NIL TUP_FLAG
 #define TAG_TUP_LEN(t) ((t) & TUP_LEN_MASK)
 #define TAG_TUP(n) (TUP_FLAG | REFS_FLAG | (n))
@@ -825,8 +825,6 @@ void value_trace_(VAL val, int fd) {
 		int_trace_(VINT(val), fd);
 	} else if (IS_STR(val)) {
 		str_trace_(VSTR(val), fd);
-	} else if (IS_PTR(val)) {
-		write(fd, "<ptr>", 5);
 	} else if (IS_FNPTR(val)) {
 		write(fd, "<fnptr>", 7);
 	} else if (IS_TUP(val)) {
@@ -835,12 +833,12 @@ void value_trace_(VAL val, int fd) {
 		if (VTUPLEN(val) == 0) {
 			write(fd, "[]", 2);
 		} else {
-			write(fd, "[", 2);
+			write(fd, "[ ", 2);
 			for(TUPLEN i = 0; i < len; i++) {
 				if (i > 0) write(fd, " ", 1);
 				value_trace_(tup->cells[i], fd);
 			}
-			write(fd, "]", 1);
+			write(fd, " ]", 2);
 		}
 	} else {
 		TRACE("value cannot be traced");
@@ -1237,7 +1235,7 @@ static void mw_std_prim_prim_str_num_bytes (void) {
 
 static void mw_std_prim_prim_pack_nil (void) {
 	PRIM_ENTER(mw_std_prim_prim_pack_nil,"prim-pack-nil");
-	push_u64(0);
+	push_value(MKNIL);
 	PRIM_EXIT(mw_std_prim_prim_pack_nil);
 }
 

--- a/src/mirth/mirth.h
+++ b/src/mirth/mirth.h
@@ -1,4 +1,5 @@
 /* MIRTH HEADER */
+#line 3 "src/mirth/mirth.h"
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
 #define MIRTH_WINDOWS 1
@@ -29,19 +30,23 @@ extern int close(int);
 extern int open(const char*, int, int);
 extern void exit(int);
 
-#define HAS_REFS_FLAG 0x8000
-typedef enum TAG {
-	// TODO: TAG_NIL
-	// TODO: TAG_PTR
-	TAG_INT  = 1,
-	TAG_CONS = 2 | HAS_REFS_FLAG,
-	TAG_STR  = 3 | HAS_REFS_FLAG,
-} TAG;
+typedef uint16_t TAG;
+#define REFS_FLAG 	 0x8000
+#define TUP_FLAG 	 0x4000
+#define TUP_LEN_MASK 0x3FFF
+#define TUP_LEN_MAX  0x3FFF
 
-typedef void (*fnptr)(void);
+#define TAG_INT 1
+#define TAG_STR (2 | REFS_FLAG)
+#define TAG_PTR 3
+#define TAG_FNPTR 4
+#define TAG_TUP_NIL TUP_FLAG
+#define TAG_TUP_LEN(t) ((t) & TUP_LEN_MASK)
+#define TAG_TUP(n) (TUP_FLAG | REFS_FLAG | (n))
 
 typedef uint32_t REFS;
 typedef uint64_t USIZE;
+typedef void (*FNPTR)(void);
 
 typedef union DATA {
 	USIZE usize;
@@ -54,11 +59,9 @@ typedef union DATA {
 	int16_t i16;
 	int8_t i8;
 	void* ptr;
-	void (*fnptr)(void);
-	struct VAL* valptr;
-	char* charptr;
+	FNPTR fnptr;
 	REFS* refs;
-	struct CONS* cons;
+	struct TUP* tup;
 	struct STR* str;
 } DATA;
 
@@ -67,6 +70,8 @@ typedef struct VAL {
 	TAG tag;
 } VAL;
 
+#define VALEQ(v1,v2) (((v1).tag == (v2).tag) && ((v1).data.u64 == (v2).data.u64))
+
 #define VREFS(v)  (*(v).data.refs)
 #define VINT(v)   ((v).data.i64)
 #define VI64(v)   ((v).data.i64)
@@ -74,32 +79,38 @@ typedef struct VAL {
 #define VPTR(v)   ((v).data.ptr)
 #define VFNPTR(v) ((v).data.fnptr)
 #define VSTR(v)   ((v).data.str)
-#define VCONS(v)  ((v).data.cons)
+#define VTUP(v)   ((v).data.tup)
+#define VTUPLEN(v) (TAG_TUP_LEN((v).tag))
 
-#define HAS_REFS(v) ((v).tag & HAS_REFS_FLAG)
+#define HAS_REFS(v) ((v).tag & REFS_FLAG)
 #define IS_INT(v)   ((v).tag == TAG_INT)
 #define IS_U64(v)   ((v).tag == TAG_INT)
 #define IS_I64(v)   ((v).tag == TAG_INT)
-#define IS_PTR(v)   ((v).tag == TAG_INT)
-#define IS_FNPTR(v) ((v).tag == TAG_INT)
+#define IS_PTR(v)   ((v).tag == TAG_PTR)
+#define IS_FNPTR(v) ((v).tag == TAG_FNPTR)
 #define IS_STR(v)   ((v).tag == TAG_STR)
-#define IS_CONS(v)  ((v).tag == TAG_CONS)
-#define IS_NIL(v)   (((v).tag == TAG_INT) && ((v).data.i64 == 0))
+#define IS_TUP(v)   ((v).tag & TUP_FLAG)
+#define IS_NIL(v)   (IS_TUP(v) && (VTUPLEN(v) == 0))
+#define IS_NIL_NULL(v) (IS_NIL(v) && !HAS_REFS(v))
+#define IS_NIL_REFS(v) (IS_NIL(v) &&  HAS_REFS(v))
 
-#define MKINT(x)   ((VAL){.tag=TAG_INT,  .data={.i64=(x)}})
-#define MKI64(x)   ((VAL){.tag=TAG_INT,  .data={.i64=(x)}})
-#define MKU64(x)   ((VAL){.tag=TAG_INT,  .data={.u64=(x)}})
-#define MKFNPTR(x) ((VAL){.tag=TAG_INT,  .data={.fnptr=(x)}})
-#define MKPTR(x)   ((VAL){.tag=TAG_INT,  .data={.ptr=(x)}})
-#define MKSTR(x)   ((VAL){.tag=TAG_STR,  .data={.str=(x)}})
-#define MKCONS(x)  ((VAL){.tag=TAG_CONS, .data={.cons=(x)}})
-#define MKNIL()    ((VAL){.tag=TAG_INT,  .data={.i64=0}})
+#define MKINT(x)   ((VAL){.tag=TAG_INT, .data={.i64=(x)}})
+#define MKI64(x)   ((VAL){.tag=TAG_INT, .data={.i64=(x)}})
+#define MKU64(x)   ((VAL){.tag=TAG_INT, .data={.u64=(x)}})
+#define MKFNPTR(x) ((VAL){.tag=TAG_FNPTR, .data={.fnptr=(x)}})
+#define MKPTR(x)   ((VAL){.tag=TAG_PTR, .data={.ptr=(x)}})
+#define MKSTR(x)   ((VAL){.tag=TAG_STR, .data={.str=(x)}})
+#define MKTUP(x,n) ((VAL){.tag=TAG_TUP(n), .data={.tup=(x)}})
+#define MKNIL_C	         {.tag=TAG_TUP_NIL, .data={.tup=NULL}}
+#define MKNIL      ((VAL)MKNIL_C)
 
-typedef struct CONS {
+typedef uint16_t TUPLEN;
+typedef struct TUP {
 	REFS refs;
-	VAL car;
-	VAL cdr;
-} CONS;
+	TUPLEN cap;
+	TUPLEN size;
+	VAL cells[];
+} TUP;
 
 typedef struct STR {
 	REFS refs;
@@ -123,7 +134,7 @@ static void mw_std_prim_prim_rdebug(void);
 
 #if MIRTH_DEBUG
 	typedef struct LOC {
-		void (*fnptr) (void);
+		FNPTR fnptr;
 		const char* word;
 		const char* path;
 		USIZE line, col;
@@ -219,32 +230,19 @@ static void mw_std_prim_prim_rdebug(void);
 #define ASSERT2(test,v1,v2) \
 	EXPECT2(test, __FILE__ ":" STR(__LINE__) ": error: assertion failed (" #test ")", v1, v2)
 
-static void free_value(VAL v);
-
-static void incref(VAL v) {
-	if (HAS_REFS(v)) {
-		VREFS(v)++;
-	}
-}
-
-static void decref(VAL v) {
-	if (HAS_REFS(v)) {
-		if(--VREFS(v) == 0) {
-			free_value(v);
-		}
-	}
-}
-
+#define incref(v) do { if (HAS_REFS(v)) VREFS(v)++; } while(0)
+#define decref(v) do { if (HAS_REFS(v)) if (!--VREFS(v)) free_value(v); } while(0)
 static void free_value(VAL v) {
 	ASSERT(HAS_REFS(v));
 	ASSERT(VREFS(v) == 0);
-	ASSERT1(IS_CONS(v)||IS_STR(v), v);
-	if (IS_CONS(v)) {
-		CONS* cons = VCONS(v);
-		ASSERT(cons);
-		decref(cons->car);
-		decref(cons->cdr);
-		free(cons);
+	ASSERT1(IS_TUP(v)||IS_STR(v), v);
+	if (IS_TUP(v)) {
+		TUP* tup = VTUP(v);
+		ASSERT(tup);
+		for (TUPLEN i = 0; i < tup->size; i++) {
+			decref(tup->cells[i]);
+		}
+		free(tup);
 	} else if (IS_STR(v)) {
 		STR* str = VSTR(v);
 		ASSERT(str);
@@ -252,45 +250,72 @@ static void free_value(VAL v) {
 	}
 }
 
-static void value_uncons(VAL val, VAL* car, VAL* cdr) {
-	if (IS_CONS(val)) {
-		CONS* cons = VCONS(val);
-		*car = cons->car;
-		*cdr = cons->cdr;
+static void value_uncons_c(VAL val, VAL* tail, VAL* head) {
+	if (IS_TUP(val)) {
+		TUPLEN len = VTUPLEN(val);
+		TUP* tup = VTUP(val);
+		ASSERT1((len > 0) && tup, val);
+		VAL tailval = MKTUP(tup, len-1);
+		VAL headval = tup->cells[len-1];
+		if (tup->refs == 1) {
+			for (TUPLEN i=len; i < tup->size; i++) { decref(tup->cells[i]); }
+			memset(tup->cells + (len-1), 0, sizeof(VAL)*(tup->size - (len-1)));
+			tup->size = len-1;
+		} else {
+			incref(headval);
+		}
+		if (len == 2) {
+			VAL ptval = tup->cells[0];
+			if (!IS_TUP(ptval)) {
+				incref(ptval);
+				decref(tailval);
+				tailval = ptval;
+			}
+		}
+		*tail = tailval;
+		*head = headval;
 	} else {
-		*car = MKNIL();
-		*cdr = val;
+		*tail = MKNIL;
+		*head = val;
 	}
 }
-static void value_uncons_c(VAL val, VAL* car, VAL* cdr) {
-	value_uncons(val, car, cdr);
-	incref(*car);
-	incref(*cdr);
-	decref(val);
+
+static uint64_t value_u64 (VAL v) {
+	ASSERT1(IS_INT(v),v);
+	return VU64(v);
+}
+
+static int64_t value_i64 (VAL v) {
+	ASSERT1(IS_INT(v),v);
+	return VI64(v);
 }
 
 static void* value_ptr (VAL v) {
-	ASSERT(IS_PTR(v));
+	ASSERT1(IS_PTR(v),v);
 	return VPTR(v);
 }
 
-#define pop_fnptr() VFNPTR(pop_value())
-#define pop_u8() ((uint8_t)VU64(pop_value()))
-#define pop_u16() ((uint16_t)VU64(pop_value()))
-#define pop_u32() ((uint32_t)VU64(pop_value()))
-#define pop_u64() (VU64(pop_value()))
-#define pop_i8() ((int8_t)VI64(pop_value()))
-#define pop_i16() ((int16_t)VI64(pop_value()))
-#define pop_i32() ((int32_t)VI64(pop_value()))
-#define pop_i64() (VI64(pop_value()))
-#define pop_usize() (VU64(pop_value()))
-#define pop_bool() ((bool)VU64(pop_value()))
-#define pop_ptr() (VPTR(pop_value()))
+static FNPTR value_fnptr (VAL v) {
+	ASSERT1(IS_FNPTR(v),v);
+	return VFNPTR(v);
+}
+
+#define pop_u8() ((uint8_t)pop_u64())
+#define pop_u16() ((uint16_t)pop_u64())
+#define pop_u32() ((uint32_t)pop_u64())
+#define pop_u64() (value_u64(pop_value()))
+#define pop_i8() ((int8_t)pop_i64())
+#define pop_i16() ((int16_t)pop_i64())
+#define pop_i32() ((int32_t)pop_i64())
+#define pop_i64() (value_i64(pop_value()))
+#define pop_usize() (pop_u64())
+#define pop_bool() (pop_u64())
+#define pop_ptr() (value_ptr(pop_value()))
+#define pop_fnptr() (value_fnptr(pop_value()))
 
 #define push_u64(v) push_value(MKU64(v))
 #define push_i64(v) push_value(MKI64(v))
 #define push_usize(v) push_u64((uint64_t)(v))
-#define push_fnptr(v) push_u64((uint64_t)(v))
 #define push_bool(b) push_u64((uint64_t)((bool)(b)))
 #define push_u8(b) push_u64((uint64_t)(b))
 #define push_u16(b) push_u64((uint64_t)(b))
@@ -298,7 +323,8 @@ static void* value_ptr (VAL v) {
 #define push_i8(b) push_i64((int64_t)(b))
 #define push_i16(b) push_i64((int64_t)(b))
 #define push_i32(b) push_i64((int64_t)(b))
-#define push_ptr(v) push_u64((uint64_t)(void*)(v))
+#define push_ptr(p) push_value(MKPTR(p))
+#define push_fnptr(p) push_value(MKFNPTR(p))
 
 static void push_value(VAL x) {
 	ASSERT(stack_counter > 0);
@@ -330,20 +356,119 @@ static VAL pop_resource(void) {
 	return rstack[rstack_counter++];
 }
 
-static VAL mkcons (VAL car, VAL cdr) {
-	if (IS_NIL(car) && !IS_CONS(cdr))
-		return cdr;
-	CONS *cons = calloc(1, sizeof(CONS));
-	EXPECT(cons, "failed to allocate a cons cell");
-	cons->refs = 1;
-	cons->car = car;
-	cons->cdr = cdr;
-	return MKCONS(cons);
+// Create a TUP with at least min(cap_hint, TUP_LEN_MAX) capacity.
+static TUP* tup_new (TUPLEN cap_hint) {
+	if (cap_hint < 3) cap_hint = 3;
+	if (cap_hint > TUP_LEN_MAX) cap_hint = TUP_LEN_MAX;
+	TUP *new_tup = calloc(1, sizeof(TUP) + sizeof(VAL)*(USIZE)cap_hint);
+	ASSERT(new_tup);
+	new_tup->refs = 1;
+	new_tup->cap = cap_hint;
+	return new_tup;
+}
+
+// Create a TUP with at least min(max(old_tup->size, cap_hint), TUP_LEN_MAX) capacity.
+// Consume old_tup and copy its elements over to the new tuple.
+static TUP* tup_resize (TUP* old_tup, TUPLEN cap_hint) {
+	ASSERT(old_tup);
+	if (cap_hint < old_tup->size) cap_hint = old_tup->size;
+	if (old_tup->refs == 1) {
+		if (cap_hint < 3) cap_hint = 3;
+		if (cap_hint > TUP_LEN_MAX) cap_hint = TUP_LEN_MAX;
+		TUPLEN old_cap = old_tup->cap;
+		TUP *new_tup = realloc(old_tup, sizeof(TUP) + sizeof(VAL)*(USIZE)cap_hint);
+		ASSERT(new_tup);
+		if (old_cap < cap_hint) {
+			memset(new_tup->cells + old_cap, 0, sizeof(VAL)*(cap_hint - old_cap));
+		}
+		new_tup->cap = cap_hint;
+		return new_tup;
+	} else {
+		TUP* new_tup = tup_new(cap_hint);
+		for (TUPLEN i = 0; i < old_tup->size; i++) {
+			VAL v = old_tup->cells[i];
+			new_tup->cells[i] = v;
+			incref(v);
+		}
+		new_tup->size = old_tup->size;
+		old_tup->refs--;
+		return new_tup;
+	}
+}
+
+static VAL mkcons_hint (VAL tail, VAL head, TUPLEN cap_hint) {
+	if (IS_TUP(tail) && HAS_REFS(tail)) {
+		TUPLEN tail_len = VTUPLEN(tail);
+		TUP *tail_tup = VTUP(tail);
+		ASSERT1(tail_tup, tail);
+		ASSERT1(tail_len <= tail_tup->size, tail);
+		if (tail_len < tail_tup->size) {
+			ASSERT1(tail_tup->refs >= 1, tail);
+			if (tail_tup->refs == 1) {
+				decref(tail_tup->cells[tail_len]);
+				tail_tup->cells[tail_len] = head;
+				return MKTUP(tail_tup, tail_len+1);
+			} else {
+				VAL *cmp = &tail_tup->cells[tail_len];
+				if (VALEQ(*cmp, head)) {
+					decref(head);
+					return MKTUP(tail_tup, tail_len+1);
+				} else {
+					if (cap_hint < tail_len+1) cap_hint = 2*tail_len+1;
+					TUP* new_tup = tup_new(cap_hint);
+					for (TUPLEN i = 0; i < tail_len; i++) {
+						VAL v = tail_tup->cells[i];
+						new_tup->cells[i] = v;
+						incref(v);
+					}
+					new_tup->cells[tail_len] = head;
+					new_tup->size = tail_len+1;
+					tail_tup->refs--;
+					return MKTUP(new_tup, tail_len+1);
+				}
+			}
+		} else {
+			ASSERT1(tail_len < TUP_LEN_MAX, tail);
+			ASSERT1(tail_len <= tail_tup->cap, tail);
+			if (tail_len < tail_tup->cap) {
+				tail_tup->cells[tail_len] = head;
+				tail_tup->size = tail_len+1;
+				return MKTUP(tail_tup, tail_len+1);
+			} else {
+				if (cap_hint < tail_len+1) cap_hint = 2*tail_len+1;
+				TUP* new_tup = tup_resize(tail_tup, cap_hint);
+				ASSERT(tail_len < new_tup->cap);
+				new_tup->size = tail_len+1;
+				new_tup->cells[tail_len] = head;
+				return MKTUP(new_tup, tail_len+1);
+			}
+		}
+	} else if (IS_TUP(tail)) { // cons onto nil
+		ASSERT(IS_NIL(tail));
+		if (IS_TUP(head)) {
+			TUP* tup = tup_new(cap_hint);
+			tup->size = 1;
+			tup->cells[0] = head;
+			return MKTUP(tup,1);
+		} else { // non-tup value pretends to be unary tuple
+			return head;
+		}
+	} else { // cons onto non-tup value pretending to be unary tuple
+		TUP* tup = tup_new(cap_hint);
+		tup->size = 2;
+		tup->cells[0] = tail;
+		tup->cells[1] = head;
+		return MKTUP(tup,2);
+	}
+}
+static VAL mkcons(VAL tail, VAL head) {
+	VAL v = mkcons_hint(tail,head,3);
+	return v;
 }
 
 static VAL lpop(VAL* stk) {
-	VAL cons=*stk, lcar, lcdr; value_uncons(cons, &lcar, &lcdr);
-	*stk=lcar; incref(lcar); incref(lcdr); decref(cons); return lcdr;
+	VAL cons=*stk, lcar, lcdr; value_uncons_c(cons, &lcar, &lcdr);
+	*stk=lcar; return lcdr;
 }
 static void lpush(VAL* stk, VAL cdr) { *stk = mkcons(*stk, cdr); }
 #define LPOP(v) push_value(lpop(&(v)))
@@ -368,20 +493,20 @@ static VAL mkstr (const char* data, USIZE size) {
 }
 
 static void do_uncons(void) {
-	VAL val, car, cdr;
+	VAL val, tail, head;
 	val = pop_value();
-	value_uncons(val, &car, &cdr);
-	push_value(car);
-	push_value(cdr);
-	incref(car);
-	incref(cdr);
-	decref(val);
+	value_uncons_c(val, &tail, &head);
+	push_value(tail);
+	push_value(head);
 }
 
 static USIZE get_data_tag(VAL v) {
-	VAL car, cdr;
-	value_uncons(v, &car, &cdr);
-	return VU64(cdr);
+	if (IS_TUP(v)) {
+		ASSERT(VTUPLEN(v) > 0);
+		return VU64(VTUP(v)->cells[VTUPLEN(v)-1]);
+	} else {
+		return VU64(v);
+	}
 }
 
 static USIZE get_top_data_tag(void) {
@@ -409,10 +534,8 @@ static void run_value(VAL v) {
 	// TODO Make a closure tag or something.
 	// As it is, this feels kinda wrong.
 	VAL car, cdr;
-	value_uncons(v, &car, &cdr);
+	value_uncons_c(v, &car, &cdr);
 	push_value(car);
-	incref(car);
-	decref(v);
 	ASSERT(IS_FNPTR(cdr) && VFNPTR(cdr));
 	VFNPTR(cdr)();
 }
@@ -441,45 +564,6 @@ static void mw_std_prim_prim_swap (void) {
 	PRIM_EXIT(mw_std_prim_prim_swap);
 }
 
-static void mw_std_prim_prim_dip (void) {
-	PRIM_ENTER(mw_std_prim_prim_dip,"dip");
-	VAL f = pop_value();
-	VAL x = pop_value();
-	run_value(f);
-	push_value(x);
-	PRIM_EXIT(mw_std_prim_prim_dip);
-}
-
-static void mw_std_prim_prim_if (void) {
-	PRIM_ENTER(mw_std_prim_prim_if,"if");
-	VAL else_branch = pop_value();
-	VAL then_branch = pop_value();
-	bool b = pop_bool();
-	if (b) {
-		decref(else_branch);
-		run_value(then_branch);
-	} else {
-		decref(then_branch);
-		run_value(else_branch);
-	}
-	PRIM_EXIT(mw_std_prim_prim_if);
-}
-
-static void mw_std_prim_prim_while (void) {
-	PRIM_ENTER(mw_std_prim_prim_while,"while");
-	VAL body = pop_value();
-	VAL cond = pop_value();
-	while(1) {
-		incref(cond); run_value(cond);
-		bool b = pop_bool();
-		if (!b) break;
-		incref(body); run_value(body);
-	}
-	decref(cond);
-	decref(body);
-	PRIM_EXIT(mw_std_prim_prim_while);
-}
-
 static void mw_std_prim_prim_rswap (void) {
 	PRIM_ENTER(mw_std_prim_prim_rswap,"prim-rswap");
 	VAL a = pop_resource();
@@ -487,15 +571,6 @@ static void mw_std_prim_prim_rswap (void) {
 	push_resource(a);
 	push_resource(b);
 	PRIM_EXIT(mw_std_prim_prim_rswap);
-}
-
-static void mw_std_prim_prim_rdip (void) {
-	PRIM_ENTER(mw_std_prim_prim_rdip,"rdip");
-	VAL f = pop_value();
-	VAL x = pop_resource();
-	run_value(f);
-	push_resource(x);
-	PRIM_EXIT(mw_std_prim_prim_rdip);
 }
 
 static void mw_std_prim_prim_int_add (void) {
@@ -746,14 +821,23 @@ void value_trace_(VAL val, int fd) {
 		int_trace_(VINT(val), fd);
 	} else if (IS_STR(val)) {
 		str_trace_(VSTR(val), fd);
-	} else if (IS_CONS(val)) {
-		VAL car, cdr;
-		value_uncons(val, &car, &cdr);
-		write(fd, "[ ", 2);
-		value_trace_(car, fd);
-		write(fd, " ", 1);
-		value_trace_(cdr, fd);
-		write(fd, " ]", 2);
+	} else if (IS_PTR(val)) {
+		write(fd, "<ptr>", 5);
+	} else if (IS_FNPTR(val)) {
+		write(fd, "<fnptr>", 7);
+	} else if (IS_TUP(val)) {
+		TUPLEN len = VTUPLEN(val);
+		TUP* tup = VTUP(val);
+		if (VTUPLEN(val) == 0) {
+			write(fd, "[]", 2);
+		} else {
+			write(fd, "[", 2);
+			for(TUPLEN i = 0; i < len; i++) {
+				if (i > 0) write(fd, " ", 1);
+				value_trace_(tup->cells[i], fd);
+			}
+			write(fd, "]", 1);
+		}
 	} else {
 		TRACE("value cannot be traced");
 		exit(1);
@@ -1163,12 +1247,7 @@ static void mw_std_prim_prim_pack_cons (void) {
 
 static void mw_std_prim_prim_pack_uncons (void) {
 	PRIM_ENTER(mw_std_prim_prim_pack_uncons,"prim-pack-uncons");
-	VAL v = pop_value();
-	VAL car,cdr;
-	value_uncons(v, &car, &cdr);
-	push_value(car);
-	push_value(cdr);
-	incref(car); incref(cdr); decref(v);
+	do_uncons();
 	PRIM_EXIT(mw_std_prim_prim_pack_uncons);
 }
 

--- a/src/mirth/need.mth
+++ b/src/mirth/need.mth
@@ -85,7 +85,9 @@ def(+Needs.run-op!, List(Arg) Op +Needs -- +Needs,
     OP_BLOCK -> nip push-block!,
     OP_COERCE -> drop2,
     OP_LABEL_PUSH -> drop2,
-    OP_LABEL_POP -> drop2)
+    OP_LABEL_POP -> drop2,
+    OP_DATA_GET_LABEL -> drop3,
+    OP_DATA_SET_LABEL -> drop3)
 def(+Needs.run-prim!, List(Arg) Prim +Needs -- +Needs,
     PRIM_CORE_DIP -> match(L1 -> run-arg!, _ -> push-args!),
     PRIM_CORE_RDIP -> match(L1 -> run-arg!, _ -> push-args!),


### PR DESCRIPTION
This PR replaces linked lists in the runtime with flat tuples, and uses them to improve the representation of data. It also makes data field accessing a runtime primitive.

Compile time comparisons on my dev machine:
- `make` went from 48s down to 40s
- `make bin/mirth1.c` went from 9.5s down to 5.5s