### PR TITLE
Try to make snake more solid.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 C99FLAGS=-std=c99 -Wall -Wextra -Wno-unused-variable -Wno-unused-function -Wno-unused-parameter \
  -Wno-unused-value -Wno-missing-braces -Wno-overlength-strings -Wno-infinite-recursion \
  -Werror -pedantic -O0
-MIRTHFLAGS=-p std:src/std -p args:src/args -p mirth:src/mirth -p posix:src/posix -p snake:src/snake -p ansi:src/ansi
+MIRTHFLAGS=-p std:src/std -p args:src/args -p mirth:src/mirth -p posix:src/posix -p examples:src/examples -p ansi:src/ansi
 
 CC=gcc $(C99FLAGS)
 CCSAN=$(CC) -fsanitize=undefined -fsanitize=address
@@ -119,8 +119,8 @@ bin/mirth_prof.c: bin/mirth3.c
 bin/mirth_prof: bin/mirth_prof.c
 	$(CC) -g -fprofile-instr-generate -o bin/mirth_prof bin/mirth_prof.c
 
-bin/snake.c: bin/mirth2 src/std/* src/posix/* src/snake/*
-	bin/mirth2 --debug $(MIRTHFLAGS) src/snake/main.mth -o bin/snake.c
+bin/snake.c: bin/mirth2 src/std/* src/posix/* src/examples/snake.mth src/examples/sdl2.mth
+	bin/mirth2 --debug $(MIRTHFLAGS) src/examples/snake.mth -o bin/snake.c
 
 bin/snake: bin/snake.c
 	$(CC) -o bin/snake bin/snake.c `pkg-config --libs sdl2`

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -5946,246 +5946,244 @@ static void mw_compilezn_0 (void);
 static void mw_parsezmpackagezmdef_0 (void);
 static void mw_compilerzmparsezmargs_0 (void);
 static void mw_main_0 (void);
-static void mw_filter_3_2358 (void);
-static void mw_reversezmfor_0_2359 (void);
-static void mw_dip2_0_2359 (void);
-static void mw_filter_2_2358 (void);
-static void mw_for_18_2253 (void);
-static void mw_reversezmfindzmsome_0_2467 (void);
-static void mw_findzmsomezmaux2_0_2467 (void);
-static void mw_filter_3_2348 (void);
-static void mw_for_18_2349 (void);
-static void mw_filter_2_2348 (void);
+static void mw_filter_3_2360 (void);
+static void mw_reversezmfor_0_2361 (void);
+static void mw_dip2_0_2361 (void);
+static void mw_filter_2_2360 (void);
+static void mw_for_18_2255 (void);
+static void mw_reversezmfindzmsome_0_2469 (void);
+static void mw_findzmsomezmaux2_0_2469 (void);
+static void mw_filter_3_2350 (void);
+static void mw_for_18_2351 (void);
+static void mw_filter_2_2350 (void);
+static void mw_reversezmfor_0_2328 (void);
+static void mw_dip2_0_2328 (void);
 static void mw_reversezmfor_0_2326 (void);
 static void mw_dip2_0_2326 (void);
-static void mw_reversezmfor_0_2324 (void);
-static void mw_dip2_0_2324 (void);
-static void mw_findzmsome_0_2499 (void);
-static void mw_findzmsomezmaux2_0_2499 (void);
-static void mw_findzmsome_0_2506 (void);
-static void mw_findzmsomezmaux2_0_2506 (void);
-static void mw_for_18_2316 (void);
-static void mw_filter_3_1004 (void);
-static void mw_filter_2_1004 (void);
-static void mw_findzmsome_0_2529 (void);
-static void mw_findzmsomezmaux2_0_2529 (void);
-static void mw_for_18_788 (void);
-static void mw_filter_3_1436 (void);
-static void mw_findzmsome_0_2563 (void);
-static void mw_findzmsomezmaux2_0_2563 (void);
-static void mw_filter_2_1436 (void);
-static void mw_for_18_2252 (void);
-static void mw_filter_3_2352 (void);
-static void mw_reversezmfor_0_2355 (void);
-static void mw_dip2_0_2355 (void);
-static void mw_filter_2_2352 (void);
-static void mw_fold_0_2622 (void);
-static void mw_filter_3_2629 (void);
-static void mw_filter_2_2629 (void);
-static void mw_findzmsome_0_2639 (void);
-static void mw_findzmsomezmaux2_0_2639 (void);
-static void mw_map_0_1370 (void);
-static void mw_filter_3_2658 (void);
-static void mw_filter_2_2658 (void);
-static void mw_findzmsome_0_2668 (void);
-static void mw_findzmsomezmaux2_0_2668 (void);
-static void mw_filter_3_2674 (void);
-static void mw_filter_2_2674 (void);
-static void mw_findzmsome_0_2684 (void);
-static void mw_findzmsomezmaux2_0_2684 (void);
-static void mw_map_0_1377 (void);
-static void mw_fold_0_2701 (void);
-static void mw_filter_3_2708 (void);
-static void mw_filter_2_2708 (void);
-static void mw_findzmsome_0_2718 (void);
-static void mw_findzmsomezmaux2_0_2718 (void);
-static void mw_map_0_1375 (void);
-static void mw_fold_0_2735 (void);
-static void mw_filter_3_2742 (void);
-static void mw_filter_2_2742 (void);
-static void mw_findzmsome_0_2752 (void);
-static void mw_findzmsomezmaux2_0_2752 (void);
+static void mw_findzmsome_0_2501 (void);
+static void mw_findzmsomezmaux2_0_2501 (void);
+static void mw_findzmsome_0_2508 (void);
+static void mw_findzmsomezmaux2_0_2508 (void);
+static void mw_for_18_2318 (void);
+static void mw_filter_3_1006 (void);
+static void mw_filter_2_1006 (void);
+static void mw_findzmsome_0_2531 (void);
+static void mw_findzmsomezmaux2_0_2531 (void);
+static void mw_for_18_790 (void);
+static void mw_filter_3_1438 (void);
+static void mw_findzmsome_0_2565 (void);
+static void mw_findzmsomezmaux2_0_2565 (void);
+static void mw_filter_2_1438 (void);
+static void mw_for_18_2254 (void);
+static void mw_filter_3_2354 (void);
+static void mw_reversezmfor_0_2357 (void);
+static void mw_dip2_0_2357 (void);
+static void mw_filter_2_2354 (void);
+static void mw_fold_0_2624 (void);
+static void mw_filter_3_2631 (void);
+static void mw_filter_2_2631 (void);
+static void mw_findzmsome_0_2641 (void);
+static void mw_findzmsomezmaux2_0_2641 (void);
 static void mw_map_0_1372 (void);
-static void mw_for_18_2184 (void);
-static void mw_reversezmfor_0_2170 (void);
-static void mw_dip2_0_2170 (void);
-static void mw_for_18_2406 (void);
-static void mw_for_18_2416 (void);
-static void mw_for_18_2417 (void);
-static void mw_for_18_2413 (void);
-static void mw_dipzq_0_2030 (void);
-static void mw_flatmap_0_2030 (void);
-static void mw_map_0_2046 (void);
-static void mw_for_18_2038 (void);
-static void mw_map_0_2039 (void);
+static void mw_filter_3_2660 (void);
+static void mw_filter_2_2660 (void);
+static void mw_findzmsome_0_2670 (void);
+static void mw_findzmsomezmaux2_0_2670 (void);
+static void mw_filter_3_2676 (void);
+static void mw_filter_2_2676 (void);
+static void mw_findzmsome_0_2686 (void);
+static void mw_findzmsomezmaux2_0_2686 (void);
+static void mw_map_0_1379 (void);
+static void mw_fold_0_2703 (void);
+static void mw_filter_3_2710 (void);
+static void mw_filter_2_2710 (void);
+static void mw_findzmsome_0_2720 (void);
+static void mw_findzmsomezmaux2_0_2720 (void);
+static void mw_map_0_1377 (void);
+static void mw_fold_0_2737 (void);
+static void mw_filter_3_2744 (void);
+static void mw_filter_2_2744 (void);
+static void mw_findzmsome_0_2754 (void);
+static void mw_findzmsomezmaux2_0_2754 (void);
+static void mw_map_0_1374 (void);
+static void mw_for_18_2186 (void);
+static void mw_reversezmfor_0_2172 (void);
+static void mw_dip2_0_2172 (void);
+static void mw_for_18_2408 (void);
+static void mw_for_18_2418 (void);
+static void mw_for_18_2419 (void);
+static void mw_for_18_2415 (void);
+static void mw_dipzq_0_2032 (void);
+static void mw_flatmap_0_2032 (void);
+static void mw_map_0_2048 (void);
+static void mw_for_18_2040 (void);
+static void mw_map_0_2041 (void);
 static void mw_for_18_170 (void);
 static void mw_for_18_168 (void);
 static void mw_for_18_165 (void);
-static void mw_for_18_2085 (void);
-static void mw_findzmsome_0_2932 (void);
-static void mw_findzmsomezmaux2_0_2932 (void);
-static void mw_findzmsome_0_2941 (void);
-static void mw_findzmsomezmaux2_0_2941 (void);
-static void mw_reversezmfor_0_2950 (void);
-static void mw_dip2_0_2950 (void);
-static void mw_for_18_2096 (void);
-static void mw_findzmsome_0_2967 (void);
-static void mw_findzmsomezmaux2_0_2967 (void);
-static void mw_for_18_1308 (void);
-static void mw_reversezmfor_0_2099 (void);
-static void mw_dip2_0_2099 (void);
 static void mw_for_18_2087 (void);
-static void mw_map_0_2078 (void);
-static void mw_reversezmfor_0_2071 (void);
-static void mw_reversezmfindzmsome_0_3018 (void);
-static void mw_findzmsomezmaux2_0_3018 (void);
-static void mw_for_18_2058 (void);
+static void mw_findzmsome_0_2934 (void);
+static void mw_findzmsomezmaux2_0_2934 (void);
+static void mw_findzmsome_0_2943 (void);
+static void mw_findzmsomezmaux2_0_2943 (void);
+static void mw_reversezmfor_0_2952 (void);
+static void mw_dip2_0_2952 (void);
+static void mw_for_18_2098 (void);
+static void mw_findzmsome_0_2969 (void);
+static void mw_findzmsomezmaux2_0_2969 (void);
+static void mw_for_18_1310 (void);
+static void mw_reversezmfor_0_2101 (void);
+static void mw_dip2_0_2101 (void);
+static void mw_for_18_2089 (void);
+static void mw_map_0_2080 (void);
+static void mw_reversezmfor_0_2073 (void);
+static void mw_reversezmfindzmsome_0_3020 (void);
+static void mw_findzmsomezmaux2_0_3020 (void);
+static void mw_for_18_2060 (void);
 static void mw_for_18_140 (void);
-static void mw_findzmsome_0_3037 (void);
-static void mw_findzmsomezmaux2_0_3037 (void);
+static void mw_findzmsome_0_3039 (void);
+static void mw_findzmsomezmaux2_0_3039 (void);
 static void mw_zeze_21_297 (void);
-static void mw_findzmsome_0_3051 (void);
-static void mw_findzmsomezmaux2_0_3051 (void);
-static void mw_findzmsome_0_3057 (void);
-static void mw_findzmsomezmaux2_0_3057 (void);
-static void mw_for_18_2037 (void);
+static void mw_findzmsome_0_3053 (void);
+static void mw_findzmsomezmaux2_0_3053 (void);
+static void mw_findzmsome_0_3059 (void);
+static void mw_findzmsomezmaux2_0_3059 (void);
+static void mw_for_18_2039 (void);
 static void mw_for_18_186 (void);
-static void mw_for_18_2024 (void);
-static void mw_findzmsome_0_2019 (void);
-static void mw_findzmsomezmaux2_0_2019 (void);
-static void mw_findzmsome_0_3120 (void);
-static void mw_findzmsomezmaux2_0_3120 (void);
-static void mw_findzmsome_0_3145 (void);
-static void mw_findzmsomezmaux2_0_3145 (void);
-static void mw_for_18_1913 (void);
-static void mw_findzmsome_0_3156 (void);
-static void mw_findzmsomezmaux2_0_3156 (void);
-static void mw_filter_3_1407 (void);
-static void mw_map_0_1408 (void);
-static void mw_filter_2_1407 (void);
-static void mw_filterzmsome_1_1413 (void);
-static void mw_filter_3_1414 (void);
-static void mw_filter_2_1414 (void);
-static void mw_filterzmsome_0_1413 (void);
-static void mw_for_18_1581 (void);
-static void mw_map_0_1584 (void);
-static void mw_for_18_1651 (void);
-static void mw_for_18_1662 (void);
-static void mw_for_18_1658 (void);
-static void mw_partitionzmeither_1_3231 (void);
-static void mw_partitionzmeitherzmbase_0_3231 (void);
-static void mw_partitionzmeitherzmsnoc_0_3231 (void);
-static void mw_partitionzmeither_0_3231 (void);
-static void mw_reversezmfor_0_1676 (void);
-static void mw_dip2_0_1676 (void);
-static void mw_partitionzmeither_1_3255 (void);
-static void mw_partitionzmeitherzmbase_0_3255 (void);
-static void mw_partitionzmeitherzmsnoc_0_3255 (void);
-static void mw_partitionzmeither_0_3255 (void);
-static void mw_findzmsome_0_3277 (void);
-static void mw_findzmsomezmaux2_0_3277 (void);
-static void mw_partitionzmeither_1_3284 (void);
-static void mw_partitionzmeitherzmbase_0_3284 (void);
-static void mw_partitionzmeitherzmsnoc_0_3284 (void);
-static void mw_partitionzmeither_0_3284 (void);
-static void mw_findzmsome_0_3307 (void);
-static void mw_findzmsomezmaux2_0_3307 (void);
-static void mw_partitionzmeither_1_3314 (void);
-static void mw_partitionzmeitherzmbase_0_3314 (void);
-static void mw_partitionzmeitherzmsnoc_0_3314 (void);
-static void mw_partitionzmeither_0_3314 (void);
-static void mw_partitionzmeither_1_3335 (void);
-static void mw_partitionzmeitherzmbase_0_3335 (void);
-static void mw_partitionzmeitherzmsnoc_0_3335 (void);
-static void mw_partitionzmeither_0_3335 (void);
-static void mw_partitionzmeither_1_3356 (void);
-static void mw_partitionzmeitherzmbase_0_3356 (void);
-static void mw_partitionzmeitherzmsnoc_0_3356 (void);
-static void mw_partitionzmeither_0_3356 (void);
-static void mw_partitionzmeither_1_3377 (void);
-static void mw_partitionzmeitherzmbase_0_3377 (void);
-static void mw_partitionzmeitherzmsnoc_0_3377 (void);
-static void mw_partitionzmeither_0_3377 (void);
-static void mw_for_18_1714 (void);
-static void mw_for_18_1989 (void);
-static void mw_for_18_1993 (void);
-static void mw_for_18_2001 (void);
-static void mw_reversezmfor_0_3474 (void);
-static void mw_dip2_0_3474 (void);
-static void mw_reversezmfor_0_3484 (void);
-static void mw_dip2_0_3484 (void);
-static void mw_reversezmfor_0_1816 (void);
-static void mw_dip2_0_1816 (void);
-static void mw_partitionzmeither_1_3509 (void);
-static void mw_partitionzmeitherzmbase_0_3509 (void);
-static void mw_partitionzmeitherzmsnoc_0_3509 (void);
-static void mw_partitionzmeither_0_3509 (void);
-static void mw_findzmsome_0_3531 (void);
-static void mw_findzmsomezmaux2_0_3531 (void);
-static void mw_partitionzmeither_1_3538 (void);
-static void mw_partitionzmeitherzmbase_0_3538 (void);
-static void mw_partitionzmeitherzmsnoc_0_3538 (void);
-static void mw_partitionzmeither_0_3538 (void);
-static void mw_filter_3_3558 (void);
-static void mw_filter_2_3558 (void);
-static void mw_for_18_1780 (void);
-static void mw_partitionzmeither_1_3570 (void);
-static void mw_partitionzmeitherzmbase_0_3570 (void);
-static void mw_partitionzmeitherzmsnoc_0_3570 (void);
-static void mw_partitionzmeither_0_3570 (void);
-static void mw_findzmsome_0_3592 (void);
-static void mw_findzmsomezmaux2_0_3592 (void);
-static void mw_reversezmfor_0_1981 (void);
-static void mw_dip2_0_1981 (void);
-static void mw_filter_3_1866 (void);
-static void mw_for_18_1790 (void);
-static void mw_map_0_1867 (void);
-static void mw_filter_2_1866 (void);
-static void mw_findzmsome_0_1851 (void);
-static void mw_findzmsomezmaux2_0_1851 (void);
-static void mw_map_0_1014 (void);
+static void mw_for_18_2026 (void);
+static void mw_findzmsome_0_2021 (void);
+static void mw_findzmsomezmaux2_0_2021 (void);
+static void mw_findzmsome_0_3122 (void);
+static void mw_findzmsomezmaux2_0_3122 (void);
+static void mw_findzmsome_0_3147 (void);
+static void mw_findzmsomezmaux2_0_3147 (void);
+static void mw_for_18_1915 (void);
+static void mw_findzmsome_0_3158 (void);
+static void mw_findzmsomezmaux2_0_3158 (void);
+static void mw_filter_3_1409 (void);
+static void mw_map_0_1410 (void);
+static void mw_filter_2_1409 (void);
+static void mw_filterzmsome_1_1415 (void);
+static void mw_filter_3_1416 (void);
+static void mw_filter_2_1416 (void);
+static void mw_filterzmsome_0_1415 (void);
+static void mw_for_18_1583 (void);
+static void mw_map_0_1586 (void);
+static void mw_for_18_1653 (void);
+static void mw_for_18_1664 (void);
+static void mw_for_18_1660 (void);
+static void mw_partitionzmeither_1_3233 (void);
+static void mw_partitionzmeitherzmbase_0_3233 (void);
+static void mw_partitionzmeitherzmsnoc_0_3233 (void);
+static void mw_partitionzmeither_0_3233 (void);
+static void mw_reversezmfor_0_1678 (void);
+static void mw_dip2_0_1678 (void);
+static void mw_partitionzmeither_1_3257 (void);
+static void mw_partitionzmeitherzmbase_0_3257 (void);
+static void mw_partitionzmeitherzmsnoc_0_3257 (void);
+static void mw_partitionzmeither_0_3257 (void);
+static void mw_findzmsome_0_3279 (void);
+static void mw_findzmsomezmaux2_0_3279 (void);
+static void mw_partitionzmeither_1_3286 (void);
+static void mw_partitionzmeitherzmbase_0_3286 (void);
+static void mw_partitionzmeitherzmsnoc_0_3286 (void);
+static void mw_partitionzmeither_0_3286 (void);
+static void mw_findzmsome_0_3309 (void);
+static void mw_findzmsomezmaux2_0_3309 (void);
+static void mw_partitionzmeither_1_3316 (void);
+static void mw_partitionzmeitherzmbase_0_3316 (void);
+static void mw_partitionzmeitherzmsnoc_0_3316 (void);
+static void mw_partitionzmeither_0_3316 (void);
+static void mw_partitionzmeither_1_3337 (void);
+static void mw_partitionzmeitherzmbase_0_3337 (void);
+static void mw_partitionzmeitherzmsnoc_0_3337 (void);
+static void mw_partitionzmeither_0_3337 (void);
+static void mw_partitionzmeither_1_3358 (void);
+static void mw_partitionzmeitherzmbase_0_3358 (void);
+static void mw_partitionzmeitherzmsnoc_0_3358 (void);
+static void mw_partitionzmeither_0_3358 (void);
+static void mw_partitionzmeither_1_3379 (void);
+static void mw_partitionzmeitherzmbase_0_3379 (void);
+static void mw_partitionzmeitherzmsnoc_0_3379 (void);
+static void mw_partitionzmeither_0_3379 (void);
+static void mw_for_18_1716 (void);
+static void mw_for_18_1991 (void);
+static void mw_for_18_1995 (void);
+static void mw_for_18_2003 (void);
+static void mw_reversezmfor_0_3476 (void);
+static void mw_dip2_0_3476 (void);
+static void mw_reversezmfor_0_3486 (void);
+static void mw_dip2_0_3486 (void);
+static void mw_reversezmfor_0_1818 (void);
+static void mw_dip2_0_1818 (void);
+static void mw_partitionzmeither_1_3511 (void);
+static void mw_partitionzmeitherzmbase_0_3511 (void);
+static void mw_partitionzmeitherzmsnoc_0_3511 (void);
+static void mw_partitionzmeither_0_3511 (void);
+static void mw_findzmsome_0_3533 (void);
+static void mw_findzmsomezmaux2_0_3533 (void);
+static void mw_partitionzmeither_1_3540 (void);
+static void mw_partitionzmeitherzmbase_0_3540 (void);
+static void mw_partitionzmeitherzmsnoc_0_3540 (void);
+static void mw_partitionzmeither_0_3540 (void);
+static void mw_filter_3_3560 (void);
+static void mw_filter_2_3560 (void);
+static void mw_for_18_1782 (void);
+static void mw_partitionzmeither_1_3572 (void);
+static void mw_partitionzmeitherzmbase_0_3572 (void);
+static void mw_partitionzmeitherzmsnoc_0_3572 (void);
+static void mw_partitionzmeither_0_3572 (void);
+static void mw_findzmsome_0_3594 (void);
+static void mw_findzmsomezmaux2_0_3594 (void);
+static void mw_reversezmfor_0_1983 (void);
+static void mw_dip2_0_1983 (void);
+static void mw_filter_3_1868 (void);
+static void mw_for_18_1792 (void);
+static void mw_map_0_1869 (void);
+static void mw_filter_2_1868 (void);
+static void mw_findzmsome_0_1853 (void);
+static void mw_findzmsomezmaux2_0_1853 (void);
+static void mw_map_0_1016 (void);
 static void mw_for_18_157 (void);
-static void mw_for_18_842 (void);
-static void mw_for_18_854 (void);
+static void mw_for_18_844 (void);
+static void mw_for_18_856 (void);
 static void mw_for_18_317 (void);
-static void mw_findzmsome_0_3671 (void);
-static void mw_findzmsomezmaux2_0_3671 (void);
-static void mw_findzmsome_0_3680 (void);
-static void mw_findzmsomezmaux2_0_3680 (void);
+static void mw_findzmsome_0_3673 (void);
+static void mw_findzmsomezmaux2_0_3673 (void);
+static void mw_findzmsome_0_3682 (void);
+static void mw_findzmsomezmaux2_0_3682 (void);
 static void mw_for_18_311 (void);
-static void mw_for_18_1098 (void);
-static void mw_for_18_1387 (void);
-static void mw_map_0_1383 (void);
+static void mw_for_18_1100 (void);
+static void mw_for_18_1389 (void);
+static void mw_map_0_1385 (void);
 static void mb_99 (void);
 static void mb_174 (void);
-static void mb_793 (void);
-static void mb_987 (void);
-static void mb_1719 (void);
-static void mb_1720 (void);
+static void mb_795 (void);
+static void mb_989 (void);
+static void mb_1721 (void);
 static void mb_1722 (void);
-static void mb_1723 (void);
+static void mb_1724 (void);
 static void mb_1725 (void);
-static void mb_1726 (void);
-static void mb_1756 (void);
-static void mb_1770 (void);
-static void mb_1779 (void);
-static void mb_1814 (void);
-static void mb_1865 (void);
-static void mb_1883 (void);
+static void mb_1727 (void);
+static void mb_1728 (void);
+static void mb_1758 (void);
+static void mb_1772 (void);
+static void mb_1781 (void);
+static void mb_1816 (void);
+static void mb_1867 (void);
 static void mb_1885 (void);
-static void mb_1886 (void);
-static void mb_1901 (void);
-static void mb_1906 (void);
-static void mb_1928 (void);
-static void mb_1941 (void);
-static void mb_1944 (void);
-static void mb_1945 (void);
+static void mb_1887 (void);
+static void mb_1888 (void);
+static void mb_1903 (void);
+static void mb_1908 (void);
+static void mb_1930 (void);
+static void mb_1943 (void);
 static void mb_1946 (void);
 static void mb_1947 (void);
 static void mb_1948 (void);
 static void mb_1949 (void);
-static void mb_1952 (void);
-static void mb_1953 (void);
+static void mb_1950 (void);
+static void mb_1951 (void);
 static void mb_1954 (void);
 static void mb_1955 (void);
 static void mb_1956 (void);
@@ -6197,30 +6195,32 @@ static void mb_1961 (void);
 static void mb_1962 (void);
 static void mb_1963 (void);
 static void mb_1964 (void);
-static void mb_1968 (void);
-static void mb_2013 (void);
-static void mb_2014 (void);
+static void mb_1965 (void);
+static void mb_1966 (void);
+static void mb_1970 (void);
 static void mb_2015 (void);
 static void mb_2016 (void);
 static void mb_2017 (void);
-static void mb_2027 (void);
-static void mb_2028 (void);
-static void mb_2057 (void);
-static void mb_2162 (void);
+static void mb_2018 (void);
+static void mb_2019 (void);
+static void mb_2029 (void);
+static void mb_2030 (void);
+static void mb_2059 (void);
 static void mb_2164 (void);
-static void mb_2165 (void);
-static void mb_2176 (void);
-static void mb_2177 (void);
-static void mb_2207 (void);
-static void mb_2210 (void);
-static void mb_2213 (void);
-static void mb_2214 (void);
-static void mb_2218 (void);
-static void mb_2219 (void);
+static void mb_2166 (void);
+static void mb_2167 (void);
+static void mb_2178 (void);
+static void mb_2179 (void);
+static void mb_2209 (void);
+static void mb_2212 (void);
+static void mb_2215 (void);
+static void mb_2216 (void);
 static void mb_2220 (void);
-static void mb_2228 (void);
-static void mb_2918 (void);
-static void mb_3012 (void);
+static void mb_2221 (void);
+static void mb_2222 (void);
+static void mb_2230 (void);
+static void mb_2920 (void);
+static void mb_3014 (void);
 static void mfld_z126Uname_0 (void);
 static void mfld_z126Upackage_0 (void);
 static void mfld_z126Uname_1 (void);
@@ -10290,10 +10290,10 @@ static void mw_fromzmbyteszmunsafe_0 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_788();
+				mw_for_18_790();
 				push_value(d4);
 			}
-			mw_for_18_788();
+			mw_for_18_790();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -11812,10 +11812,10 @@ static void mw_printzmusage_0 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_842();
+				mw_for_18_844();
 				push_value(d4);
 			}
-			mw_for_18_842();
+			mw_for_18_844();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -12122,10 +12122,10 @@ static void mw_printzmusagezmforzmoption_0 (void) {
 						mp_primzmdrop();
 						{
 							VAL d7 = pop_value();
-							mw_for_18_854();
+							mw_for_18_856();
 							push_value(d7);
 						}
-						mw_for_18_854();
+						mw_for_18_856();
 						break;
 					default:
 						push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -12282,7 +12282,7 @@ static void mw_parsezmflags_0 (void) {
 				break;
 			case 1LL: // SOME
 				mtp_SOME_0();
-				mw_findzmsome_0_3680();
+				mw_findzmsome_0_3682();
 				break;
 			default:
 				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -12380,7 +12380,7 @@ static void mw_parsezmflags_0 (void) {
 				break;
 			case 1LL: // SOME
 				mtp_SOME_0();
-				mw_findzmsome_0_3671();
+				mw_findzmsome_0_3673();
 				break;
 			default:
 				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -14745,7 +14745,7 @@ static void mw_delay0_0 (void) {
 	{
 		VAL var_f = pop_value();
 		push_i64(0LL);
-		push_fnptr(&mb_987);
+		push_fnptr(&mb_989);
 		incref(var_f);
 		push_value(var_f);
 		mp_primzmpackzmcons();
@@ -15086,7 +15086,7 @@ static void mw_visible_0 (void) {
 				break;
 			case 1LL: // SOME
 				mtp_SOME_0();
-				mw_findzmsome_0_3120();
+				mw_findzmsome_0_3122();
 				break;
 			default:
 				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -15368,7 +15368,7 @@ static void mw_lookup_0 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_reversezmfindzmsome_0_3018();
+			mw_reversezmfindzmsome_0_3020();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -16101,13 +16101,13 @@ static void mw_makezmprimzmdatazn_0 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1383();
+					mw_map_0_1385();
 					push_value(d5);
 				}
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1383();
+					mw_map_0_1385();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -16242,10 +16242,10 @@ static void mw_makezmprimzmdatazn_0 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_1387();
+				mw_for_18_1389();
 				push_value(d4);
 			}
-			mw_for_18_1387();
+			mw_for_18_1389();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -16733,7 +16733,7 @@ static void mw_iszmenumz63U_0 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_findzmsome_0_3145();
+			mw_findzmsome_0_3147();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -16854,7 +16854,7 @@ static void mw_labelzminputszmfromzmsig_0 (void) {
 		case 1LL: // SOME
 			mtp_SOME_0();
 			mw_runzmtokens_0();
-			mw_filter_3_1407();
+			mw_filter_3_1409();
 			switch (get_top_data_tag()) {
 				case 0LL: // L0
 					(void)pop_u64();
@@ -16948,13 +16948,13 @@ static void mw_labelzminputszmfromzmsig_0 (void) {
 						VAL d6 = pop_value();
 						{
 							VAL d7 = pop_value();
-							mw_map_0_1408();
+							mw_map_0_1410();
 							push_value(d7);
 						}
 						mp_primzmswap();
 						{
 							VAL d7 = pop_value();
-							mw_map_0_1408();
+							mw_map_0_1410();
 							push_value(d7);
 						}
 						mp_primzmswap();
@@ -17023,8 +17023,8 @@ static void mw_numzmresourcezminputszmfromzmsig_0 (void) {
 		case 1LL: // SOME
 			mtp_SOME_0();
 			mw_runzmtokens_0();
-			mw_filterzmsome_1_1413();
-			mw_filter_3_1414();
+			mw_filterzmsome_1_1415();
+			mw_filter_3_1416();
 			mw_len_2();
 			break;
 		case 0LL: // NONE
@@ -17336,7 +17336,7 @@ static void mw_haszmdefaultzmcasez63U_0 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_findzmsome_0_2499();
+			mw_findzmsome_0_2501();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -17346,7 +17346,7 @@ static void mw_haszmdefaultzmcasez63U_0 (void) {
 }
 static void mw_scrutineezmdataz63U_0 (void) {
 	mw_cases_0();
-	mw_filter_3_1436();
+	mw_filter_3_1438();
 	mp_primzmdup();
 	mw_first_1();
 	switch (get_top_data_tag()) {
@@ -17389,7 +17389,7 @@ static void mw_scrutineezmdataz63U_0 (void) {
 					break;
 				case 1LL: // SOME
 					mtp_SOME_0();
-					mw_findzmsome_0_2563();
+					mw_findzmsome_0_2565();
 					break;
 				default:
 					push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -17498,7 +17498,7 @@ static void mw_casezmredundantz63U_0 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_findzmsome_0_2967();
+			mw_findzmsome_0_2969();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -17717,10 +17717,10 @@ static void mw_dom_9 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_1308();
+				mw_for_18_1310();
 				push_value(d4);
 			}
-			mw_for_18_1308();
+			mw_for_18_1310();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -17759,7 +17759,7 @@ static void mw_iszmdefaultz63U_0 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_findzmsome_0_2506();
+			mw_findzmsome_0_2508();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -18888,13 +18888,13 @@ static void mw_freezmvars_4 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1370();
+					mw_map_0_1372();
 					push_value(d5);
 				}
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1370();
+					mw_map_0_1372();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -18914,7 +18914,7 @@ static void mw_freezmvars_4 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_fold_0_2622();
+			mw_fold_0_2624();
 			mtw_SOME_0();
 			break;
 		default:
@@ -19018,13 +19018,13 @@ static void mw_freezmvars_3 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1372();
+					mw_map_0_1374();
 					push_value(d5);
 				}
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1372();
+					mw_map_0_1374();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -19044,7 +19044,7 @@ static void mw_freezmvars_3 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_fold_0_2735();
+			mw_fold_0_2737();
 			mtw_SOME_0();
 			break;
 		default:
@@ -19076,7 +19076,7 @@ static void mw_freezmvars_3 (void) {
 		VAL d2 = pop_value();
 		mp_primzmswap();
 		mp_primzmswap();
-		mw_filter_3_2658();
+		mw_filter_3_2660();
 		{
 			VAL d3 = pop_value();
 			mp_primzmdrop();
@@ -19275,13 +19275,13 @@ static void mw_freezmvars_6 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1375();
+					mw_map_0_1377();
 					push_value(d5);
 				}
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1375();
+					mw_map_0_1377();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -19301,7 +19301,7 @@ static void mw_freezmvars_6 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_fold_0_2701();
+			mw_fold_0_2703();
 			mtw_SOME_0();
 			break;
 		default:
@@ -19412,13 +19412,13 @@ static void mw_freezmvars_1 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1377();
+					mw_map_0_1379();
 					push_value(d5);
 				}
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1377();
+					mw_map_0_1379();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -19431,7 +19431,7 @@ static void mw_freezmvars_1 (void) {
 			mp_primzmpanic();
 	}
 	mp_primzmswap();
-	mw_filter_3_2674();
+	mw_filter_3_2676();
 	{
 		VAL d2 = pop_value();
 		mp_primzmdrop();
@@ -19844,10 +19844,10 @@ static void mw_TT_0 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_1098();
+				mw_for_18_1100();
 				push_value(d4);
 			}
-			mw_for_18_1098();
+			mw_for_18_1100();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -28481,7 +28481,7 @@ static void mw_runzmarrowz63U_0 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_findzmsome_0_3592();
+			mw_findzmsome_0_3594();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -28570,7 +28570,7 @@ static void mw_patzmtokens_0 (void) {
 		push_u64(1LL); // T
 		push_value(d2);
 	}
-	mw_filter_3_3558();
+	mw_filter_3_3560();
 	{
 		VAL d2 = pop_value();
 		mp_primzmdrop();
@@ -29162,7 +29162,7 @@ static void mw_defzmindex_0 (void) {
 	mp_primzmdup();
 	mw_name_9();
 	mw_defs_0();
-	mw_filter_3_1004();
+	mw_filter_3_1006();
 	mw_len_2();
 	{
 		VAL d2 = pop_value();
@@ -30025,7 +30025,7 @@ static void mw_defz63U_0 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_findzmsome_0_2529();
+			mw_findzmsome_0_2531();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -31263,7 +31263,7 @@ static void mw_dnamez63U_2 (void) {
 				}
 				push_value(d4);
 			}
-			mw_map_0_1014();
+			mw_map_0_1016();
 			mtw_DNAME_0();
 			mtw_SOME_0();
 			break;
@@ -32036,10 +32036,10 @@ static void mw_elabzmtypezmsigzn_0 (void) {
 				mp_primzmdrop();
 				{
 					VAL d5 = pop_value();
-					mw_for_18_1581();
+					mw_for_18_1583();
 					push_value(d5);
 				}
-				mw_for_18_1581();
+				mw_for_18_1583();
 				break;
 			default:
 				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -32153,13 +32153,13 @@ static void mw_elabzmtypezmsigzmparamszn_0 (void) {
 						VAL d6 = pop_value();
 						{
 							VAL d7 = pop_value();
-							mw_map_0_1584();
+							mw_map_0_1586();
 							push_value(d7);
 						}
 						mp_primzmswap();
 						{
 							VAL d7 = pop_value();
-							mw_map_0_1584();
+							mw_map_0_1586();
 							push_value(d7);
 						}
 						mp_primzmswap();
@@ -32800,10 +32800,10 @@ static void mw_resolvezmdefzmambiguous_0 (void) {
 				mp_primzmdrop();
 				{
 					VAL d5 = pop_value();
-					mw_for_18_1658();
+					mw_for_18_1660();
 					push_value(d5);
 				}
-				mw_for_18_1658();
+				mw_for_18_1660();
 				break;
 			default:
 				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -32988,10 +32988,10 @@ static void mw_resolvezmdefzmambiguous_0 (void) {
 				mp_primzmdrop();
 				{
 					VAL d5 = pop_value();
-					mw_for_18_1662();
+					mw_for_18_1664();
 					push_value(d5);
 				}
-				mw_for_18_1662();
+				mw_for_18_1664();
 				break;
 			default:
 				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -34376,10 +34376,10 @@ static void mw_resolvezmdefzmunknown_0 (void) {
 					mp_primzmdrop();
 					{
 						VAL d6 = pop_value();
-						mw_for_18_1651();
+						mw_for_18_1653();
 						push_value(d6);
 					}
-					mw_for_18_1651();
+					mw_for_18_1653();
 					break;
 				default:
 					push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -34396,7 +34396,7 @@ static void mw_filterzmarity_0 (void) {
 	mw_token_8();
 	mw_numzmargs_0();
 	mw_candidates_0();
-	mw_partitionzmeither_1_3356();
+	mw_partitionzmeither_1_3358();
 	{
 		VAL d2 = pop_value();
 		mw_rejected_0();
@@ -34413,7 +34413,7 @@ static void mw_filterzmarity_0 (void) {
 }
 static void mw_filterzmvisible_0 (void) {
 	mw_candidates_0();
-	mw_partitionzmeither_1_3335();
+	mw_partitionzmeither_1_3337();
 	{
 		VAL d2 = pop_value();
 		mw_rejected_0();
@@ -34437,7 +34437,7 @@ static void mw_filterzmqualifiers_0 (void) {
 		case 1LL: // SOME
 			mtp_SOME_0();
 			mw_candidates_0();
-			mw_partitionzmeither_1_3314();
+			mw_partitionzmeither_1_3316();
 			{
 				VAL d4 = pop_value();
 				mw_rejected_0();
@@ -34465,7 +34465,7 @@ static void mw_filterzmroots_0 (void) {
 			mtp_SOME_0();
 			mp_primzmdrop();
 			mw_candidates_0();
-			mw_partitionzmeither_1_3284();
+			mw_partitionzmeither_1_3286();
 			{
 				VAL d4 = pop_value();
 				mw_rejected_0();
@@ -34498,7 +34498,7 @@ static void mw_filterzmroots_0 (void) {
 			mw_iszmrelativez63U_0();
 			if (pop_u64()) {
 				mw_candidates_0();
-				mw_partitionzmeither_1_3255();
+				mw_partitionzmeither_1_3257();
 				{
 					VAL d5 = pop_value();
 					mw_rejected_0();
@@ -34513,7 +34513,7 @@ static void mw_filterzmroots_0 (void) {
 				mw_candidateszn_0();
 			} else {
 				mw_candidates_0();
-				mw_partitionzmeither_1_3231();
+				mw_partitionzmeither_1_3233();
 				{
 					VAL d5 = pop_value();
 					mw_rejected_0();
@@ -34807,7 +34807,7 @@ static void mw_climbzmupzmdnamez63U_0 (void) {
 				mp_primzmswap();
 				push_value(d4);
 			}
-			mw_dip2_0_1676();
+			mw_dip2_0_1678();
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
@@ -34876,10 +34876,10 @@ static void mw_climbzmupzmdnamez63U_0 (void) {
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_reversezmfor_0_1676();
+				mw_reversezmfor_0_1678();
 				push_value(d4);
 			}
-			mw_reversezmfor_0_1676();
+			mw_reversezmfor_0_1678();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -34913,7 +34913,7 @@ static void mw_resolvezmtypezmconzmnamezn_0 (void) {
 	LPUSH(lbl_rejected);
 	mtw_RESOLVEzuDEF_0();
 	mw_candidates_0();
-	mw_partitionzmeither_1_3377();
+	mw_partitionzmeither_1_3379();
 	{
 		VAL d2 = pop_value();
 		mw_rejected_0();
@@ -35123,10 +35123,10 @@ static void mw_elabzmtypezmargszn_0 (void) {
 					mp_primzmdrop();
 					{
 						VAL d6 = pop_value();
-						mw_for_18_1714();
+						mw_for_18_1716();
 						push_value(d6);
 					}
-					mw_for_18_1714();
+					mw_for_18_1716();
 					break;
 				default:
 					push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -35360,7 +35360,7 @@ static void mw_abzmbuildzn_0 (void) {
 static void mw_abzmbuildzmhomzn_0 (void) {
 	{
 		VAL var_f = pop_value();
-		push_fnptr(&mb_1719);
+		push_fnptr(&mb_1721);
 		{
 			VAL var_f = pop_value();
 			{
@@ -35375,7 +35375,7 @@ static void mw_abzmbuildzmhomzn_0 (void) {
 			}
 			decref(var_f);
 		}
-		push_fnptr(&mb_1720);
+		push_fnptr(&mb_1722);
 		incref(var_f);
 		push_value(var_f);
 		mp_primzmpackzmcons();
@@ -35386,7 +35386,7 @@ static void mw_abzmbuildzmhomzn_0 (void) {
 static void mw_abzmbuildzmwordzmarrowzn_0 (void) {
 	{
 		VAL var_f = pop_value();
-		push_fnptr(&mb_1722);
+		push_fnptr(&mb_1724);
 		{
 			VAL var_f = pop_value();
 			mp_primzmdup();
@@ -35398,7 +35398,7 @@ static void mw_abzmbuildzmwordzmarrowzn_0 (void) {
 			}
 			decref(var_f);
 		}
-		push_fnptr(&mb_1723);
+		push_fnptr(&mb_1725);
 		{
 			VAL var_f = pop_value();
 			mp_primzmdup();
@@ -35420,7 +35420,7 @@ static void mw_abzmbuildzmwordzmarrowzn_0 (void) {
 static void mw_abzmbuildzmwordzn_0 (void) {
 	{
 		VAL var_f = pop_value();
-		push_fnptr(&mb_1725);
+		push_fnptr(&mb_1727);
 		incref(var_f);
 		push_value(var_f);
 		mp_primzmpackzmcons();
@@ -35880,7 +35880,7 @@ static void mw_abzmlambdazmatzn_0 (void) {
 				mw_abzmtypez64U_0();
 				push_value(d4);
 			}
-			push_fnptr(&mb_1756);
+			push_fnptr(&mb_1758);
 			mw_reversezmfor_1();
 			{
 				VAL d4 = pop_value();
@@ -36341,7 +36341,7 @@ static void mw_elabzmblockzmatzn_0 (void) {
 	mfld_z126Ucod_0();
 	mp_primzmmutzmset();
 	mp_primzmdup();
-	push_fnptr(&mb_1779);
+	push_fnptr(&mb_1781);
 	mtw_LAZZYzuDELAY_0();
 	{
 		VAL d2 = pop_value();
@@ -36393,10 +36393,10 @@ static void mw_elabzmargszn_0 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_1780();
+				mw_for_18_1782();
 				push_value(d4);
 			}
-			mw_for_18_1780();
+			mw_for_18_1782();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -36486,7 +36486,7 @@ static void mw_elabzmatomzmresolvezmdefzn_0 (void) {
 	LPUSH(lbl_rejected);
 	mtw_RESOLVEzuDEF_0();
 	mw_candidates_0();
-	mw_partitionzmeither_1_3570();
+	mw_partitionzmeither_1_3572();
 	{
 		VAL d2 = pop_value();
 		mw_rejected_0();
@@ -36716,10 +36716,10 @@ static void mw_elabzmambiguouszmnamezmerrorzn_0 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_1790();
+				mw_for_18_1792();
 				push_value(d4);
 			}
-			mw_for_18_1790();
+			mw_for_18_1792();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -37129,7 +37129,7 @@ static void mw_elabzmpatternzn_0 (void) {
 				mp_primzmswap();
 				push_value(d4);
 			}
-			mw_dip2_0_1816();
+			mw_dip2_0_1818();
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
@@ -37144,10 +37144,10 @@ static void mw_elabzmpatternzn_0 (void) {
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_reversezmfor_0_1816();
+				mw_reversezmfor_0_1818();
 				push_value(d4);
 			}
-			mw_reversezmfor_0_1816();
+			mw_reversezmfor_0_1818();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -37203,7 +37203,7 @@ static void mw_elabzmpatternzmatomzn_0 (void) {
 				LPUSH(lbl_rejected);
 				mtw_RESOLVEzuDEF_0();
 				mw_candidates_0();
-				mw_partitionzmeither_1_3538();
+				mw_partitionzmeither_1_3540();
 				{
 					VAL d5 = pop_value();
 					mw_rejected_0();
@@ -37243,7 +37243,7 @@ static void mw_elabzmpatternzmatomzn_0 (void) {
 								mtp_SOME_0();
 								mp_primzmdrop();
 								mw_candidates_0();
-								mw_partitionzmeither_1_3509();
+								mw_partitionzmeither_1_3511();
 								{
 									VAL d9 = pop_value();
 									mw_rejected_0();
@@ -37426,7 +37426,7 @@ static void mw_casezn_0 (void) {
 			mw_home_9();
 			{
 				VAL d4 = pop_resource();
-				push_fnptr(&mb_1814);
+				push_fnptr(&mb_1816);
 				incref(var_mkbod);
 				push_value(var_mkbod);
 				mp_primzmpackzmcons();
@@ -37705,7 +37705,7 @@ static void mw_elabzmatomzmlambdazn_0 (void) {
 					mp_primzmswap();
 					push_value(d5);
 				}
-				mw_dip2_0_3484();
+				mw_dip2_0_3486();
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
@@ -37774,10 +37774,10 @@ static void mw_elabzmatomzmlambdazn_0 (void) {
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_reversezmfor_0_3484();
+					mw_reversezmfor_0_3486();
 					push_value(d5);
 				}
-				mw_reversezmfor_0_3484();
+				mw_reversezmfor_0_3486();
 				break;
 			default:
 				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -38155,7 +38155,7 @@ static void mw_elabzmmodulezmdeclzn_0 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_findzmsome_0_1851();
+			mw_findzmsome_0_1853();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -38375,10 +38375,10 @@ static void mw_elabzmdatazn_0 (void) {
 				mp_primzmdrop();
 				{
 					VAL d5 = pop_value();
-					mw_for_18_1913();
+					mw_for_18_1915();
 					push_value(d5);
 				}
-				mw_for_18_1913();
+				mw_for_18_1915();
 				break;
 			default:
 				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -38607,7 +38607,7 @@ static void mw_elabzmdatazmtagzn_0 (void) {
 		}
 	}
 	mp_primzmdup();
-	push_fnptr(&mb_1928);
+	push_fnptr(&mb_1930);
 	mtw_LAZZYzuDELAY_0();
 	{
 		VAL d2 = pop_value();
@@ -38685,7 +38685,7 @@ static void mw_elabzmdatazmtagzn_0 (void) {
 					break;
 				case 1LL: // SOME
 					mtp_SOME_0();
-					mw_findzmsome_0_3156();
+					mw_findzmsome_0_3158();
 					break;
 				default:
 					push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -38742,7 +38742,7 @@ static void mw_elabzmdatazmdonezn_0 (void) {
 		incref(var_dat);
 		push_value(var_dat);
 		mw_iszmenumz63U_0();
-		push_fnptr(&mb_1941);
+		push_fnptr(&mb_1943);
 		incref(var_dat);
 		push_value(var_dat);
 		mp_primzmpackzmcons();
@@ -38778,7 +38778,7 @@ static void mw_elabzmdatazmdonezn_0 (void) {
 						VAL var_untag = pop_value();
 						incref(var_tag);
 						push_value(var_tag);
-						push_fnptr(&mb_1944);
+						push_fnptr(&mb_1946);
 						mtw_LAZZYzuDELAY_0();
 						incref(var_untag);
 						push_value(var_untag);
@@ -38786,7 +38786,7 @@ static void mw_elabzmdatazmdonezn_0 (void) {
 						mp_primzmmutzmset();
 						incref(var_untag);
 						push_value(var_untag);
-						push_fnptr(&mb_1945);
+						push_fnptr(&mb_1947);
 						incref(var_tag);
 						push_value(var_tag);
 						mp_primzmpackzmcons();
@@ -38916,7 +38916,7 @@ static void mw_datazmgetzmlabelzmtype_0 (void) {
 		push_value(var_tag);
 		mw_data_0();
 		mw_iszmresourcez63U_0();
-		push_fnptr(&mb_1770);
+		push_fnptr(&mb_1772);
 		incref(var_tag);
 		push_value(var_tag);
 		mp_primzmpackzmcons();
@@ -38969,7 +38969,7 @@ static void mw_createzmprojectorszn_0 (void) {
 		incref(var_tag);
 		push_value(var_tag);
 		mw_labelzminputs_0();
-		push_fnptr(&mb_1952);
+		push_fnptr(&mb_1954);
 		incref(var_tag);
 		push_value(var_tag);
 		mp_primzmpackzmcons();
@@ -39181,7 +39181,7 @@ static void mw_elabzmaliaszn_0 (void) {
 				mp_primzmpanic();
 		}
 		mw_pack2_0();
-		push_fnptr(&mb_1865);
+		push_fnptr(&mb_1867);
 		incref(var_aliasqname);
 		push_value(var_aliasqname);
 		mp_primzmpackzmcons();
@@ -39338,7 +39338,7 @@ static void mw_elabzmdefzn_0 (void) {
 	mfld_z126Upreferzminlinez63U_0();
 	mp_primzmmutzmset();
 	mp_primzmdup();
-	push_fnptr(&mb_1883);
+	push_fnptr(&mb_1885);
 	mtw_LAZZYzuDELAY_0();
 	{
 		VAL d2 = pop_value();
@@ -39349,7 +39349,7 @@ static void mw_elabzmdefzn_0 (void) {
 	mfld_z126Uctxzmtype_2();
 	mp_primzmmutzmset();
 	mp_primzmdup();
-	push_fnptr(&mb_1885);
+	push_fnptr(&mb_1887);
 	mtw_LAZZYzuDELAY_0();
 	{
 		VAL d2 = pop_value();
@@ -39360,7 +39360,7 @@ static void mw_elabzmdefzn_0 (void) {
 	mfld_z126Uparams_0();
 	mp_primzmmutzmset();
 	mp_primzmdup();
-	push_fnptr(&mb_1886);
+	push_fnptr(&mb_1888);
 	mtw_LAZZYzuDELAY_0();
 	mp_primzmswap();
 	mfld_z126Uarrow_1();
@@ -39434,10 +39434,10 @@ static void mw_checkzminlinezmrecursionzmarrowzn_0 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_1989();
+				mw_for_18_1991();
 				push_value(d4);
 			}
-			mw_for_18_1989();
+			mw_for_18_1991();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -39535,10 +39535,10 @@ static void mw_checkzminlinezmrecursionzmatomzn_0 (void) {
 				mp_primzmdrop();
 				{
 					VAL d5 = pop_value();
-					mw_for_18_1993();
+					mw_for_18_1995();
 					push_value(d5);
 				}
-				mw_for_18_1993();
+				mw_for_18_1995();
 				break;
 			default:
 				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -39679,10 +39679,10 @@ static void mw_checkzminlinezmrecursionzmopzn_0 (void) {
 					mp_primzmdrop();
 					{
 						VAL d6 = pop_value();
-						mw_for_18_2001();
+						mw_for_18_2003();
 						push_value(d6);
 					}
-					mw_for_18_2001();
+					mw_for_18_2003();
 					break;
 				default:
 					push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -40044,7 +40044,7 @@ static void mw_elabzmdefzmparamszn_0 (void) {
 				mp_primzmswap();
 				push_value(d4);
 			}
-			mw_dip2_0_1981();
+			mw_dip2_0_1983();
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
@@ -40233,10 +40233,10 @@ static void mw_elabzmdefzmparamszn_0 (void) {
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_reversezmfor_0_1981();
+				mw_reversezmfor_0_1983();
 				push_value(d4);
 			}
-			mw_reversezmfor_0_1981();
+			mw_reversezmfor_0_1983();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -40359,7 +40359,7 @@ static void mw_elabzmdefzmexternalzn_0 (void) {
 	mfld_z126Uhead_2();
 	mp_primzmmutzmset();
 	mp_primzmdup();
-	push_fnptr(&mb_1901);
+	push_fnptr(&mb_1903);
 	mtw_LAZZYzuDELAY_0();
 	{
 		VAL d2 = pop_value();
@@ -40489,7 +40489,7 @@ static void mw_elabzmvariablezn_0 (void) {
 		push_value(d2);
 	}
 	mp_primzmswap();
-	push_fnptr(&mb_1906);
+	push_fnptr(&mb_1908);
 	mtw_LAZZYzuDELAY_0();
 	mw_newzn_9();
 	mp_primzmdrop();
@@ -41799,7 +41799,7 @@ static void mw_tablezmnewzn_0 (void) {
 			mp_primzmmutzmset();
 			incref(var_w);
 			push_value(var_w);
-			push_fnptr(&mb_2013);
+			push_fnptr(&mb_2015);
 			incref(var_x);
 			push_value(var_x);
 			mp_primzmpackzmcons();
@@ -42068,7 +42068,7 @@ static void mw_elabzmtycon_0 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_findzmsome_0_2019();
+			mw_findzmsome_0_2021();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -42579,10 +42579,10 @@ static void mw_elabzmabsolutezmnamespace_0 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2024();
+				mw_for_18_2026();
 				push_value(d4);
 			}
-			mw_for_18_2024();
+			mw_for_18_2026();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -42727,7 +42727,7 @@ static void mw_fieldzmnewzn_0 (void) {
 	mfld_z126Uhead_4();
 	mp_primzmmutzmset();
 	mp_primzmswap();
-	push_fnptr(&mb_2027);
+	push_fnptr(&mb_2029);
 	mtw_LAZZYzuDELAY_0();
 	{
 		VAL d2 = pop_value();
@@ -42738,7 +42738,7 @@ static void mw_fieldzmnewzn_0 (void) {
 	mfld_z126Uvaluezmtype_0();
 	mp_primzmmutzmset();
 	mp_primzmswap();
-	push_fnptr(&mb_2028);
+	push_fnptr(&mb_2030);
 	mtw_LAZZYzuDELAY_0();
 	{
 		VAL d2 = pop_value();
@@ -42893,7 +42893,7 @@ static void mw_checkzmarrowzn_0 (void) {
 					mw_checkzmatomzn_0();
 					push_value(d5);
 				}
-				mw_dipzq_0_2030();
+				mw_dipzq_0_2032();
 				mw_cat_2();
 				break;
 			case 3LL: // L3
@@ -42905,11 +42905,11 @@ static void mw_checkzmarrowzn_0 (void) {
 						mw_checkzmatomzn_0();
 						push_value(d6);
 					}
-					mw_dipzq_0_2030();
+					mw_dipzq_0_2032();
 					mw_cat_2();
 					push_value(d5);
 				}
-				mw_dipzq_0_2030();
+				mw_dipzq_0_2032();
 				mw_cat_2();
 				break;
 			case 4LL: // LCAT
@@ -42917,13 +42917,13 @@ static void mw_checkzmarrowzn_0 (void) {
 				mp_primzmdrop();
 				{
 					VAL d5 = pop_value();
-					mw_flatmap_0_2030();
+					mw_flatmap_0_2032();
 					push_value(d5);
 				}
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_flatmap_0_2030();
+					mw_flatmap_0_2032();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -43094,10 +43094,10 @@ static void mw_checkzmprimzmatomzn_0 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2037();
+				mw_for_18_2039();
 				push_value(d4);
 			}
-			mw_for_18_2037();
+			mw_for_18_2039();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -43123,10 +43123,10 @@ static void mw_checkzmwordzmatomzn_0 (void) {
 		case 1LL: // SOME
 			mtp_SOME_0();
 			mp_primzmdup();
-			mw_for_18_2038();
+			mw_for_18_2040();
 			mp_primzmdup();
-			mw_map_0_2039();
-			mw_findzmsome_0_3051();
+			mw_map_0_2041();
+			mw_findzmsome_0_3053();
 			mw_zgBool_1();
 			if (pop_u64()) {
 				mp_primzmdrop();
@@ -43281,13 +43281,13 @@ static void mw_checkzmmatchzn_0 (void) {
 					VAL d5 = pop_value();
 					{
 						VAL d6 = pop_value();
-						mw_map_0_2046();
+						mw_map_0_2048();
 						push_value(d6);
 					}
 					mp_primzmswap();
 					{
 						VAL d6 = pop_value();
-						mw_map_0_2046();
+						mw_map_0_2048();
 						push_value(d6);
 					}
 					mp_primzmswap();
@@ -43499,7 +43499,7 @@ static void mw_specializzezmwordzn_0 (void) {
 				break;
 			case 1LL: // SOME
 				mtp_SOME_0();
-				mw_findzmsome_0_3037();
+				mw_findzmsome_0_3039();
 				break;
 			default:
 				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -43577,7 +43577,7 @@ static void mw_specializzezmwordzn_0 (void) {
 					push_value(var_w);
 					mfld_z126Uspzmsynthed_0();
 					mp_primzmmutzmset();
-					push_fnptr(&mb_2057);
+					push_fnptr(&mb_2059);
 					incref(var_k);
 					push_value(var_k);
 					mp_primzmpackzmcons();
@@ -43594,7 +43594,7 @@ static void mw_specializzezmwordzn_0 (void) {
 					incref(var_w);
 					push_value(var_w);
 					mw_pack2_0();
-					push_fnptr(&mb_3012);
+					push_fnptr(&mb_3014);
 					mtw_LAZZYzuDELAY_0();
 					incref(var_wzq);
 					push_value(var_wzq);
@@ -43612,7 +43612,7 @@ static void mw_specializzezmwordzn_0 (void) {
 					incref(var_wzq);
 					push_value(var_wzq);
 					mw_pack3_0();
-					push_fnptr(&mb_2918);
+					push_fnptr(&mb_2920);
 					mtw_LAZZYzuDELAY_0();
 					incref(var_wzq);
 					push_value(var_wzq);
@@ -43670,7 +43670,7 @@ static void mw_specializzezmctxzmtype_0 (void) {
 		mp_primzmswap();
 		push_value(d2);
 	}
-	mw_reversezmfor_0_2071();
+	mw_reversezmfor_0_2073();
 	LPOP(lbl_gamma);
 	mp_primzmdrop();
 	mp_primzmswap();
@@ -43820,13 +43820,13 @@ static void mw_synthzmspecializzedzmwordzn_0 (void) {
 						VAL d6 = pop_value();
 						{
 							VAL d7 = pop_value();
-							mw_map_0_2078();
+							mw_map_0_2080();
 							push_value(d7);
 						}
 						mp_primzmswap();
 						{
 							VAL d7 = pop_value();
-							mw_map_0_2078();
+							mw_map_0_2080();
 							push_value(d7);
 						}
 						mp_primzmswap();
@@ -44086,10 +44086,10 @@ static void mw_synthzmarrowzn_0 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2085();
+				mw_for_18_2087();
 				push_value(d4);
 			}
-			mw_for_18_2085();
+			mw_for_18_2087();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -44147,10 +44147,10 @@ static void mw_synthzmatomzn_0 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2087();
+				mw_for_18_2089();
 				push_value(d4);
 			}
-			mw_for_18_2087();
+			mw_for_18_2089();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -44217,7 +44217,7 @@ static void mw_synthzmblockzn_0 (void) {
 					break;
 				case 1LL: // SOME
 					mtp_SOME_0();
-					mw_findzmsome_0_2941();
+					mw_findzmsome_0_2943();
 					break;
 				default:
 					push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -44336,7 +44336,7 @@ static void mw_synthzmvarzn_0 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_findzmsome_0_2932();
+			mw_findzmsome_0_2934();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -44495,7 +44495,7 @@ static void mw_synthzmmatchzn_0 (void) {
 											mp_primzmswap();
 											push_value(d11);
 										}
-										mw_dip2_0_2099();
+										mw_dip2_0_2101();
 										mp_primzmswap();
 										{
 											VAL d11 = pop_value();
@@ -44512,10 +44512,10 @@ static void mw_synthzmmatchzn_0 (void) {
 										mp_primzmswap();
 										{
 											VAL d11 = pop_value();
-											mw_reversezmfor_0_2099();
+											mw_reversezmfor_0_2101();
 											push_value(d11);
 										}
-										mw_reversezmfor_0_2099();
+										mw_reversezmfor_0_2101();
 										break;
 									default:
 										push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -44666,7 +44666,7 @@ static void mw_synthzmmatchzn_0 (void) {
 												mp_primzmswap();
 												push_value(d12);
 											}
-											mw_dip2_0_2099();
+											mw_dip2_0_2101();
 											mp_primzmswap();
 											{
 												VAL d12 = pop_value();
@@ -44683,10 +44683,10 @@ static void mw_synthzmmatchzn_0 (void) {
 											mp_primzmswap();
 											{
 												VAL d12 = pop_value();
-												mw_reversezmfor_0_2099();
+												mw_reversezmfor_0_2101();
 												push_value(d12);
 											}
-											mw_reversezmfor_0_2099();
+											mw_reversezmfor_0_2101();
 											break;
 										default:
 											push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -44834,7 +44834,7 @@ static void mw_synthzmmatchzn_0 (void) {
 											mp_primzmswap();
 											push_value(d11);
 										}
-										mw_dip2_0_2099();
+										mw_dip2_0_2101();
 										mp_primzmswap();
 										{
 											VAL d11 = pop_value();
@@ -44851,10 +44851,10 @@ static void mw_synthzmmatchzn_0 (void) {
 										mp_primzmswap();
 										{
 											VAL d11 = pop_value();
-											mw_reversezmfor_0_2099();
+											mw_reversezmfor_0_2101();
 											push_value(d11);
 										}
-										mw_reversezmfor_0_2099();
+										mw_reversezmfor_0_2101();
 										break;
 									default:
 										push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -45007,7 +45007,7 @@ static void mw_synthzmmatchzn_0 (void) {
 													mp_primzmswap();
 													push_value(d13);
 												}
-												mw_dip2_0_2099();
+												mw_dip2_0_2101();
 												mp_primzmswap();
 												{
 													VAL d13 = pop_value();
@@ -45024,10 +45024,10 @@ static void mw_synthzmmatchzn_0 (void) {
 												mp_primzmswap();
 												{
 													VAL d13 = pop_value();
-													mw_reversezmfor_0_2099();
+													mw_reversezmfor_0_2101();
 													push_value(d13);
 												}
-												mw_reversezmfor_0_2099();
+												mw_reversezmfor_0_2101();
 												break;
 											default:
 												push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -45175,7 +45175,7 @@ static void mw_synthzmmatchzn_0 (void) {
 												mp_primzmswap();
 												push_value(d12);
 											}
-											mw_dip2_0_2099();
+											mw_dip2_0_2101();
 											mp_primzmswap();
 											{
 												VAL d12 = pop_value();
@@ -45192,10 +45192,10 @@ static void mw_synthzmmatchzn_0 (void) {
 											mp_primzmswap();
 											{
 												VAL d12 = pop_value();
-												mw_reversezmfor_0_2099();
+												mw_reversezmfor_0_2101();
 												push_value(d12);
 											}
-											mw_reversezmfor_0_2099();
+											mw_reversezmfor_0_2101();
 											break;
 										default:
 											push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -45343,7 +45343,7 @@ static void mw_synthzmmatchzn_0 (void) {
 											mp_primzmswap();
 											push_value(d11);
 										}
-										mw_dip2_0_2099();
+										mw_dip2_0_2101();
 										mp_primzmswap();
 										{
 											VAL d11 = pop_value();
@@ -45360,10 +45360,10 @@ static void mw_synthzmmatchzn_0 (void) {
 										mp_primzmswap();
 										{
 											VAL d11 = pop_value();
-											mw_reversezmfor_0_2099();
+											mw_reversezmfor_0_2101();
 											push_value(d11);
 										}
-										mw_reversezmfor_0_2099();
+										mw_reversezmfor_0_2101();
 										break;
 									default:
 										push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -45449,10 +45449,10 @@ static void mw_synthzmmatchzn_0 (void) {
 						mp_primzmdrop();
 						{
 							VAL d7 = pop_value();
-							mw_for_18_2096();
+							mw_for_18_2098();
 							push_value(d7);
 						}
-						mw_for_18_2096();
+						mw_for_18_2098();
 						break;
 					default:
 						push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -45597,7 +45597,7 @@ static void mw_synthzmlambdazn_0 (void) {
 							mp_primzmswap();
 							push_value(d7);
 						}
-						mw_dip2_0_2950();
+						mw_dip2_0_2952();
 						mp_primzmswap();
 						{
 							VAL d7 = pop_value();
@@ -45666,10 +45666,10 @@ static void mw_synthzmlambdazn_0 (void) {
 						mp_primzmswap();
 						{
 							VAL d7 = pop_value();
-							mw_reversezmfor_0_2950();
+							mw_reversezmfor_0_2952();
 							push_value(d7);
 						}
-						mw_reversezmfor_0_2950();
+						mw_reversezmfor_0_2952();
 						break;
 					default:
 						push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -46146,7 +46146,7 @@ static void mw_zmNEEDS_0 (void) {
 }
 static void mw_new_1 (void) {
 	push_u64(0LL); // STACK_NIL
-	push_fnptr(&mb_793);
+	push_fnptr(&mb_795);
 	mw_SETzuINITIALzuSIZZE_0();
 	mw_new_2();
 	mtw_zpSET_0();
@@ -46346,10 +46346,10 @@ static void mw_runzmarrowzn_0 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2406();
+				mw_for_18_2408();
 				push_value(d4);
 			}
-			mw_for_18_2406();
+			mw_for_18_2408();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -46599,10 +46599,10 @@ static void mw_runzmmatchzn_0 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2416();
+				mw_for_18_2418();
 				push_value(d4);
 			}
-			mw_for_18_2416();
+			mw_for_18_2418();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -46658,10 +46658,10 @@ static void mw_runzmpatternzn_0 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2417();
+				mw_for_18_2419();
 				push_value(d4);
 			}
-			mw_for_18_2417();
+			mw_for_18_2419();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -46720,10 +46720,10 @@ static void mw_pushzmargszn_0 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2413();
+				mw_for_18_2415();
 				push_value(d4);
 			}
-			mw_for_18_2413();
+			mw_for_18_2415();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -49016,7 +49016,7 @@ static void mw_c99zmtagzmdefzn_0 (void) {
 		incref(var_tag);
 		push_value(var_tag);
 		mw_preferzminlinez63U_0();
-		push_fnptr(&mb_2162);
+		push_fnptr(&mb_2164);
 		incref(var_tag);
 		push_value(var_tag);
 		mp_primzmpackzmcons();
@@ -49054,7 +49054,7 @@ static void mw_c99zmtagzmlabelzmindex_0 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_reversezmfindzmsome_0_2467();
+			mw_reversezmfindzmsome_0_2469();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -49314,7 +49314,7 @@ static void mw_c99zmtagzmsetzmlabelzn_0 (void) {
 		}
 		mw_put_0();
 		mw_line_0();
-		push_fnptr(&mb_2207);
+		push_fnptr(&mb_2209);
 		incref(var_tag);
 		push_value(var_tag);
 		mp_primzmpackzmcons();
@@ -49323,7 +49323,7 @@ static void mw_c99zmtagzmsetzmlabelzn_0 (void) {
 		push_value(var_tag);
 		mw_outputszmresourcez63U_0();
 		if (pop_u64()) {
-			push_fnptr(&mb_2210);
+			push_fnptr(&mb_2212);
 			incref(var_lbl);
 			push_value(var_lbl);
 			mp_primzmpackzmcons();
@@ -49358,7 +49358,7 @@ static void mw_c99zmtagzmsetzmlabelzn_0 (void) {
 			}
 			mw_put_0();
 			mw_line_0();
-			push_fnptr(&mb_2213);
+			push_fnptr(&mb_2215);
 			incref(var_lbl);
 			push_value(var_lbl);
 			mp_primzmpackzmcons();
@@ -49379,7 +49379,7 @@ static void mw_c99zmtagzmsetzmlabelzn_0 (void) {
 			}
 			mw_put_0();
 			mw_line_0();
-			push_fnptr(&mb_2218);
+			push_fnptr(&mb_2220);
 			incref(var_lbl);
 			push_value(var_lbl);
 			mp_primzmpackzmcons();
@@ -49965,10 +49965,10 @@ static void mw_c99zmarrowzn_0 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2253();
+				mw_for_18_2255();
 				push_value(d4);
 			}
-			mw_for_18_2253();
+			mw_for_18_2255();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -51484,10 +51484,10 @@ static void mw_c99zmargszmpushzn_0 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2252();
+				mw_for_18_2254();
 				push_value(d4);
 			}
-			mw_for_18_2252();
+			mw_for_18_2254();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -51525,7 +51525,7 @@ static void mw_paramzmput_0 (void) {
 	mw_varzmput_0();
 }
 static void mw_c99zmpackzmclosurezmvarszn_0 (void) {
-	mw_filter_3_2348();
+	mw_filter_3_2350();
 	switch (get_top_data_tag()) {
 		case 0LL: // L0
 			(void)pop_u64();
@@ -51586,10 +51586,10 @@ static void mw_c99zmpackzmclosurezmvarszn_0 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2349();
+				mw_for_18_2351();
 				push_value(d4);
 			}
-			mw_for_18_2349();
+			mw_for_18_2351();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -51597,7 +51597,7 @@ static void mw_c99zmpackzmclosurezmvarszn_0 (void) {
 	}
 }
 static void mw_c99zmunpackzmclosurezmvarszn_0 (void) {
-	mw_filter_3_2352();
+	mw_filter_3_2354();
 	mp_primzmdup();
 	mw_emptyz63U_0();
 	if (pop_u64()) {
@@ -51713,7 +51713,7 @@ static void mw_c99zmunpackzmclosurezmvarszn_0 (void) {
 					mp_primzmswap();
 					push_value(d5);
 				}
-				mw_dip2_0_2355();
+				mw_dip2_0_2357();
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
@@ -51784,10 +51784,10 @@ static void mw_c99zmunpackzmclosurezmvarszn_0 (void) {
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_reversezmfor_0_2355();
+					mw_reversezmfor_0_2357();
 					push_value(d5);
 				}
-				mw_reversezmfor_0_2355();
+				mw_reversezmfor_0_2357();
 				break;
 			default:
 				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -51809,7 +51809,7 @@ static void mw_c99zmunpackzmclosurezmvarszn_0 (void) {
 	}
 }
 static void mw_c99zmdecrefzmclosurezmvarszn_0 (void) {
-	mw_filter_3_2358();
+	mw_filter_3_2360();
 	switch (get_top_data_tag()) {
 		case 0LL: // L0
 			(void)pop_u64();
@@ -51908,7 +51908,7 @@ static void mw_c99zmdecrefzmclosurezmvarszn_0 (void) {
 				mp_primzmswap();
 				push_value(d4);
 			}
-			mw_dip2_0_2359();
+			mw_dip2_0_2361();
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
@@ -51971,10 +51971,10 @@ static void mw_c99zmdecrefzmclosurezmvarszn_0 (void) {
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_reversezmfor_0_2359();
+				mw_reversezmfor_0_2361();
 				push_value(d4);
 			}
-			mw_reversezmfor_0_2359();
+			mw_reversezmfor_0_2361();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -52270,7 +52270,7 @@ static void mw_c99zmlambdazn_0 (void) {
 				mp_primzmswap();
 				push_value(d4);
 			}
-			mw_dip2_0_2324();
+			mw_dip2_0_2326();
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
@@ -52333,10 +52333,10 @@ static void mw_c99zmlambdazn_0 (void) {
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_reversezmfor_0_2324();
+				mw_reversezmfor_0_2326();
 				push_value(d4);
 			}
-			mw_reversezmfor_0_2324();
+			mw_reversezmfor_0_2326();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -52444,7 +52444,7 @@ static void mw_c99zmlambdazn_0 (void) {
 				mp_primzmswap();
 				push_value(d4);
 			}
-			mw_dip2_0_2326();
+			mw_dip2_0_2328();
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
@@ -52507,10 +52507,10 @@ static void mw_c99zmlambdazn_0 (void) {
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_reversezmfor_0_2326();
+				mw_reversezmfor_0_2328();
 				push_value(d4);
 			}
-			mw_reversezmfor_0_2326();
+			mw_reversezmfor_0_2328();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -52642,10 +52642,10 @@ static void mw_c99zmmatchzn_0 (void) {
 				mp_primzmdrop();
 				{
 					VAL d5 = pop_value();
-					mw_for_18_2316();
+					mw_for_18_2318();
 					push_value(d5);
 				}
-				mw_for_18_2316();
+				mw_for_18_2318();
 				break;
 			default:
 				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -54736,7 +54736,7 @@ static void mw_main_0 (void) {
 	}
 	mw_compilezn_0();
 }
-static void mw_filter_3_2358 (void) {
+static void mw_filter_3_2360 (void) {
 	mw_zgListzp_0();
 	switch (get_top_data_tag()) {
 		case 0LL: // NONE
@@ -54745,14 +54745,14 @@ static void mw_filter_3_2358 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_filter_2_2358();
+			mw_filter_2_2360();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_reversezmfor_0_2359 (void) {
+static void mw_reversezmfor_0_2361 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -54848,7 +54848,7 @@ static void mw_reversezmfor_0_2359 (void) {
 				mp_primzmswap();
 				push_value(d4);
 			}
-			mw_dip2_0_2359();
+			mw_dip2_0_2361();
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
@@ -54911,17 +54911,17 @@ static void mw_reversezmfor_0_2359 (void) {
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_reversezmfor_0_2359();
+				mw_reversezmfor_0_2361();
 				push_value(d4);
 			}
-			mw_reversezmfor_0_2359();
+			mw_reversezmfor_0_2361();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_dip2_0_2359 (void) {
+static void mw_dip2_0_2361 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -54956,20 +54956,20 @@ static void mw_dip2_0_2359 (void) {
 		push_value(d2);
 	}
 }
-static void mw_filter_2_2358 (void) {
+static void mw_filter_2_2360 (void) {
 	switch (get_top_data_tag()) {
 		case 3LL: // LCAT+
 			mtp_LCATzp_0();
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_filter_2_2358();
+				mw_filter_2_2360();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_filter_2_2358();
+				mw_filter_2_2360();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -54988,7 +54988,7 @@ static void mw_filter_2_2358 (void) {
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_filter_3_2358();
+					mw_filter_3_2360();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -54999,12 +54999,12 @@ static void mw_filter_2_2358 (void) {
 					mp_primzmdrop();
 					push_value(d5);
 				}
-				mw_filter_3_2358();
+				mw_filter_3_2360();
 			}
 			break;
 	}
 }
-static void mw_for_18_2253 (void) {
+static void mw_for_18_2255 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -55038,17 +55038,17 @@ static void mw_for_18_2253 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2253();
+				mw_for_18_2255();
 				push_value(d4);
 			}
-			mw_for_18_2253();
+			mw_for_18_2255();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_reversezmfindzmsome_0_2467 (void) {
+static void mw_reversezmfindzmsome_0_2469 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -55087,7 +55087,7 @@ static void mw_reversezmfindzmsome_0_2467 (void) {
 		case 1LL: // L2+
 			mtp_L2zp_0();
 			mp_primzmswap();
-			mw_findzmsomezmaux2_0_2467();
+			mw_findzmsomezmaux2_0_2469();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -55142,7 +55142,7 @@ static void mw_reversezmfindzmsome_0_2467 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_2467();
+					mw_findzmsomezmaux2_0_2469();
 					break;
 				default:
 					{
@@ -55160,14 +55160,14 @@ static void mw_reversezmfindzmsome_0_2467 (void) {
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_reversezmfindzmsome_0_2467();
+				mw_reversezmfindzmsome_0_2469();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_reversezmfindzmsome_0_2467();
+					mw_reversezmfindzmsome_0_2469();
 					break;
 				default:
 					{
@@ -55183,7 +55183,7 @@ static void mw_reversezmfindzmsome_0_2467 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_2467 (void) {
+static void mw_findzmsomezmaux2_0_2469 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -55264,7 +55264,7 @@ static void mw_findzmsomezmaux2_0_2467 (void) {
 			break;
 	}
 }
-static void mw_filter_3_2348 (void) {
+static void mw_filter_3_2350 (void) {
 	mw_zgListzp_0();
 	switch (get_top_data_tag()) {
 		case 0LL: // NONE
@@ -55273,14 +55273,14 @@ static void mw_filter_3_2348 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_filter_2_2348();
+			mw_filter_2_2350();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_for_18_2349 (void) {
+static void mw_for_18_2351 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -55338,30 +55338,30 @@ static void mw_for_18_2349 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2349();
+				mw_for_18_2351();
 				push_value(d4);
 			}
-			mw_for_18_2349();
+			mw_for_18_2351();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_filter_2_2348 (void) {
+static void mw_filter_2_2350 (void) {
 	switch (get_top_data_tag()) {
 		case 3LL: // LCAT+
 			mtp_LCATzp_0();
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_filter_2_2348();
+				mw_filter_2_2350();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_filter_2_2348();
+				mw_filter_2_2350();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -55380,7 +55380,7 @@ static void mw_filter_2_2348 (void) {
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_filter_3_2348();
+					mw_filter_3_2350();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -55391,12 +55391,12 @@ static void mw_filter_2_2348 (void) {
 					mp_primzmdrop();
 					push_value(d5);
 				}
-				mw_filter_3_2348();
+				mw_filter_3_2350();
 			}
 			break;
 	}
 }
-static void mw_reversezmfor_0_2326 (void) {
+static void mw_reversezmfor_0_2328 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -55492,7 +55492,7 @@ static void mw_reversezmfor_0_2326 (void) {
 				mp_primzmswap();
 				push_value(d4);
 			}
-			mw_dip2_0_2326();
+			mw_dip2_0_2328();
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
@@ -55541,6 +55541,210 @@ static void mw_reversezmfor_0_2326 (void) {
 				static VAL v;
 				if (! vready) {
 					v = mkstr(");", 2);
+					vready = true;
+				}
+				push_value(v);
+				incref(v);
+			}
+			mw_put_0();
+			mw_line_0();
+			break;
+		case 3LL: // LCAT+
+			mtp_LCATzp_0();
+			mp_primzmdrop();
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mw_reversezmfor_0_2328();
+				push_value(d4);
+			}
+			mw_reversezmfor_0_2328();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primzmpanic();
+	}
+}
+static void mw_dip2_0_2328 (void) {
+	{
+		VAL d2 = pop_value();
+		{
+			VAL d3 = pop_value();
+			mw_indent_0();
+			{
+				static bool vready = false;
+				static VAL v;
+				if (! vready) {
+					v = mkstr("decref(", 7);
+					vready = true;
+				}
+				push_value(v);
+				incref(v);
+			}
+			mw_put_0();
+			mw_paramzmput_0();
+			{
+				static bool vready = false;
+				static VAL v;
+				if (! vready) {
+					v = mkstr(");", 2);
+					vready = true;
+				}
+				push_value(v);
+				incref(v);
+			}
+			mw_put_0();
+			mw_line_0();
+			push_value(d3);
+		}
+		push_value(d2);
+	}
+}
+static void mw_reversezmfor_0_2326 (void) {
+	switch (get_top_data_tag()) {
+		case 0LL: // L1+
+			mtp_L1zp_0();
+			mw_indent_0();
+			{
+				static bool vready = false;
+				static VAL v;
+				if (! vready) {
+					v = mkstr("VAL ", 4);
+					vready = true;
+				}
+				push_value(v);
+				incref(v);
+			}
+			mw_put_0();
+			mw_paramzmput_0();
+			{
+				static bool vready = false;
+				static VAL v;
+				if (! vready) {
+					v = mkstr(" = pop_value();", 15);
+					vready = true;
+				}
+				push_value(v);
+				incref(v);
+			}
+			mw_put_0();
+			mw_line_0();
+			break;
+		case 1LL: // L2+
+			mtp_L2zp_0();
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mw_indent_0();
+				{
+					static bool vready = false;
+					static VAL v;
+					if (! vready) {
+						v = mkstr("VAL ", 4);
+						vready = true;
+					}
+					push_value(v);
+					incref(v);
+				}
+				mw_put_0();
+				mw_paramzmput_0();
+				{
+					static bool vready = false;
+					static VAL v;
+					if (! vready) {
+						v = mkstr(" = pop_value();", 15);
+						vready = true;
+					}
+					push_value(v);
+					incref(v);
+				}
+				mw_put_0();
+				mw_line_0();
+				push_value(d4);
+			}
+			mw_indent_0();
+			{
+				static bool vready = false;
+				static VAL v;
+				if (! vready) {
+					v = mkstr("VAL ", 4);
+					vready = true;
+				}
+				push_value(v);
+				incref(v);
+			}
+			mw_put_0();
+			mw_paramzmput_0();
+			{
+				static bool vready = false;
+				static VAL v;
+				if (! vready) {
+					v = mkstr(" = pop_value();", 15);
+					vready = true;
+				}
+				push_value(v);
+				incref(v);
+			}
+			mw_put_0();
+			mw_line_0();
+			break;
+		case 2LL: // L3+
+			mtp_L3zp_0();
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mw_dip2_0_2326();
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mw_indent_0();
+				{
+					static bool vready = false;
+					static VAL v;
+					if (! vready) {
+						v = mkstr("VAL ", 4);
+						vready = true;
+					}
+					push_value(v);
+					incref(v);
+				}
+				mw_put_0();
+				mw_paramzmput_0();
+				{
+					static bool vready = false;
+					static VAL v;
+					if (! vready) {
+						v = mkstr(" = pop_value();", 15);
+						vready = true;
+					}
+					push_value(v);
+					incref(v);
+				}
+				mw_put_0();
+				mw_line_0();
+				push_value(d4);
+			}
+			mw_indent_0();
+			{
+				static bool vready = false;
+				static VAL v;
+				if (! vready) {
+					v = mkstr("VAL ", 4);
+					vready = true;
+				}
+				push_value(v);
+				incref(v);
+			}
+			mw_put_0();
+			mw_paramzmput_0();
+			{
+				static bool vready = false;
+				static VAL v;
+				if (! vready) {
+					v = mkstr(" = pop_value();", 15);
 					vready = true;
 				}
 				push_value(v);
@@ -55575,210 +55779,6 @@ static void mw_dip2_0_2326 (void) {
 				static bool vready = false;
 				static VAL v;
 				if (! vready) {
-					v = mkstr("decref(", 7);
-					vready = true;
-				}
-				push_value(v);
-				incref(v);
-			}
-			mw_put_0();
-			mw_paramzmput_0();
-			{
-				static bool vready = false;
-				static VAL v;
-				if (! vready) {
-					v = mkstr(");", 2);
-					vready = true;
-				}
-				push_value(v);
-				incref(v);
-			}
-			mw_put_0();
-			mw_line_0();
-			push_value(d3);
-		}
-		push_value(d2);
-	}
-}
-static void mw_reversezmfor_0_2324 (void) {
-	switch (get_top_data_tag()) {
-		case 0LL: // L1+
-			mtp_L1zp_0();
-			mw_indent_0();
-			{
-				static bool vready = false;
-				static VAL v;
-				if (! vready) {
-					v = mkstr("VAL ", 4);
-					vready = true;
-				}
-				push_value(v);
-				incref(v);
-			}
-			mw_put_0();
-			mw_paramzmput_0();
-			{
-				static bool vready = false;
-				static VAL v;
-				if (! vready) {
-					v = mkstr(" = pop_value();", 15);
-					vready = true;
-				}
-				push_value(v);
-				incref(v);
-			}
-			mw_put_0();
-			mw_line_0();
-			break;
-		case 1LL: // L2+
-			mtp_L2zp_0();
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mw_indent_0();
-				{
-					static bool vready = false;
-					static VAL v;
-					if (! vready) {
-						v = mkstr("VAL ", 4);
-						vready = true;
-					}
-					push_value(v);
-					incref(v);
-				}
-				mw_put_0();
-				mw_paramzmput_0();
-				{
-					static bool vready = false;
-					static VAL v;
-					if (! vready) {
-						v = mkstr(" = pop_value();", 15);
-						vready = true;
-					}
-					push_value(v);
-					incref(v);
-				}
-				mw_put_0();
-				mw_line_0();
-				push_value(d4);
-			}
-			mw_indent_0();
-			{
-				static bool vready = false;
-				static VAL v;
-				if (! vready) {
-					v = mkstr("VAL ", 4);
-					vready = true;
-				}
-				push_value(v);
-				incref(v);
-			}
-			mw_put_0();
-			mw_paramzmput_0();
-			{
-				static bool vready = false;
-				static VAL v;
-				if (! vready) {
-					v = mkstr(" = pop_value();", 15);
-					vready = true;
-				}
-				push_value(v);
-				incref(v);
-			}
-			mw_put_0();
-			mw_line_0();
-			break;
-		case 2LL: // L3+
-			mtp_L3zp_0();
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mw_dip2_0_2324();
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mw_indent_0();
-				{
-					static bool vready = false;
-					static VAL v;
-					if (! vready) {
-						v = mkstr("VAL ", 4);
-						vready = true;
-					}
-					push_value(v);
-					incref(v);
-				}
-				mw_put_0();
-				mw_paramzmput_0();
-				{
-					static bool vready = false;
-					static VAL v;
-					if (! vready) {
-						v = mkstr(" = pop_value();", 15);
-						vready = true;
-					}
-					push_value(v);
-					incref(v);
-				}
-				mw_put_0();
-				mw_line_0();
-				push_value(d4);
-			}
-			mw_indent_0();
-			{
-				static bool vready = false;
-				static VAL v;
-				if (! vready) {
-					v = mkstr("VAL ", 4);
-					vready = true;
-				}
-				push_value(v);
-				incref(v);
-			}
-			mw_put_0();
-			mw_paramzmput_0();
-			{
-				static bool vready = false;
-				static VAL v;
-				if (! vready) {
-					v = mkstr(" = pop_value();", 15);
-					vready = true;
-				}
-				push_value(v);
-				incref(v);
-			}
-			mw_put_0();
-			mw_line_0();
-			break;
-		case 3LL: // LCAT+
-			mtp_LCATzp_0();
-			mp_primzmdrop();
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mw_reversezmfor_0_2324();
-				push_value(d4);
-			}
-			mw_reversezmfor_0_2324();
-			break;
-		default:
-			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-			mp_primzmpanic();
-	}
-}
-static void mw_dip2_0_2324 (void) {
-	{
-		VAL d2 = pop_value();
-		{
-			VAL d3 = pop_value();
-			mw_indent_0();
-			{
-				static bool vready = false;
-				static VAL v;
-				if (! vready) {
 					v = mkstr("VAL ", 4);
 					vready = true;
 				}
@@ -55804,7 +55804,7 @@ static void mw_dip2_0_2324 (void) {
 		push_value(d2);
 	}
 }
-static void mw_findzmsome_0_2499 (void) {
+static void mw_findzmsome_0_2501 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -55819,7 +55819,7 @@ static void mw_findzmsome_0_2499 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_2499();
+			mw_findzmsomezmaux2_0_2501();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -55844,7 +55844,7 @@ static void mw_findzmsome_0_2499 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_2499();
+					mw_findzmsomezmaux2_0_2501();
 					break;
 				default:
 					{
@@ -55861,14 +55861,14 @@ static void mw_findzmsome_0_2499 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_2499();
+				mw_findzmsome_0_2501();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_2499();
+					mw_findzmsome_0_2501();
 					break;
 				default:
 					{
@@ -55884,7 +55884,7 @@ static void mw_findzmsome_0_2499 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_2499 (void) {
+static void mw_findzmsomezmaux2_0_2501 (void) {
 	{
 		VAL d2 = pop_value();
 		mp_primzmdup();
@@ -55919,7 +55919,7 @@ static void mw_findzmsomezmaux2_0_2499 (void) {
 			break;
 	}
 }
-static void mw_findzmsome_0_2506 (void) {
+static void mw_findzmsome_0_2508 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -55936,7 +55936,7 @@ static void mw_findzmsome_0_2506 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_2506();
+			mw_findzmsomezmaux2_0_2508();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -55963,7 +55963,7 @@ static void mw_findzmsome_0_2506 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_2506();
+					mw_findzmsomezmaux2_0_2508();
 					break;
 				default:
 					{
@@ -55980,14 +55980,14 @@ static void mw_findzmsome_0_2506 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_2506();
+				mw_findzmsome_0_2508();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_2506();
+					mw_findzmsome_0_2508();
 					break;
 				default:
 					{
@@ -56003,7 +56003,7 @@ static void mw_findzmsome_0_2506 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_2506 (void) {
+static void mw_findzmsomezmaux2_0_2508 (void) {
 	{
 		VAL d2 = pop_value();
 		mp_primzmdup();
@@ -56042,7 +56042,7 @@ static void mw_findzmsomezmaux2_0_2506 (void) {
 			break;
 	}
 }
-static void mw_for_18_2316 (void) {
+static void mw_for_18_2318 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -56076,17 +56076,17 @@ static void mw_for_18_2316 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2316();
+				mw_for_18_2318();
 				push_value(d4);
 			}
-			mw_for_18_2316();
+			mw_for_18_2318();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_filter_3_1004 (void) {
+static void mw_filter_3_1006 (void) {
 	mw_zgListzp_0();
 	switch (get_top_data_tag()) {
 		case 0LL: // NONE
@@ -56095,27 +56095,27 @@ static void mw_filter_3_1004 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_filter_2_1004();
+			mw_filter_2_1006();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_filter_2_1004 (void) {
+static void mw_filter_2_1006 (void) {
 	switch (get_top_data_tag()) {
 		case 3LL: // LCAT+
 			mtp_LCATzp_0();
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_filter_2_1004();
+				mw_filter_2_1006();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_filter_2_1004();
+				mw_filter_2_1006();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -56146,7 +56146,7 @@ static void mw_filter_2_1004 (void) {
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_filter_3_1004();
+					mw_filter_3_1006();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -56157,12 +56157,12 @@ static void mw_filter_2_1004 (void) {
 					mp_primzmdrop();
 					push_value(d5);
 				}
-				mw_filter_3_1004();
+				mw_filter_3_1006();
 			}
 			break;
 	}
 }
-static void mw_findzmsome_0_2529 (void) {
+static void mw_findzmsome_0_2531 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -56189,7 +56189,7 @@ static void mw_findzmsome_0_2529 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_2529();
+			mw_findzmsomezmaux2_0_2531();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -56226,7 +56226,7 @@ static void mw_findzmsome_0_2529 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_2529();
+					mw_findzmsomezmaux2_0_2531();
 					break;
 				default:
 					{
@@ -56243,14 +56243,14 @@ static void mw_findzmsome_0_2529 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_2529();
+				mw_findzmsome_0_2531();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_2529();
+					mw_findzmsome_0_2531();
 					break;
 				default:
 					{
@@ -56266,7 +56266,7 @@ static void mw_findzmsome_0_2529 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_2529 (void) {
+static void mw_findzmsomezmaux2_0_2531 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -56325,7 +56325,7 @@ static void mw_findzmsomezmaux2_0_2529 (void) {
 			break;
 	}
 }
-static void mw_for_18_788 (void) {
+static void mw_for_18_790 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -56413,17 +56413,17 @@ static void mw_for_18_788 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_788();
+				mw_for_18_790();
 				push_value(d4);
 			}
-			mw_for_18_788();
+			mw_for_18_790();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_filter_3_1436 (void) {
+static void mw_filter_3_1438 (void) {
 	mw_zgListzp_0();
 	switch (get_top_data_tag()) {
 		case 0LL: // NONE
@@ -56432,14 +56432,14 @@ static void mw_filter_3_1436 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_filter_2_1436();
+			mw_filter_2_1438();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsome_0_2563 (void) {
+static void mw_findzmsome_0_2565 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -56480,7 +56480,7 @@ static void mw_findzmsome_0_2563 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_2563();
+			mw_findzmsomezmaux2_0_2565();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -56531,7 +56531,7 @@ static void mw_findzmsome_0_2563 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_2563();
+					mw_findzmsomezmaux2_0_2565();
 					break;
 				default:
 					{
@@ -56548,14 +56548,14 @@ static void mw_findzmsome_0_2563 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_2563();
+				mw_findzmsome_0_2565();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_2563();
+					mw_findzmsome_0_2565();
 					break;
 				default:
 					{
@@ -56571,7 +56571,7 @@ static void mw_findzmsome_0_2563 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_2563 (void) {
+static void mw_findzmsomezmaux2_0_2565 (void) {
 	{
 		VAL d2 = pop_value();
 		mp_primzmdup();
@@ -56658,20 +56658,20 @@ static void mw_findzmsomezmaux2_0_2563 (void) {
 			break;
 	}
 }
-static void mw_filter_2_1436 (void) {
+static void mw_filter_2_1438 (void) {
 	switch (get_top_data_tag()) {
 		case 3LL: // LCAT+
 			mtp_LCATzp_0();
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_filter_2_1436();
+				mw_filter_2_1438();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_filter_2_1436();
+				mw_filter_2_1438();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -56691,7 +56691,7 @@ static void mw_filter_2_1436 (void) {
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_filter_3_1436();
+					mw_filter_3_1438();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -56702,12 +56702,12 @@ static void mw_filter_2_1436 (void) {
 					mp_primzmdrop();
 					push_value(d5);
 				}
-				mw_filter_3_1436();
+				mw_filter_3_1438();
 			}
 			break;
 	}
 }
-static void mw_for_18_2252 (void) {
+static void mw_for_18_2254 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -56741,17 +56741,17 @@ static void mw_for_18_2252 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2252();
+				mw_for_18_2254();
 				push_value(d4);
 			}
-			mw_for_18_2252();
+			mw_for_18_2254();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_filter_3_2352 (void) {
+static void mw_filter_3_2354 (void) {
 	mw_zgListzp_0();
 	switch (get_top_data_tag()) {
 		case 0LL: // NONE
@@ -56760,14 +56760,14 @@ static void mw_filter_3_2352 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_filter_2_2352();
+			mw_filter_2_2354();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_reversezmfor_0_2355 (void) {
+static void mw_reversezmfor_0_2357 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -56875,7 +56875,7 @@ static void mw_reversezmfor_0_2355 (void) {
 				mp_primzmswap();
 				push_value(d4);
 			}
-			mw_dip2_0_2355();
+			mw_dip2_0_2357();
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
@@ -56946,17 +56946,17 @@ static void mw_reversezmfor_0_2355 (void) {
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_reversezmfor_0_2355();
+				mw_reversezmfor_0_2357();
 				push_value(d4);
 			}
-			mw_reversezmfor_0_2355();
+			mw_reversezmfor_0_2357();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_dip2_0_2355 (void) {
+static void mw_dip2_0_2357 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -56995,20 +56995,20 @@ static void mw_dip2_0_2355 (void) {
 		push_value(d2);
 	}
 }
-static void mw_filter_2_2352 (void) {
+static void mw_filter_2_2354 (void) {
 	switch (get_top_data_tag()) {
 		case 3LL: // LCAT+
 			mtp_LCATzp_0();
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_filter_2_2352();
+				mw_filter_2_2354();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_filter_2_2352();
+				mw_filter_2_2354();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -57027,7 +57027,7 @@ static void mw_filter_2_2352 (void) {
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_filter_3_2352();
+					mw_filter_3_2354();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -57038,12 +57038,12 @@ static void mw_filter_2_2352 (void) {
 					mp_primzmdrop();
 					push_value(d5);
 				}
-				mw_filter_3_2352();
+				mw_filter_3_2354();
 			}
 			break;
 	}
 }
-static void mw_fold_0_2622 (void) {
+static void mw_fold_0_2624 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -57060,7 +57060,7 @@ static void mw_fold_0_2622 (void) {
 				VAL d4 = pop_value();
 				mp_primzmswap();
 				mp_primzmswap();
-				mw_filter_3_2629();
+				mw_filter_3_2631();
 				{
 					VAL d5 = pop_value();
 					mp_primzmdrop();
@@ -57084,7 +57084,7 @@ static void mw_fold_0_2622 (void) {
 					VAL d5 = pop_value();
 					mp_primzmswap();
 					mp_primzmswap();
-					mw_filter_3_2629();
+					mw_filter_3_2631();
 					{
 						VAL d6 = pop_value();
 						mp_primzmdrop();
@@ -57105,7 +57105,7 @@ static void mw_fold_0_2622 (void) {
 				VAL d4 = pop_value();
 				mp_primzmswap();
 				mp_primzmswap();
-				mw_filter_3_2629();
+				mw_filter_3_2631();
 				{
 					VAL d5 = pop_value();
 					mp_primzmdrop();
@@ -57120,13 +57120,13 @@ static void mw_fold_0_2622 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_fold_0_2622();
+				mw_fold_0_2624();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_fold_0_2622();
+				mw_fold_0_2624();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -57140,7 +57140,7 @@ static void mw_fold_0_2622 (void) {
 				VAL d4 = pop_value();
 				mp_primzmswap();
 				mp_primzmswap();
-				mw_filter_3_2629();
+				mw_filter_3_2631();
 				{
 					VAL d5 = pop_value();
 					mp_primzmdrop();
@@ -57155,7 +57155,7 @@ static void mw_fold_0_2622 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_filter_3_2629 (void) {
+static void mw_filter_3_2631 (void) {
 	mw_zgListzp_0();
 	switch (get_top_data_tag()) {
 		case 0LL: // NONE
@@ -57164,27 +57164,27 @@ static void mw_filter_3_2629 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_filter_2_2629();
+			mw_filter_2_2631();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_filter_2_2629 (void) {
+static void mw_filter_2_2631 (void) {
 	switch (get_top_data_tag()) {
 		case 3LL: // LCAT+
 			mtp_LCATzp_0();
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_filter_2_2629();
+				mw_filter_2_2631();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_filter_2_2629();
+				mw_filter_2_2631();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -57219,7 +57219,7 @@ static void mw_filter_2_2629 (void) {
 								break;
 							case 1LL: // SOME
 								mtp_SOME_0();
-								mw_findzmsome_0_2639();
+								mw_findzmsome_0_2641();
 								break;
 							default:
 								push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -57249,7 +57249,7 @@ static void mw_filter_2_2629 (void) {
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_filter_3_2629();
+					mw_filter_3_2631();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -57260,12 +57260,12 @@ static void mw_filter_2_2629 (void) {
 					mp_primzmdrop();
 					push_value(d5);
 				}
-				mw_filter_3_2629();
+				mw_filter_3_2631();
 			}
 			break;
 	}
 }
-static void mw_findzmsome_0_2639 (void) {
+static void mw_findzmsome_0_2641 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -57305,7 +57305,7 @@ static void mw_findzmsome_0_2639 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_2639();
+			mw_findzmsomezmaux2_0_2641();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -57355,7 +57355,7 @@ static void mw_findzmsome_0_2639 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_2639();
+					mw_findzmsomezmaux2_0_2641();
 					break;
 				default:
 					{
@@ -57372,14 +57372,14 @@ static void mw_findzmsome_0_2639 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_2639();
+				mw_findzmsome_0_2641();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_2639();
+					mw_findzmsome_0_2641();
 					break;
 				default:
 					{
@@ -57395,1822 +57395,7 @@ static void mw_findzmsome_0_2639 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_2639 (void) {
-	{
-		VAL d2 = pop_value();
-		{
-			VAL d3 = pop_value();
-			mp_primzmdup();
-			push_value(d3);
-		}
-		mp_primzmswap();
-		{
-			VAL d3 = pop_value();
-			mp_primzmdup();
-			push_value(d3);
-		}
-		mp_primzmswap();
-		{
-			VAL d3 = pop_value();
-			{
-				VAL d4 = pop_value();
-				mw_zeze_18();
-				push_value(d4);
-			}
-			push_value(d3);
-		}
-		{
-			VAL d3 = pop_value();
-			mp_primzmswap();
-			push_value(d3);
-		}
-		mp_primzmswap();
-		if (pop_u64()) {
-			mtw_SOME_0();
-		} else {
-			mp_primzmdrop();
-			push_u64(0LL); // NONE
-		}
-		push_value(d2);
-	}
-	mp_primzmswap();
-	switch (get_top_data_tag()) {
-		case 0LL: // NONE
-			(void)pop_u64();
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mw_zeze_18();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			if (pop_u64()) {
-				mtw_SOME_0();
-			} else {
-				mp_primzmdrop();
-				push_u64(0LL); // NONE
-			}
-			break;
-		default:
-			{
-				VAL d4 = pop_value();
-				mp_primzmdrop();
-				push_value(d4);
-			}
-			break;
-	}
-}
-static void mw_map_0_1370 (void) {
-	switch (get_top_data_tag()) {
-		case 0LL: // L1+
-			mtp_L1zp_0();
-			mw_freezmvars_3();
-			mtw_L1zp_0();
-			break;
-		case 1LL: // L2+
-			mtp_L2zp_0();
-			{
-				VAL d4 = pop_value();
-				mw_freezmvars_3();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mw_freezmvars_3();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			mtw_L2zp_0();
-			break;
-		case 2LL: // L3+
-			mtp_L3zp_0();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mw_freezmvars_3();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				push_value(d4);
-			}
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mw_freezmvars_3();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				push_value(d4);
-			}
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mw_freezmvars_3();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mtw_L3zp_0();
-			break;
-		case 3LL: // LCAT+
-			mtp_LCATzp_0();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mw_map_0_1370();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				{
-					VAL d5 = pop_value();
-					mw_map_0_1370();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mtw_LCATzp_0();
-			break;
-		default:
-			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-			mp_primzmpanic();
-	}
-}
-static void mw_filter_3_2658 (void) {
-	mw_zgListzp_0();
-	switch (get_top_data_tag()) {
-		case 0LL: // NONE
-			(void)pop_u64();
-			push_u64(0LL); // L0
-			break;
-		case 1LL: // SOME
-			mtp_SOME_0();
-			mw_filter_2_2658();
-			break;
-		default:
-			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-			mp_primzmpanic();
-	}
-}
-static void mw_filter_2_2658 (void) {
-	switch (get_top_data_tag()) {
-		case 3LL: // LCAT+
-			mtp_LCATzp_0();
-			mp_primzmdrop();
-			{
-				VAL d4 = pop_value();
-				mw_filter_2_2658();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mw_filter_2_2658();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			mw_cat_2();
-			break;
-		default:
-			mw_uncons_0();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mp_primzmdup();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				{
-					VAL d5 = pop_value();
-					mp_primzmdup();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				{
-					VAL d5 = pop_value();
-					{
-						VAL d6 = pop_value();
-						mp_primzmswap();
-						mw_zgListzp_0();
-						switch (get_top_data_tag()) {
-							case 0LL: // NONE
-								(void)pop_u64();
-								push_u64(0LL); // NONE
-								break;
-							case 1LL: // SOME
-								mtp_SOME_0();
-								mw_findzmsome_0_2668();
-								break;
-							default:
-								push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-								mp_primzmpanic();
-						}
-						mw_zgBool_1();
-						{
-							VAL d7 = pop_value();
-							mp_primzmdrop();
-							push_value(d7);
-						}
-						mw_not_1();
-						push_value(d6);
-					}
-					push_value(d5);
-				}
-				{
-					VAL d5 = pop_value();
-					mp_primzmswap();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			if (pop_u64()) {
-				mp_primzmswap();
-				{
-					VAL d5 = pop_value();
-					mw_filter_3_2658();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				mw_cons_2();
-			} else {
-				{
-					VAL d5 = pop_value();
-					mp_primzmdrop();
-					push_value(d5);
-				}
-				mw_filter_3_2658();
-			}
-			break;
-	}
-}
-static void mw_findzmsome_0_2668 (void) {
-	switch (get_top_data_tag()) {
-		case 0LL: // L1+
-			mtp_L1zp_0();
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mw_zeze_18();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			if (pop_u64()) {
-				mtw_SOME_0();
-			} else {
-				mp_primzmdrop();
-				push_u64(0LL); // NONE
-			}
-			break;
-		case 1LL: // L2+
-			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_2668();
-			break;
-		case 2LL: // L3+
-			mtp_L3zp_0();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					{
-						VAL d6 = pop_value();
-						mp_primzmdup();
-						push_value(d6);
-					}
-					mp_primzmswap();
-					{
-						VAL d6 = pop_value();
-						mp_primzmdup();
-						push_value(d6);
-					}
-					mp_primzmswap();
-					{
-						VAL d6 = pop_value();
-						{
-							VAL d7 = pop_value();
-							mw_zeze_18();
-							push_value(d7);
-						}
-						push_value(d6);
-					}
-					{
-						VAL d6 = pop_value();
-						mp_primzmswap();
-						push_value(d6);
-					}
-					mp_primzmswap();
-					if (pop_u64()) {
-						mtw_SOME_0();
-					} else {
-						mp_primzmdrop();
-						push_u64(0LL); // NONE
-					}
-					push_value(d5);
-				}
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			switch (get_top_data_tag()) {
-				case 0LL: // NONE
-					(void)pop_u64();
-					mw_findzmsomezmaux2_0_2668();
-					break;
-				default:
-					{
-						VAL d6 = pop_value();
-						mp_primzmdrop();
-						mp_primzmdrop();
-						push_value(d6);
-					}
-					break;
-			}
-			break;
-		case 3LL: // LCAT+
-			mtp_LCATzp_0();
-			mp_primzmdrop();
-			{
-				VAL d4 = pop_value();
-				mw_findzmsome_0_2668();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			switch (get_top_data_tag()) {
-				case 0LL: // NONE
-					(void)pop_u64();
-					mw_findzmsome_0_2668();
-					break;
-				default:
-					{
-						VAL d6 = pop_value();
-						mp_primzmdrop();
-						push_value(d6);
-					}
-					break;
-			}
-			break;
-		default:
-			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-			mp_primzmpanic();
-	}
-}
-static void mw_findzmsomezmaux2_0_2668 (void) {
-	{
-		VAL d2 = pop_value();
-		{
-			VAL d3 = pop_value();
-			mp_primzmdup();
-			push_value(d3);
-		}
-		mp_primzmswap();
-		{
-			VAL d3 = pop_value();
-			mp_primzmdup();
-			push_value(d3);
-		}
-		mp_primzmswap();
-		{
-			VAL d3 = pop_value();
-			{
-				VAL d4 = pop_value();
-				mw_zeze_18();
-				push_value(d4);
-			}
-			push_value(d3);
-		}
-		{
-			VAL d3 = pop_value();
-			mp_primzmswap();
-			push_value(d3);
-		}
-		mp_primzmswap();
-		if (pop_u64()) {
-			mtw_SOME_0();
-		} else {
-			mp_primzmdrop();
-			push_u64(0LL); // NONE
-		}
-		push_value(d2);
-	}
-	mp_primzmswap();
-	switch (get_top_data_tag()) {
-		case 0LL: // NONE
-			(void)pop_u64();
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mw_zeze_18();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			if (pop_u64()) {
-				mtw_SOME_0();
-			} else {
-				mp_primzmdrop();
-				push_u64(0LL); // NONE
-			}
-			break;
-		default:
-			{
-				VAL d4 = pop_value();
-				mp_primzmdrop();
-				push_value(d4);
-			}
-			break;
-	}
-}
-static void mw_filter_3_2674 (void) {
-	mw_zgListzp_0();
-	switch (get_top_data_tag()) {
-		case 0LL: // NONE
-			(void)pop_u64();
-			push_u64(0LL); // L0
-			break;
-		case 1LL: // SOME
-			mtp_SOME_0();
-			mw_filter_2_2674();
-			break;
-		default:
-			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-			mp_primzmpanic();
-	}
-}
-static void mw_filter_2_2674 (void) {
-	switch (get_top_data_tag()) {
-		case 3LL: // LCAT+
-			mtp_LCATzp_0();
-			mp_primzmdrop();
-			{
-				VAL d4 = pop_value();
-				mw_filter_2_2674();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mw_filter_2_2674();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			mw_cat_2();
-			break;
-		default:
-			mw_uncons_0();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mp_primzmdup();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				{
-					VAL d5 = pop_value();
-					mp_primzmdup();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				{
-					VAL d5 = pop_value();
-					{
-						VAL d6 = pop_value();
-						mp_primzmswap();
-						mw_zgListzp_0();
-						switch (get_top_data_tag()) {
-							case 0LL: // NONE
-								(void)pop_u64();
-								push_u64(0LL); // NONE
-								break;
-							case 1LL: // SOME
-								mtp_SOME_0();
-								mw_findzmsome_0_2684();
-								break;
-							default:
-								push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-								mp_primzmpanic();
-						}
-						mw_zgBool_1();
-						{
-							VAL d7 = pop_value();
-							mp_primzmdrop();
-							push_value(d7);
-						}
-						mw_not_1();
-						push_value(d6);
-					}
-					push_value(d5);
-				}
-				{
-					VAL d5 = pop_value();
-					mp_primzmswap();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			if (pop_u64()) {
-				mp_primzmswap();
-				{
-					VAL d5 = pop_value();
-					mw_filter_3_2674();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				mw_cons_2();
-			} else {
-				{
-					VAL d5 = pop_value();
-					mp_primzmdrop();
-					push_value(d5);
-				}
-				mw_filter_3_2674();
-			}
-			break;
-	}
-}
-static void mw_findzmsome_0_2684 (void) {
-	switch (get_top_data_tag()) {
-		case 0LL: // L1+
-			mtp_L1zp_0();
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mw_zeze_18();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			if (pop_u64()) {
-				mtw_SOME_0();
-			} else {
-				mp_primzmdrop();
-				push_u64(0LL); // NONE
-			}
-			break;
-		case 1LL: // L2+
-			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_2684();
-			break;
-		case 2LL: // L3+
-			mtp_L3zp_0();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					{
-						VAL d6 = pop_value();
-						mp_primzmdup();
-						push_value(d6);
-					}
-					mp_primzmswap();
-					{
-						VAL d6 = pop_value();
-						mp_primzmdup();
-						push_value(d6);
-					}
-					mp_primzmswap();
-					{
-						VAL d6 = pop_value();
-						{
-							VAL d7 = pop_value();
-							mw_zeze_18();
-							push_value(d7);
-						}
-						push_value(d6);
-					}
-					{
-						VAL d6 = pop_value();
-						mp_primzmswap();
-						push_value(d6);
-					}
-					mp_primzmswap();
-					if (pop_u64()) {
-						mtw_SOME_0();
-					} else {
-						mp_primzmdrop();
-						push_u64(0LL); // NONE
-					}
-					push_value(d5);
-				}
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			switch (get_top_data_tag()) {
-				case 0LL: // NONE
-					(void)pop_u64();
-					mw_findzmsomezmaux2_0_2684();
-					break;
-				default:
-					{
-						VAL d6 = pop_value();
-						mp_primzmdrop();
-						mp_primzmdrop();
-						push_value(d6);
-					}
-					break;
-			}
-			break;
-		case 3LL: // LCAT+
-			mtp_LCATzp_0();
-			mp_primzmdrop();
-			{
-				VAL d4 = pop_value();
-				mw_findzmsome_0_2684();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			switch (get_top_data_tag()) {
-				case 0LL: // NONE
-					(void)pop_u64();
-					mw_findzmsome_0_2684();
-					break;
-				default:
-					{
-						VAL d6 = pop_value();
-						mp_primzmdrop();
-						push_value(d6);
-					}
-					break;
-			}
-			break;
-		default:
-			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-			mp_primzmpanic();
-	}
-}
-static void mw_findzmsomezmaux2_0_2684 (void) {
-	{
-		VAL d2 = pop_value();
-		{
-			VAL d3 = pop_value();
-			mp_primzmdup();
-			push_value(d3);
-		}
-		mp_primzmswap();
-		{
-			VAL d3 = pop_value();
-			mp_primzmdup();
-			push_value(d3);
-		}
-		mp_primzmswap();
-		{
-			VAL d3 = pop_value();
-			{
-				VAL d4 = pop_value();
-				mw_zeze_18();
-				push_value(d4);
-			}
-			push_value(d3);
-		}
-		{
-			VAL d3 = pop_value();
-			mp_primzmswap();
-			push_value(d3);
-		}
-		mp_primzmswap();
-		if (pop_u64()) {
-			mtw_SOME_0();
-		} else {
-			mp_primzmdrop();
-			push_u64(0LL); // NONE
-		}
-		push_value(d2);
-	}
-	mp_primzmswap();
-	switch (get_top_data_tag()) {
-		case 0LL: // NONE
-			(void)pop_u64();
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mw_zeze_18();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			if (pop_u64()) {
-				mtw_SOME_0();
-			} else {
-				mp_primzmdrop();
-				push_u64(0LL); // NONE
-			}
-			break;
-		default:
-			{
-				VAL d4 = pop_value();
-				mp_primzmdrop();
-				push_value(d4);
-			}
-			break;
-	}
-}
-static void mw_map_0_1377 (void) {
-	switch (get_top_data_tag()) {
-		case 0LL: // L1+
-			mtp_L1zp_0();
-			mw_zsPARAM_0();
-			mtw_L1zp_0();
-			break;
-		case 1LL: // L2+
-			mtp_L2zp_0();
-			{
-				VAL d4 = pop_value();
-				mw_zsPARAM_0();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mw_zsPARAM_0();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			mtw_L2zp_0();
-			break;
-		case 2LL: // L3+
-			mtp_L3zp_0();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mw_zsPARAM_0();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				push_value(d4);
-			}
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mw_zsPARAM_0();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				push_value(d4);
-			}
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mw_zsPARAM_0();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mtw_L3zp_0();
-			break;
-		case 3LL: // LCAT+
-			mtp_LCATzp_0();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mw_map_0_1377();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				{
-					VAL d5 = pop_value();
-					mw_map_0_1377();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mtw_LCATzp_0();
-			break;
-		default:
-			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-			mp_primzmpanic();
-	}
-}
-static void mw_fold_0_2701 (void) {
-	switch (get_top_data_tag()) {
-		case 0LL: // L1+
-			mtp_L1zp_0();
-			break;
-		case 1LL: // L2+
-			mtp_L2zp_0();
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				mp_primzmswap();
-				mw_filter_3_2708();
-				{
-					VAL d5 = pop_value();
-					mp_primzmdrop();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			mw_cat_2();
-			break;
-		case 2LL: // L3+
-			mtp_L3zp_0();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mp_primzmdup();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				{
-					VAL d5 = pop_value();
-					mp_primzmswap();
-					mp_primzmswap();
-					mw_filter_3_2708();
-					{
-						VAL d6 = pop_value();
-						mp_primzmdrop();
-						push_value(d6);
-					}
-					push_value(d5);
-				}
-				mw_cat_2();
-				push_value(d4);
-			}
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				mp_primzmswap();
-				mw_filter_3_2708();
-				{
-					VAL d5 = pop_value();
-					mp_primzmdrop();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			mw_cat_2();
-			break;
-		case 3LL: // LCAT+
-			mtp_LCATzp_0();
-			mp_primzmdrop();
-			{
-				VAL d4 = pop_value();
-				mw_fold_0_2701();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mw_fold_0_2701();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				mp_primzmswap();
-				mw_filter_3_2708();
-				{
-					VAL d5 = pop_value();
-					mp_primzmdrop();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			mw_cat_2();
-			break;
-		default:
-			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-			mp_primzmpanic();
-	}
-}
-static void mw_filter_3_2708 (void) {
-	mw_zgListzp_0();
-	switch (get_top_data_tag()) {
-		case 0LL: // NONE
-			(void)pop_u64();
-			push_u64(0LL); // L0
-			break;
-		case 1LL: // SOME
-			mtp_SOME_0();
-			mw_filter_2_2708();
-			break;
-		default:
-			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-			mp_primzmpanic();
-	}
-}
-static void mw_filter_2_2708 (void) {
-	switch (get_top_data_tag()) {
-		case 3LL: // LCAT+
-			mtp_LCATzp_0();
-			mp_primzmdrop();
-			{
-				VAL d4 = pop_value();
-				mw_filter_2_2708();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mw_filter_2_2708();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			mw_cat_2();
-			break;
-		default:
-			mw_uncons_0();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mp_primzmdup();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				{
-					VAL d5 = pop_value();
-					mp_primzmdup();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				{
-					VAL d5 = pop_value();
-					{
-						VAL d6 = pop_value();
-						mp_primzmswap();
-						mw_zgListzp_0();
-						switch (get_top_data_tag()) {
-							case 0LL: // NONE
-								(void)pop_u64();
-								push_u64(0LL); // NONE
-								break;
-							case 1LL: // SOME
-								mtp_SOME_0();
-								mw_findzmsome_0_2718();
-								break;
-							default:
-								push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-								mp_primzmpanic();
-						}
-						mw_zgBool_1();
-						{
-							VAL d7 = pop_value();
-							mp_primzmdrop();
-							push_value(d7);
-						}
-						mw_not_1();
-						push_value(d6);
-					}
-					push_value(d5);
-				}
-				{
-					VAL d5 = pop_value();
-					mp_primzmswap();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			if (pop_u64()) {
-				mp_primzmswap();
-				{
-					VAL d5 = pop_value();
-					mw_filter_3_2708();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				mw_cons_2();
-			} else {
-				{
-					VAL d5 = pop_value();
-					mp_primzmdrop();
-					push_value(d5);
-				}
-				mw_filter_3_2708();
-			}
-			break;
-	}
-}
-static void mw_findzmsome_0_2718 (void) {
-	switch (get_top_data_tag()) {
-		case 0LL: // L1+
-			mtp_L1zp_0();
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mw_zeze_18();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			if (pop_u64()) {
-				mtw_SOME_0();
-			} else {
-				mp_primzmdrop();
-				push_u64(0LL); // NONE
-			}
-			break;
-		case 1LL: // L2+
-			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_2718();
-			break;
-		case 2LL: // L3+
-			mtp_L3zp_0();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					{
-						VAL d6 = pop_value();
-						mp_primzmdup();
-						push_value(d6);
-					}
-					mp_primzmswap();
-					{
-						VAL d6 = pop_value();
-						mp_primzmdup();
-						push_value(d6);
-					}
-					mp_primzmswap();
-					{
-						VAL d6 = pop_value();
-						{
-							VAL d7 = pop_value();
-							mw_zeze_18();
-							push_value(d7);
-						}
-						push_value(d6);
-					}
-					{
-						VAL d6 = pop_value();
-						mp_primzmswap();
-						push_value(d6);
-					}
-					mp_primzmswap();
-					if (pop_u64()) {
-						mtw_SOME_0();
-					} else {
-						mp_primzmdrop();
-						push_u64(0LL); // NONE
-					}
-					push_value(d5);
-				}
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			switch (get_top_data_tag()) {
-				case 0LL: // NONE
-					(void)pop_u64();
-					mw_findzmsomezmaux2_0_2718();
-					break;
-				default:
-					{
-						VAL d6 = pop_value();
-						mp_primzmdrop();
-						mp_primzmdrop();
-						push_value(d6);
-					}
-					break;
-			}
-			break;
-		case 3LL: // LCAT+
-			mtp_LCATzp_0();
-			mp_primzmdrop();
-			{
-				VAL d4 = pop_value();
-				mw_findzmsome_0_2718();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			switch (get_top_data_tag()) {
-				case 0LL: // NONE
-					(void)pop_u64();
-					mw_findzmsome_0_2718();
-					break;
-				default:
-					{
-						VAL d6 = pop_value();
-						mp_primzmdrop();
-						push_value(d6);
-					}
-					break;
-			}
-			break;
-		default:
-			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-			mp_primzmpanic();
-	}
-}
-static void mw_findzmsomezmaux2_0_2718 (void) {
-	{
-		VAL d2 = pop_value();
-		{
-			VAL d3 = pop_value();
-			mp_primzmdup();
-			push_value(d3);
-		}
-		mp_primzmswap();
-		{
-			VAL d3 = pop_value();
-			mp_primzmdup();
-			push_value(d3);
-		}
-		mp_primzmswap();
-		{
-			VAL d3 = pop_value();
-			{
-				VAL d4 = pop_value();
-				mw_zeze_18();
-				push_value(d4);
-			}
-			push_value(d3);
-		}
-		{
-			VAL d3 = pop_value();
-			mp_primzmswap();
-			push_value(d3);
-		}
-		mp_primzmswap();
-		if (pop_u64()) {
-			mtw_SOME_0();
-		} else {
-			mp_primzmdrop();
-			push_u64(0LL); // NONE
-		}
-		push_value(d2);
-	}
-	mp_primzmswap();
-	switch (get_top_data_tag()) {
-		case 0LL: // NONE
-			(void)pop_u64();
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mw_zeze_18();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			if (pop_u64()) {
-				mtw_SOME_0();
-			} else {
-				mp_primzmdrop();
-				push_u64(0LL); // NONE
-			}
-			break;
-		default:
-			{
-				VAL d4 = pop_value();
-				mp_primzmdrop();
-				push_value(d4);
-			}
-			break;
-	}
-}
-static void mw_map_0_1375 (void) {
-	switch (get_top_data_tag()) {
-		case 0LL: // L1+
-			mtp_L1zp_0();
-			mw_freezmvars_7();
-			mtw_L1zp_0();
-			break;
-		case 1LL: // L2+
-			mtp_L2zp_0();
-			{
-				VAL d4 = pop_value();
-				mw_freezmvars_7();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mw_freezmvars_7();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			mtw_L2zp_0();
-			break;
-		case 2LL: // L3+
-			mtp_L3zp_0();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mw_freezmvars_7();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				push_value(d4);
-			}
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mw_freezmvars_7();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				push_value(d4);
-			}
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mw_freezmvars_7();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mtw_L3zp_0();
-			break;
-		case 3LL: // LCAT+
-			mtp_LCATzp_0();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mw_map_0_1375();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				{
-					VAL d5 = pop_value();
-					mw_map_0_1375();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mtw_LCATzp_0();
-			break;
-		default:
-			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-			mp_primzmpanic();
-	}
-}
-static void mw_fold_0_2735 (void) {
-	switch (get_top_data_tag()) {
-		case 0LL: // L1+
-			mtp_L1zp_0();
-			break;
-		case 1LL: // L2+
-			mtp_L2zp_0();
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				mp_primzmswap();
-				mw_filter_3_2742();
-				{
-					VAL d5 = pop_value();
-					mp_primzmdrop();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			mw_cat_2();
-			break;
-		case 2LL: // L3+
-			mtp_L3zp_0();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mp_primzmdup();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				{
-					VAL d5 = pop_value();
-					mp_primzmswap();
-					mp_primzmswap();
-					mw_filter_3_2742();
-					{
-						VAL d6 = pop_value();
-						mp_primzmdrop();
-						push_value(d6);
-					}
-					push_value(d5);
-				}
-				mw_cat_2();
-				push_value(d4);
-			}
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				mp_primzmswap();
-				mw_filter_3_2742();
-				{
-					VAL d5 = pop_value();
-					mp_primzmdrop();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			mw_cat_2();
-			break;
-		case 3LL: // LCAT+
-			mtp_LCATzp_0();
-			mp_primzmdrop();
-			{
-				VAL d4 = pop_value();
-				mw_fold_0_2735();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mw_fold_0_2735();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				mp_primzmswap();
-				mw_filter_3_2742();
-				{
-					VAL d5 = pop_value();
-					mp_primzmdrop();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			mw_cat_2();
-			break;
-		default:
-			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-			mp_primzmpanic();
-	}
-}
-static void mw_filter_3_2742 (void) {
-	mw_zgListzp_0();
-	switch (get_top_data_tag()) {
-		case 0LL: // NONE
-			(void)pop_u64();
-			push_u64(0LL); // L0
-			break;
-		case 1LL: // SOME
-			mtp_SOME_0();
-			mw_filter_2_2742();
-			break;
-		default:
-			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-			mp_primzmpanic();
-	}
-}
-static void mw_filter_2_2742 (void) {
-	switch (get_top_data_tag()) {
-		case 3LL: // LCAT+
-			mtp_LCATzp_0();
-			mp_primzmdrop();
-			{
-				VAL d4 = pop_value();
-				mw_filter_2_2742();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mw_filter_2_2742();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			mw_cat_2();
-			break;
-		default:
-			mw_uncons_0();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mp_primzmdup();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				{
-					VAL d5 = pop_value();
-					mp_primzmdup();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				{
-					VAL d5 = pop_value();
-					{
-						VAL d6 = pop_value();
-						mp_primzmswap();
-						mw_zgListzp_0();
-						switch (get_top_data_tag()) {
-							case 0LL: // NONE
-								(void)pop_u64();
-								push_u64(0LL); // NONE
-								break;
-							case 1LL: // SOME
-								mtp_SOME_0();
-								mw_findzmsome_0_2752();
-								break;
-							default:
-								push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-								mp_primzmpanic();
-						}
-						mw_zgBool_1();
-						{
-							VAL d7 = pop_value();
-							mp_primzmdrop();
-							push_value(d7);
-						}
-						mw_not_1();
-						push_value(d6);
-					}
-					push_value(d5);
-				}
-				{
-					VAL d5 = pop_value();
-					mp_primzmswap();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			if (pop_u64()) {
-				mp_primzmswap();
-				{
-					VAL d5 = pop_value();
-					mw_filter_3_2742();
-					push_value(d5);
-				}
-				mp_primzmswap();
-				mw_cons_2();
-			} else {
-				{
-					VAL d5 = pop_value();
-					mp_primzmdrop();
-					push_value(d5);
-				}
-				mw_filter_3_2742();
-			}
-			break;
-	}
-}
-static void mw_findzmsome_0_2752 (void) {
-	switch (get_top_data_tag()) {
-		case 0LL: // L1+
-			mtp_L1zp_0();
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				mp_primzmdup();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					mw_zeze_18();
-					push_value(d5);
-				}
-				push_value(d4);
-			}
-			{
-				VAL d4 = pop_value();
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			if (pop_u64()) {
-				mtw_SOME_0();
-			} else {
-				mp_primzmdrop();
-				push_u64(0LL); // NONE
-			}
-			break;
-		case 1LL: // L2+
-			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_2752();
-			break;
-		case 2LL: // L3+
-			mtp_L3zp_0();
-			{
-				VAL d4 = pop_value();
-				{
-					VAL d5 = pop_value();
-					{
-						VAL d6 = pop_value();
-						mp_primzmdup();
-						push_value(d6);
-					}
-					mp_primzmswap();
-					{
-						VAL d6 = pop_value();
-						mp_primzmdup();
-						push_value(d6);
-					}
-					mp_primzmswap();
-					{
-						VAL d6 = pop_value();
-						{
-							VAL d7 = pop_value();
-							mw_zeze_18();
-							push_value(d7);
-						}
-						push_value(d6);
-					}
-					{
-						VAL d6 = pop_value();
-						mp_primzmswap();
-						push_value(d6);
-					}
-					mp_primzmswap();
-					if (pop_u64()) {
-						mtw_SOME_0();
-					} else {
-						mp_primzmdrop();
-						push_u64(0LL); // NONE
-					}
-					push_value(d5);
-				}
-				mp_primzmswap();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			switch (get_top_data_tag()) {
-				case 0LL: // NONE
-					(void)pop_u64();
-					mw_findzmsomezmaux2_0_2752();
-					break;
-				default:
-					{
-						VAL d6 = pop_value();
-						mp_primzmdrop();
-						mp_primzmdrop();
-						push_value(d6);
-					}
-					break;
-			}
-			break;
-		case 3LL: // LCAT+
-			mtp_LCATzp_0();
-			mp_primzmdrop();
-			{
-				VAL d4 = pop_value();
-				mw_findzmsome_0_2752();
-				push_value(d4);
-			}
-			mp_primzmswap();
-			switch (get_top_data_tag()) {
-				case 0LL: // NONE
-					(void)pop_u64();
-					mw_findzmsome_0_2752();
-					break;
-				default:
-					{
-						VAL d6 = pop_value();
-						mp_primzmdrop();
-						push_value(d6);
-					}
-					break;
-			}
-			break;
-		default:
-			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-			mp_primzmpanic();
-	}
-}
-static void mw_findzmsomezmaux2_0_2752 (void) {
+static void mw_findzmsomezmaux2_0_2641 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -59299,6 +57484,1821 @@ static void mw_map_0_1372 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
+			mw_freezmvars_3();
+			mtw_L1zp_0();
+			break;
+		case 1LL: // L2+
+			mtp_L2zp_0();
+			{
+				VAL d4 = pop_value();
+				mw_freezmvars_3();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mw_freezmvars_3();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			mtw_L2zp_0();
+			break;
+		case 2LL: // L3+
+			mtp_L3zp_0();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mw_freezmvars_3();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				push_value(d4);
+			}
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mw_freezmvars_3();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				push_value(d4);
+			}
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mw_freezmvars_3();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mtw_L3zp_0();
+			break;
+		case 3LL: // LCAT+
+			mtp_LCATzp_0();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mw_map_0_1372();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				{
+					VAL d5 = pop_value();
+					mw_map_0_1372();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mtw_LCATzp_0();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primzmpanic();
+	}
+}
+static void mw_filter_3_2660 (void) {
+	mw_zgListzp_0();
+	switch (get_top_data_tag()) {
+		case 0LL: // NONE
+			(void)pop_u64();
+			push_u64(0LL); // L0
+			break;
+		case 1LL: // SOME
+			mtp_SOME_0();
+			mw_filter_2_2660();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primzmpanic();
+	}
+}
+static void mw_filter_2_2660 (void) {
+	switch (get_top_data_tag()) {
+		case 3LL: // LCAT+
+			mtp_LCATzp_0();
+			mp_primzmdrop();
+			{
+				VAL d4 = pop_value();
+				mw_filter_2_2660();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mw_filter_2_2660();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			mw_cat_2();
+			break;
+		default:
+			mw_uncons_0();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mp_primzmdup();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				{
+					VAL d5 = pop_value();
+					mp_primzmdup();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				{
+					VAL d5 = pop_value();
+					{
+						VAL d6 = pop_value();
+						mp_primzmswap();
+						mw_zgListzp_0();
+						switch (get_top_data_tag()) {
+							case 0LL: // NONE
+								(void)pop_u64();
+								push_u64(0LL); // NONE
+								break;
+							case 1LL: // SOME
+								mtp_SOME_0();
+								mw_findzmsome_0_2670();
+								break;
+							default:
+								push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+								mp_primzmpanic();
+						}
+						mw_zgBool_1();
+						{
+							VAL d7 = pop_value();
+							mp_primzmdrop();
+							push_value(d7);
+						}
+						mw_not_1();
+						push_value(d6);
+					}
+					push_value(d5);
+				}
+				{
+					VAL d5 = pop_value();
+					mp_primzmswap();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			if (pop_u64()) {
+				mp_primzmswap();
+				{
+					VAL d5 = pop_value();
+					mw_filter_3_2660();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				mw_cons_2();
+			} else {
+				{
+					VAL d5 = pop_value();
+					mp_primzmdrop();
+					push_value(d5);
+				}
+				mw_filter_3_2660();
+			}
+			break;
+	}
+}
+static void mw_findzmsome_0_2670 (void) {
+	switch (get_top_data_tag()) {
+		case 0LL: // L1+
+			mtp_L1zp_0();
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mw_zeze_18();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			if (pop_u64()) {
+				mtw_SOME_0();
+			} else {
+				mp_primzmdrop();
+				push_u64(0LL); // NONE
+			}
+			break;
+		case 1LL: // L2+
+			mtp_L2zp_0();
+			mw_findzmsomezmaux2_0_2670();
+			break;
+		case 2LL: // L3+
+			mtp_L3zp_0();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					{
+						VAL d6 = pop_value();
+						mp_primzmdup();
+						push_value(d6);
+					}
+					mp_primzmswap();
+					{
+						VAL d6 = pop_value();
+						mp_primzmdup();
+						push_value(d6);
+					}
+					mp_primzmswap();
+					{
+						VAL d6 = pop_value();
+						{
+							VAL d7 = pop_value();
+							mw_zeze_18();
+							push_value(d7);
+						}
+						push_value(d6);
+					}
+					{
+						VAL d6 = pop_value();
+						mp_primzmswap();
+						push_value(d6);
+					}
+					mp_primzmswap();
+					if (pop_u64()) {
+						mtw_SOME_0();
+					} else {
+						mp_primzmdrop();
+						push_u64(0LL); // NONE
+					}
+					push_value(d5);
+				}
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			switch (get_top_data_tag()) {
+				case 0LL: // NONE
+					(void)pop_u64();
+					mw_findzmsomezmaux2_0_2670();
+					break;
+				default:
+					{
+						VAL d6 = pop_value();
+						mp_primzmdrop();
+						mp_primzmdrop();
+						push_value(d6);
+					}
+					break;
+			}
+			break;
+		case 3LL: // LCAT+
+			mtp_LCATzp_0();
+			mp_primzmdrop();
+			{
+				VAL d4 = pop_value();
+				mw_findzmsome_0_2670();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			switch (get_top_data_tag()) {
+				case 0LL: // NONE
+					(void)pop_u64();
+					mw_findzmsome_0_2670();
+					break;
+				default:
+					{
+						VAL d6 = pop_value();
+						mp_primzmdrop();
+						push_value(d6);
+					}
+					break;
+			}
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primzmpanic();
+	}
+}
+static void mw_findzmsomezmaux2_0_2670 (void) {
+	{
+		VAL d2 = pop_value();
+		{
+			VAL d3 = pop_value();
+			mp_primzmdup();
+			push_value(d3);
+		}
+		mp_primzmswap();
+		{
+			VAL d3 = pop_value();
+			mp_primzmdup();
+			push_value(d3);
+		}
+		mp_primzmswap();
+		{
+			VAL d3 = pop_value();
+			{
+				VAL d4 = pop_value();
+				mw_zeze_18();
+				push_value(d4);
+			}
+			push_value(d3);
+		}
+		{
+			VAL d3 = pop_value();
+			mp_primzmswap();
+			push_value(d3);
+		}
+		mp_primzmswap();
+		if (pop_u64()) {
+			mtw_SOME_0();
+		} else {
+			mp_primzmdrop();
+			push_u64(0LL); // NONE
+		}
+		push_value(d2);
+	}
+	mp_primzmswap();
+	switch (get_top_data_tag()) {
+		case 0LL: // NONE
+			(void)pop_u64();
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mw_zeze_18();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			if (pop_u64()) {
+				mtw_SOME_0();
+			} else {
+				mp_primzmdrop();
+				push_u64(0LL); // NONE
+			}
+			break;
+		default:
+			{
+				VAL d4 = pop_value();
+				mp_primzmdrop();
+				push_value(d4);
+			}
+			break;
+	}
+}
+static void mw_filter_3_2676 (void) {
+	mw_zgListzp_0();
+	switch (get_top_data_tag()) {
+		case 0LL: // NONE
+			(void)pop_u64();
+			push_u64(0LL); // L0
+			break;
+		case 1LL: // SOME
+			mtp_SOME_0();
+			mw_filter_2_2676();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primzmpanic();
+	}
+}
+static void mw_filter_2_2676 (void) {
+	switch (get_top_data_tag()) {
+		case 3LL: // LCAT+
+			mtp_LCATzp_0();
+			mp_primzmdrop();
+			{
+				VAL d4 = pop_value();
+				mw_filter_2_2676();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mw_filter_2_2676();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			mw_cat_2();
+			break;
+		default:
+			mw_uncons_0();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mp_primzmdup();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				{
+					VAL d5 = pop_value();
+					mp_primzmdup();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				{
+					VAL d5 = pop_value();
+					{
+						VAL d6 = pop_value();
+						mp_primzmswap();
+						mw_zgListzp_0();
+						switch (get_top_data_tag()) {
+							case 0LL: // NONE
+								(void)pop_u64();
+								push_u64(0LL); // NONE
+								break;
+							case 1LL: // SOME
+								mtp_SOME_0();
+								mw_findzmsome_0_2686();
+								break;
+							default:
+								push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+								mp_primzmpanic();
+						}
+						mw_zgBool_1();
+						{
+							VAL d7 = pop_value();
+							mp_primzmdrop();
+							push_value(d7);
+						}
+						mw_not_1();
+						push_value(d6);
+					}
+					push_value(d5);
+				}
+				{
+					VAL d5 = pop_value();
+					mp_primzmswap();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			if (pop_u64()) {
+				mp_primzmswap();
+				{
+					VAL d5 = pop_value();
+					mw_filter_3_2676();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				mw_cons_2();
+			} else {
+				{
+					VAL d5 = pop_value();
+					mp_primzmdrop();
+					push_value(d5);
+				}
+				mw_filter_3_2676();
+			}
+			break;
+	}
+}
+static void mw_findzmsome_0_2686 (void) {
+	switch (get_top_data_tag()) {
+		case 0LL: // L1+
+			mtp_L1zp_0();
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mw_zeze_18();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			if (pop_u64()) {
+				mtw_SOME_0();
+			} else {
+				mp_primzmdrop();
+				push_u64(0LL); // NONE
+			}
+			break;
+		case 1LL: // L2+
+			mtp_L2zp_0();
+			mw_findzmsomezmaux2_0_2686();
+			break;
+		case 2LL: // L3+
+			mtp_L3zp_0();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					{
+						VAL d6 = pop_value();
+						mp_primzmdup();
+						push_value(d6);
+					}
+					mp_primzmswap();
+					{
+						VAL d6 = pop_value();
+						mp_primzmdup();
+						push_value(d6);
+					}
+					mp_primzmswap();
+					{
+						VAL d6 = pop_value();
+						{
+							VAL d7 = pop_value();
+							mw_zeze_18();
+							push_value(d7);
+						}
+						push_value(d6);
+					}
+					{
+						VAL d6 = pop_value();
+						mp_primzmswap();
+						push_value(d6);
+					}
+					mp_primzmswap();
+					if (pop_u64()) {
+						mtw_SOME_0();
+					} else {
+						mp_primzmdrop();
+						push_u64(0LL); // NONE
+					}
+					push_value(d5);
+				}
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			switch (get_top_data_tag()) {
+				case 0LL: // NONE
+					(void)pop_u64();
+					mw_findzmsomezmaux2_0_2686();
+					break;
+				default:
+					{
+						VAL d6 = pop_value();
+						mp_primzmdrop();
+						mp_primzmdrop();
+						push_value(d6);
+					}
+					break;
+			}
+			break;
+		case 3LL: // LCAT+
+			mtp_LCATzp_0();
+			mp_primzmdrop();
+			{
+				VAL d4 = pop_value();
+				mw_findzmsome_0_2686();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			switch (get_top_data_tag()) {
+				case 0LL: // NONE
+					(void)pop_u64();
+					mw_findzmsome_0_2686();
+					break;
+				default:
+					{
+						VAL d6 = pop_value();
+						mp_primzmdrop();
+						push_value(d6);
+					}
+					break;
+			}
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primzmpanic();
+	}
+}
+static void mw_findzmsomezmaux2_0_2686 (void) {
+	{
+		VAL d2 = pop_value();
+		{
+			VAL d3 = pop_value();
+			mp_primzmdup();
+			push_value(d3);
+		}
+		mp_primzmswap();
+		{
+			VAL d3 = pop_value();
+			mp_primzmdup();
+			push_value(d3);
+		}
+		mp_primzmswap();
+		{
+			VAL d3 = pop_value();
+			{
+				VAL d4 = pop_value();
+				mw_zeze_18();
+				push_value(d4);
+			}
+			push_value(d3);
+		}
+		{
+			VAL d3 = pop_value();
+			mp_primzmswap();
+			push_value(d3);
+		}
+		mp_primzmswap();
+		if (pop_u64()) {
+			mtw_SOME_0();
+		} else {
+			mp_primzmdrop();
+			push_u64(0LL); // NONE
+		}
+		push_value(d2);
+	}
+	mp_primzmswap();
+	switch (get_top_data_tag()) {
+		case 0LL: // NONE
+			(void)pop_u64();
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mw_zeze_18();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			if (pop_u64()) {
+				mtw_SOME_0();
+			} else {
+				mp_primzmdrop();
+				push_u64(0LL); // NONE
+			}
+			break;
+		default:
+			{
+				VAL d4 = pop_value();
+				mp_primzmdrop();
+				push_value(d4);
+			}
+			break;
+	}
+}
+static void mw_map_0_1379 (void) {
+	switch (get_top_data_tag()) {
+		case 0LL: // L1+
+			mtp_L1zp_0();
+			mw_zsPARAM_0();
+			mtw_L1zp_0();
+			break;
+		case 1LL: // L2+
+			mtp_L2zp_0();
+			{
+				VAL d4 = pop_value();
+				mw_zsPARAM_0();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mw_zsPARAM_0();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			mtw_L2zp_0();
+			break;
+		case 2LL: // L3+
+			mtp_L3zp_0();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mw_zsPARAM_0();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				push_value(d4);
+			}
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mw_zsPARAM_0();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				push_value(d4);
+			}
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mw_zsPARAM_0();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mtw_L3zp_0();
+			break;
+		case 3LL: // LCAT+
+			mtp_LCATzp_0();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mw_map_0_1379();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				{
+					VAL d5 = pop_value();
+					mw_map_0_1379();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mtw_LCATzp_0();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primzmpanic();
+	}
+}
+static void mw_fold_0_2703 (void) {
+	switch (get_top_data_tag()) {
+		case 0LL: // L1+
+			mtp_L1zp_0();
+			break;
+		case 1LL: // L2+
+			mtp_L2zp_0();
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				mp_primzmswap();
+				mw_filter_3_2710();
+				{
+					VAL d5 = pop_value();
+					mp_primzmdrop();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			mw_cat_2();
+			break;
+		case 2LL: // L3+
+			mtp_L3zp_0();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mp_primzmdup();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				{
+					VAL d5 = pop_value();
+					mp_primzmswap();
+					mp_primzmswap();
+					mw_filter_3_2710();
+					{
+						VAL d6 = pop_value();
+						mp_primzmdrop();
+						push_value(d6);
+					}
+					push_value(d5);
+				}
+				mw_cat_2();
+				push_value(d4);
+			}
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				mp_primzmswap();
+				mw_filter_3_2710();
+				{
+					VAL d5 = pop_value();
+					mp_primzmdrop();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			mw_cat_2();
+			break;
+		case 3LL: // LCAT+
+			mtp_LCATzp_0();
+			mp_primzmdrop();
+			{
+				VAL d4 = pop_value();
+				mw_fold_0_2703();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mw_fold_0_2703();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				mp_primzmswap();
+				mw_filter_3_2710();
+				{
+					VAL d5 = pop_value();
+					mp_primzmdrop();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			mw_cat_2();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primzmpanic();
+	}
+}
+static void mw_filter_3_2710 (void) {
+	mw_zgListzp_0();
+	switch (get_top_data_tag()) {
+		case 0LL: // NONE
+			(void)pop_u64();
+			push_u64(0LL); // L0
+			break;
+		case 1LL: // SOME
+			mtp_SOME_0();
+			mw_filter_2_2710();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primzmpanic();
+	}
+}
+static void mw_filter_2_2710 (void) {
+	switch (get_top_data_tag()) {
+		case 3LL: // LCAT+
+			mtp_LCATzp_0();
+			mp_primzmdrop();
+			{
+				VAL d4 = pop_value();
+				mw_filter_2_2710();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mw_filter_2_2710();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			mw_cat_2();
+			break;
+		default:
+			mw_uncons_0();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mp_primzmdup();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				{
+					VAL d5 = pop_value();
+					mp_primzmdup();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				{
+					VAL d5 = pop_value();
+					{
+						VAL d6 = pop_value();
+						mp_primzmswap();
+						mw_zgListzp_0();
+						switch (get_top_data_tag()) {
+							case 0LL: // NONE
+								(void)pop_u64();
+								push_u64(0LL); // NONE
+								break;
+							case 1LL: // SOME
+								mtp_SOME_0();
+								mw_findzmsome_0_2720();
+								break;
+							default:
+								push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+								mp_primzmpanic();
+						}
+						mw_zgBool_1();
+						{
+							VAL d7 = pop_value();
+							mp_primzmdrop();
+							push_value(d7);
+						}
+						mw_not_1();
+						push_value(d6);
+					}
+					push_value(d5);
+				}
+				{
+					VAL d5 = pop_value();
+					mp_primzmswap();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			if (pop_u64()) {
+				mp_primzmswap();
+				{
+					VAL d5 = pop_value();
+					mw_filter_3_2710();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				mw_cons_2();
+			} else {
+				{
+					VAL d5 = pop_value();
+					mp_primzmdrop();
+					push_value(d5);
+				}
+				mw_filter_3_2710();
+			}
+			break;
+	}
+}
+static void mw_findzmsome_0_2720 (void) {
+	switch (get_top_data_tag()) {
+		case 0LL: // L1+
+			mtp_L1zp_0();
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mw_zeze_18();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			if (pop_u64()) {
+				mtw_SOME_0();
+			} else {
+				mp_primzmdrop();
+				push_u64(0LL); // NONE
+			}
+			break;
+		case 1LL: // L2+
+			mtp_L2zp_0();
+			mw_findzmsomezmaux2_0_2720();
+			break;
+		case 2LL: // L3+
+			mtp_L3zp_0();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					{
+						VAL d6 = pop_value();
+						mp_primzmdup();
+						push_value(d6);
+					}
+					mp_primzmswap();
+					{
+						VAL d6 = pop_value();
+						mp_primzmdup();
+						push_value(d6);
+					}
+					mp_primzmswap();
+					{
+						VAL d6 = pop_value();
+						{
+							VAL d7 = pop_value();
+							mw_zeze_18();
+							push_value(d7);
+						}
+						push_value(d6);
+					}
+					{
+						VAL d6 = pop_value();
+						mp_primzmswap();
+						push_value(d6);
+					}
+					mp_primzmswap();
+					if (pop_u64()) {
+						mtw_SOME_0();
+					} else {
+						mp_primzmdrop();
+						push_u64(0LL); // NONE
+					}
+					push_value(d5);
+				}
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			switch (get_top_data_tag()) {
+				case 0LL: // NONE
+					(void)pop_u64();
+					mw_findzmsomezmaux2_0_2720();
+					break;
+				default:
+					{
+						VAL d6 = pop_value();
+						mp_primzmdrop();
+						mp_primzmdrop();
+						push_value(d6);
+					}
+					break;
+			}
+			break;
+		case 3LL: // LCAT+
+			mtp_LCATzp_0();
+			mp_primzmdrop();
+			{
+				VAL d4 = pop_value();
+				mw_findzmsome_0_2720();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			switch (get_top_data_tag()) {
+				case 0LL: // NONE
+					(void)pop_u64();
+					mw_findzmsome_0_2720();
+					break;
+				default:
+					{
+						VAL d6 = pop_value();
+						mp_primzmdrop();
+						push_value(d6);
+					}
+					break;
+			}
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primzmpanic();
+	}
+}
+static void mw_findzmsomezmaux2_0_2720 (void) {
+	{
+		VAL d2 = pop_value();
+		{
+			VAL d3 = pop_value();
+			mp_primzmdup();
+			push_value(d3);
+		}
+		mp_primzmswap();
+		{
+			VAL d3 = pop_value();
+			mp_primzmdup();
+			push_value(d3);
+		}
+		mp_primzmswap();
+		{
+			VAL d3 = pop_value();
+			{
+				VAL d4 = pop_value();
+				mw_zeze_18();
+				push_value(d4);
+			}
+			push_value(d3);
+		}
+		{
+			VAL d3 = pop_value();
+			mp_primzmswap();
+			push_value(d3);
+		}
+		mp_primzmswap();
+		if (pop_u64()) {
+			mtw_SOME_0();
+		} else {
+			mp_primzmdrop();
+			push_u64(0LL); // NONE
+		}
+		push_value(d2);
+	}
+	mp_primzmswap();
+	switch (get_top_data_tag()) {
+		case 0LL: // NONE
+			(void)pop_u64();
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mw_zeze_18();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			if (pop_u64()) {
+				mtw_SOME_0();
+			} else {
+				mp_primzmdrop();
+				push_u64(0LL); // NONE
+			}
+			break;
+		default:
+			{
+				VAL d4 = pop_value();
+				mp_primzmdrop();
+				push_value(d4);
+			}
+			break;
+	}
+}
+static void mw_map_0_1377 (void) {
+	switch (get_top_data_tag()) {
+		case 0LL: // L1+
+			mtp_L1zp_0();
+			mw_freezmvars_7();
+			mtw_L1zp_0();
+			break;
+		case 1LL: // L2+
+			mtp_L2zp_0();
+			{
+				VAL d4 = pop_value();
+				mw_freezmvars_7();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mw_freezmvars_7();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			mtw_L2zp_0();
+			break;
+		case 2LL: // L3+
+			mtp_L3zp_0();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mw_freezmvars_7();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				push_value(d4);
+			}
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mw_freezmvars_7();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				push_value(d4);
+			}
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mw_freezmvars_7();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mtw_L3zp_0();
+			break;
+		case 3LL: // LCAT+
+			mtp_LCATzp_0();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mw_map_0_1377();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				{
+					VAL d5 = pop_value();
+					mw_map_0_1377();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mtw_LCATzp_0();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primzmpanic();
+	}
+}
+static void mw_fold_0_2737 (void) {
+	switch (get_top_data_tag()) {
+		case 0LL: // L1+
+			mtp_L1zp_0();
+			break;
+		case 1LL: // L2+
+			mtp_L2zp_0();
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				mp_primzmswap();
+				mw_filter_3_2744();
+				{
+					VAL d5 = pop_value();
+					mp_primzmdrop();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			mw_cat_2();
+			break;
+		case 2LL: // L3+
+			mtp_L3zp_0();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mp_primzmdup();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				{
+					VAL d5 = pop_value();
+					mp_primzmswap();
+					mp_primzmswap();
+					mw_filter_3_2744();
+					{
+						VAL d6 = pop_value();
+						mp_primzmdrop();
+						push_value(d6);
+					}
+					push_value(d5);
+				}
+				mw_cat_2();
+				push_value(d4);
+			}
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				mp_primzmswap();
+				mw_filter_3_2744();
+				{
+					VAL d5 = pop_value();
+					mp_primzmdrop();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			mw_cat_2();
+			break;
+		case 3LL: // LCAT+
+			mtp_LCATzp_0();
+			mp_primzmdrop();
+			{
+				VAL d4 = pop_value();
+				mw_fold_0_2737();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mw_fold_0_2737();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				mp_primzmswap();
+				mw_filter_3_2744();
+				{
+					VAL d5 = pop_value();
+					mp_primzmdrop();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			mw_cat_2();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primzmpanic();
+	}
+}
+static void mw_filter_3_2744 (void) {
+	mw_zgListzp_0();
+	switch (get_top_data_tag()) {
+		case 0LL: // NONE
+			(void)pop_u64();
+			push_u64(0LL); // L0
+			break;
+		case 1LL: // SOME
+			mtp_SOME_0();
+			mw_filter_2_2744();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primzmpanic();
+	}
+}
+static void mw_filter_2_2744 (void) {
+	switch (get_top_data_tag()) {
+		case 3LL: // LCAT+
+			mtp_LCATzp_0();
+			mp_primzmdrop();
+			{
+				VAL d4 = pop_value();
+				mw_filter_2_2744();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mw_filter_2_2744();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			mw_cat_2();
+			break;
+		default:
+			mw_uncons_0();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mp_primzmdup();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				{
+					VAL d5 = pop_value();
+					mp_primzmdup();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				{
+					VAL d5 = pop_value();
+					{
+						VAL d6 = pop_value();
+						mp_primzmswap();
+						mw_zgListzp_0();
+						switch (get_top_data_tag()) {
+							case 0LL: // NONE
+								(void)pop_u64();
+								push_u64(0LL); // NONE
+								break;
+							case 1LL: // SOME
+								mtp_SOME_0();
+								mw_findzmsome_0_2754();
+								break;
+							default:
+								push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+								mp_primzmpanic();
+						}
+						mw_zgBool_1();
+						{
+							VAL d7 = pop_value();
+							mp_primzmdrop();
+							push_value(d7);
+						}
+						mw_not_1();
+						push_value(d6);
+					}
+					push_value(d5);
+				}
+				{
+					VAL d5 = pop_value();
+					mp_primzmswap();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			if (pop_u64()) {
+				mp_primzmswap();
+				{
+					VAL d5 = pop_value();
+					mw_filter_3_2744();
+					push_value(d5);
+				}
+				mp_primzmswap();
+				mw_cons_2();
+			} else {
+				{
+					VAL d5 = pop_value();
+					mp_primzmdrop();
+					push_value(d5);
+				}
+				mw_filter_3_2744();
+			}
+			break;
+	}
+}
+static void mw_findzmsome_0_2754 (void) {
+	switch (get_top_data_tag()) {
+		case 0LL: // L1+
+			mtp_L1zp_0();
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mw_zeze_18();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			if (pop_u64()) {
+				mtw_SOME_0();
+			} else {
+				mp_primzmdrop();
+				push_u64(0LL); // NONE
+			}
+			break;
+		case 1LL: // L2+
+			mtp_L2zp_0();
+			mw_findzmsomezmaux2_0_2754();
+			break;
+		case 2LL: // L3+
+			mtp_L3zp_0();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					{
+						VAL d6 = pop_value();
+						mp_primzmdup();
+						push_value(d6);
+					}
+					mp_primzmswap();
+					{
+						VAL d6 = pop_value();
+						mp_primzmdup();
+						push_value(d6);
+					}
+					mp_primzmswap();
+					{
+						VAL d6 = pop_value();
+						{
+							VAL d7 = pop_value();
+							mw_zeze_18();
+							push_value(d7);
+						}
+						push_value(d6);
+					}
+					{
+						VAL d6 = pop_value();
+						mp_primzmswap();
+						push_value(d6);
+					}
+					mp_primzmswap();
+					if (pop_u64()) {
+						mtw_SOME_0();
+					} else {
+						mp_primzmdrop();
+						push_u64(0LL); // NONE
+					}
+					push_value(d5);
+				}
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			switch (get_top_data_tag()) {
+				case 0LL: // NONE
+					(void)pop_u64();
+					mw_findzmsomezmaux2_0_2754();
+					break;
+				default:
+					{
+						VAL d6 = pop_value();
+						mp_primzmdrop();
+						mp_primzmdrop();
+						push_value(d6);
+					}
+					break;
+			}
+			break;
+		case 3LL: // LCAT+
+			mtp_LCATzp_0();
+			mp_primzmdrop();
+			{
+				VAL d4 = pop_value();
+				mw_findzmsome_0_2754();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			switch (get_top_data_tag()) {
+				case 0LL: // NONE
+					(void)pop_u64();
+					mw_findzmsome_0_2754();
+					break;
+				default:
+					{
+						VAL d6 = pop_value();
+						mp_primzmdrop();
+						push_value(d6);
+					}
+					break;
+			}
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primzmpanic();
+	}
+}
+static void mw_findzmsomezmaux2_0_2754 (void) {
+	{
+		VAL d2 = pop_value();
+		{
+			VAL d3 = pop_value();
+			mp_primzmdup();
+			push_value(d3);
+		}
+		mp_primzmswap();
+		{
+			VAL d3 = pop_value();
+			mp_primzmdup();
+			push_value(d3);
+		}
+		mp_primzmswap();
+		{
+			VAL d3 = pop_value();
+			{
+				VAL d4 = pop_value();
+				mw_zeze_18();
+				push_value(d4);
+			}
+			push_value(d3);
+		}
+		{
+			VAL d3 = pop_value();
+			mp_primzmswap();
+			push_value(d3);
+		}
+		mp_primzmswap();
+		if (pop_u64()) {
+			mtw_SOME_0();
+		} else {
+			mp_primzmdrop();
+			push_u64(0LL); // NONE
+		}
+		push_value(d2);
+	}
+	mp_primzmswap();
+	switch (get_top_data_tag()) {
+		case 0LL: // NONE
+			(void)pop_u64();
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				mp_primzmdup();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mw_zeze_18();
+					push_value(d5);
+				}
+				push_value(d4);
+			}
+			{
+				VAL d4 = pop_value();
+				mp_primzmswap();
+				push_value(d4);
+			}
+			mp_primzmswap();
+			if (pop_u64()) {
+				mtw_SOME_0();
+			} else {
+				mp_primzmdrop();
+				push_u64(0LL); // NONE
+			}
+			break;
+		default:
+			{
+				VAL d4 = pop_value();
+				mp_primzmdrop();
+				push_value(d4);
+			}
+			break;
+	}
+}
+static void mw_map_0_1374 (void) {
+	switch (get_top_data_tag()) {
+		case 0LL: // L1+
+			mtp_L1zp_0();
 			mw_freezmvars_5();
 			mtw_L1zp_0();
 			break;
@@ -59373,13 +59373,13 @@ static void mw_map_0_1372 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1372();
+					mw_map_0_1374();
 					push_value(d5);
 				}
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1372();
+					mw_map_0_1374();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -59392,7 +59392,7 @@ static void mw_map_0_1372 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_for_18_2184 (void) {
+static void mw_for_18_2186 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -59672,17 +59672,17 @@ static void mw_for_18_2184 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2184();
+				mw_for_18_2186();
 				push_value(d4);
 			}
-			mw_for_18_2184();
+			mw_for_18_2186();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_reversezmfor_0_2170 (void) {
+static void mw_reversezmfor_0_2172 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -59847,7 +59847,7 @@ static void mw_reversezmfor_0_2170 (void) {
 				mp_primzmswap();
 				push_value(d4);
 			}
-			mw_dip2_0_2170();
+			mw_dip2_0_2172();
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
@@ -59956,17 +59956,17 @@ static void mw_reversezmfor_0_2170 (void) {
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_reversezmfor_0_2170();
+				mw_reversezmfor_0_2172();
 				push_value(d4);
 			}
-			mw_reversezmfor_0_2170();
+			mw_reversezmfor_0_2172();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_dip2_0_2170 (void) {
+static void mw_dip2_0_2172 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -60024,7 +60024,7 @@ static void mw_dip2_0_2170 (void) {
 		push_value(d2);
 	}
 }
-static void mw_for_18_2406 (void) {
+static void mw_for_18_2408 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -60058,17 +60058,17 @@ static void mw_for_18_2406 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2406();
+				mw_for_18_2408();
 				push_value(d4);
 			}
-			mw_for_18_2406();
+			mw_for_18_2408();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_for_18_2416 (void) {
+static void mw_for_18_2418 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -60102,17 +60102,17 @@ static void mw_for_18_2416 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2416();
+				mw_for_18_2418();
 				push_value(d4);
 			}
-			mw_for_18_2416();
+			mw_for_18_2418();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_for_18_2417 (void) {
+static void mw_for_18_2419 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -60146,17 +60146,17 @@ static void mw_for_18_2417 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2417();
+				mw_for_18_2419();
 				push_value(d4);
 			}
-			mw_for_18_2417();
+			mw_for_18_2419();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_for_18_2413 (void) {
+static void mw_for_18_2415 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -60190,17 +60190,17 @@ static void mw_for_18_2413 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2413();
+				mw_for_18_2415();
 				push_value(d4);
 			}
-			mw_for_18_2413();
+			mw_for_18_2415();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_dipzq_0_2030 (void) {
+static void mw_dipzq_0_2032 (void) {
 	mp_primzmswap();
 	{
 		VAL d2 = pop_value();
@@ -60209,7 +60209,7 @@ static void mw_dipzq_0_2030 (void) {
 	}
 	mp_primzmswap();
 }
-static void mw_flatmap_0_2030 (void) {
+static void mw_flatmap_0_2032 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -60222,7 +60222,7 @@ static void mw_flatmap_0_2030 (void) {
 				mw_checkzmatomzn_0();
 				push_value(d4);
 			}
-			mw_dipzq_0_2030();
+			mw_dipzq_0_2032();
 			mw_cat_2();
 			break;
 		case 2LL: // L3+
@@ -60234,11 +60234,11 @@ static void mw_flatmap_0_2030 (void) {
 					mw_checkzmatomzn_0();
 					push_value(d5);
 				}
-				mw_dipzq_0_2030();
+				mw_dipzq_0_2032();
 				mw_cat_2();
 				push_value(d4);
 			}
-			mw_dipzq_0_2030();
+			mw_dipzq_0_2032();
 			mw_cat_2();
 			break;
 		case 3LL: // LCAT+
@@ -60246,13 +60246,13 @@ static void mw_flatmap_0_2030 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_flatmap_0_2030();
+				mw_flatmap_0_2032();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_flatmap_0_2030();
+				mw_flatmap_0_2032();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -60263,7 +60263,7 @@ static void mw_flatmap_0_2030 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_map_0_2046 (void) {
+static void mw_map_0_2048 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -60341,13 +60341,13 @@ static void mw_map_0_2046 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_2046();
+					mw_map_0_2048();
 					push_value(d5);
 				}
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_2046();
+					mw_map_0_2048();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -60360,7 +60360,7 @@ static void mw_map_0_2046 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_for_18_2038 (void) {
+static void mw_for_18_2040 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -60394,17 +60394,17 @@ static void mw_for_18_2038 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2038();
+				mw_for_18_2040();
 				push_value(d4);
 			}
-			mw_for_18_2038();
+			mw_for_18_2040();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_map_0_2039 (void) {
+static void mw_map_0_2041 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -60482,13 +60482,13 @@ static void mw_map_0_2039 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_2039();
+					mw_map_0_2041();
 					push_value(d5);
 				}
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_2039();
+					mw_map_0_2041();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -61149,7 +61149,7 @@ static void mw_for_18_165 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_for_18_2085 (void) {
+static void mw_for_18_2087 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -61183,17 +61183,17 @@ static void mw_for_18_2085 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2085();
+				mw_for_18_2087();
 				push_value(d4);
 			}
-			mw_for_18_2085();
+			mw_for_18_2087();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsome_0_2932 (void) {
+static void mw_findzmsome_0_2934 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -61220,7 +61220,7 @@ static void mw_findzmsome_0_2932 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_2932();
+			mw_findzmsomezmaux2_0_2934();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -61257,7 +61257,7 @@ static void mw_findzmsome_0_2932 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_2932();
+					mw_findzmsomezmaux2_0_2934();
 					break;
 				default:
 					{
@@ -61274,14 +61274,14 @@ static void mw_findzmsome_0_2932 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_2932();
+				mw_findzmsome_0_2934();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_2932();
+					mw_findzmsome_0_2934();
 					break;
 				default:
 					{
@@ -61297,7 +61297,7 @@ static void mw_findzmsome_0_2932 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_2932 (void) {
+static void mw_findzmsomezmaux2_0_2934 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -61356,7 +61356,7 @@ static void mw_findzmsomezmaux2_0_2932 (void) {
 			break;
 	}
 }
-static void mw_findzmsome_0_2941 (void) {
+static void mw_findzmsome_0_2943 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -61383,7 +61383,7 @@ static void mw_findzmsome_0_2941 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_2941();
+			mw_findzmsomezmaux2_0_2943();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -61420,7 +61420,7 @@ static void mw_findzmsome_0_2941 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_2941();
+					mw_findzmsomezmaux2_0_2943();
 					break;
 				default:
 					{
@@ -61437,14 +61437,14 @@ static void mw_findzmsome_0_2941 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_2941();
+				mw_findzmsome_0_2943();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_2941();
+					mw_findzmsome_0_2943();
 					break;
 				default:
 					{
@@ -61460,7 +61460,7 @@ static void mw_findzmsome_0_2941 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_2941 (void) {
+static void mw_findzmsomezmaux2_0_2943 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -61519,7 +61519,7 @@ static void mw_findzmsomezmaux2_0_2941 (void) {
 			break;
 	}
 }
-static void mw_reversezmfor_0_2950 (void) {
+static void mw_reversezmfor_0_2952 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -61624,7 +61624,7 @@ static void mw_reversezmfor_0_2950 (void) {
 				mp_primzmswap();
 				push_value(d4);
 			}
-			mw_dip2_0_2950();
+			mw_dip2_0_2952();
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
@@ -61693,17 +61693,17 @@ static void mw_reversezmfor_0_2950 (void) {
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_reversezmfor_0_2950();
+				mw_reversezmfor_0_2952();
 				push_value(d4);
 			}
-			mw_reversezmfor_0_2950();
+			mw_reversezmfor_0_2952();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_dip2_0_2950 (void) {
+static void mw_dip2_0_2952 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -61741,7 +61741,7 @@ static void mw_dip2_0_2950 (void) {
 		push_value(d2);
 	}
 }
-static void mw_for_18_2096 (void) {
+static void mw_for_18_2098 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -61811,7 +61811,7 @@ static void mw_for_18_2096 (void) {
 								mp_primzmswap();
 								push_value(d8);
 							}
-							mw_dip2_0_2099();
+							mw_dip2_0_2101();
 							mp_primzmswap();
 							{
 								VAL d8 = pop_value();
@@ -61828,10 +61828,10 @@ static void mw_for_18_2096 (void) {
 							mp_primzmswap();
 							{
 								VAL d8 = pop_value();
-								mw_reversezmfor_0_2099();
+								mw_reversezmfor_0_2101();
 								push_value(d8);
 							}
-							mw_reversezmfor_0_2099();
+							mw_reversezmfor_0_2101();
 							break;
 						default:
 							push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -61982,7 +61982,7 @@ static void mw_for_18_2096 (void) {
 									mp_primzmswap();
 									push_value(d9);
 								}
-								mw_dip2_0_2099();
+								mw_dip2_0_2101();
 								mp_primzmswap();
 								{
 									VAL d9 = pop_value();
@@ -61999,10 +61999,10 @@ static void mw_for_18_2096 (void) {
 								mp_primzmswap();
 								{
 									VAL d9 = pop_value();
-									mw_reversezmfor_0_2099();
+									mw_reversezmfor_0_2101();
 									push_value(d9);
 								}
-								mw_reversezmfor_0_2099();
+								mw_reversezmfor_0_2101();
 								break;
 							default:
 								push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -62150,7 +62150,7 @@ static void mw_for_18_2096 (void) {
 								mp_primzmswap();
 								push_value(d8);
 							}
-							mw_dip2_0_2099();
+							mw_dip2_0_2101();
 							mp_primzmswap();
 							{
 								VAL d8 = pop_value();
@@ -62167,10 +62167,10 @@ static void mw_for_18_2096 (void) {
 							mp_primzmswap();
 							{
 								VAL d8 = pop_value();
-								mw_reversezmfor_0_2099();
+								mw_reversezmfor_0_2101();
 								push_value(d8);
 							}
-							mw_reversezmfor_0_2099();
+							mw_reversezmfor_0_2101();
 							break;
 						default:
 							push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -62323,7 +62323,7 @@ static void mw_for_18_2096 (void) {
 										mp_primzmswap();
 										push_value(d10);
 									}
-									mw_dip2_0_2099();
+									mw_dip2_0_2101();
 									mp_primzmswap();
 									{
 										VAL d10 = pop_value();
@@ -62340,10 +62340,10 @@ static void mw_for_18_2096 (void) {
 									mp_primzmswap();
 									{
 										VAL d10 = pop_value();
-										mw_reversezmfor_0_2099();
+										mw_reversezmfor_0_2101();
 										push_value(d10);
 									}
-									mw_reversezmfor_0_2099();
+									mw_reversezmfor_0_2101();
 									break;
 								default:
 									push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -62491,7 +62491,7 @@ static void mw_for_18_2096 (void) {
 									mp_primzmswap();
 									push_value(d9);
 								}
-								mw_dip2_0_2099();
+								mw_dip2_0_2101();
 								mp_primzmswap();
 								{
 									VAL d9 = pop_value();
@@ -62508,10 +62508,10 @@ static void mw_for_18_2096 (void) {
 								mp_primzmswap();
 								{
 									VAL d9 = pop_value();
-									mw_reversezmfor_0_2099();
+									mw_reversezmfor_0_2101();
 									push_value(d9);
 								}
-								mw_reversezmfor_0_2099();
+								mw_reversezmfor_0_2101();
 								break;
 							default:
 								push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -62659,7 +62659,7 @@ static void mw_for_18_2096 (void) {
 								mp_primzmswap();
 								push_value(d8);
 							}
-							mw_dip2_0_2099();
+							mw_dip2_0_2101();
 							mp_primzmswap();
 							{
 								VAL d8 = pop_value();
@@ -62676,10 +62676,10 @@ static void mw_for_18_2096 (void) {
 							mp_primzmswap();
 							{
 								VAL d8 = pop_value();
-								mw_reversezmfor_0_2099();
+								mw_reversezmfor_0_2101();
 								push_value(d8);
 							}
-							mw_reversezmfor_0_2099();
+							mw_reversezmfor_0_2101();
 							break;
 						default:
 							push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -62765,17 +62765,17 @@ static void mw_for_18_2096 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2096();
+				mw_for_18_2098();
 				push_value(d4);
 			}
-			mw_for_18_2096();
+			mw_for_18_2098();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsome_0_2967 (void) {
+static void mw_findzmsome_0_2969 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -62801,7 +62801,7 @@ static void mw_findzmsome_0_2967 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_2967();
+			mw_findzmsomezmaux2_0_2969();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -62837,7 +62837,7 @@ static void mw_findzmsome_0_2967 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_2967();
+					mw_findzmsomezmaux2_0_2969();
 					break;
 				default:
 					{
@@ -62854,14 +62854,14 @@ static void mw_findzmsome_0_2967 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_2967();
+				mw_findzmsome_0_2969();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_2967();
+					mw_findzmsome_0_2969();
 					break;
 				default:
 					{
@@ -62877,7 +62877,7 @@ static void mw_findzmsome_0_2967 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_2967 (void) {
+static void mw_findzmsomezmaux2_0_2969 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -62934,7 +62934,7 @@ static void mw_findzmsomezmaux2_0_2967 (void) {
 			break;
 	}
 }
-static void mw_for_18_1308 (void) {
+static void mw_for_18_1310 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -62968,17 +62968,17 @@ static void mw_for_18_1308 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_1308();
+				mw_for_18_1310();
 				push_value(d4);
 			}
-			mw_for_18_1308();
+			mw_for_18_1310();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_reversezmfor_0_2099 (void) {
+static void mw_reversezmfor_0_2101 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -63005,7 +63005,7 @@ static void mw_reversezmfor_0_2099 (void) {
 				mp_primzmswap();
 				push_value(d4);
 			}
-			mw_dip2_0_2099();
+			mw_dip2_0_2101();
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
@@ -63022,17 +63022,17 @@ static void mw_reversezmfor_0_2099 (void) {
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_reversezmfor_0_2099();
+				mw_reversezmfor_0_2101();
 				push_value(d4);
 			}
-			mw_reversezmfor_0_2099();
+			mw_reversezmfor_0_2101();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_dip2_0_2099 (void) {
+static void mw_dip2_0_2101 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -63044,7 +63044,7 @@ static void mw_dip2_0_2099 (void) {
 		push_value(d2);
 	}
 }
-static void mw_for_18_2087 (void) {
+static void mw_for_18_2089 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -63078,17 +63078,17 @@ static void mw_for_18_2087 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2087();
+				mw_for_18_2089();
 				push_value(d4);
 			}
-			mw_for_18_2087();
+			mw_for_18_2089();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_map_0_2078 (void) {
+static void mw_map_0_2080 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -63166,13 +63166,13 @@ static void mw_map_0_2078 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_2078();
+					mw_map_0_2080();
 					push_value(d5);
 				}
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_2078();
+					mw_map_0_2080();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -63185,7 +63185,7 @@ static void mw_map_0_2078 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_reversezmfor_0_2071 (void) {
+static void mw_reversezmfor_0_2073 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -63496,17 +63496,17 @@ static void mw_reversezmfor_0_2071 (void) {
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_reversezmfor_0_2071();
+				mw_reversezmfor_0_2073();
 				push_value(d4);
 			}
-			mw_reversezmfor_0_2071();
+			mw_reversezmfor_0_2073();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_reversezmfindzmsome_0_3018 (void) {
+static void mw_reversezmfindzmsome_0_3020 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -63534,7 +63534,7 @@ static void mw_reversezmfindzmsome_0_3018 (void) {
 		case 1LL: // L2+
 			mtp_L2zp_0();
 			mp_primzmswap();
-			mw_findzmsomezmaux2_0_3018();
+			mw_findzmsomezmaux2_0_3020();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -63578,7 +63578,7 @@ static void mw_reversezmfindzmsome_0_3018 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_3018();
+					mw_findzmsomezmaux2_0_3020();
 					break;
 				default:
 					{
@@ -63596,14 +63596,14 @@ static void mw_reversezmfindzmsome_0_3018 (void) {
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_reversezmfindzmsome_0_3018();
+				mw_reversezmfindzmsome_0_3020();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_reversezmfindzmsome_0_3018();
+					mw_reversezmfindzmsome_0_3020();
 					break;
 				default:
 					{
@@ -63619,7 +63619,7 @@ static void mw_reversezmfindzmsome_0_3018 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_3018 (void) {
+static void mw_findzmsomezmaux2_0_3020 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -63678,7 +63678,7 @@ static void mw_findzmsomezmaux2_0_3018 (void) {
 			break;
 	}
 }
-static void mw_for_18_2058 (void) {
+static void mw_for_18_2060 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -63796,10 +63796,10 @@ static void mw_for_18_2058 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2058();
+				mw_for_18_2060();
 				push_value(d4);
 			}
-			mw_for_18_2058();
+			mw_for_18_2060();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -63946,7 +63946,7 @@ static void mw_for_18_140 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsome_0_3037 (void) {
+static void mw_findzmsome_0_3039 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -63973,7 +63973,7 @@ static void mw_findzmsome_0_3037 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_3037();
+			mw_findzmsomezmaux2_0_3039();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -64010,7 +64010,7 @@ static void mw_findzmsome_0_3037 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_3037();
+					mw_findzmsomezmaux2_0_3039();
 					break;
 				default:
 					{
@@ -64027,14 +64027,14 @@ static void mw_findzmsome_0_3037 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_3037();
+				mw_findzmsome_0_3039();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_3037();
+					mw_findzmsome_0_3039();
 					break;
 				default:
 					{
@@ -64050,7 +64050,7 @@ static void mw_findzmsome_0_3037 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_3037 (void) {
+static void mw_findzmsomezmaux2_0_3039 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -64174,7 +64174,7 @@ static void mw_zeze_21_297 (void) {
 		push_u64(0LL); // F
 	}
 }
-static void mw_findzmsome_0_3051 (void) {
+static void mw_findzmsome_0_3053 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -64187,7 +64187,7 @@ static void mw_findzmsome_0_3051 (void) {
 					break;
 				case 1LL: // SOME
 					mtp_SOME_0();
-					mw_findzmsome_0_3057();
+					mw_findzmsome_0_3059();
 					break;
 				default:
 					push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -64203,7 +64203,7 @@ static void mw_findzmsome_0_3051 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_3051();
+			mw_findzmsomezmaux2_0_3053();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -64220,7 +64220,7 @@ static void mw_findzmsome_0_3051 (void) {
 							break;
 						case 1LL: // SOME
 							mtp_SOME_0();
-							mw_findzmsome_0_3057();
+							mw_findzmsome_0_3059();
 							break;
 						default:
 							push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -64242,7 +64242,7 @@ static void mw_findzmsome_0_3051 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_3051();
+					mw_findzmsomezmaux2_0_3053();
 					break;
 				default:
 					{
@@ -64259,14 +64259,14 @@ static void mw_findzmsome_0_3051 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_3051();
+				mw_findzmsome_0_3053();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_3051();
+					mw_findzmsome_0_3053();
 					break;
 				default:
 					{
@@ -64282,7 +64282,7 @@ static void mw_findzmsome_0_3051 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_3051 (void) {
+static void mw_findzmsomezmaux2_0_3053 (void) {
 	{
 		VAL d2 = pop_value();
 		mp_primzmdup();
@@ -64294,7 +64294,7 @@ static void mw_findzmsomezmaux2_0_3051 (void) {
 				break;
 			case 1LL: // SOME
 				mtp_SOME_0();
-				mw_findzmsome_0_3057();
+				mw_findzmsome_0_3059();
 				break;
 			default:
 				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -64322,7 +64322,7 @@ static void mw_findzmsomezmaux2_0_3051 (void) {
 					break;
 				case 1LL: // SOME
 					mtp_SOME_0();
-					mw_findzmsome_0_3057();
+					mw_findzmsome_0_3059();
 					break;
 				default:
 					push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -64345,7 +64345,7 @@ static void mw_findzmsomezmaux2_0_3051 (void) {
 			break;
 	}
 }
-static void mw_findzmsome_0_3057 (void) {
+static void mw_findzmsome_0_3059 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -64360,7 +64360,7 @@ static void mw_findzmsome_0_3057 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_3057();
+			mw_findzmsomezmaux2_0_3059();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -64385,7 +64385,7 @@ static void mw_findzmsome_0_3057 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_3057();
+					mw_findzmsomezmaux2_0_3059();
 					break;
 				default:
 					{
@@ -64402,14 +64402,14 @@ static void mw_findzmsome_0_3057 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_3057();
+				mw_findzmsome_0_3059();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_3057();
+					mw_findzmsome_0_3059();
 					break;
 				default:
 					{
@@ -64425,7 +64425,7 @@ static void mw_findzmsome_0_3057 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_3057 (void) {
+static void mw_findzmsomezmaux2_0_3059 (void) {
 	{
 		VAL d2 = pop_value();
 		mp_primzmdup();
@@ -64460,7 +64460,7 @@ static void mw_findzmsomezmaux2_0_3057 (void) {
 			break;
 	}
 }
-static void mw_for_18_2037 (void) {
+static void mw_for_18_2039 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -64494,10 +64494,10 @@ static void mw_for_18_2037 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2037();
+				mw_for_18_2039();
 				push_value(d4);
 			}
-			mw_for_18_2037();
+			mw_for_18_2039();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -64548,7 +64548,7 @@ static void mw_for_18_186 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_for_18_2024 (void) {
+static void mw_for_18_2026 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -65008,17 +65008,17 @@ static void mw_for_18_2024 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2024();
+				mw_for_18_2026();
 				push_value(d4);
 			}
-			mw_for_18_2024();
+			mw_for_18_2026();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsome_0_2019 (void) {
+static void mw_findzmsome_0_2021 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -65049,7 +65049,7 @@ static void mw_findzmsome_0_2019 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_2019();
+			mw_findzmsomezmaux2_0_2021();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -65090,7 +65090,7 @@ static void mw_findzmsome_0_2019 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_2019();
+					mw_findzmsomezmaux2_0_2021();
 					break;
 				default:
 					{
@@ -65107,14 +65107,14 @@ static void mw_findzmsome_0_2019 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_2019();
+				mw_findzmsome_0_2021();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_2019();
+					mw_findzmsome_0_2021();
 					break;
 				default:
 					{
@@ -65130,7 +65130,7 @@ static void mw_findzmsome_0_2019 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_2019 (void) {
+static void mw_findzmsomezmaux2_0_2021 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -65197,7 +65197,7 @@ static void mw_findzmsomezmaux2_0_2019 (void) {
 			break;
 	}
 }
-static void mw_findzmsome_0_3120 (void) {
+static void mw_findzmsome_0_3122 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -65223,7 +65223,7 @@ static void mw_findzmsome_0_3120 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_3120();
+			mw_findzmsomezmaux2_0_3122();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -65259,7 +65259,7 @@ static void mw_findzmsome_0_3120 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_3120();
+					mw_findzmsomezmaux2_0_3122();
 					break;
 				default:
 					{
@@ -65276,14 +65276,14 @@ static void mw_findzmsome_0_3120 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_3120();
+				mw_findzmsome_0_3122();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_3120();
+					mw_findzmsome_0_3122();
 					break;
 				default:
 					{
@@ -65299,7 +65299,7 @@ static void mw_findzmsome_0_3120 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_3120 (void) {
+static void mw_findzmsomezmaux2_0_3122 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -65356,7 +65356,7 @@ static void mw_findzmsomezmaux2_0_3120 (void) {
 			break;
 	}
 }
-static void mw_findzmsome_0_3145 (void) {
+static void mw_findzmsome_0_3147 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -65382,7 +65382,7 @@ static void mw_findzmsome_0_3145 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_3145();
+			mw_findzmsomezmaux2_0_3147();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -65418,7 +65418,7 @@ static void mw_findzmsome_0_3145 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_3145();
+					mw_findzmsomezmaux2_0_3147();
 					break;
 				default:
 					{
@@ -65435,14 +65435,14 @@ static void mw_findzmsome_0_3145 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_3145();
+				mw_findzmsome_0_3147();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_3145();
+					mw_findzmsome_0_3147();
 					break;
 				default:
 					{
@@ -65458,7 +65458,7 @@ static void mw_findzmsome_0_3145 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_3145 (void) {
+static void mw_findzmsomezmaux2_0_3147 (void) {
 	{
 		VAL d2 = pop_value();
 		mp_primzmdup();
@@ -65515,7 +65515,7 @@ static void mw_findzmsomezmaux2_0_3145 (void) {
 			break;
 	}
 }
-static void mw_for_18_1913 (void) {
+static void mw_for_18_1915 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -65549,17 +65549,17 @@ static void mw_for_18_1913 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_1913();
+				mw_for_18_1915();
 				push_value(d4);
 			}
-			mw_for_18_1913();
+			mw_for_18_1915();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsome_0_3156 (void) {
+static void mw_findzmsome_0_3158 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -65580,7 +65580,7 @@ static void mw_findzmsome_0_3156 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_3156();
+			mw_findzmsomezmaux2_0_3158();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -65611,7 +65611,7 @@ static void mw_findzmsome_0_3156 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_3156();
+					mw_findzmsomezmaux2_0_3158();
 					break;
 				default:
 					{
@@ -65628,14 +65628,14 @@ static void mw_findzmsome_0_3156 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_3156();
+				mw_findzmsome_0_3158();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_3156();
+					mw_findzmsome_0_3158();
 					break;
 				default:
 					{
@@ -65651,7 +65651,7 @@ static void mw_findzmsome_0_3156 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_3156 (void) {
+static void mw_findzmsomezmaux2_0_3158 (void) {
 	{
 		VAL d2 = pop_value();
 		mp_primzmdup();
@@ -65698,7 +65698,7 @@ static void mw_findzmsomezmaux2_0_3156 (void) {
 			break;
 	}
 }
-static void mw_filter_3_1407 (void) {
+static void mw_filter_3_1409 (void) {
 	mw_zgListzp_0();
 	switch (get_top_data_tag()) {
 		case 0LL: // NONE
@@ -65707,14 +65707,14 @@ static void mw_filter_3_1407 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_filter_2_1407();
+			mw_filter_2_1409();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_map_0_1408 (void) {
+static void mw_map_0_1410 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -65804,13 +65804,13 @@ static void mw_map_0_1408 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1408();
+					mw_map_0_1410();
 					push_value(d5);
 				}
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1408();
+					mw_map_0_1410();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -65823,20 +65823,20 @@ static void mw_map_0_1408 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_filter_2_1407 (void) {
+static void mw_filter_2_1409 (void) {
 	switch (get_top_data_tag()) {
 		case 3LL: // LCAT+
 			mtp_LCATzp_0();
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_filter_2_1407();
+				mw_filter_2_1409();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_filter_2_1407();
+				mw_filter_2_1409();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -65855,7 +65855,7 @@ static void mw_filter_2_1407 (void) {
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_filter_3_1407();
+					mw_filter_3_1409();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -65866,17 +65866,17 @@ static void mw_filter_2_1407 (void) {
 					mp_primzmdrop();
 					push_value(d5);
 				}
-				mw_filter_3_1407();
+				mw_filter_3_1409();
 			}
 			break;
 	}
 }
-static void mw_filterzmsome_1_1413 (void) {
+static void mw_filterzmsome_1_1415 (void) {
 	mw_zgListzp_0();
 	switch (get_top_data_tag()) {
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_filterzmsome_0_1413();
+			mw_filterzmsome_0_1415();
 			break;
 		case 0LL: // NONE
 			(void)pop_u64();
@@ -65887,7 +65887,7 @@ static void mw_filterzmsome_1_1413 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_filter_3_1414 (void) {
+static void mw_filter_3_1416 (void) {
 	mw_zgListzp_0();
 	switch (get_top_data_tag()) {
 		case 0LL: // NONE
@@ -65896,27 +65896,27 @@ static void mw_filter_3_1414 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_filter_2_1414();
+			mw_filter_2_1416();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_filter_2_1414 (void) {
+static void mw_filter_2_1416 (void) {
 	switch (get_top_data_tag()) {
 		case 3LL: // LCAT+
 			mtp_LCATzp_0();
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_filter_2_1414();
+				mw_filter_2_1416();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_filter_2_1414();
+				mw_filter_2_1416();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -65941,7 +65941,7 @@ static void mw_filter_2_1414 (void) {
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_filter_3_1414();
+					mw_filter_3_1416();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -65952,25 +65952,25 @@ static void mw_filter_2_1414 (void) {
 					mp_primzmdrop();
 					push_value(d5);
 				}
-				mw_filter_3_1414();
+				mw_filter_3_1416();
 			}
 			break;
 	}
 }
-static void mw_filterzmsome_0_1413 (void) {
+static void mw_filterzmsome_0_1415 (void) {
 	switch (get_top_data_tag()) {
 		case 3LL: // LCAT+
 			mtp_LCATzp_0();
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_filterzmsome_0_1413();
+				mw_filterzmsome_0_1415();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_filterzmsome_0_1413();
+				mw_filterzmsome_0_1415();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -65980,7 +65980,7 @@ static void mw_filterzmsome_0_1413 (void) {
 			mw_unsnoc_0();
 			{
 				VAL d4 = pop_value();
-				mw_filterzmsome_1_1413();
+				mw_filterzmsome_1_1415();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -66005,7 +66005,7 @@ static void mw_filterzmsome_0_1413 (void) {
 			break;
 	}
 }
-static void mw_for_18_1581 (void) {
+static void mw_for_18_1583 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -66039,17 +66039,17 @@ static void mw_for_18_1581 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_1581();
+				mw_for_18_1583();
 				push_value(d4);
 			}
-			mw_for_18_1581();
+			mw_for_18_1583();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_map_0_1584 (void) {
+static void mw_map_0_1586 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -66139,13 +66139,13 @@ static void mw_map_0_1584 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1584();
+					mw_map_0_1586();
 					push_value(d5);
 				}
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1584();
+					mw_map_0_1586();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -66158,7 +66158,7 @@ static void mw_map_0_1584 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_for_18_1651 (void) {
+static void mw_for_18_1653 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -67230,17 +67230,17 @@ static void mw_for_18_1651 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_1651();
+				mw_for_18_1653();
 				push_value(d4);
 			}
-			mw_for_18_1651();
+			mw_for_18_1653();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_for_18_1662 (void) {
+static void mw_for_18_1664 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -67358,17 +67358,17 @@ static void mw_for_18_1662 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_1662();
+				mw_for_18_1664();
 				push_value(d4);
 			}
-			mw_for_18_1662();
+			mw_for_18_1664();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_for_18_1658 (void) {
+static void mw_for_18_1660 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -67486,17 +67486,17 @@ static void mw_for_18_1658 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_1658();
+				mw_for_18_1660();
 				push_value(d4);
 			}
-			mw_for_18_1658();
+			mw_for_18_1660();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeither_1_3231 (void) {
+static void mw_partitionzmeither_1_3233 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L0
 			(void)pop_u64();
@@ -67505,16 +67505,16 @@ static void mw_partitionzmeither_1_3231 (void) {
 			break;
 		case 1LL: // L1
 			mtp_L1_0();
-			mw_partitionzmeitherzmbase_0_3231();
+			mw_partitionzmeitherzmbase_0_3233();
 			break;
 		case 2LL: // L2
 			mtp_L2_0();
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeitherzmbase_0_3231();
+				mw_partitionzmeitherzmbase_0_3233();
 				push_value(d4);
 			}
-			mw_partitionzmeitherzmsnoc_0_3231();
+			mw_partitionzmeitherzmsnoc_0_3233();
 			break;
 		case 3LL: // L3
 			mtp_L3_0();
@@ -67522,24 +67522,24 @@ static void mw_partitionzmeither_1_3231 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_partitionzmeitherzmbase_0_3231();
+					mw_partitionzmeitherzmbase_0_3233();
 					push_value(d5);
 				}
 				push_value(d4);
 			}
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeitherzmsnoc_0_3231();
+				mw_partitionzmeitherzmsnoc_0_3233();
 				push_value(d4);
 			}
-			mw_partitionzmeitherzmsnoc_0_3231();
+			mw_partitionzmeitherzmsnoc_0_3233();
 			break;
 		case 4LL: // LCAT
 			mtp_LCAT_0();
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeither_0_3231();
+				mw_partitionzmeither_0_3233();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -67552,7 +67552,7 @@ static void mw_partitionzmeither_1_3231 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_partitionzmeither_0_3231();
+					mw_partitionzmeither_0_3233();
 					push_value(d5);
 				}
 				push_value(d4);
@@ -67580,7 +67580,7 @@ static void mw_partitionzmeither_1_3231 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeitherzmbase_0_3231 (void) {
+static void mw_partitionzmeitherzmbase_0_3233 (void) {
 	{
 		VAL d2 = pop_value();
 		mp_primzmdup();
@@ -67636,7 +67636,7 @@ static void mw_partitionzmeitherzmbase_0_3231 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeitherzmsnoc_0_3231 (void) {
+static void mw_partitionzmeitherzmsnoc_0_3233 (void) {
 	mp_primzmswap();
 	{
 		VAL d2 = pop_value();
@@ -67711,11 +67711,11 @@ static void mw_partitionzmeitherzmsnoc_0_3231 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeither_0_3231 (void) {
+static void mw_partitionzmeither_0_3233 (void) {
 	mw_zgList_1();
-	mw_partitionzmeither_1_3231();
+	mw_partitionzmeither_1_3233();
 }
-static void mw_reversezmfor_0_1676 (void) {
+static void mw_reversezmfor_0_1678 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -67820,7 +67820,7 @@ static void mw_reversezmfor_0_1676 (void) {
 				mp_primzmswap();
 				push_value(d4);
 			}
-			mw_dip2_0_1676();
+			mw_dip2_0_1678();
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
@@ -67889,17 +67889,17 @@ static void mw_reversezmfor_0_1676 (void) {
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_reversezmfor_0_1676();
+				mw_reversezmfor_0_1678();
 				push_value(d4);
 			}
-			mw_reversezmfor_0_1676();
+			mw_reversezmfor_0_1678();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_dip2_0_1676 (void) {
+static void mw_dip2_0_1678 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -67937,7 +67937,7 @@ static void mw_dip2_0_1676 (void) {
 		push_value(d2);
 	}
 }
-static void mw_partitionzmeither_1_3255 (void) {
+static void mw_partitionzmeither_1_3257 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L0
 			(void)pop_u64();
@@ -67946,16 +67946,16 @@ static void mw_partitionzmeither_1_3255 (void) {
 			break;
 		case 1LL: // L1
 			mtp_L1_0();
-			mw_partitionzmeitherzmbase_0_3255();
+			mw_partitionzmeitherzmbase_0_3257();
 			break;
 		case 2LL: // L2
 			mtp_L2_0();
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeitherzmbase_0_3255();
+				mw_partitionzmeitherzmbase_0_3257();
 				push_value(d4);
 			}
-			mw_partitionzmeitherzmsnoc_0_3255();
+			mw_partitionzmeitherzmsnoc_0_3257();
 			break;
 		case 3LL: // L3
 			mtp_L3_0();
@@ -67963,24 +67963,24 @@ static void mw_partitionzmeither_1_3255 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_partitionzmeitherzmbase_0_3255();
+					mw_partitionzmeitherzmbase_0_3257();
 					push_value(d5);
 				}
 				push_value(d4);
 			}
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeitherzmsnoc_0_3255();
+				mw_partitionzmeitherzmsnoc_0_3257();
 				push_value(d4);
 			}
-			mw_partitionzmeitherzmsnoc_0_3255();
+			mw_partitionzmeitherzmsnoc_0_3257();
 			break;
 		case 4LL: // LCAT
 			mtp_LCAT_0();
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeither_0_3255();
+				mw_partitionzmeither_0_3257();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -67993,7 +67993,7 @@ static void mw_partitionzmeither_1_3255 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_partitionzmeither_0_3255();
+					mw_partitionzmeither_0_3257();
 					push_value(d5);
 				}
 				push_value(d4);
@@ -68021,7 +68021,7 @@ static void mw_partitionzmeither_1_3255 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeitherzmbase_0_3255 (void) {
+static void mw_partitionzmeitherzmbase_0_3257 (void) {
 	{
 		VAL d2 = pop_value();
 		mp_primzmdup();
@@ -68067,7 +68067,7 @@ static void mw_partitionzmeitherzmbase_0_3255 (void) {
 					break;
 				case 1LL: // SOME
 					mtp_SOME_0();
-					mw_findzmsome_0_3277();
+					mw_findzmsome_0_3279();
 					break;
 				default:
 					push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -68126,7 +68126,7 @@ static void mw_partitionzmeitherzmbase_0_3255 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeitherzmsnoc_0_3255 (void) {
+static void mw_partitionzmeitherzmsnoc_0_3257 (void) {
 	mp_primzmswap();
 	{
 		VAL d2 = pop_value();
@@ -68182,7 +68182,7 @@ static void mw_partitionzmeitherzmsnoc_0_3255 (void) {
 							break;
 						case 1LL: // SOME
 							mtp_SOME_0();
-							mw_findzmsome_0_3277();
+							mw_findzmsome_0_3279();
 							break;
 						default:
 							push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -68250,11 +68250,11 @@ static void mw_partitionzmeitherzmsnoc_0_3255 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeither_0_3255 (void) {
+static void mw_partitionzmeither_0_3257 (void) {
 	mw_zgList_1();
-	mw_partitionzmeither_1_3255();
+	mw_partitionzmeither_1_3257();
 }
-static void mw_findzmsome_0_3277 (void) {
+static void mw_findzmsome_0_3279 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -68294,7 +68294,7 @@ static void mw_findzmsome_0_3277 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_3277();
+			mw_findzmsomezmaux2_0_3279();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -68344,7 +68344,7 @@ static void mw_findzmsome_0_3277 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_3277();
+					mw_findzmsomezmaux2_0_3279();
 					break;
 				default:
 					{
@@ -68361,14 +68361,14 @@ static void mw_findzmsome_0_3277 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_3277();
+				mw_findzmsome_0_3279();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_3277();
+					mw_findzmsome_0_3279();
 					break;
 				default:
 					{
@@ -68384,7 +68384,7 @@ static void mw_findzmsome_0_3277 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_3277 (void) {
+static void mw_findzmsomezmaux2_0_3279 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -68469,7 +68469,7 @@ static void mw_findzmsomezmaux2_0_3277 (void) {
 			break;
 	}
 }
-static void mw_partitionzmeither_1_3284 (void) {
+static void mw_partitionzmeither_1_3286 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L0
 			(void)pop_u64();
@@ -68478,16 +68478,16 @@ static void mw_partitionzmeither_1_3284 (void) {
 			break;
 		case 1LL: // L1
 			mtp_L1_0();
-			mw_partitionzmeitherzmbase_0_3284();
+			mw_partitionzmeitherzmbase_0_3286();
 			break;
 		case 2LL: // L2
 			mtp_L2_0();
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeitherzmbase_0_3284();
+				mw_partitionzmeitherzmbase_0_3286();
 				push_value(d4);
 			}
-			mw_partitionzmeitherzmsnoc_0_3284();
+			mw_partitionzmeitherzmsnoc_0_3286();
 			break;
 		case 3LL: // L3
 			mtp_L3_0();
@@ -68495,24 +68495,24 @@ static void mw_partitionzmeither_1_3284 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_partitionzmeitherzmbase_0_3284();
+					mw_partitionzmeitherzmbase_0_3286();
 					push_value(d5);
 				}
 				push_value(d4);
 			}
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeitherzmsnoc_0_3284();
+				mw_partitionzmeitherzmsnoc_0_3286();
 				push_value(d4);
 			}
-			mw_partitionzmeitherzmsnoc_0_3284();
+			mw_partitionzmeitherzmsnoc_0_3286();
 			break;
 		case 4LL: // LCAT
 			mtp_LCAT_0();
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeither_0_3284();
+				mw_partitionzmeither_0_3286();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -68525,7 +68525,7 @@ static void mw_partitionzmeither_1_3284 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_partitionzmeither_0_3284();
+					mw_partitionzmeither_0_3286();
 					push_value(d5);
 				}
 				push_value(d4);
@@ -68553,7 +68553,7 @@ static void mw_partitionzmeither_1_3284 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeitherzmbase_0_3284 (void) {
+static void mw_partitionzmeitherzmbase_0_3286 (void) {
 	{
 		VAL d2 = pop_value();
 		mp_primzmdup();
@@ -68577,7 +68577,7 @@ static void mw_partitionzmeitherzmbase_0_3284 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_findzmsome_0_3307();
+			mw_findzmsome_0_3309();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -68659,7 +68659,7 @@ static void mw_partitionzmeitherzmbase_0_3284 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeitherzmsnoc_0_3284 (void) {
+static void mw_partitionzmeitherzmsnoc_0_3286 (void) {
 	mp_primzmswap();
 	{
 		VAL d2 = pop_value();
@@ -68693,7 +68693,7 @@ static void mw_partitionzmeitherzmsnoc_0_3284 (void) {
 					break;
 				case 1LL: // SOME
 					mtp_SOME_0();
-					mw_findzmsome_0_3307();
+					mw_findzmsome_0_3309();
 					break;
 				default:
 					push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -68784,11 +68784,11 @@ static void mw_partitionzmeitherzmsnoc_0_3284 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeither_0_3284 (void) {
+static void mw_partitionzmeither_0_3286 (void) {
 	mw_zgList_1();
-	mw_partitionzmeither_1_3284();
+	mw_partitionzmeither_1_3286();
 }
-static void mw_findzmsome_0_3307 (void) {
+static void mw_findzmsome_0_3309 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -68828,7 +68828,7 @@ static void mw_findzmsome_0_3307 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_3307();
+			mw_findzmsomezmaux2_0_3309();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -68878,7 +68878,7 @@ static void mw_findzmsome_0_3307 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_3307();
+					mw_findzmsomezmaux2_0_3309();
 					break;
 				default:
 					{
@@ -68895,14 +68895,14 @@ static void mw_findzmsome_0_3307 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_3307();
+				mw_findzmsome_0_3309();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_3307();
+					mw_findzmsome_0_3309();
 					break;
 				default:
 					{
@@ -68918,7 +68918,7 @@ static void mw_findzmsome_0_3307 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_3307 (void) {
+static void mw_findzmsomezmaux2_0_3309 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -69003,7 +69003,7 @@ static void mw_findzmsomezmaux2_0_3307 (void) {
 			break;
 	}
 }
-static void mw_partitionzmeither_1_3314 (void) {
+static void mw_partitionzmeither_1_3316 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L0
 			(void)pop_u64();
@@ -69012,16 +69012,16 @@ static void mw_partitionzmeither_1_3314 (void) {
 			break;
 		case 1LL: // L1
 			mtp_L1_0();
-			mw_partitionzmeitherzmbase_0_3314();
+			mw_partitionzmeitherzmbase_0_3316();
 			break;
 		case 2LL: // L2
 			mtp_L2_0();
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeitherzmbase_0_3314();
+				mw_partitionzmeitherzmbase_0_3316();
 				push_value(d4);
 			}
-			mw_partitionzmeitherzmsnoc_0_3314();
+			mw_partitionzmeitherzmsnoc_0_3316();
 			break;
 		case 3LL: // L3
 			mtp_L3_0();
@@ -69029,24 +69029,24 @@ static void mw_partitionzmeither_1_3314 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_partitionzmeitherzmbase_0_3314();
+					mw_partitionzmeitherzmbase_0_3316();
 					push_value(d5);
 				}
 				push_value(d4);
 			}
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeitherzmsnoc_0_3314();
+				mw_partitionzmeitherzmsnoc_0_3316();
 				push_value(d4);
 			}
-			mw_partitionzmeitherzmsnoc_0_3314();
+			mw_partitionzmeitherzmsnoc_0_3316();
 			break;
 		case 4LL: // LCAT
 			mtp_LCAT_0();
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeither_0_3314();
+				mw_partitionzmeither_0_3316();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -69059,7 +69059,7 @@ static void mw_partitionzmeither_1_3314 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_partitionzmeither_0_3314();
+					mw_partitionzmeither_0_3316();
 					push_value(d5);
 				}
 				push_value(d4);
@@ -69087,7 +69087,7 @@ static void mw_partitionzmeither_1_3314 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeitherzmbase_0_3314 (void) {
+static void mw_partitionzmeitherzmbase_0_3316 (void) {
 	{
 		VAL d2 = pop_value();
 		mp_primzmdup();
@@ -69129,7 +69129,7 @@ static void mw_partitionzmeitherzmbase_0_3314 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeitherzmsnoc_0_3314 (void) {
+static void mw_partitionzmeitherzmsnoc_0_3316 (void) {
 	mp_primzmswap();
 	{
 		VAL d2 = pop_value();
@@ -69190,11 +69190,11 @@ static void mw_partitionzmeitherzmsnoc_0_3314 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeither_0_3314 (void) {
+static void mw_partitionzmeither_0_3316 (void) {
 	mw_zgList_1();
-	mw_partitionzmeither_1_3314();
+	mw_partitionzmeither_1_3316();
 }
-static void mw_partitionzmeither_1_3335 (void) {
+static void mw_partitionzmeither_1_3337 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L0
 			(void)pop_u64();
@@ -69203,16 +69203,16 @@ static void mw_partitionzmeither_1_3335 (void) {
 			break;
 		case 1LL: // L1
 			mtp_L1_0();
-			mw_partitionzmeitherzmbase_0_3335();
+			mw_partitionzmeitherzmbase_0_3337();
 			break;
 		case 2LL: // L2
 			mtp_L2_0();
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeitherzmbase_0_3335();
+				mw_partitionzmeitherzmbase_0_3337();
 				push_value(d4);
 			}
-			mw_partitionzmeitherzmsnoc_0_3335();
+			mw_partitionzmeitherzmsnoc_0_3337();
 			break;
 		case 3LL: // L3
 			mtp_L3_0();
@@ -69220,24 +69220,24 @@ static void mw_partitionzmeither_1_3335 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_partitionzmeitherzmbase_0_3335();
+					mw_partitionzmeitherzmbase_0_3337();
 					push_value(d5);
 				}
 				push_value(d4);
 			}
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeitherzmsnoc_0_3335();
+				mw_partitionzmeitherzmsnoc_0_3337();
 				push_value(d4);
 			}
-			mw_partitionzmeitherzmsnoc_0_3335();
+			mw_partitionzmeitherzmsnoc_0_3337();
 			break;
 		case 4LL: // LCAT
 			mtp_LCAT_0();
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeither_0_3335();
+				mw_partitionzmeither_0_3337();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -69250,7 +69250,7 @@ static void mw_partitionzmeither_1_3335 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_partitionzmeither_0_3335();
+					mw_partitionzmeither_0_3337();
 					push_value(d5);
 				}
 				push_value(d4);
@@ -69278,7 +69278,7 @@ static void mw_partitionzmeither_1_3335 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeitherzmbase_0_3335 (void) {
+static void mw_partitionzmeitherzmbase_0_3337 (void) {
 	mw_token_8();
 	{
 		VAL d2 = pop_value();
@@ -69313,7 +69313,7 @@ static void mw_partitionzmeitherzmbase_0_3335 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeitherzmsnoc_0_3335 (void) {
+static void mw_partitionzmeitherzmsnoc_0_3337 (void) {
 	mp_primzmswap();
 	{
 		VAL d2 = pop_value();
@@ -69367,11 +69367,11 @@ static void mw_partitionzmeitherzmsnoc_0_3335 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeither_0_3335 (void) {
+static void mw_partitionzmeither_0_3337 (void) {
 	mw_zgList_1();
-	mw_partitionzmeither_1_3335();
+	mw_partitionzmeither_1_3337();
 }
-static void mw_partitionzmeither_1_3356 (void) {
+static void mw_partitionzmeither_1_3358 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L0
 			(void)pop_u64();
@@ -69380,16 +69380,16 @@ static void mw_partitionzmeither_1_3356 (void) {
 			break;
 		case 1LL: // L1
 			mtp_L1_0();
-			mw_partitionzmeitherzmbase_0_3356();
+			mw_partitionzmeitherzmbase_0_3358();
 			break;
 		case 2LL: // L2
 			mtp_L2_0();
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeitherzmbase_0_3356();
+				mw_partitionzmeitherzmbase_0_3358();
 				push_value(d4);
 			}
-			mw_partitionzmeitherzmsnoc_0_3356();
+			mw_partitionzmeitherzmsnoc_0_3358();
 			break;
 		case 3LL: // L3
 			mtp_L3_0();
@@ -69397,24 +69397,24 @@ static void mw_partitionzmeither_1_3356 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_partitionzmeitherzmbase_0_3356();
+					mw_partitionzmeitherzmbase_0_3358();
 					push_value(d5);
 				}
 				push_value(d4);
 			}
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeitherzmsnoc_0_3356();
+				mw_partitionzmeitherzmsnoc_0_3358();
 				push_value(d4);
 			}
-			mw_partitionzmeitherzmsnoc_0_3356();
+			mw_partitionzmeitherzmsnoc_0_3358();
 			break;
 		case 4LL: // LCAT
 			mtp_LCAT_0();
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeither_0_3356();
+				mw_partitionzmeither_0_3358();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -69427,7 +69427,7 @@ static void mw_partitionzmeither_1_3356 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_partitionzmeither_0_3356();
+					mw_partitionzmeither_0_3358();
 					push_value(d5);
 				}
 				push_value(d4);
@@ -69455,7 +69455,7 @@ static void mw_partitionzmeither_1_3356 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeitherzmbase_0_3356 (void) {
+static void mw_partitionzmeitherzmbase_0_3358 (void) {
 	{
 		VAL d2 = pop_value();
 		mp_primzmdup();
@@ -69497,7 +69497,7 @@ static void mw_partitionzmeitherzmbase_0_3356 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeitherzmsnoc_0_3356 (void) {
+static void mw_partitionzmeitherzmsnoc_0_3358 (void) {
 	mp_primzmswap();
 	{
 		VAL d2 = pop_value();
@@ -69558,11 +69558,11 @@ static void mw_partitionzmeitherzmsnoc_0_3356 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeither_0_3356 (void) {
+static void mw_partitionzmeither_0_3358 (void) {
 	mw_zgList_1();
-	mw_partitionzmeither_1_3356();
+	mw_partitionzmeither_1_3358();
 }
-static void mw_partitionzmeither_1_3377 (void) {
+static void mw_partitionzmeither_1_3379 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L0
 			(void)pop_u64();
@@ -69571,16 +69571,16 @@ static void mw_partitionzmeither_1_3377 (void) {
 			break;
 		case 1LL: // L1
 			mtp_L1_0();
-			mw_partitionzmeitherzmbase_0_3377();
+			mw_partitionzmeitherzmbase_0_3379();
 			break;
 		case 2LL: // L2
 			mtp_L2_0();
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeitherzmbase_0_3377();
+				mw_partitionzmeitherzmbase_0_3379();
 				push_value(d4);
 			}
-			mw_partitionzmeitherzmsnoc_0_3377();
+			mw_partitionzmeitherzmsnoc_0_3379();
 			break;
 		case 3LL: // L3
 			mtp_L3_0();
@@ -69588,24 +69588,24 @@ static void mw_partitionzmeither_1_3377 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_partitionzmeitherzmbase_0_3377();
+					mw_partitionzmeitherzmbase_0_3379();
 					push_value(d5);
 				}
 				push_value(d4);
 			}
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeitherzmsnoc_0_3377();
+				mw_partitionzmeitherzmsnoc_0_3379();
 				push_value(d4);
 			}
-			mw_partitionzmeitherzmsnoc_0_3377();
+			mw_partitionzmeitherzmsnoc_0_3379();
 			break;
 		case 4LL: // LCAT
 			mtp_LCAT_0();
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeither_0_3377();
+				mw_partitionzmeither_0_3379();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -69618,7 +69618,7 @@ static void mw_partitionzmeither_1_3377 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_partitionzmeither_0_3377();
+					mw_partitionzmeither_0_3379();
 					push_value(d5);
 				}
 				push_value(d4);
@@ -69646,7 +69646,7 @@ static void mw_partitionzmeither_1_3377 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeitherzmbase_0_3377 (void) {
+static void mw_partitionzmeitherzmbase_0_3379 (void) {
 	mp_primzmdup();
 	mw_defineszmazmtypez63U_0();
 	if (pop_u64()) {
@@ -69675,7 +69675,7 @@ static void mw_partitionzmeitherzmbase_0_3377 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeitherzmsnoc_0_3377 (void) {
+static void mw_partitionzmeitherzmsnoc_0_3379 (void) {
 	mp_primzmswap();
 	{
 		VAL d2 = pop_value();
@@ -69723,11 +69723,11 @@ static void mw_partitionzmeitherzmsnoc_0_3377 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeither_0_3377 (void) {
+static void mw_partitionzmeither_0_3379 (void) {
 	mw_zgList_1();
-	mw_partitionzmeither_1_3377();
+	mw_partitionzmeither_1_3379();
 }
-static void mw_for_18_1714 (void) {
+static void mw_for_18_1716 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -69773,17 +69773,17 @@ static void mw_for_18_1714 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_1714();
+				mw_for_18_1716();
 				push_value(d4);
 			}
-			mw_for_18_1714();
+			mw_for_18_1716();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_for_18_1989 (void) {
+static void mw_for_18_1991 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -69847,17 +69847,17 @@ static void mw_for_18_1989 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_1989();
+				mw_for_18_1991();
 				push_value(d4);
 			}
-			mw_for_18_1989();
+			mw_for_18_1991();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_for_18_1993 (void) {
+static void mw_for_18_1995 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -69921,17 +69921,17 @@ static void mw_for_18_1993 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_1993();
+				mw_for_18_1995();
 				push_value(d4);
 			}
-			mw_for_18_1993();
+			mw_for_18_1995();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_for_18_2001 (void) {
+static void mw_for_18_2003 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -70001,17 +70001,17 @@ static void mw_for_18_2001 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_2001();
+				mw_for_18_2003();
 				push_value(d4);
 			}
-			mw_for_18_2001();
+			mw_for_18_2003();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_reversezmfor_0_3474 (void) {
+static void mw_reversezmfor_0_3476 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -70116,7 +70116,7 @@ static void mw_reversezmfor_0_3474 (void) {
 				mp_primzmswap();
 				push_value(d4);
 			}
-			mw_dip2_0_3474();
+			mw_dip2_0_3476();
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
@@ -70185,17 +70185,17 @@ static void mw_reversezmfor_0_3474 (void) {
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_reversezmfor_0_3474();
+				mw_reversezmfor_0_3476();
 				push_value(d4);
 			}
-			mw_reversezmfor_0_3474();
+			mw_reversezmfor_0_3476();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_dip2_0_3474 (void) {
+static void mw_dip2_0_3476 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -70233,7 +70233,7 @@ static void mw_dip2_0_3474 (void) {
 		push_value(d2);
 	}
 }
-static void mw_reversezmfor_0_3484 (void) {
+static void mw_reversezmfor_0_3486 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -70338,7 +70338,7 @@ static void mw_reversezmfor_0_3484 (void) {
 				mp_primzmswap();
 				push_value(d4);
 			}
-			mw_dip2_0_3484();
+			mw_dip2_0_3486();
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
@@ -70407,17 +70407,17 @@ static void mw_reversezmfor_0_3484 (void) {
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_reversezmfor_0_3484();
+				mw_reversezmfor_0_3486();
 				push_value(d4);
 			}
-			mw_reversezmfor_0_3484();
+			mw_reversezmfor_0_3486();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_dip2_0_3484 (void) {
+static void mw_dip2_0_3486 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -70455,7 +70455,7 @@ static void mw_dip2_0_3484 (void) {
 		push_value(d2);
 	}
 }
-static void mw_reversezmfor_0_1816 (void) {
+static void mw_reversezmfor_0_1818 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -70479,7 +70479,7 @@ static void mw_reversezmfor_0_1816 (void) {
 				mp_primzmswap();
 				push_value(d4);
 			}
-			mw_dip2_0_1816();
+			mw_dip2_0_1818();
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
@@ -70494,17 +70494,17 @@ static void mw_reversezmfor_0_1816 (void) {
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_reversezmfor_0_1816();
+				mw_reversezmfor_0_1818();
 				push_value(d4);
 			}
-			mw_reversezmfor_0_1816();
+			mw_reversezmfor_0_1818();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_dip2_0_1816 (void) {
+static void mw_dip2_0_1818 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -70515,7 +70515,7 @@ static void mw_dip2_0_1816 (void) {
 		push_value(d2);
 	}
 }
-static void mw_partitionzmeither_1_3509 (void) {
+static void mw_partitionzmeither_1_3511 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L0
 			(void)pop_u64();
@@ -70524,16 +70524,16 @@ static void mw_partitionzmeither_1_3509 (void) {
 			break;
 		case 1LL: // L1
 			mtp_L1_0();
-			mw_partitionzmeitherzmbase_0_3509();
+			mw_partitionzmeitherzmbase_0_3511();
 			break;
 		case 2LL: // L2
 			mtp_L2_0();
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeitherzmbase_0_3509();
+				mw_partitionzmeitherzmbase_0_3511();
 				push_value(d4);
 			}
-			mw_partitionzmeitherzmsnoc_0_3509();
+			mw_partitionzmeitherzmsnoc_0_3511();
 			break;
 		case 3LL: // L3
 			mtp_L3_0();
@@ -70541,24 +70541,24 @@ static void mw_partitionzmeither_1_3509 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_partitionzmeitherzmbase_0_3509();
+					mw_partitionzmeitherzmbase_0_3511();
 					push_value(d5);
 				}
 				push_value(d4);
 			}
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeitherzmsnoc_0_3509();
+				mw_partitionzmeitherzmsnoc_0_3511();
 				push_value(d4);
 			}
-			mw_partitionzmeitherzmsnoc_0_3509();
+			mw_partitionzmeitherzmsnoc_0_3511();
 			break;
 		case 4LL: // LCAT
 			mtp_LCAT_0();
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeither_0_3509();
+				mw_partitionzmeither_0_3511();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -70571,7 +70571,7 @@ static void mw_partitionzmeither_1_3509 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_partitionzmeither_0_3509();
+					mw_partitionzmeither_0_3511();
 					push_value(d5);
 				}
 				push_value(d4);
@@ -70599,7 +70599,7 @@ static void mw_partitionzmeither_1_3509 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeitherzmbase_0_3509 (void) {
+static void mw_partitionzmeitherzmbase_0_3511 (void) {
 	{
 		VAL d2 = pop_value();
 		mp_primzmdup();
@@ -70623,7 +70623,7 @@ static void mw_partitionzmeitherzmbase_0_3509 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_findzmsome_0_3531();
+			mw_findzmsome_0_3533();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -70661,7 +70661,7 @@ static void mw_partitionzmeitherzmbase_0_3509 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeitherzmsnoc_0_3509 (void) {
+static void mw_partitionzmeitherzmsnoc_0_3511 (void) {
 	mp_primzmswap();
 	{
 		VAL d2 = pop_value();
@@ -70695,7 +70695,7 @@ static void mw_partitionzmeitherzmsnoc_0_3509 (void) {
 					break;
 				case 1LL: // SOME
 					mtp_SOME_0();
-					mw_findzmsome_0_3531();
+					mw_findzmsome_0_3533();
 					break;
 				default:
 					push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -70742,11 +70742,11 @@ static void mw_partitionzmeitherzmsnoc_0_3509 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeither_0_3509 (void) {
+static void mw_partitionzmeither_0_3511 (void) {
 	mw_zgList_1();
-	mw_partitionzmeither_1_3509();
+	mw_partitionzmeither_1_3511();
 }
-static void mw_findzmsome_0_3531 (void) {
+static void mw_findzmsome_0_3533 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -70786,7 +70786,7 @@ static void mw_findzmsome_0_3531 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_3531();
+			mw_findzmsomezmaux2_0_3533();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -70836,7 +70836,7 @@ static void mw_findzmsome_0_3531 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_3531();
+					mw_findzmsomezmaux2_0_3533();
 					break;
 				default:
 					{
@@ -70853,14 +70853,14 @@ static void mw_findzmsome_0_3531 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_3531();
+				mw_findzmsome_0_3533();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_3531();
+					mw_findzmsome_0_3533();
 					break;
 				default:
 					{
@@ -70876,7 +70876,7 @@ static void mw_findzmsome_0_3531 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_3531 (void) {
+static void mw_findzmsomezmaux2_0_3533 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -70961,7 +70961,7 @@ static void mw_findzmsomezmaux2_0_3531 (void) {
 			break;
 	}
 }
-static void mw_partitionzmeither_1_3538 (void) {
+static void mw_partitionzmeither_1_3540 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L0
 			(void)pop_u64();
@@ -70970,16 +70970,16 @@ static void mw_partitionzmeither_1_3538 (void) {
 			break;
 		case 1LL: // L1
 			mtp_L1_0();
-			mw_partitionzmeitherzmbase_0_3538();
+			mw_partitionzmeitherzmbase_0_3540();
 			break;
 		case 2LL: // L2
 			mtp_L2_0();
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeitherzmbase_0_3538();
+				mw_partitionzmeitherzmbase_0_3540();
 				push_value(d4);
 			}
-			mw_partitionzmeitherzmsnoc_0_3538();
+			mw_partitionzmeitherzmsnoc_0_3540();
 			break;
 		case 3LL: // L3
 			mtp_L3_0();
@@ -70987,24 +70987,24 @@ static void mw_partitionzmeither_1_3538 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_partitionzmeitherzmbase_0_3538();
+					mw_partitionzmeitherzmbase_0_3540();
 					push_value(d5);
 				}
 				push_value(d4);
 			}
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeitherzmsnoc_0_3538();
+				mw_partitionzmeitherzmsnoc_0_3540();
 				push_value(d4);
 			}
-			mw_partitionzmeitherzmsnoc_0_3538();
+			mw_partitionzmeitherzmsnoc_0_3540();
 			break;
 		case 4LL: // LCAT
 			mtp_LCAT_0();
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeither_0_3538();
+				mw_partitionzmeither_0_3540();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -71017,7 +71017,7 @@ static void mw_partitionzmeither_1_3538 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_partitionzmeither_0_3538();
+					mw_partitionzmeither_0_3540();
 					push_value(d5);
 				}
 				push_value(d4);
@@ -71045,7 +71045,7 @@ static void mw_partitionzmeither_1_3538 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeitherzmbase_0_3538 (void) {
+static void mw_partitionzmeitherzmbase_0_3540 (void) {
 	mp_primzmdup();
 	mw_tagz63U_0();
 	mw_zgBool_1();
@@ -71075,7 +71075,7 @@ static void mw_partitionzmeitherzmbase_0_3538 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeitherzmsnoc_0_3538 (void) {
+static void mw_partitionzmeitherzmsnoc_0_3540 (void) {
 	mp_primzmswap();
 	{
 		VAL d2 = pop_value();
@@ -71124,11 +71124,11 @@ static void mw_partitionzmeitherzmsnoc_0_3538 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeither_0_3538 (void) {
+static void mw_partitionzmeither_0_3540 (void) {
 	mw_zgList_1();
-	mw_partitionzmeither_1_3538();
+	mw_partitionzmeither_1_3540();
 }
-static void mw_filter_3_3558 (void) {
+static void mw_filter_3_3560 (void) {
 	mw_zgListzp_0();
 	switch (get_top_data_tag()) {
 		case 0LL: // NONE
@@ -71137,27 +71137,27 @@ static void mw_filter_3_3558 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_filter_2_3558();
+			mw_filter_2_3560();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_filter_2_3558 (void) {
+static void mw_filter_2_3560 (void) {
 	switch (get_top_data_tag()) {
 		case 3LL: // LCAT+
 			mtp_LCATzp_0();
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_filter_2_3558();
+				mw_filter_2_3560();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_filter_2_3558();
+				mw_filter_2_3560();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -71189,7 +71189,7 @@ static void mw_filter_2_3558 (void) {
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_filter_3_3558();
+					mw_filter_3_3560();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -71200,12 +71200,12 @@ static void mw_filter_2_3558 (void) {
 					mp_primzmdrop();
 					push_value(d5);
 				}
-				mw_filter_3_3558();
+				mw_filter_3_3560();
 			}
 			break;
 	}
 }
-static void mw_for_18_1780 (void) {
+static void mw_for_18_1782 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -71239,17 +71239,17 @@ static void mw_for_18_1780 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_1780();
+				mw_for_18_1782();
 				push_value(d4);
 			}
-			mw_for_18_1780();
+			mw_for_18_1782();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeither_1_3570 (void) {
+static void mw_partitionzmeither_1_3572 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L0
 			(void)pop_u64();
@@ -71258,16 +71258,16 @@ static void mw_partitionzmeither_1_3570 (void) {
 			break;
 		case 1LL: // L1
 			mtp_L1_0();
-			mw_partitionzmeitherzmbase_0_3570();
+			mw_partitionzmeitherzmbase_0_3572();
 			break;
 		case 2LL: // L2
 			mtp_L2_0();
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeitherzmbase_0_3570();
+				mw_partitionzmeitherzmbase_0_3572();
 				push_value(d4);
 			}
-			mw_partitionzmeitherzmsnoc_0_3570();
+			mw_partitionzmeitherzmsnoc_0_3572();
 			break;
 		case 3LL: // L3
 			mtp_L3_0();
@@ -71275,24 +71275,24 @@ static void mw_partitionzmeither_1_3570 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_partitionzmeitherzmbase_0_3570();
+					mw_partitionzmeitherzmbase_0_3572();
 					push_value(d5);
 				}
 				push_value(d4);
 			}
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeitherzmsnoc_0_3570();
+				mw_partitionzmeitherzmsnoc_0_3572();
 				push_value(d4);
 			}
-			mw_partitionzmeitherzmsnoc_0_3570();
+			mw_partitionzmeitherzmsnoc_0_3572();
 			break;
 		case 4LL: // LCAT
 			mtp_LCAT_0();
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_partitionzmeither_0_3570();
+				mw_partitionzmeither_0_3572();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -71305,7 +71305,7 @@ static void mw_partitionzmeither_1_3570 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_partitionzmeither_0_3570();
+					mw_partitionzmeither_0_3572();
 					push_value(d5);
 				}
 				push_value(d4);
@@ -71333,7 +71333,7 @@ static void mw_partitionzmeither_1_3570 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeitherzmbase_0_3570 (void) {
+static void mw_partitionzmeitherzmbase_0_3572 (void) {
 	mp_primzmdup();
 	mw_callablez63U_0();
 	if (pop_u64()) {
@@ -71362,7 +71362,7 @@ static void mw_partitionzmeitherzmbase_0_3570 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeitherzmsnoc_0_3570 (void) {
+static void mw_partitionzmeitherzmsnoc_0_3572 (void) {
 	mp_primzmswap();
 	{
 		VAL d2 = pop_value();
@@ -71410,11 +71410,11 @@ static void mw_partitionzmeitherzmsnoc_0_3570 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_partitionzmeither_0_3570 (void) {
+static void mw_partitionzmeither_0_3572 (void) {
 	mw_zgList_1();
-	mw_partitionzmeither_1_3570();
+	mw_partitionzmeither_1_3572();
 }
-static void mw_findzmsome_0_3592 (void) {
+static void mw_findzmsome_0_3594 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -71429,7 +71429,7 @@ static void mw_findzmsome_0_3592 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_3592();
+			mw_findzmsomezmaux2_0_3594();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -71454,7 +71454,7 @@ static void mw_findzmsome_0_3592 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_3592();
+					mw_findzmsomezmaux2_0_3594();
 					break;
 				default:
 					{
@@ -71471,14 +71471,14 @@ static void mw_findzmsome_0_3592 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_3592();
+				mw_findzmsome_0_3594();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_3592();
+					mw_findzmsome_0_3594();
 					break;
 				default:
 					{
@@ -71494,7 +71494,7 @@ static void mw_findzmsome_0_3592 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_3592 (void) {
+static void mw_findzmsomezmaux2_0_3594 (void) {
 	{
 		VAL d2 = pop_value();
 		mp_primzmdup();
@@ -71529,7 +71529,7 @@ static void mw_findzmsomezmaux2_0_3592 (void) {
 			break;
 	}
 }
-static void mw_reversezmfor_0_1981 (void) {
+static void mw_reversezmfor_0_1983 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -71814,7 +71814,7 @@ static void mw_reversezmfor_0_1981 (void) {
 				mp_primzmswap();
 				push_value(d4);
 			}
-			mw_dip2_0_1981();
+			mw_dip2_0_1983();
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
@@ -72003,17 +72003,17 @@ static void mw_reversezmfor_0_1981 (void) {
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_reversezmfor_0_1981();
+				mw_reversezmfor_0_1983();
 				push_value(d4);
 			}
-			mw_reversezmfor_0_1981();
+			mw_reversezmfor_0_1983();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_dip2_0_1981 (void) {
+static void mw_dip2_0_1983 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -72111,7 +72111,7 @@ static void mw_dip2_0_1981 (void) {
 		push_value(d2);
 	}
 }
-static void mw_filter_3_1866 (void) {
+static void mw_filter_3_1868 (void) {
 	mw_zgListzp_0();
 	switch (get_top_data_tag()) {
 		case 0LL: // NONE
@@ -72120,14 +72120,14 @@ static void mw_filter_3_1866 (void) {
 			break;
 		case 1LL: // SOME
 			mtp_SOME_0();
-			mw_filter_2_1866();
+			mw_filter_2_1868();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_for_18_1790 (void) {
+static void mw_for_18_1792 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -72257,17 +72257,17 @@ static void mw_for_18_1790 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_1790();
+				mw_for_18_1792();
 				push_value(d4);
 			}
-			mw_for_18_1790();
+			mw_for_18_1792();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_map_0_1867 (void) {
+static void mw_map_0_1869 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -72345,13 +72345,13 @@ static void mw_map_0_1867 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1867();
+					mw_map_0_1869();
 					push_value(d5);
 				}
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1867();
+					mw_map_0_1869();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -72364,20 +72364,20 @@ static void mw_map_0_1867 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_filter_2_1866 (void) {
+static void mw_filter_2_1868 (void) {
 	switch (get_top_data_tag()) {
 		case 3LL: // LCAT+
 			mtp_LCATzp_0();
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_filter_2_1866();
+				mw_filter_2_1868();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			{
 				VAL d4 = pop_value();
-				mw_filter_2_1866();
+				mw_filter_2_1868();
 				push_value(d4);
 			}
 			mp_primzmswap();
@@ -72407,7 +72407,7 @@ static void mw_filter_2_1866 (void) {
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_filter_3_1866();
+					mw_filter_3_1868();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -72418,12 +72418,12 @@ static void mw_filter_2_1866 (void) {
 					mp_primzmdrop();
 					push_value(d5);
 				}
-				mw_filter_3_1866();
+				mw_filter_3_1868();
 			}
 			break;
 	}
 }
-static void mw_findzmsome_0_1851 (void) {
+static void mw_findzmsome_0_1853 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -72431,7 +72431,7 @@ static void mw_findzmsome_0_1851 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_1851();
+			mw_findzmsomezmaux2_0_1853();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -72449,7 +72449,7 @@ static void mw_findzmsome_0_1851 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_1851();
+					mw_findzmsomezmaux2_0_1853();
 					break;
 				default:
 					{
@@ -72466,14 +72466,14 @@ static void mw_findzmsome_0_1851 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_1851();
+				mw_findzmsome_0_1853();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_1851();
+					mw_findzmsome_0_1853();
 					break;
 				default:
 					{
@@ -72489,7 +72489,7 @@ static void mw_findzmsome_0_1851 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_1851 (void) {
+static void mw_findzmsomezmaux2_0_1853 (void) {
 	{
 		VAL d2 = pop_value();
 		mw_primz63U_0();
@@ -72510,7 +72510,7 @@ static void mw_findzmsomezmaux2_0_1851 (void) {
 			break;
 	}
 }
-static void mw_map_0_1014 (void) {
+static void mw_map_0_1016 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -72588,13 +72588,13 @@ static void mw_map_0_1014 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1014();
+					mw_map_0_1016();
 					push_value(d5);
 				}
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1014();
+					mw_map_0_1016();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -72675,7 +72675,7 @@ static void mw_for_18_157 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_for_18_842 (void) {
+static void mw_for_18_844 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -72709,17 +72709,17 @@ static void mw_for_18_842 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_842();
+				mw_for_18_844();
 				push_value(d4);
 			}
-			mw_for_18_842();
+			mw_for_18_844();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_for_18_854 (void) {
+static void mw_for_18_856 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -72819,10 +72819,10 @@ static void mw_for_18_854 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_854();
+				mw_for_18_856();
 				push_value(d4);
 			}
-			mw_for_18_854();
+			mw_for_18_856();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -73821,7 +73821,7 @@ static void mw_for_18_317 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsome_0_3671 (void) {
+static void mw_findzmsome_0_3673 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -73841,7 +73841,7 @@ static void mw_findzmsome_0_3671 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_3671();
+			mw_findzmsomezmaux2_0_3673();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -73871,7 +73871,7 @@ static void mw_findzmsome_0_3671 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_3671();
+					mw_findzmsomezmaux2_0_3673();
 					break;
 				default:
 					{
@@ -73888,14 +73888,14 @@ static void mw_findzmsome_0_3671 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_3671();
+				mw_findzmsome_0_3673();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_3671();
+					mw_findzmsome_0_3673();
 					break;
 				default:
 					{
@@ -73911,7 +73911,7 @@ static void mw_findzmsome_0_3671 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_3671 (void) {
+static void mw_findzmsomezmaux2_0_3673 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -73956,7 +73956,7 @@ static void mw_findzmsomezmaux2_0_3671 (void) {
 			break;
 	}
 }
-static void mw_findzmsome_0_3680 (void) {
+static void mw_findzmsome_0_3682 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -73976,7 +73976,7 @@ static void mw_findzmsome_0_3680 (void) {
 			break;
 		case 1LL: // L2+
 			mtp_L2zp_0();
-			mw_findzmsomezmaux2_0_3680();
+			mw_findzmsomezmaux2_0_3682();
 			break;
 		case 2LL: // L3+
 			mtp_L3zp_0();
@@ -74006,7 +74006,7 @@ static void mw_findzmsome_0_3680 (void) {
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsomezmaux2_0_3680();
+					mw_findzmsomezmaux2_0_3682();
 					break;
 				default:
 					{
@@ -74023,14 +74023,14 @@ static void mw_findzmsome_0_3680 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_findzmsome_0_3680();
+				mw_findzmsome_0_3682();
 				push_value(d4);
 			}
 			mp_primzmswap();
 			switch (get_top_data_tag()) {
 				case 0LL: // NONE
 					(void)pop_u64();
-					mw_findzmsome_0_3680();
+					mw_findzmsome_0_3682();
 					break;
 				default:
 					{
@@ -74046,7 +74046,7 @@ static void mw_findzmsome_0_3680 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_findzmsomezmaux2_0_3680 (void) {
+static void mw_findzmsomezmaux2_0_3682 (void) {
 	{
 		VAL d2 = pop_value();
 		{
@@ -74567,7 +74567,7 @@ static void mw_for_18_311 (void) {
 			mp_primzmpanic();
 	}
 }
-static void mw_for_18_1098 (void) {
+static void mw_for_18_1100 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -74601,17 +74601,17 @@ static void mw_for_18_1098 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_1098();
+				mw_for_18_1100();
 				push_value(d4);
 			}
-			mw_for_18_1098();
+			mw_for_18_1100();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_for_18_1387 (void) {
+static void mw_for_18_1389 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -74711,17 +74711,17 @@ static void mw_for_18_1387 (void) {
 			mp_primzmdrop();
 			{
 				VAL d4 = pop_value();
-				mw_for_18_1387();
+				mw_for_18_1389();
 				push_value(d4);
 			}
-			mw_for_18_1387();
+			mw_for_18_1389();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primzmpanic();
 	}
 }
-static void mw_map_0_1383 (void) {
+static void mw_map_0_1385 (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // L1+
 			mtp_L1zp_0();
@@ -74835,13 +74835,13 @@ static void mw_map_0_1383 (void) {
 				VAL d4 = pop_value();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1383();
+					mw_map_0_1385();
 					push_value(d5);
 				}
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_map_0_1383();
+					mw_map_0_1385();
 					push_value(d5);
 				}
 				mp_primzmswap();
@@ -74860,10 +74860,10 @@ static void mb_99 (void) {
 static void mb_174 (void) {
 	mw_manglezmcomputezn_0();
 }
-static void mb_793 (void) {
+static void mb_795 (void) {
 	mw_zgInt_3();
 }
-static void mb_987 (void) {
+static void mb_989 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_f = pop_value();
 	pop_value();
@@ -74872,7 +74872,7 @@ static void mb_987 (void) {
 	run_value(var_f);
 	decref(var_f);
 }
-static void mb_1719 (void) {
+static void mb_1721 (void) {
 	mw_unpack_1();
 	mp_primzmswap();
 	{
@@ -74881,7 +74881,7 @@ static void mb_1719 (void) {
 		push_value(d2);
 	}
 }
-static void mb_1720 (void) {
+static void mb_1722 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_f = pop_value();
 	pop_value();
@@ -74890,17 +74890,17 @@ static void mb_1720 (void) {
 	mw_abzmunifyzmtypezn_0();
 	decref(var_f);
 }
-static void mb_1722 (void) {
+static void mb_1724 (void) {
 	mw_ctxzmtype_2();
 }
-static void mb_1723 (void) {
+static void mb_1725 (void) {
 	mw_body_8();
 }
-static void mb_1725 (void) {
+static void mb_1727 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_f = pop_value();
 	pop_value();
-	push_fnptr(&mb_1726);
+	push_fnptr(&mb_1728);
 	incref(var_f);
 	push_value(var_f);
 	mp_primzmpackzmcons();
@@ -74908,7 +74908,7 @@ static void mb_1725 (void) {
 	mw_ready_0();
 	decref(var_f);
 }
-static void mb_1726 (void) {
+static void mb_1728 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_f = pop_value();
 	pop_value();
@@ -74920,7 +74920,7 @@ static void mb_1726 (void) {
 	}
 	decref(var_f);
 }
-static void mb_1756 (void) {
+static void mb_1758 (void) {
 	mp_primzmswap();
 	{
 		VAL d2 = pop_value();
@@ -74950,7 +74950,7 @@ static void mb_1756 (void) {
 	mp_primzmdrop();
 	mp_primzmdrop();
 }
-static void mb_1770 (void) {
+static void mb_1772 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	pop_value();
@@ -74960,7 +74960,7 @@ static void mb_1770 (void) {
 	mw_Tztzp_0();
 	decref(var_tag);
 }
-static void mb_1779 (void) {
+static void mb_1781 (void) {
 	mp_primzmdup();
 	mw_ctx_0();
 	mp_primzmswap();
@@ -74976,7 +74976,7 @@ static void mb_1779 (void) {
 	mw_home_0();
 	mw_elabzmarrowzmhomzn_0();
 }
-static void mb_1814 (void) {
+static void mb_1816 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_mkbod = pop_value();
 	pop_value();
@@ -74988,7 +74988,7 @@ static void mb_1814 (void) {
 	}
 	decref(var_mkbod);
 }
-static void mb_1865 (void) {
+static void mb_1867 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_aliasqname = pop_value();
 	pop_value();
@@ -74997,7 +74997,7 @@ static void mb_1865 (void) {
 		case 0LL: // LEFT
 			mtp_LEFT_0();
 			mw_defs_0();
-			mw_filter_3_1866();
+			mw_filter_3_1868();
 			switch (get_top_data_tag()) {
 				case 0LL: // L0
 					(void)pop_u64();
@@ -75098,13 +75098,13 @@ static void mb_1865 (void) {
 								VAL d8 = pop_value();
 								{
 									VAL d9 = pop_value();
-									mw_map_0_1867();
+									mw_map_0_1869();
 									push_value(d9);
 								}
 								mp_primzmswap();
 								{
 									VAL d9 = pop_value();
-									mw_map_0_1867();
+									mw_map_0_1869();
 									push_value(d9);
 								}
 								mp_primzmswap();
@@ -75283,7 +75283,7 @@ static void mb_1865 (void) {
 	}
 	decref(var_aliasqname);
 }
-static void mb_1883 (void) {
+static void mb_1885 (void) {
 	mw_sig_1();
 	mw_unwrap_0();
 	mw_typezmsigzmstartzn_0();
@@ -75296,10 +75296,10 @@ static void mb_1883 (void) {
 	mw_pack2_0();
 	mw_rdrop_1();
 }
-static void mb_1885 (void) {
+static void mb_1887 (void) {
 	mw_elabzmdefzmparamszn_0();
 }
-static void mb_1886 (void) {
+static void mb_1888 (void) {
 	mp_primzmdup();
 	mp_primzmdup();
 	mp_primzmdup();
@@ -75472,7 +75472,7 @@ static void mb_1886 (void) {
 						mp_primzmswap();
 						push_value(d6);
 					}
-					mw_dip2_0_3474();
+					mw_dip2_0_3476();
 					mp_primzmswap();
 					{
 						VAL d6 = pop_value();
@@ -75541,10 +75541,10 @@ static void mb_1886 (void) {
 					mp_primzmswap();
 					{
 						VAL d6 = pop_value();
-						mw_reversezmfor_0_3474();
+						mw_reversezmfor_0_3476();
 						push_value(d6);
 					}
-					mw_reversezmfor_0_3474();
+					mw_reversezmfor_0_3476();
 					break;
 				default:
 					push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -75602,7 +75602,7 @@ static void mb_1886 (void) {
 	}
 	mw_checkzminlinezmrecursionzmarrowzn_0();
 }
-static void mb_1901 (void) {
+static void mb_1903 (void) {
 	mw_sig_0();
 	mw_typezmsigzmstartzn_0();
 	mw_elabzmtypezmsigzn_0();
@@ -75614,10 +75614,10 @@ static void mb_1901 (void) {
 	mw_pack2_0();
 	mw_rdrop_1();
 }
-static void mb_1906 (void) {
+static void mb_1908 (void) {
 	mw_elabzmsimplezmtypezmargzn_0();
 }
-static void mb_1928 (void) {
+static void mb_1930 (void) {
 	mp_primzmdup();
 	mw_data_0();
 	mw_headz63U_0();
@@ -75669,7 +75669,7 @@ static void mb_1928 (void) {
 	mw_pack2_0();
 	mw_rdrop_1();
 }
-static void mb_1941 (void) {
+static void mb_1943 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_dat = pop_value();
 	pop_value();
@@ -75871,14 +75871,14 @@ static void mb_1941 (void) {
 	}
 	decref(var_dat);
 }
-static void mb_1944 (void) {
+static void mb_1946 (void) {
 	mw_ctxzmtype_0();
 	mw_unpack_1();
 	mp_primzmswap();
 	mw_Tzmzg_0();
 	mw_pack2_0();
 }
-static void mb_1945 (void) {
+static void mb_1947 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_untag = pop_value();
 	mp_primzmpackzmuncons();
@@ -75886,7 +75886,7 @@ static void mb_1945 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	pop_value();
-	push_fnptr(&mb_1946);
+	push_fnptr(&mb_1948);
 	incref(var_tag);
 	push_value(var_tag);
 	mp_primzmpackzmcons();
@@ -75901,7 +75901,7 @@ static void mb_1945 (void) {
 	decref(var_dat);
 	decref(var_tag);
 }
-static void mb_1946 (void) {
+static void mb_1948 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_untag = pop_value();
 	mp_primzmpackzmuncons();
@@ -75919,7 +75919,7 @@ static void mb_1946 (void) {
 	mw_headz63U_0();
 	mw_unwrap_0();
 	LPUSH(lbl_body);
-	push_fnptr(&mb_1947);
+	push_fnptr(&mb_1949);
 	incref(var_tag);
 	push_value(var_tag);
 	mp_primzmpackzmcons();
@@ -75931,7 +75931,7 @@ static void mb_1946 (void) {
 	decref(var_dat);
 	decref(var_tag);
 }
-static void mb_1947 (void) {
+static void mb_1949 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_dat = pop_value();
 	mp_primzmpackzmuncons();
@@ -75942,16 +75942,16 @@ static void mb_1947 (void) {
 	mw_headz63U_0();
 	mw_unwrap_0();
 	mp_primzmdup();
-	push_fnptr(&mb_1948);
+	push_fnptr(&mb_1950);
 	incref(var_tag);
 	push_value(var_tag);
 	mp_primzmpackzmcons();
-	push_fnptr(&mb_1949);
+	push_fnptr(&mb_1951);
 	mw_casezn_0();
 	decref(var_dat);
 	decref(var_tag);
 }
-static void mb_1948 (void) {
+static void mb_1950 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	pop_value();
@@ -75960,9 +75960,9 @@ static void mb_1948 (void) {
 	mw_tagzn_0();
 	decref(var_tag);
 }
-static void mb_1949 (void) {
+static void mb_1951 (void) {
 }
-static void mb_1952 (void) {
+static void mb_1954 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_dat = pop_value();
 	mp_primzmpackzmuncons();
@@ -75978,7 +75978,7 @@ static void mb_1952 (void) {
 		push_i64(0LL);
 		mw_datazmqname_0();
 		mw_undefinedz63U_0();
-		push_fnptr(&mb_1953);
+		push_fnptr(&mb_1955);
 		incref(var_tag);
 		push_value(var_tag);
 		mp_primzmpackzmcons();
@@ -75994,7 +75994,7 @@ static void mb_1952 (void) {
 	decref(var_dat);
 	decref(var_tag);
 }
-static void mb_1953 (void) {
+static void mb_1955 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_dat = pop_value();
 	mp_primzmpackzmuncons();
@@ -76038,7 +76038,7 @@ static void mb_1953 (void) {
 		VAL var_lblzulens = pop_value();
 		VAL var_lblzuset = pop_value();
 		VAL var_lblzuget = pop_value();
-		push_fnptr(&mb_1954);
+		push_fnptr(&mb_1956);
 		incref(var_lbl);
 		push_value(var_lbl);
 		mp_primzmpackzmcons();
@@ -76052,18 +76052,6 @@ static void mb_1953 (void) {
 		mp_primzmmutzmset();
 		incref(var_lblzuget);
 		push_value(var_lblzuget);
-		push_fnptr(&mb_1955);
-		incref(var_lbl);
-		push_value(var_lbl);
-		mp_primzmpackzmcons();
-		incref(var_tag);
-		push_value(var_tag);
-		mp_primzmpackzmcons();
-		mw_delay_0();
-		incref(var_lblzuget);
-		push_value(var_lblzuget);
-		mfld_z126Uarrow_1();
-		mp_primzmmutzmset();
 		push_fnptr(&mb_1957);
 		incref(var_lbl);
 		push_value(var_lbl);
@@ -76071,6 +76059,18 @@ static void mb_1953 (void) {
 		incref(var_tag);
 		push_value(var_tag);
 		mp_primzmpackzmcons();
+		mw_delay_0();
+		incref(var_lblzuget);
+		push_value(var_lblzuget);
+		mfld_z126Uarrow_1();
+		mp_primzmmutzmset();
+		push_fnptr(&mb_1959);
+		incref(var_lbl);
+		push_value(var_lbl);
+		mp_primzmpackzmcons();
+		incref(var_tag);
+		push_value(var_tag);
+		mp_primzmpackzmcons();
 		mw_delay0_0();
 		incref(var_lblzuset);
 		push_value(var_lblzuset);
@@ -76078,7 +76078,7 @@ static void mb_1953 (void) {
 		mp_primzmmutzmset();
 		incref(var_lblzuset);
 		push_value(var_lblzuset);
-		push_fnptr(&mb_1958);
+		push_fnptr(&mb_1960);
 		incref(var_lbl);
 		push_value(var_lbl);
 		mp_primzmpackzmcons();
@@ -76090,7 +76090,7 @@ static void mb_1953 (void) {
 		push_value(var_lblzuset);
 		mfld_z126Uarrow_1();
 		mp_primzmmutzmset();
-		push_fnptr(&mb_1960);
+		push_fnptr(&mb_1962);
 		incref(var_tag);
 		push_value(var_tag);
 		mp_primzmpackzmcons();
@@ -76104,7 +76104,7 @@ static void mb_1953 (void) {
 		mp_primzmmutzmset();
 		incref(var_lblzulens);
 		push_value(var_lblzulens);
-		push_fnptr(&mb_1961);
+		push_fnptr(&mb_1963);
 		mtw_LAZZYzuDELAY_0();
 		incref(var_lblzulens);
 		push_value(var_lblzulens);
@@ -76112,7 +76112,7 @@ static void mb_1953 (void) {
 		mp_primzmmutzmset();
 		incref(var_lblzulens);
 		push_value(var_lblzulens);
-		push_fnptr(&mb_1962);
+		push_fnptr(&mb_1964);
 		incref(var_lblzuset);
 		push_value(var_lblzuset);
 		mp_primzmpackzmcons();
@@ -76138,7 +76138,7 @@ static void mb_1953 (void) {
 	decref(var_lbl);
 	decref(var_tag);
 }
-static void mb_1954 (void) {
+static void mb_1956 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	mp_primzmpackzmuncons();
@@ -76156,13 +76156,13 @@ static void mb_1954 (void) {
 	decref(var_tag);
 	decref(var_lbl);
 }
-static void mb_1955 (void) {
+static void mb_1957 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	mp_primzmpackzmuncons();
 	VAL var_lbl = pop_value();
 	pop_value();
-	push_fnptr(&mb_1956);
+	push_fnptr(&mb_1958);
 	incref(var_lbl);
 	push_value(var_lbl);
 	mp_primzmpackzmcons();
@@ -76173,7 +76173,7 @@ static void mb_1955 (void) {
 	decref(var_tag);
 	decref(var_lbl);
 }
-static void mb_1956 (void) {
+static void mb_1958 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	mp_primzmpackzmuncons();
@@ -76188,7 +76188,7 @@ static void mb_1956 (void) {
 	decref(var_tag);
 	decref(var_lbl);
 }
-static void mb_1957 (void) {
+static void mb_1959 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	mp_primzmpackzmuncons();
@@ -76206,13 +76206,13 @@ static void mb_1957 (void) {
 	decref(var_tag);
 	decref(var_lbl);
 }
-static void mb_1958 (void) {
+static void mb_1960 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	mp_primzmpackzmuncons();
 	VAL var_lbl = pop_value();
 	pop_value();
-	push_fnptr(&mb_1959);
+	push_fnptr(&mb_1961);
 	incref(var_lbl);
 	push_value(var_lbl);
 	mp_primzmpackzmcons();
@@ -76223,7 +76223,7 @@ static void mb_1958 (void) {
 	decref(var_tag);
 	decref(var_lbl);
 }
-static void mb_1959 (void) {
+static void mb_1961 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	mp_primzmpackzmuncons();
@@ -76238,7 +76238,7 @@ static void mb_1959 (void) {
 	decref(var_tag);
 	decref(var_lbl);
 }
-static void mb_1960 (void) {
+static void mb_1962 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_lbl = pop_value();
 	mp_primzmpackzmuncons();
@@ -76331,7 +76331,7 @@ static void mb_1960 (void) {
 	decref(var_lbl);
 	decref(var_tag);
 }
-static void mb_1961 (void) {
+static void mb_1963 (void) {
 	mw_type_10();
 	mw_dom_15();
 	mw_forcezmconsz63Uzn_0();
@@ -76356,7 +76356,7 @@ static void mb_1961 (void) {
 	mw_newzmautozmrunzn_0();
 	mtw_L1_0();
 }
-static void mb_1962 (void) {
+static void mb_1964 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_lblzulens = pop_value();
 	mp_primzmpackzmuncons();
@@ -76366,7 +76366,7 @@ static void mb_1962 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_lblzuset = pop_value();
 	pop_value();
-	push_fnptr(&mb_1963);
+	push_fnptr(&mb_1965);
 	incref(var_lblzuset);
 	push_value(var_lblzuset);
 	mp_primzmpackzmcons();
@@ -76385,7 +76385,7 @@ static void mb_1962 (void) {
 	decref(var_lblzuget);
 	decref(var_lblzuset);
 }
-static void mb_1963 (void) {
+static void mb_1965 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_lblzulens = pop_value();
 	mp_primzmpackzmuncons();
@@ -76399,7 +76399,7 @@ static void mb_1963 (void) {
 	push_value(var_lblzulens);
 	mw_params_2();
 	mp_primzmdup();
-	push_fnptr(&mb_1964);
+	push_fnptr(&mb_1966);
 	incref(var_lblzuset);
 	push_value(var_lblzuset);
 	mp_primzmpackzmcons();
@@ -76415,7 +76415,7 @@ static void mb_1963 (void) {
 	decref(var_lblzuget);
 	decref(var_lblzuset);
 }
-static void mb_1964 (void) {
+static void mb_1966 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_dat = pop_value();
 	mp_primzmpackzmuncons();
@@ -76477,7 +76477,7 @@ static void mb_1964 (void) {
 	} else {
 		push_u64(1LL); // PRIM_CORE_DUP
 		mw_abzmprimzn_0();
-		push_fnptr(&mb_1968);
+		push_fnptr(&mb_1970);
 		incref(var_lblzuget);
 		push_value(var_lblzuget);
 		mp_primzmpackzmcons();
@@ -76490,7 +76490,7 @@ static void mb_1964 (void) {
 	decref(var_lblzuget);
 	decref(var_lblzuset);
 }
-static void mb_1968 (void) {
+static void mb_1970 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_lblzuget = pop_value();
 	pop_value();
@@ -76501,7 +76501,7 @@ static void mb_1968 (void) {
 	mw_abzmvarzn_0();
 	decref(var_lblzuget);
 }
-static void mb_2013 (void) {
+static void mb_2015 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_t = pop_value();
 	mp_primzmpackzmuncons();
@@ -76515,7 +76515,7 @@ static void mb_2013 (void) {
 	push_value(var_x);
 	mw_zgParam_0();
 	mtw_L1_0();
-	push_fnptr(&mb_2014);
+	push_fnptr(&mb_2016);
 	incref(var_x);
 	push_value(var_x);
 	mp_primzmpackzmcons();
@@ -76526,7 +76526,7 @@ static void mb_2013 (void) {
 	decref(var_t);
 	decref(var_x);
 }
-static void mb_2014 (void) {
+static void mb_2016 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_t = pop_value();
 	mp_primzmpackzmuncons();
@@ -76534,11 +76534,11 @@ static void mb_2014 (void) {
 	pop_value();
 	push_i64(1LL);
 	mw_abzmintzn_0();
-	push_fnptr(&mb_2015);
+	push_fnptr(&mb_2017);
 	incref(var_t);
 	push_value(var_t);
 	mp_primzmpackzmcons();
-	push_fnptr(&mb_2016);
+	push_fnptr(&mb_2018);
 	incref(var_x);
 	push_value(var_x);
 	mp_primzmpackzmcons();
@@ -76548,7 +76548,7 @@ static void mb_2014 (void) {
 	decref(var_t);
 	decref(var_x);
 }
-static void mb_2015 (void) {
+static void mb_2017 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_t = pop_value();
 	pop_value();
@@ -76570,13 +76570,13 @@ static void mb_2015 (void) {
 	mw_abzmprimzn_0();
 	decref(var_t);
 }
-static void mb_2016 (void) {
+static void mb_2018 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_x = pop_value();
 	pop_value();
 	push_u64(1LL); // PRIM_CORE_DUP
 	mw_abzmprimzn_0();
-	push_fnptr(&mb_2017);
+	push_fnptr(&mb_2019);
 	incref(var_x);
 	push_value(var_x);
 	mp_primzmpackzmcons();
@@ -76587,7 +76587,7 @@ static void mb_2016 (void) {
 	mw_abzmprimzn_0();
 	decref(var_x);
 }
-static void mb_2017 (void) {
+static void mb_2019 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_x = pop_value();
 	pop_value();
@@ -76598,13 +76598,13 @@ static void mb_2017 (void) {
 	mw_abzmvarzn_0();
 	decref(var_x);
 }
-static void mb_2027 (void) {
+static void mb_2029 (void) {
 	mw_elabzmsimplezmtypezmargzn_0();
 }
-static void mb_2028 (void) {
+static void mb_2030 (void) {
 	mw_elabzmsimplezmtypezmargzn_0();
 }
-static void mb_2057 (void) {
+static void mb_2059 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_w = pop_value();
 	mp_primzmpackzmuncons();
@@ -76617,11 +76617,11 @@ static void mb_2057 (void) {
 	incref(var_k);
 	push_value(var_k);
 	mw_zsSPKEY_0();
-	mw_for_18_2058();
+	mw_for_18_2060();
 	decref(var_w);
 	decref(var_k);
 }
-static void mb_2162 (void) {
+static void mb_2164 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	pop_value();
@@ -76642,7 +76642,7 @@ static void mb_2162 (void) {
 		push_value(d2);
 	}
 	mtw_MKC99_0();
-	push_fnptr(&mb_2164);
+	push_fnptr(&mb_2166);
 	incref(var_tag);
 	push_value(var_tag);
 	mp_primzmpackzmcons();
@@ -76664,14 +76664,14 @@ static void mb_2162 (void) {
 		push_value(d2);
 	}
 	mtw_MKC99_0();
-	push_fnptr(&mb_2176);
+	push_fnptr(&mb_2178);
 	incref(var_tag);
 	push_value(var_tag);
 	mp_primzmpackzmcons();
 	mw_then_1();
 	decref(var_tag);
 }
-static void mb_2164 (void) {
+static void mb_2166 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	pop_value();
@@ -76694,7 +76694,7 @@ static void mb_2164 (void) {
 	incref(var_tag);
 	push_value(var_tag);
 	mw_iszmtransparentz63U_0();
-	push_fnptr(&mb_2165);
+	push_fnptr(&mb_2167);
 	incref(var_tag);
 	push_value(var_tag);
 	mp_primzmpackzmcons();
@@ -76713,7 +76713,7 @@ static void mb_2164 (void) {
 	mw_line_0();
 	decref(var_tag);
 }
-static void mb_2165 (void) {
+static void mb_2167 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	pop_value();
@@ -77027,7 +77027,7 @@ static void mb_2165 (void) {
 					mp_primzmswap();
 					push_value(d5);
 				}
-				mw_dip2_0_2170();
+				mw_dip2_0_2172();
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
@@ -77136,10 +77136,10 @@ static void mb_2165 (void) {
 				mp_primzmswap();
 				{
 					VAL d5 = pop_value();
-					mw_reversezmfor_0_2170();
+					mw_reversezmfor_0_2172();
 					push_value(d5);
 				}
-				mw_reversezmfor_0_2170();
+				mw_reversezmfor_0_2172();
 				break;
 			default:
 				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -77289,7 +77289,7 @@ static void mb_2165 (void) {
 	}
 	decref(var_tag);
 }
-static void mb_2176 (void) {
+static void mb_2178 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	pop_value();
@@ -77312,7 +77312,7 @@ static void mb_2176 (void) {
 	incref(var_tag);
 	push_value(var_tag);
 	mw_iszmtransparentz63U_0();
-	push_fnptr(&mb_2177);
+	push_fnptr(&mb_2179);
 	incref(var_tag);
 	push_value(var_tag);
 	mp_primzmpackzmcons();
@@ -77331,7 +77331,7 @@ static void mb_2176 (void) {
 	mw_line_0();
 	decref(var_tag);
 }
-static void mb_2177 (void) {
+static void mb_2179 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	pop_value();
@@ -77784,10 +77784,10 @@ static void mb_2177 (void) {
 				mp_primzmdrop();
 				{
 					VAL d5 = pop_value();
-					mw_for_18_2184();
+					mw_for_18_2186();
 					push_value(d5);
 				}
-				mw_for_18_2184();
+				mw_for_18_2186();
 				break;
 			default:
 				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -77905,7 +77905,7 @@ static void mb_2177 (void) {
 	}
 	decref(var_tag);
 }
-static void mb_2207 (void) {
+static void mb_2209 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	pop_value();
@@ -77940,7 +77940,7 @@ static void mb_2207 (void) {
 	mw_put_0();
 	decref(var_tag);
 }
-static void mb_2210 (void) {
+static void mb_2212 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	mp_primzmpackzmuncons();
@@ -77978,13 +77978,13 @@ static void mb_2210 (void) {
 	decref(var_tag);
 	decref(var_lbl);
 }
-static void mb_2213 (void) {
+static void mb_2215 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	mp_primzmpackzmuncons();
 	VAL var_lbl = pop_value();
 	pop_value();
-	push_fnptr(&mb_2214);
+	push_fnptr(&mb_2216);
 	incref(var_lbl);
 	push_value(var_lbl);
 	mp_primzmpackzmcons();
@@ -78021,7 +78021,7 @@ static void mb_2213 (void) {
 	decref(var_tag);
 	decref(var_lbl);
 }
-static void mb_2214 (void) {
+static void mb_2216 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	mp_primzmpackzmuncons();
@@ -78059,18 +78059,18 @@ static void mb_2214 (void) {
 	decref(var_tag);
 	decref(var_lbl);
 }
-static void mb_2218 (void) {
+static void mb_2220 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	mp_primzmpackzmuncons();
 	VAL var_lbl = pop_value();
 	pop_value();
-	push_fnptr(&mb_2219);
+	push_fnptr(&mb_2221);
 	incref(var_tag);
 	push_value(var_tag);
 	mp_primzmpackzmcons();
 	mw_c99zmline_0();
-	push_fnptr(&mb_2220);
+	push_fnptr(&mb_2222);
 	incref(var_tag);
 	push_value(var_tag);
 	mp_primzmpackzmcons();
@@ -78203,7 +78203,7 @@ static void mb_2218 (void) {
 	}
 	mw_put_0();
 	mw_line_0();
-	push_fnptr(&mb_2228);
+	push_fnptr(&mb_2230);
 	incref(var_tag);
 	push_value(var_tag);
 	mp_primzmpackzmcons();
@@ -78211,7 +78211,7 @@ static void mb_2218 (void) {
 	decref(var_tag);
 	decref(var_lbl);
 }
-static void mb_2219 (void) {
+static void mb_2221 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	pop_value();
@@ -78246,7 +78246,7 @@ static void mb_2219 (void) {
 	mw_put_0();
 	decref(var_tag);
 }
-static void mb_2220 (void) {
+static void mb_2222 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	pop_value();
@@ -78281,7 +78281,7 @@ static void mb_2220 (void) {
 	mw_put_0();
 	decref(var_tag);
 }
-static void mb_2228 (void) {
+static void mb_2230 (void) {
 	mp_primzmpackzmuncons();
 	VAL var_tag = pop_value();
 	pop_value();
@@ -78316,7 +78316,7 @@ static void mb_2228 (void) {
 	mw_put_0();
 	decref(var_tag);
 }
-static void mb_2918 (void) {
+static void mb_2920 (void) {
 	mw_unpack3_0();
 	mp_primzmdup();
 	{
@@ -78368,7 +78368,7 @@ static void mb_2918 (void) {
 	mw_zsMKAB_0();
 	LPOP(lbl_arrow);
 }
-static void mb_3012 (void) {
+static void mb_3014 (void) {
 	mw_unpack2_0();
 	mw_ctxzmtype_2();
 	mw_specializzezmctxzmtype_0();

--- a/src/examples/sdl2.mth
+++ b/src/examples/sdl2.mth
@@ -1,4 +1,4 @@
-module(snake.sdl2)
+module(examples.sdl2)
 import(std.prelude)
 import(std.str)
 

--- a/src/examples/snake.mth
+++ b/src/examples/snake.mth
@@ -1,9 +1,9 @@
-module(snake.main)
+module(examples.snake)
+
+import(examples.sdl2)
 import(std.prelude)
 import(std.list)
 import(std.maybe)
-import(snake.sdl2)
-import(posix.posix)
 
 ##############
 # Snake Game #

--- a/src/snake/main.mth
+++ b/src/snake/main.mth
@@ -1,90 +1,87 @@
 module(snake.main)
 import(std.prelude)
+import(std.list)
+import(std.maybe)
 import(snake.sdl2)
 
 ##############
 # Snake Game #
 ##############
 
-def(main, --,
-    snake-init!
-    snake-loop!
-    snake-quit!)
+def(main, +World -- +World,
+    +Snake.init!
+    loop!
+    quit!)
+
+data(+Snake, SNAKE! ->
+    +SnakePlatform
+    +SnakeLogic)
+
+def(+Snake.platform(f),
+        (*a +SnakePlatform -- *b +SnakePlatform)
+        *a +Snake -- *b +Snake,
+    /SNAKE! rdip:f SNAKE!)
+def(+Snake.logic(f),
+        (*a +SnakeLogic -- *b +SnakeLogic)
+        *a +Snake -- *b +Snake,
+    /SNAKE! rswap rdip:f rswap SNAKE!)
+
+data(+SnakePlatform, SNAKE_PLATFORM! ->
+    +SDL
+    +SDL_Window
+    +SDL_Renderer
+    controller: SDL_JoystickID)
+
+def(+SnakePlatform.renderer(f),
+        (*a +SDL +SDL_Window +SDL_Renderer -- *b +SDL +SDL_Window +SDL_Renderer)
+        *a +SnakePlatform -- *b +SnakePlatform,
+    /SNAKE_PLATFORM!
+    ^controller:dip(f)
+    SNAKE_PLATFORM!)
+
+def(+SnakePlatform.window(f),
+        (*a +SDL +SDL_Window -- *b +SDL +SDL_Window)
+        *a +SnakePlatform -- *b +SnakePlatform,
+    renderer:rdip:f)
+
+def(+SnakePlatform.sdl(f),
+        (*a +SDL -- *b +SDL)
+        *a +SnakePlatform -- *b +SnakePlatform,
+    window:rdip:f)
+
+buffer(SNAKE_EVENT, 0x100) # TODO: fold into +SnakePlatform, or perhaps get rid of it via SDL bindings.
+buffer(SNAKE_RECT, 16) # TODO: incorporate into platform or into bindings
+
+data(+SnakeLogic, SNAKE_LOGIC! ->
+    done: Bool dead: Bool
+    direction: Direction
+    last-direction: Direction
+    mouse: Position
+    snake: List+(Position)
+    points: Int
+    timer: Int)
+
+data(Position, POSITION -> x:Int y:Int)
+def(Position.wrap, Position -- Position,
+    x(SNAKE_W %) y(SNAKE_H %))
+
+def(Position.==, Position Position -- Bool,
+    dip(/POSITION) /POSITION x> x> == y> y> == &&)
+
+data(Direction, DNORTH, DEAST, DSOUTH, DWEST)
+def(Direction.apply, Position Direction -- Position,
+    DNORTH -> y:1- wrap, DSOUTH -> y:1+ wrap,
+    DWEST -> x:1- wrap, DEAST -> x:1+ wrap)
+
+def(+SnakeLogic.enqueue, +SnakeLogic Position -- +SnakeLogic,
+    snake:cons+)
+def(+SnakeLogic.dequeue, +SnakeLogic -- +SnakeLogic Position,
+    snake(unsnoc swap >List+ unwrap))
+def(+SnakeLogic.head, +SnakeLogic -- +SnakeLogic Position,
+    snake first)
 
 def(SNAKE_W, Int, 20)
 def(SNAKE_H, Int, 20)
-
-var(snake-done, Bool)
-var(snake-dead, Bool)
-var(snake-direction, Direction)
-var(snake-last-direction, Direction)
-var(snake-x, XCoord)
-var(snake-y, YCoord)
-var(snake-window, SDL_Window*)
-var(snake-renderer, SDL_Renderer*)
-var(snake-controller, SDL_JoystickID)
-var(snake-queue-length, Offset)
-buffer(SNAKE_QUEUE_X, 0x1000)
-buffer(SNAKE_QUEUE_Y, 0x1000)
-buffer(SNAKE_GRID, 0x1000)
-buffer(SNAKE_EVENT, 0x100)
-
-data(Direction, DNORTH, DEAST, DSOUTH, DWEST)
-
-def-type(XCoord, U8)
-def(XCoord->Int, XCoord -- Int, >Int)
-def(Int->XCoord, Int -- XCoord, >U8)
-
-def-type(YCoord, U8)
-def(YCoord->Int, YCoord -- Int, >Int)
-def(Int->YCoord, Int -- YCoord, >U8)
-
-def-type(State, U8)
-def(state-occupy, State -- State, >Int 0x1 | >U8)
-def(state-vacate, State -- State, >Int 0xFE & >U8)
-def(state-is-occupied, State -- Bool, >Int 0x1 & 0>)
-def(state-is-occupied?, State -- State Bool, dup state-is-occupied)
-
-def(snake-xy@, XCoord YCoord, snake-x @ snake-y @)
-def(snake-xy!, XCoord YCoord --, snake-y ! snake-x !)
-
-def(coords-offset, XCoord YCoord -- Offset,
-    dip(XCoord->Int) YCoord->Int SNAKE_W * + >Offset)
-def(snake-grid@, XCoord YCoord -- State,
-    coords-offset SNAKE_GRID unsafe(offset @U8))
-def(snake-grid!, State XCoord YCoord --,
-    coords-offset SNAKE_GRID unsafe(offset !U8))
-def(snake-grid-clear!, --,
-    SNAKE_W SNAKE_H * >Size SNAKE_GRID unsafe(erase))
-
-def(snake-queue-x?, Offset -- Offset XCoord, dup snake-queue-x@)
-def(snake-queue-x@, Offset -- XCoord, SNAKE_QUEUE_X unsafe(offset @U8))
-def(snake-queue-x!, XCoord Offset --, SNAKE_QUEUE_X unsafe(offset !U8))
-
-def(snake-queue-y?, Offset -- Offset YCoord, dup snake-queue-y@)
-def(snake-queue-y@, Offset -- YCoord, SNAKE_QUEUE_Y unsafe(offset @U8))
-def(snake-queue-y!, YCoord Offset --, SNAKE_QUEUE_Y unsafe(offset !U8))
-
-def(snake-queue-xy?, Offset -- Offset XCoord YCoord,
-    dup snake-queue-xy@)
-def(snake-queue-xy@, Offset -- XCoord YCoord,
-    snake-queue-y? dip(snake-queue-x@))
-def(snake-queue-xy!, XCoord YCoord Offset --,
-    tuck snake-queue-y! snake-queue-x!)
-
-def(snake-enqueue-xy!, XCoord YCoord --,
-    snake-queue-length @ snake-queue-xy!
-    snake-queue-length modify(1+))
-
-def(snake-dequeue-xy!, -- XCoord YCoord,
-    0 >Offset snake-queue-xy@
-    0 >Offset
-    while(dup 1+ snake-queue-length @ <,
-        dup
-        dip(1+ snake-queue-xy?) snake-queue-xy!)
-    drop
-    snake-queue-length modify(1-))
-
 def(SNAKE_CELL_SIZE, Int, 30)
 def(SNAKE_WINDOW_W, Int, SNAKE_W SNAKE_CELL_SIZE *)
 def(SNAKE_WINDOW_H, Int, SNAKE_H SNAKE_CELL_SIZE *)
@@ -95,94 +92,95 @@ def(SNAKE_RENDERER_FLAGS, SDL_RendererFlags,
     SDL_RENDERER_PRESENTVSYNC |)
 
 data(SnakeButton,
-    SNAKE_BUTTON_NONE,
-    SNAKE_BUTTON_UP,
-    SNAKE_BUTTON_RIGHT,
-    SNAKE_BUTTON_DOWN,
-    SNAKE_BUTTON_LEFT,
-    SNAKE_BUTTON_START)
+    UP,
+    RIGHT,
+    DOWN,
+    LEFT,
+    START)
 
-def(SDL_Scancode->SnakeButton, SDL_Scancode -- SnakeButton,
-    SDL_SCANCODE_UP -> SNAKE_BUTTON_UP,
-    SDL_SCANCODE_DOWN -> SNAKE_BUTTON_DOWN,
-    SDL_SCANCODE_LEFT -> SNAKE_BUTTON_LEFT,
-    SDL_SCANCODE_RIGHT -> SNAKE_BUTTON_RIGHT,
-    SDL_SCANCODE_SPACE -> SNAKE_BUTTON_START,
-    _ -> drop SNAKE_BUTTON_NONE)
+def(SDL_Scancode.>SnakeButton?, SDL_Scancode -- Maybe(SnakeButton),
+    SDL_SCANCODE_UP -> SnakeButton.UP SOME,
+    SDL_SCANCODE_DOWN -> SnakeButton.DOWN SOME,
+    SDL_SCANCODE_LEFT -> SnakeButton.LEFT SOME,
+    SDL_SCANCODE_RIGHT -> SnakeButton.RIGHT SOME,
+    SDL_SCANCODE_SPACE -> SnakeButton.START SOME,
+    _ -> drop NONE)
 
-def(SDL_GameControllerButton->SnakeButton, SDL_GameControllerButton -- SnakeButton,
-    SDL_CONTROLLER_BUTTON_DPAD_UP -> SNAKE_BUTTON_UP,
-    SDL_CONTROLLER_BUTTON_DPAD_DOWN -> SNAKE_BUTTON_DOWN,
-    SDL_CONTROLLER_BUTTON_DPAD_LEFT -> SNAKE_BUTTON_LEFT,
-    SDL_CONTROLLER_BUTTON_DPAD_RIGHT -> SNAKE_BUTTON_RIGHT,
-    SDL_CONTROLLER_BUTTON_START -> SNAKE_BUTTON_START,
-    _ -> drop SNAKE_BUTTON_NONE)
+def(SDL_GameControllerButton.>SnakeButton?, SDL_GameControllerButton -- Maybe(SnakeButton),
+    SDL_CONTROLLER_BUTTON_DPAD_UP -> SnakeButton.UP SOME,
+    SDL_CONTROLLER_BUTTON_DPAD_DOWN -> SnakeButton.DOWN SOME,
+    SDL_CONTROLLER_BUTTON_DPAD_LEFT -> SnakeButton.LEFT SOME,
+    SDL_CONTROLLER_BUTTON_DPAD_RIGHT -> SnakeButton.RIGHT SOME,
+    SDL_CONTROLLER_BUTTON_START -> SnakeButton.START SOME,
+    _ -> drop NONE)
 
+def(+SnakeLogic.init!, -- +SnakeLogic,
+    F >done
+    DNORTH >direction
+    DNORTH >last-direction
+    random-position >mouse
+    center-position L1+ >snake
+    F >dead
+    0 >timer
+    0 >points
+    SNAKE_LOGIC!)
 
-def(snake-reset!, --,
-    DNORTH snake-direction !
-    SNAKE_W 2 / Int->XCoord snake-x !
-    SNAKE_H 2 / Int->YCoord snake-y !
-    0 >Offset snake-queue-length !
-    snake-grid-clear!
-    snake-randomize-mouse!
-    F snake-dead !
-    0 snake-points !
-    0 tick-timer !)
+def(+SnakeLogic.rdrop, +SnakeLogic --,
+    /SNAKE_LOGIC!
+    points> timer> drop2
+    dead> snake> drop2
+    mouse> direction> drop2
+    last-direction> done> drop2)
 
-def(SNAKE_INIT_FLAGS, SDL_InitFlags,
-    SDL_INIT_VIDEO >Int
-    SDL_INIT_GAMECONTROLLER >Int |
-    >U32)
+def(+SnakeLogic.reset!, +SnakeLogic -- +SnakeLogic,
+    rdrop +SnakeLogic.init!)
 
-def(snake-init!, --,
-    snake-reset!
-
-    SNAKE_INIT_FLAGS SDL_Init 0> if(
-        SDL_GetError panic!,
-        id
-    )
-
-    SDL_NumJoysticks 0 >SDL_JoystickID while(dup2 >,
-        dup SDL_IsGameController if(
-            snake-controller ! dup
-            snake-controller @ SDL_GameControllerOpen drop,
-            1+
-        )
-    ) drop2
+def(+SnakePlatform.init!, +World -- +World +SnakePlatform,
+    SNAKE_INIT_FLAGS +SDL.init! unwrap!
 
     "Snake!" >title
     100 >x 100 >y
     SNAKE_WINDOW_W >w
     SNAKE_WINDOW_H >h
     SNAKE_WINDOW_FLAGS >flags
-    SDL_CreateWindow
-    dup .is-null if(
-        SDL_GetError panic!,
-        snake-window !
-    )
+    create-window! unwrap!
 
-    snake-window @
-    -1
-    SNAKE_RENDERER_FLAGS
-    SDL_CreateRenderer
-    dup .is-null if(
-        SDL_GetError panic!,
-        snake-renderer !
+    -1 >index
+    SNAKE_RENDERER_FLAGS >flags
+    create-renderer! unwrap!
+
+    -1 >SDL_JoystickID
+    SDL_NumJoysticks 0 >SDL_JoystickID while(dup2 >,
+        dup SDL_IsGameController if(dip:nip swap dup, 1+)
+    ) drop2 >controller
+
+    SNAKE_PLATFORM!)
+
+def(SNAKE_INIT_FLAGS, SDL_InitFlags,
+    SDL_INIT_VIDEO
+    SDL_INIT_GAMECONTROLLER |)
+
+def(+Snake.init!, +World -- +World +Snake,
+    +SnakePlatform.init!
+    +SnakeLogic.init!
+    SNAKE!)
+
+def(+Snake.loop!, +Snake -- +Snake,
+    process-events!
+    while(logic:done not,
+        present!
+        10 ms platform:sdl:delay!
+        process-events!
+        logic:update!
     ))
 
-def(snake-loop!, --,
-    F snake-done !
-    snake-process-events!
-    while(snake-done @ not,
-        snake-present!
-        0 ms SDL_Delay # maybe use a self-adjusting delay to interval reduce input latency.
-        snake-process-events!
-        snake-update!
-    ))
+def(+Snake.quit!, +World +Snake -- +World,
+    /SNAKE! rdrop quit!)
 
-def(snake-quit!, --,
-    SDL_Quit)
+def(+SnakePlatform.quit!, +World +SnakePlatform -- +World,
+    /SNAKE_PLATFORM!
+    controller> drop
+    destroy! destroy! quit!)
 
 def-type(R, Int)
 def-type(G, Int)
@@ -200,7 +198,6 @@ def-type(Y, Int)
 def-type(W, Int)
 def-type(H, Int)
 
-buffer(SNAKE_RECT, 16)
 def(snake-rect!, X Y W H --,
     unsafe(
         >I32 12 >Offset SNAKE_RECT offset !I32
@@ -209,41 +206,37 @@ def(snake-rect!, X Y W H --,
         >I32  0 >Offset SNAKE_RECT offset !I32
     ))
 
-def(snake-rect-cell!, XCoord YCoord --,
-    dip(>Int SNAKE_CELL_SIZE *)
-    >Int SNAKE_CELL_SIZE *
+def(snake-rect-cell!, Position --,
+    /POSITION
+    x> SNAKE_CELL_SIZE *
+    y> SNAKE_CELL_SIZE *
     SNAKE_CELL_SIZE
     SNAKE_CELL_SIZE
     snake-rect!)
 
-def(snake-present!, --,
-    snake-window @ SDL_ShowWindow
+def(+Snake.present!, +Snake -- +Snake,
+    platform:window:show!
+    platform:clear!
+    logic:snake for(platform:draw-cell!)
+    logic:mouse platform:draw-cell!
+    platform:renderer:unsafe-ptr SDL_RenderPresent)
 
-    snake-renderer @ snake-background-color SDL_SetRenderDrawColor
-    snake-renderer @ SDL_RenderClear
+def(+SnakePlatform.clear!, +SnakePlatform -- +SnakePlatform,
+    renderer:unsafe-ptr snake-background-color SDL_SetRenderDrawColor
+    renderer:unsafe-ptr SDL_RenderClear
+    renderer:unsafe-ptr snake-foreground-color SDL_SetRenderDrawColor)
 
-    snake-renderer @ snake-foreground-color SDL_SetRenderDrawColor
-    snake-xy@ snake-rect-cell!
-    snake-renderer @ SNAKE_RECT SDL_RenderFillRect
-    0 >Offset
-    while(dup snake-queue-length @ <,
-        snake-queue-xy? snake-rect-cell!
-        snake-renderer @ SNAKE_RECT SDL_RenderFillRect
-        1+)
-    drop
-    snake-mouse-xy@ snake-rect-cell!
-    snake-renderer @ SNAKE_RECT SDL_RenderFillRect
+def(+SnakePlatform.draw-cell!, +SnakePlatform Position -- +SnakePlatform,
+    snake-rect-cell!
+    renderer:unsafe-ptr SNAKE_RECT SDL_RenderFillRect)
 
-    snake-renderer @ SDL_RenderPresent)
+def(+Snake.process-events!, +Snake -- +Snake,
+    while(SNAKE_EVENT >SDL_Event SDL_PollEvent 0>, process-event!))
 
-def(snake-process-events!, --,
-    while(SNAKE_EVENT >SDL_Event SDL_PollEvent 0>,
-        snake-process-event!))
-
-def(snake-process-event!, --,
+def(+Snake.process-event!, +Snake -- +Snake,
     SNAKE_EVENT >SDL_Event type@
     dup SDL_QUIT == if(
-        drop T snake-done !,
+        drop T logic:done!,
 
     dup SDL_KEYDOWN == if(
         drop
@@ -251,118 +244,89 @@ def(snake-process-event!, --,
             id,
             SNAKE_EVENT >SDL_Event key keysym scancode@
             match(
-                SDL_SCANCODE_ESCAPE -> T snake-done !,
-                _ -> SDL_Scancode->SnakeButton snake-press!
+                SDL_SCANCODE_ESCAPE -> T logic:done!,
+                _ -> >SnakeButton? for:logic:press!
             )
         ),
 
     dup SDL_CONTROLLERBUTTONDOWN == if(
         drop
-        SNAKE_EVENT >SDL_Event cbutton which@ snake-controller @ == if(
+        SNAKE_EVENT >SDL_Event cbutton which@ platform:controller == if(
             SNAKE_EVENT >SDL_Event cbutton button@
-            SDL_GameControllerButton->SnakeButton snake-press!,
+            >SnakeButton? for:logic:press!,
             id
         ),
 
         drop
     ))))
 
-def(snake-press!, SnakeButton --,
-    SNAKE_BUTTON_NONE -> id,
-    SNAKE_BUTTON_UP -> DNORTH snake-turn!,
-    SNAKE_BUTTON_RIGHT -> DWEST snake-turn!,
-    SNAKE_BUTTON_DOWN -> DSOUTH snake-turn!,
-    SNAKE_BUTTON_LEFT -> DEAST snake-turn!,
-    SNAKE_BUTTON_START -> snake-dead @ if(snake-reset!, id))
+def(+SnakeLogic.press!, +SnakeLogic SnakeButton -- +SnakeLogic,
+    UP -> DNORTH turn!,
+    LEFT -> DWEST turn!,
+    DOWN -> DSOUTH turn!,
+    RIGHT -> DEAST turn!,
+    START -> dead if(reset!, id))
 
-var(tick-timer, Int)
-def(TICK_FRAMES, Int, 7)
+def(+SnakeLogic.tick-frames, +SnakeLogic -- +SnakeLogic Int,
+    40 points 5 + / 2 +)
 
-def(snake-tick!, Bool,
-    tick-timer @
-    1+ dup TICK_FRAMES >= if(
-        drop 0 tick-timer ! T,
-        tick-timer ! F
+def(+SnakeLogic.tick!, +SnakeLogic -- +SnakeLogic Bool,
+    timer:1+
+    timer tick-frames >= if(
+        0 timer! T,
+        F
     ))
 
-def(snake-update!, --,
-    snake-dead @ if(
-        id,
+def(+SnakeLogic.in-snake, +SnakeLogic Position -- +SnakeLogic Bool,
+    snake member(==))
 
-    snake-tick! if(
-        snake-direction @ snake-last-direction !
+def(+SnakeLogic.randomize-mouse!, +SnakeLogic -- +SnakeLogic,
+    random-position
+    while(dup in-snake, drop random-position)
+    mouse!)
 
-        snake-xy@
-        snake-direction @
-        snake-apply-direction
-        snake-xy!
+def(+SnakeLogic.update!, +SnakeLogic -- +SnakeLogic,
+    dead not and(tick!) then(
+        direction last-direction!
+        head direction apply
+        dup in-snake if(
+            T dead! drop,
 
-        snake-xy@ snake-grid@ >Int 0> if(
-            T snake-dead !,
-
-            1 >U8 snake-xy@ snake-grid!
-            snake-check-mouse!
-
-            snake-xy@ snake-enqueue-xy!
-            snake-queue-length @ snake-desired-length > if(
-                0 >U8 snake-dequeue-xy! snake-grid!,
-                id
+            enqueue
+            head mouse == then(
+                points:1+
+                randomize-mouse!
             )
-        ),
 
-        id
-    )))
+            snake len desired-length > then(
+                dequeue drop
+            )
+        )
+    ))
 
-var(snake-points, Int)
-def(snake-desired-length, Offset, snake-points @ 5 + >Offset)
-
-var(snake-mouse-x, XCoord)
-var(snake-mouse-y, YCoord)
-def(snake-mouse-xy@, XCoord YCoord,
-    snake-mouse-x @ snake-mouse-y @)
+def(+SnakeLogic.desired-length, +SnakeLogic -- +SnakeLogic Nat, points 5 + >Nat)
 
 def-external(libc-rand -> rand, Int)
+def(random-position, -- Position,
+    libc-rand SNAKE_W % >x
+    libc-rand SNAKE_H % >y
+    POSITION)
+def(center-position, -- Position,
+    SNAKE_W 2/ >x
+    SNAKE_H 2/ >y
+    POSITION)
 
-def(snake-randomize-mouse!, --,
-    libc-rand SNAKE_W % Int->XCoord snake-mouse-x !
-    libc-rand SNAKE_H % Int->YCoord snake-mouse-y !
+def(Direction.>Int, Direction -- Int, Direction.tag)
+def(Direction.==, Direction Direction -- Bool, both(tag) ==)
 
-    snake-mouse-xy@ snake-grid@ >Int 0> if(
-        snake-randomize-mouse!, # might lead to crash if there is no empty space ...
-        id
-    ))
-
-def(snake-check-mouse!, --,
-    snake-x @ snake-mouse-x @ both(>Int) ==
-    snake-y @ snake-mouse-y @ both(>Int) == && if(
-        snake-randomize-mouse!
-        snake-points modify(1+),
-
-        id
-    ))
-
-def(Direction->Int, Direction -- Int, Direction.tag)
-def(direction==, Direction Direction -- Bool, both(Direction->Int) ==)
-
-def(snake-turn!, Direction --,
-    dup snake-flip-direction snake-last-direction @ direction== if(
+def(+SnakeLogic.turn!, +SnakeLogic Direction -- +SnakeLogic,
+    dup flip last-direction == if(
         drop, # can't turn back directly
-        snake-direction !
+        direction!
     ))
 
-def(snake-flip-direction, Direction -- Direction,
+def(Direction.flip, Direction -- Direction,
     DNORTH -> DSOUTH,
     DWEST -> DEAST,
     DSOUTH -> DNORTH,
     DEAST -> DWEST)
-
-def(snake-direction-offset, Direction -- Int Int,
-    DNORTH ->  0 -1,
-    DEAST  -> -1  0,
-    DSOUTH ->  0  1,
-    DWEST  ->  1  0)
-
-def(snake-apply-direction, XCoord YCoord Direction -- XCoord YCoord,
-    snake-direction-offset
-    dip(swap YCoord->Int) + SNAKE_H + SNAKE_H % Int->YCoord
-    dip(dip(XCoord->Int) + SNAKE_W + SNAKE_W % Int->XCoord))

--- a/src/snake/main.mth
+++ b/src/snake/main.mth
@@ -3,6 +3,7 @@ import(std.prelude)
 import(std.list)
 import(std.maybe)
 import(snake.sdl2)
+import(posix.posix)
 
 ##############
 # Snake Game #
@@ -30,13 +31,20 @@ data(+SnakePlatform, SNAKE_PLATFORM! ->
     +SDL
     +SDL_Window
     +SDL_Renderer
-    controller: SDL_JoystickID)
+    +SDL_GameController?)
+
+def(+SnakePlatform.controller?(f),
+    (*a +SDL +SDL_GameController? -- *b +SDL +SDL_GameController?)
+    *a +SnakePlatform -- *b +SnakePlatform,
+    /SNAKE_PLATFORM!
+    rrotr rdip2(f) rrotl
+    SNAKE_PLATFORM!)
 
 def(+SnakePlatform.renderer(f),
         (*a +SDL +SDL_Window +SDL_Renderer -- *b +SDL +SDL_Window +SDL_Renderer)
         *a +SnakePlatform -- *b +SnakePlatform,
     /SNAKE_PLATFORM!
-    ^controller:dip(f)
+    rdip(f)
     SNAKE_PLATFORM!)
 
 def(+SnakePlatform.window(f),
@@ -149,10 +157,14 @@ def(+SnakePlatform.init!, +World -- +World +SnakePlatform,
     SNAKE_RENDERER_FLAGS >flags
     create-renderer! unwrap!
 
-    -1 >SDL_JoystickID
-    SDL_NumJoysticks 0 >SDL_JoystickID while(dup2 >,
-        dup SDL_IsGameController if(dip:nip swap dup, 1+)
-    ) drop2 >controller
+    rdip2(
+        0 num-joysticks range
+        find(dup is-game-controller)
+        match(
+            SOME -> game-controller-open! unwrap! +SDL_GameController?.OK!,
+            NONE -> "no controller detected" +SDL_GameController?.ERROR!
+        )
+    ) rrotl
 
     SNAKE_PLATFORM!)
 
@@ -179,7 +191,7 @@ def(+Snake.quit!, +World +Snake -- +World,
 
 def(+SnakePlatform.quit!, +World +SnakePlatform -- +World,
     /SNAKE_PLATFORM!
-    controller> drop
+    for!(rrotr rdip2(close!))
     destroy! destroy! quit!)
 
 def-type(R, Int)
@@ -251,11 +263,8 @@ def(+Snake.process-event!, +Snake -- +Snake,
 
     dup SDL_CONTROLLERBUTTONDOWN == if(
         drop
-        SNAKE_EVENT >SDL_Event cbutton which@ platform:controller == if(
-            SNAKE_EVENT >SDL_Event cbutton button@
-            >SnakeButton? for:logic:press!,
-            id
-        ),
+        SNAKE_EVENT >SDL_Event cbutton button@
+        >SnakeButton? for:logic:press!,
 
         drop
     ))))

--- a/src/snake/sdl2.mth
+++ b/src/snake/sdl2.mth
@@ -527,12 +527,32 @@ def(SDL_JoystickID.>, SDL_JoystickID SDL_JoystickID -- Bool, both(>Int) >)
 def(SDL_JoystickID.1+, SDL_JoystickID -- SDL_JoystickID, >Int 1+ >SDL_JoystickID)
 def(SDL_JoystickID.==, SDL_JoystickID SDL_JoystickID -- Bool, both(>Int) ==)
 
-data(SDL_GameController, WRAP_SDL_GAMECONTROLLER -> Ptr)
-def(Ptr.>SDL_GameController, Ptr -- SDL_GameController, WRAP_SDL_GAMECONTROLLER)
-def(SDL_GameController.>Ptr, SDL_GameController -- Ptr, WRAP_SDL_GAMECONTROLLER -> id)
-def-external(SDL_NumJoysticks, SDL_JoystickID)
-def-external(SDL_IsGameController, SDL_JoystickID -- Bool)
-def-external(SDL_GameControllerOpen, SDL_JoystickID -- SDL_GameController)
+def-external(+Unsafe.SDL_NumJoysticks, Int)
+def-external(+Unsafe.SDL_IsGameController, Int -- Bool)
+def-external(+Unsafe.SDL_GameControllerOpen, Int -- Ptr)
+def-external(+Unsafe.SDL_GameControllerClose, Ptr --)
+
+def(+SDL.num-joysticks, +SDL -- +SDL Int, unsafe(.SDL_NumJoysticks))
+def(+SDL.is-game-controller, +SDL Int -- +SDL Bool, unsafe(.SDL_IsGameController))
+
+data(+SDL_GameController, SDL_GAME_CONTROLLER! -> unsafe-ptr:Ptr)
+data(+SDL_GameController?, OK! -> +SDL_GameController, ERROR! -> Str)
+def(+SDL_GameController?.unwrap!, +SDL_GameController? -- +SDL_GameController, OK! -> id, ERROR! -> panic!)
+def(+SDL_GameController?.map!(f), (*a +SDL_GameController -- *a +SDL_GameController) *a +SDL_GameController? -- *a +SDL_GameController?,
+    OK! -> f +SDL_GameController?.OK!,
+    ERROR! -> +SDL_GameController?.ERROR!)
+def(+SDL_GameController?.for!(f), (*a +SDL_GameController -- *a) *a +SDL_GameController? -- *a,
+    OK! -> f,
+    ERROR! -> drop)
+
+def(+SDL.game-controller-open!, +SDL Int -- +SDL +SDL_GameController?,
+    unsafe(.SDL_GameControllerOpen)
+    dup is-null if(
+        drop get-error! +SDL_GameController?.ERROR!,
+        >unsafe-ptr SDL_GAME_CONTROLLER! +SDL_GameController?.OK!
+    ))
+def(+SDL_GameController.close!, +SDL +SDL_GameController -- +SDL,
+    /SDL_GAME_CONTROLLER! unsafe-ptr> unsafe(.SDL_GameControllerClose))
 
 data(SDL_GameControllerButton,
     SDL_CONTROLLER_BUTTON_A,

--- a/src/snake/sdl2.mth
+++ b/src/snake/sdl2.mth
@@ -6,16 +6,40 @@ import(std.str)
 # SDL2 Bindings #
 #################
 
-def-external(SDL_Init, SDL_InitFlags -- Int)
-def-type(SDL_InitFlags, U32) # technically this ought to be U32...
-def(SDL_INIT_TIMER, SDL_InitFlags, 0x0001 >U32)
-def(SDL_INIT_AUDIO, SDL_InitFlags, 0x0010 >U32)
-def(SDL_INIT_VIDEO, SDL_InitFlags, 0x0020 >U32)
-def(SDL_INIT_JOYSTICK, SDL_InitFlags, 0x200 >U32)
-def(SDL_INIT_HAPTIC, SDL_InitFlags, 0x1000 >U32)
-def(SDL_INIT_GAMECONTROLLER, SDL_InitFlags, 0x2000 >U32)
-def(SDL_INIT_EVENTS, SDL_InitFlags, 0x4000 >U32)
-def(SDL_INIT_SENSOR, SDL_InitFlags, 1 15 << >U32)
+def-external(+Unsafe.SDL_Init -> SDL_Init, SDL_InitFlags -- Int)
+def-external(+Unsafe.SDL_Quit -> SDL_Quit, --)
+def-external(+Unsafe.SDL_GetError -> SDL_GetError, -- Ptr)
+
+data(+SDL, SDL!)
+data(+SDL?, OK! -> +SDL, ERROR! -> Str)
+def(+SDL?.unwrap!, +SDL? -- +SDL, OK! -> id, ERROR! -> panic!)
+
+def(+SDL.get-error!, -- Str, unsafe(.SDL_GetError Str.copy-cstr))
+
+def(+SDL.init!, +World SDL_InitFlags -- +World +SDL?,
+    unsafe(.SDL_Init) 0= if(
+        SDL! +SDL?.OK!,
+        +SDL.get-error! +SDL?.ERROR!
+    ))
+
+def(+SDL.quit!, +World +SDL -- +World,
+    /SDL! unsafe(.SDL_Quit))
+
+data(SDL_InitFlags, WRAP -> U32)
+inline(
+    def(U32.>SDL_InitFlags, U32 -- SDL_InitFlags, SDL_InitFlags.WRAP)
+    def(SDL_InitFlags.>U32, SDL_InitFlags -- U32, /WRAP)
+    def(SDL_InitFlags.|, SDL_InitFlags SDL_InitFlags -- SDL_InitFlags,
+        both(>U32) | >SDL_InitFlags)
+)
+def(SDL_INIT_TIMER, SDL_InitFlags, 0x0001 >U32 >SDL_InitFlags)
+def(SDL_INIT_AUDIO, SDL_InitFlags, 0x0010 >U32 >SDL_InitFlags)
+def(SDL_INIT_VIDEO, SDL_InitFlags, 0x0020 >U32 >SDL_InitFlags)
+def(SDL_INIT_JOYSTICK, SDL_InitFlags, 0x200 >U32 >SDL_InitFlags)
+def(SDL_INIT_HAPTIC, SDL_InitFlags, 0x1000 >U32 >SDL_InitFlags)
+def(SDL_INIT_GAMECONTROLLER, SDL_InitFlags, 0x2000 >U32 >SDL_InitFlags)
+def(SDL_INIT_EVENTS, SDL_InitFlags, 0x4000 >U32 >SDL_InitFlags)
+def(SDL_INIT_SENSOR, SDL_InitFlags, 1 15 << >U32 >SDL_InitFlags)
 def(SDL_INIT_EVERYTHING, SDL_InitFlags,
     SDL_INIT_TIMER
     SDL_INIT_AUDIO |
@@ -26,56 +50,97 @@ def(SDL_INIT_EVERYTHING, SDL_InitFlags,
     SDL_INIT_EVENTS |
     SDL_INIT_SENSOR |)
 
-def-external(SDL_Quit, --)
-def-external(SDL_GetError-unsafe -> SDL_GetError, Ptr)
-def(SDL_GetError, Str, SDL_GetError-unsafe unsafe(Str.copy-cstr))
-
-def-external(SDL_Delay, SDL_Ticks --)
-def-external(SDL_GetTicks, SDL_Ticks)
+def-external(+Unsafe.SDL_Delay, SDL_Ticks --)
+def-external(+Unsafe.SDL_GetTicks, -- SDL_Ticks)
+def(+SDL.delay!, +SDL SDL_Ticks -- +SDL, unsafe(.SDL_Delay))
+def(+SDL.get-ticks!, +SDL -- SDL_Ticks +SDL, unsafe(.SDL_GetTicks))
 def-type(SDL_Ticks, U32)
 def(ms, Int -- SDL_Ticks, >U32)
 
-def-external(SDL_CreateWindow-unsafe -> SDL_CreateWindow, Ptr Int Int Int Int SDL_WindowFlags -- SDL_Window*)
-def(SDL_CreateWindow,
-    title:Str
-    x:Int y:Int
-    w:Int h:Int
-    flags:SDL_WindowFlags
-    -- SDL_Window*,
-    title> with-data-cstr(x> y> w> h> flags> SDL_CreateWindow-unsafe))
+data(+SDL_Window, SDL_WINDOW! -> unsafe-ptr:Ptr)
+data(+SDL_Window?, OK! -> +SDL_Window, ERROR! -> Str)
+def(+SDL_Window?.unwrap!, +SDL_Window? -- +SDL_Window, OK! -> id, ERROR! -> panic!)
+def-external(+Unsafe.SDL_CreateWindow -> SDL_CreateWindow, Ptr Int Int Int Int SDL_WindowFlags -- Ptr)
+def-external(+Unsafe.SDL_DestroyWindow -> SDL_DestroyWindow, Ptr --)
+def(+SDL.create-window!,
+        +SDL title:Str
+        x:Int y:Int
+        w:Int h:Int
+        flags:SDL_WindowFlags
+        -- +SDL +SDL_Window?,
+    title> with-data-cstr(
+        x> y> w> h> flags>
+        unsafe(.SDL_CreateWindow)
+    )
+    dup is-null if(
+        drop get-error! +SDL_Window?.ERROR!,
+        >unsafe-ptr SDL_WINDOW! +SDL_Window?.OK!
+    ))
+def(+SDL_Window.destroy!, +SDL +SDL_Window -- +SDL,
+    /SDL_WINDOW! unsafe-ptr> unsafe(.SDL_DestroyWindow))
 
-def-type(SDL_Window*, Ptr)
-def-type(SDL_WindowFlags, U32)
+data(SDL_WindowFlags, SDL_WINDOW_FLAGS -> U32)
+inline(
+    def(Int.>SDL_WindowFlags, Int -- SDL_WindowFlags, >U32 >SDL_WindowFlags)
+    def(U32.>SDL_WindowFlags, U32 -- SDL_WindowFlags, SDL_WINDOW_FLAGS)
+    def(SDL_WindowFlags.>U32, SDL_WindowFlags -- U32, /SDL_WINDOW_FLAGS)
+    def(SDL_WindowFlags.|, SDL_WindowFlags SDL_WindowFlags -- SDL_WindowFlags,
+        both(>U32) | >SDL_WindowFlags)
+)
+
 def(SDL_WINDOWPOS_UNDEFINED, Int, 0x1FFF 16 <<)
 def(SDL_WINDOWPOS_CENTERED, Int, 0x2FFF 16 <<)
-def(SDL_WINDOW_NONE, SDL_WindowFlags, 0 >U32)
-def(SDL_WINDOW_FULLSCREEN, SDL_WindowFlags, 0x1 >U32)
-def(SDL_WINDOW_OPENGL, SDL_WindowFlags, 0x2 >U32)
-def(SDL_WINDOW_SHOWN, SDL_WindowFlags, 0x4 >U32)
-def(SDL_WINDOW_HIDDEN, SDL_WindowFlags, 0x8 >U32)
-def(SDL_WINDOW_BORDERLESS, SDL_WindowFlags, 0x10 >U32)
-def(SDL_WINDOW_RESIZABLE, SDL_WindowFlags, 0x20 >U32)
-def(SDL_WINDOW_MINIMIZED, SDL_WindowFlags, 0x40 >U32)
-def(SDL_WINDOW_MAXIMIZED, SDL_WindowFlags, 0x80 >U32)
-def(SDL_WINDOW_INPUT_GRABBED, SDL_WindowFlags, 0x100 >U32)
-def(SDL_WINDOW_INPUT_FOCUS, SDL_WindowFlags, 0x200 >U32)
-def(SDL_WINDOW_MOUSE_FOCUS, SDL_WindowFlags, 0x400 >U32)
-def(SDL_WINDOW_FULLSCREEN_DESKTOP, SDL_WindowFlags, 0x1001 >U32)
-def(SDL_WINDOW_FOREIGN, SDL_WindowFlags, 0x800 >U32)
-def(SDL_WINDOW_ALLOW_HIGHDPI, SDL_WindowFlags, 0x2000 >U32)
-def(SDL_WINDOW_MOUSE_CAPTURE, SDL_WindowFlags, 0x4000 >U32)
-def(SDL_WINDOW_ALWAYS_ON_TOP, SDL_WindowFlags, 1 15 << >U32)
-def(SDL_WINDOW_SKIP_TASKBAR, SDL_WindowFlags, 1 16 << >U32)
-def(SDL_WINDOW_UTILITY, SDL_WindowFlags, 1 17 << >U32)
-def(SDL_WINDOW_TOOLTIP, SDL_WindowFlags, 1 18 << >U32)
-def(SDL_WINDOW_POPUP_MENU, SDL_WindowFlags, 1 19 << >U32)
-def(SDL_WINDOW_VULKAN, SDL_WindowFlags, 1 28 << >U32)
 
-def-external(SDL_ShowWindow, SDL_Window* --)
-def-external(SDL_HideWindow, SDL_Window* --)
-def-external(SDL_RaiseWindow, SDL_Window* --)
+def(SDL_WINDOW_NONE, SDL_WindowFlags, 0 >SDL_WindowFlags)
+def(SDL_WINDOW_FULLSCREEN, SDL_WindowFlags, 0x1 >SDL_WindowFlags)
+def(SDL_WINDOW_OPENGL, SDL_WindowFlags, 0x2 >SDL_WindowFlags)
+def(SDL_WINDOW_SHOWN, SDL_WindowFlags, 0x4 >SDL_WindowFlags)
+def(SDL_WINDOW_HIDDEN, SDL_WindowFlags, 0x8 >SDL_WindowFlags)
+def(SDL_WINDOW_BORDERLESS, SDL_WindowFlags, 0x10 >SDL_WindowFlags)
+def(SDL_WINDOW_RESIZABLE, SDL_WindowFlags, 0x20 >SDL_WindowFlags)
+def(SDL_WINDOW_MINIMIZED, SDL_WindowFlags, 0x40 >SDL_WindowFlags)
+def(SDL_WINDOW_MAXIMIZED, SDL_WindowFlags, 0x80 >SDL_WindowFlags)
+def(SDL_WINDOW_INPUT_GRABBED, SDL_WindowFlags, 0x100 >SDL_WindowFlags)
+def(SDL_WINDOW_INPUT_FOCUS, SDL_WindowFlags, 0x200 >SDL_WindowFlags)
+def(SDL_WINDOW_MOUSE_FOCUS, SDL_WindowFlags, 0x400 >SDL_WindowFlags)
+def(SDL_WINDOW_FULLSCREEN_DESKTOP, SDL_WindowFlags, 0x1001 >SDL_WindowFlags)
+def(SDL_WINDOW_FOREIGN, SDL_WindowFlags, 0x800 >SDL_WindowFlags)
+def(SDL_WINDOW_ALLOW_HIGHDPI, SDL_WindowFlags, 0x2000 >SDL_WindowFlags)
+def(SDL_WINDOW_MOUSE_CAPTURE, SDL_WindowFlags, 0x4000 >SDL_WindowFlags)
+def(SDL_WINDOW_ALWAYS_ON_TOP, SDL_WindowFlags, 1 15 << >SDL_WindowFlags)
+def(SDL_WINDOW_SKIP_TASKBAR, SDL_WindowFlags, 1 16 << >SDL_WindowFlags)
+def(SDL_WINDOW_UTILITY, SDL_WindowFlags, 1 17 << >SDL_WindowFlags)
+def(SDL_WINDOW_TOOLTIP, SDL_WindowFlags, 1 18 << >SDL_WindowFlags)
+def(SDL_WINDOW_POPUP_MENU, SDL_WindowFlags, 1 19 << >SDL_WindowFlags)
+def(SDL_WINDOW_VULKAN, SDL_WindowFlags, 1 28 << >SDL_WindowFlags)
 
-def-external(SDL_CreateRenderer, SDL_Window* Int SDL_RendererFlags -- SDL_Renderer*)
+def-external(+Unsafe.SDL_ShowWindow -> SDL_ShowWindow, Ptr --)
+def-external(+Unsafe.SDL_HideWindow -> SDL_HideWindow, Ptr --)
+def-external(+Unsafe.SDL_RaiseWindow -> SDL_RaiseWindow, Ptr --)
+def(+SDL_Window.show!, +SDL_Window -- +SDL_Window, .unsafe-ptr unsafe(.SDL_ShowWindow))
+def(+SDL_Window.hide!, +SDL_Window -- +SDL_Window, .unsafe-ptr unsafe(.SDL_HideWindow))
+def(+SDL_Window.raise!, +SDL_Window -- +SDL_Window, .unsafe-ptr unsafe(.SDL_RaiseWindow))
+
+data(+SDL_Renderer, SDL_RENDERER! -> unsafe-ptr:Ptr)
+data(+SDL_Renderer?, OK! -> +SDL_Renderer, ERROR! -> Str)
+def(+SDL_Renderer?.unwrap!, +SDL_Renderer? -- +SDL_Renderer, OK! -> id, ERROR! -> panic!)
+
+def-external(+Unsafe.SDL_CreateRenderer, Ptr Int SDL_RendererFlags -- Ptr)
+def-external(+Unsafe.SDL_DestroyRenderer, Ptr --)
+
+def(+SDL_Window.create-renderer!,
+        +SDL +SDL_Window index:Int flags:SDL_RendererFlags
+        -- +SDL +SDL_Window +SDL_Renderer?,
+    .unsafe-ptr index> flags> unsafe(.SDL_CreateRenderer)
+    dup is-null if(
+        drop rdip:get-error! +SDL_Renderer?.ERROR!,
+        >unsafe-ptr SDL_RENDERER! +SDL_Renderer?.OK!
+    ))
+def(+SDL_Renderer.destroy!,
+        +SDL +SDL_Window +SDL_Renderer
+        -- +SDL +SDL_Window,
+    /SDL_RENDERER! unsafe-ptr> unsafe(.SDL_DestroyRenderer))
+
 def-type(SDL_Renderer*, Ptr)
 def-type(SDL_RendererFlags, U32)
 def(SDL_RENDERER_SOFTWARE, SDL_RendererFlags, 0x1 >U32)

--- a/src/std/list.mth
+++ b/src/std/list.mth
@@ -396,6 +396,9 @@ def(List+.==(eq), (*c a a -- *c Bool) *c List+(a) List+(a) -- *c Bool,
 def(List.member(eq), (*c a a -- *c Bool) *c a List(a) -- *c Bool,
     any(dup2 dip2(eq) rotl) nip)
 
+def(List+.member(eq), (*c a a -- *c Bool) *c a List+(a) -- *c Bool,
+    any(dup2 dip2(eq) rotl) nip)
+
 def(List.difference(eq), (*c a a -- *c Bool) *c List(a) List(a) -- *c List(a),
     swap filter(dup2 dip2(swap member(eq) not) rotl) nip)
 


### PR DESCRIPTION
This PR tries to make the SDL2 bindings a little more modern by using resources. The snake example was mostly rewritten using the modern API.

Not everything has been converted to mirth-friendly types -- the renderer and event polling APIs are still very raw.
