### PR TITLE
Add macos-12 runner for CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
   build-san:
     strategy:
       matrix:
-        os: [macOS-latest, ubuntu-latest]
+        os: [macos-latest, macos-12, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        arch: [amd64,arm64,x86]
-        os: [macOS-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, macos-12, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
+        arch: [amd64,arm64,x86]
         os: [macOS-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
The change to macos-latest moved macos-14 which runs on arm64. This PR adds macos-12 runner so we don't stop testing on x64-based macs.