### PR TITLE
Fix T*, T+, T-> names.

### DIFF
--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -5160,10 +5160,10 @@ static void mw_mirth_type_PrimType_ZToInt (void);
 static void mw_mirth_type_PrimType_ZEqualZEqual (void);
 static void mw_mirth_type_defZ_primZ_typeZBang (void);
 static void mw_mirth_type_initZ_typesZBang (void);
-static void mw_mirth_type_TrueZPlus (void);
-static void mw_mirth_type_TrueZMul (void);
-static void mw_mirth_type_TrueZMulZPlus (void);
-static void mw_mirth_type_TrueZ_ZTo (void);
+static void mw_mirth_type_TZPlus (void);
+static void mw_mirth_type_TZMul (void);
+static void mw_mirth_type_TZMulZPlus (void);
+static void mw_mirth_type_TZ_ZTo (void);
 static void mw_mirth_type_TT (void);
 static void mw_mirth_type_T0 (void);
 static void mw_mirth_type_T1 (void);
@@ -13638,7 +13638,7 @@ static void mw_mirth_table_Field_type (void) {
 		push_value(d2);
 	}
 	mw_mirth_table_Field_cod();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 }
 static void mw_mirth_table_Field_ZEqualZEqual (void) {
 	{
@@ -13897,7 +13897,7 @@ static void mw_mirth_data_makeZ_primZ_tagZBang (void) {
 		mw_mirth_data_Tag_data();
 		mtw_mirth_type_Type_TData();
 		mw_mirth_type_T1();
-		mw_mirth_type_TrueZ_ZTo();
+		mw_mirth_type_TZ_ZTo();
 		mw_std_lazzy_ready2();
 		push_value(d2);
 	}
@@ -15717,7 +15717,7 @@ static void mw_mirth_arrow_Arrow_type (void) {
 		push_value(d2);
 	}
 	mw_mirth_arrow_Arrow_cod();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 }
 static void mw_mirth_arrow_Atom_ZDivAtom (void) {
 	switch (get_top_data_tag()) {
@@ -15960,7 +15960,7 @@ static void mw_mirth_arrow_Block_type (void) {
 		push_value(d2);
 	}
 	mw_mirth_arrow_Block_cod();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 }
 static void mw_mirth_arrow_Block_arrow (void) {
 	mfld_mirth_arrow_Block_ZTildearrow();
@@ -16770,28 +16770,28 @@ static void mw_mirth_type_initZ_typesZBang (void) {
 	mw_mirth_type_defZ_primZ_typeZBang();
 	mw_mirth_data_initZ_dataZBang();
 }
-static void mw_mirth_type_TrueZPlus (void) {
+static void mw_mirth_type_TZPlus (void) {
 	mtw_mirth_type_StackType_STWith();
 }
-static void mw_mirth_type_TrueZMul (void) {
+static void mw_mirth_type_TZMul (void) {
 	mtw_mirth_type_StackType_STCons();
 }
-static void mw_mirth_type_TrueZMulZPlus (void) {
+static void mw_mirth_type_TZMulZPlus (void) {
 	switch (get_top_data_tag()) {
 		case 0LL: // Left
 			mtp_std_either_Either_2_Left();
-			mw_mirth_type_TrueZMul();
+			mw_mirth_type_TZMul();
 			break;
 		case 1LL: // Right
 			mtp_std_either_Either_2_Right();
-			mw_mirth_type_TrueZPlus();
+			mw_mirth_type_TZPlus();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primZ_panic();
 	}
 }
-static void mw_mirth_type_TrueZ_ZTo (void) {
+static void mw_mirth_type_TZ_ZTo (void) {
 	mtw_mirth_type_ArrowType_ARROWz_TYPE();
 }
 static void mw_mirth_type_TT (void) {
@@ -16809,7 +16809,7 @@ static void mw_mirth_type_T1 (void) {
 		mw_mirth_type_T0();
 		push_value(d2);
 	}
-	mw_mirth_type_TrueZMul();
+	mw_mirth_type_TZMul();
 }
 static void mw_mirth_type_T2 (void) {
 	{
@@ -16817,7 +16817,7 @@ static void mw_mirth_type_T2 (void) {
 		mw_mirth_type_T1();
 		push_value(d2);
 	}
-	mw_mirth_type_TrueZMul();
+	mw_mirth_type_TZMul();
 }
 static void mw_mirth_type_T3 (void) {
 	{
@@ -16825,7 +16825,7 @@ static void mw_mirth_type_T3 (void) {
 		mw_mirth_type_T2();
 		push_value(d2);
 	}
-	mw_mirth_type_TrueZMul();
+	mw_mirth_type_TZMul();
 }
 static void mw_mirth_type_T4 (void) {
 	{
@@ -16833,7 +16833,7 @@ static void mw_mirth_type_T4 (void) {
 		mw_mirth_type_T3();
 		push_value(d2);
 	}
-	mw_mirth_type_TrueZMul();
+	mw_mirth_type_TZMul();
 }
 static void mw_mirth_type_T5 (void) {
 	{
@@ -16841,7 +16841,7 @@ static void mw_mirth_type_T5 (void) {
 		mw_mirth_type_T4();
 		push_value(d2);
 	}
-	mw_mirth_type_TrueZMul();
+	mw_mirth_type_TZMul();
 }
 static void mw_mirth_type_T6 (void) {
 	{
@@ -16849,7 +16849,7 @@ static void mw_mirth_type_T6 (void) {
 		mw_mirth_type_T5();
 		push_value(d2);
 	}
-	mw_mirth_type_TrueZMul();
+	mw_mirth_type_TZMul();
 }
 static void mw_mirth_type_Type_errorZAsk (void) {
 	mw_mirth_type_Type_expand();
@@ -17710,7 +17710,7 @@ static void mw_mirth_type_Type_unifyZ_blockZBang (void) {
 			(void)pop_u64();
 			push_u64(0LL); // STACK_TYPE_ERROR
 			push_u64(0LL); // STACK_TYPE_ERROR
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			mw_mirth_arrow_blockZ_unifyZ_typeZBang();
 			mp_primZ_drop();
 			push_u64(0LL); // TYPE_ERROR
@@ -22070,7 +22070,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_var_Ctx0();
 	mw_mirth_type_T0();
 	mw_mirth_type_T0();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	{
 		VAL d2 = pop_value();
 		mp_primZ_dup();
@@ -22107,7 +22107,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T2();
 	mw_mirth_type_TYPEz_INT();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	{
 		VAL d2 = pop_value();
 		mp_primZ_dup();
@@ -22256,7 +22256,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T2();
 	mw_mirth_data_TYPEz_BOOL();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	{
 		VAL d2 = pop_value();
 		mp_primZ_dup();
@@ -22292,7 +22292,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T1();
 	mw_mirth_type_TYPEz_STR();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(26LL); // PRIM_INT_TO_STR
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22300,7 +22300,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T1();
 	mw_mirth_type_TYPEz_PTR();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(38LL); // PRIM_PTR_GET
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22308,7 +22308,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T1();
 	mw_mirth_data_TYPEz_U8();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(50LL); // PRIM_U8_GET
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22316,7 +22316,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T1();
 	mw_mirth_data_TYPEz_U16();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(52LL); // PRIM_U16_GET
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22324,7 +22324,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T1();
 	mw_mirth_data_TYPEz_U32();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(54LL); // PRIM_U32_GET
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22332,7 +22332,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T1();
 	mw_mirth_data_TYPEz_U64();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(56LL); // PRIM_U64_GET
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22340,7 +22340,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T1();
 	mw_mirth_data_TYPEz_I8();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(58LL); // PRIM_I8_GET
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22348,7 +22348,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T1();
 	mw_mirth_data_TYPEz_I16();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(60LL); // PRIM_I16_GET
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22356,7 +22356,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T1();
 	mw_mirth_data_TYPEz_I32();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(62LL); // PRIM_I32_GET
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22364,7 +22364,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T1();
 	mw_mirth_data_TYPEz_I64();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(64LL); // PRIM_I64_GET
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22372,7 +22372,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_TYPEz_PTR();
 	mw_mirth_type_T2();
 	mw_mirth_type_T0();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(39LL); // PRIM_PTR_SET
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22380,7 +22380,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_TYPEz_PTR();
 	mw_mirth_type_T2();
 	mw_mirth_type_T0();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(51LL); // PRIM_U8_SET
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22388,7 +22388,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_TYPEz_PTR();
 	mw_mirth_type_T2();
 	mw_mirth_type_T0();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(53LL); // PRIM_U16_SET
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22396,7 +22396,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_TYPEz_PTR();
 	mw_mirth_type_T2();
 	mw_mirth_type_T0();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(55LL); // PRIM_U32_SET
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22404,7 +22404,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_TYPEz_PTR();
 	mw_mirth_type_T2();
 	mw_mirth_type_T0();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(57LL); // PRIM_U64_SET
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22412,7 +22412,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_TYPEz_PTR();
 	mw_mirth_type_T2();
 	mw_mirth_type_T0();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(59LL); // PRIM_I8_SET
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22420,7 +22420,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_TYPEz_PTR();
 	mw_mirth_type_T2();
 	mw_mirth_type_T0();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(61LL); // PRIM_I16_SET
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22428,7 +22428,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_TYPEz_PTR();
 	mw_mirth_type_T2();
 	mw_mirth_type_T0();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(63LL); // PRIM_I32_SET
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22436,7 +22436,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_TYPEz_PTR();
 	mw_mirth_type_T2();
 	mw_mirth_type_T0();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(65LL); // PRIM_I64_SET
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22446,7 +22446,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T3();
 	mw_mirth_type_TYPEz_INT();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(70LL); // PRIM_POSIX_READ
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22456,7 +22456,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T3();
 	mw_mirth_type_TYPEz_INT();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(71LL); // PRIM_POSIX_WRITE
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22466,7 +22466,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T3();
 	mw_mirth_type_TYPEz_INT();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(72LL); // PRIM_POSIX_OPEN
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22474,7 +22474,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T1();
 	mw_mirth_type_TYPEz_INT();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(73LL); // PRIM_POSIX_CLOSE
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22487,14 +22487,14 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T6();
 	mw_mirth_type_TYPEz_PTR();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(75LL); // PRIM_POSIX_MMAP
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
 	mw_mirth_type_T0();
 	mw_mirth_type_TYPEz_PTR();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(34LL); // PRIM_PTR_NIL
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22503,7 +22503,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T2();
 	mw_mirth_data_TYPEz_BOOL();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(35LL); // PRIM_PTR_EQ
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22512,14 +22512,14 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T2();
 	mw_mirth_type_TYPEz_PTR();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(36LL); // PRIM_PTR_ADD
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
 	mw_mirth_type_T0();
 	mw_mirth_type_TYPEz_INT();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(37LL); // PRIM_PTR_SIZE
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22527,7 +22527,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T1();
 	mw_mirth_type_TYPEz_PTR();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(40LL); // PRIM_PTR_ALLOC
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22536,14 +22536,14 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T2();
 	mw_mirth_type_TYPEz_PTR();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(41LL); // PRIM_PTR_REALLOC
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
 	mw_mirth_type_TYPEz_PTR();
 	mw_mirth_type_T1();
 	mw_mirth_type_T0();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(42LL); // PRIM_PTR_FREE
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22552,7 +22552,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_TYPEz_PTR();
 	mw_mirth_type_T3();
 	mw_mirth_type_T0();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(43LL); // PRIM_PTR_COPY
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22561,7 +22561,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_TYPEz_PTR();
 	mw_mirth_type_T3();
 	mw_mirth_type_T0();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(44LL); // PRIM_PTR_FILL
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22570,7 +22570,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T2();
 	mw_mirth_type_TYPEz_STR();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(46LL); // PRIM_STR_COPY
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22578,7 +22578,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T1();
 	mw_mirth_type_TYPEz_INT();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(47LL); // PRIM_STR_NUM_BYTES
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22586,7 +22586,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T1();
 	mw_mirth_type_TYPEz_PTR();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(48LL); // PRIM_STR_BASE
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22595,7 +22595,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T2();
 	mw_mirth_type_TYPEz_STR();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(49LL); // PRIM_STR_CAT
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22604,35 +22604,35 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T2();
 	mw_mirth_type_TYPEz_INT();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(45LL); // PRIM_STR_CMP
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
 	mw_mirth_type_T0();
 	mw_mirth_type_TYPEz_INT();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(66LL); // PRIM_SYS_OS
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
 	mw_mirth_type_T0();
 	mw_mirth_type_TYPEz_INT();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(67LL); // PRIM_SYS_ARCH
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
 	mw_mirth_type_T0();
 	mw_mirth_type_TYPEz_INT();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(68LL); // PRIM_SYS_ARGC
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
 	mw_mirth_type_T0();
 	mw_mirth_type_TYPEz_PTR();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(69LL); // PRIM_SYS_ARGV
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_var_Ctx0();
@@ -22640,7 +22640,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	mw_mirth_type_T0();
 	mw_mirth_type_StackType_ZToType();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	push_u64(27LL); // PRIM_PACK_NIL
 	mw_mirth_prim_Prim_ctxZ_typeZBang();
 	mw_mirth_type_TYPEz_TYPE();
@@ -22778,7 +22778,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 			push_value(var_ta);
 			mw_mirth_type_T1();
 			mw_mirth_type_T0();
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			push_u64(2LL); // PRIM_CORE_DROP
 			mw_mirth_prim_Prim_ctxZ_typeZBang();
 			incref(var_a);
@@ -22792,7 +22792,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 			incref(var_ta);
 			push_value(var_ta);
 			mw_mirth_type_T2();
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			push_u64(1LL); // PRIM_CORE_DUP
 			mw_mirth_prim_Prim_ctxZ_typeZBang();
 			incref(var_a);
@@ -22810,7 +22810,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 			incref(var_ta);
 			push_value(var_ta);
 			mw_mirth_type_T2();
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			push_u64(3LL); // PRIM_CORE_SWAP
 			mw_mirth_prim_Prim_ctxZ_typeZBang();
 			incref(var_xs);
@@ -22824,12 +22824,12 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 			push_value(var_txs);
 			incref(var_tys);
 			push_value(var_tys);
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			mw_mirth_type_ArrowType_ZToType();
-			mw_mirth_type_TrueZMul();
+			mw_mirth_type_TZMul();
 			incref(var_tys);
 			push_value(var_tys);
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			push_u64(9LL); // PRIM_CORE_RUN
 			mw_mirth_prim_Prim_ctxZ_typeZBang();
 			incref(var_xs);
@@ -22840,10 +22840,10 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 			incref(var_txs);
 			push_value(var_txs);
 			mw_mirth_type_TYPEz_INT();
-			mw_mirth_type_TrueZMul();
+			mw_mirth_type_TZMul();
 			incref(var_tys);
 			push_value(var_tys);
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			push_u64(74LL); // PRIM_POSIX_EXIT
 			mw_mirth_prim_Prim_ctxZ_typeZBang();
 			incref(var_xs);
@@ -22854,10 +22854,10 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 			incref(var_txs);
 			push_value(var_txs);
 			mw_mirth_type_TYPEz_STR();
-			mw_mirth_type_TrueZMul();
+			mw_mirth_type_TZMul();
 			incref(var_tys);
 			push_value(var_tys);
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			push_u64(8LL); // PRIM_CORE_PANIC
 			mw_mirth_prim_Prim_ctxZ_typeZBang();
 			incref(var_xs);
@@ -22871,20 +22871,20 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 			push_value(var_txs);
 			incref(var_tc);
 			push_value(var_tc);
-			mw_mirth_type_TrueZMul();
+			mw_mirth_type_TZMul();
 			incref(var_txs);
 			push_value(var_txs);
 			incref(var_tys);
 			push_value(var_tys);
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			mw_mirth_type_ArrowType_ZToType();
-			mw_mirth_type_TrueZMul();
+			mw_mirth_type_TZMul();
 			incref(var_tys);
 			push_value(var_tys);
 			incref(var_tc);
 			push_value(var_tc);
-			mw_mirth_type_TrueZMul();
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZMul();
+			mw_mirth_type_TZ_ZTo();
 			push_u64(4LL); // PRIM_CORE_DIP
 			mw_mirth_prim_Prim_ctxZ_typeZBang();
 			incref(var_xs);
@@ -22895,23 +22895,23 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 			incref(var_txs);
 			push_value(var_txs);
 			mw_mirth_data_TYPEz_BOOL();
-			mw_mirth_type_TrueZMul();
+			mw_mirth_type_TZMul();
 			incref(var_txs);
 			push_value(var_txs);
 			incref(var_tys);
 			push_value(var_tys);
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			mw_mirth_type_ArrowType_ZToType();
 			mp_primZ_dup();
 			{
 				VAL d4 = pop_value();
-				mw_mirth_type_TrueZMul();
+				mw_mirth_type_TZMul();
 				push_value(d4);
 			}
-			mw_mirth_type_TrueZMul();
+			mw_mirth_type_TZMul();
 			incref(var_tys);
 			push_value(var_tys);
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			push_u64(5LL); // PRIM_CORE_IF
 			mw_mirth_prim_Prim_ctxZ_typeZBang();
 			incref(var_xs);
@@ -22924,20 +22924,20 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 			incref(var_txs);
 			push_value(var_txs);
 			mw_mirth_data_TYPEz_BOOL();
-			mw_mirth_type_TrueZMul();
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZMul();
+			mw_mirth_type_TZ_ZTo();
 			mw_mirth_type_ArrowType_ZToType();
-			mw_mirth_type_TrueZMul();
+			mw_mirth_type_TZMul();
 			incref(var_txs);
 			push_value(var_txs);
 			incref(var_txs);
 			push_value(var_txs);
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			mw_mirth_type_ArrowType_ZToType();
-			mw_mirth_type_TrueZMul();
+			mw_mirth_type_TZMul();
 			incref(var_txs);
 			push_value(var_txs);
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			push_u64(6LL); // PRIM_CORE_WHILE
 			mw_mirth_prim_Prim_ctxZ_typeZBang();
 			incref(var_rr);
@@ -22948,18 +22948,18 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 			mw_mirth_type_T0();
 			incref(var_trr);
 			push_value(var_trr);
-			mw_mirth_type_TrueZPlus();
+			mw_mirth_type_TZPlus();
 			incref(var_tsr);
 			push_value(var_tsr);
-			mw_mirth_type_TrueZPlus();
+			mw_mirth_type_TZPlus();
 			mw_mirth_type_T0();
 			incref(var_tsr);
 			push_value(var_tsr);
-			mw_mirth_type_TrueZPlus();
+			mw_mirth_type_TZPlus();
 			incref(var_trr);
 			push_value(var_trr);
-			mw_mirth_type_TrueZPlus();
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZPlus();
+			mw_mirth_type_TZ_ZTo();
 			push_u64(12LL); // PRIM_CORE_RSWAP
 			mw_mirth_prim_Prim_ctxZ_typeZBang();
 			incref(var_xs);
@@ -22973,20 +22973,20 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 			push_value(var_txs);
 			incref(var_trr);
 			push_value(var_trr);
-			mw_mirth_type_TrueZPlus();
+			mw_mirth_type_TZPlus();
 			incref(var_txs);
 			push_value(var_txs);
 			incref(var_tys);
 			push_value(var_tys);
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			mw_mirth_type_ArrowType_ZToType();
-			mw_mirth_type_TrueZMul();
+			mw_mirth_type_TZMul();
 			incref(var_tys);
 			push_value(var_tys);
 			incref(var_trr);
 			push_value(var_trr);
-			mw_mirth_type_TrueZPlus();
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZPlus();
+			mw_mirth_type_TZ_ZTo();
 			push_u64(13LL); // PRIM_CORE_RDIP
 			mw_mirth_prim_Prim_ctxZ_typeZBang();
 			incref(var_xs);
@@ -23004,10 +23004,10 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 			push_value(var_txs);
 			incref(var_tb);
 			push_value(var_tb);
-			mw_mirth_type_TrueZMul();
+			mw_mirth_type_TZMul();
 			mw_mirth_type_StackType_ZToType();
 			mw_mirth_type_T1();
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			push_u64(28LL); // PRIM_PACK_CONS
 			mw_mirth_prim_Prim_ctxZ_typeZBang();
 			incref(var_xs);
@@ -23019,7 +23019,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 			push_value(var_txs);
 			incref(var_tb);
 			push_value(var_tb);
-			mw_mirth_type_TrueZMul();
+			mw_mirth_type_TZMul();
 			mw_mirth_type_StackType_ZToType();
 			mw_mirth_type_T1();
 			incref(var_txs);
@@ -23028,7 +23028,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 			incref(var_tb);
 			push_value(var_tb);
 			mw_mirth_type_T2();
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			push_u64(29LL); // PRIM_PACK_UNCONS
 			mw_mirth_prim_Prim_ctxZ_typeZBang();
 			incref(var_a);
@@ -23041,7 +23041,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 			push_value(var_ta);
 			mtw_mirth_type_Type_TMut();
 			mw_mirth_type_T1();
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			push_u64(30LL); // PRIM_MUT_NEW
 			mw_mirth_prim_Prim_ctxZ_typeZBang();
 			incref(var_a);
@@ -23054,7 +23054,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 			incref(var_ta);
 			push_value(var_ta);
 			mw_mirth_type_T1();
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			push_u64(31LL); // PRIM_MUT_GET
 			mw_mirth_prim_Prim_ctxZ_typeZBang();
 			incref(var_a);
@@ -23067,7 +23067,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 			mtw_mirth_type_Type_TMut();
 			mw_mirth_type_T2();
 			mw_mirth_type_T0();
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			push_u64(32LL); // PRIM_MUT_SET
 			mw_mirth_prim_Prim_ctxZ_typeZBang();
 			incref(var_a);
@@ -23079,7 +23079,7 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 			mw_mirth_type_T1();
 			mw_mirth_data_TYPEz_BOOL();
 			mw_mirth_type_T1();
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			push_u64(33LL); // PRIM_MUT_IS_SET
 			mw_mirth_prim_Prim_ctxZ_typeZBang();
 			decref(var_tys);
@@ -27724,7 +27724,7 @@ static void mw_mirth_elab_ZPlusTypeElab_elabZ_typeZ_sigZBang (void) {
 		mw_std_list_List_1_for_1();
 		push_value(d2);
 	}
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 }
 static void mw_mirth_elab_ZPlusTypeElab_elabZ_typeZ_sigZ_paramsZBang (void) {
 	mw_mirth_elab_ZPlusTypeElab_token();
@@ -29349,7 +29349,7 @@ static void mw_mirth_elab_dataZ_getZ_tagZ_type (void) {
 	mw_mirth_type_T1();
 	mw_mirth_type_TYPEz_INT();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 }
 static void mw_mirth_elab_elabZ_coerceZ_sigZBang (void) {
 	switch (get_top_data_tag()) {
@@ -29360,12 +29360,12 @@ static void mw_mirth_elab_elabZ_coerceZ_sigZBang (void) {
 			mp_primZ_dup();
 			mw_mirth_type_MetaVar_newZBang();
 			mtw_mirth_type_Type_TMeta();
-			mw_mirth_type_TrueZMul();
+			mw_mirth_type_TZMul();
 			mp_primZ_swap();
 			mw_mirth_type_MetaVar_newZBang();
 			mtw_mirth_type_Type_TMeta();
-			mw_mirth_type_TrueZMul();
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZMul();
+			mw_mirth_type_TZ_ZTo();
 			mtw_mirth_elab_OpSig_OPSIGz_APPLY();
 			break;
 		default:
@@ -29386,7 +29386,7 @@ static void mw_mirth_elab_elabZ_matchZ_sigZBang (void) {
 		push_value(d2);
 	}
 	mw_mirth_match_Match_cod();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	mtw_mirth_elab_OpSig_OPSIGz_APPLY();
 }
 static void mw_mirth_elab_elabZ_lambdaZ_sigZBang (void) {
@@ -29397,7 +29397,7 @@ static void mw_mirth_elab_elabZ_lambdaZ_sigZBang (void) {
 		push_value(d2);
 	}
 	mw_mirth_arrow_Lambda_cod();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	mtw_mirth_elab_OpSig_OPSIGz_APPLY();
 }
 static void mw_mirth_elab_elabZ_varZ_sigZBang (void) {
@@ -29441,7 +29441,7 @@ static void mw_mirth_elab_elabZ_labelZ_pushZ_sigZBang (void) {
 		mtw_mirth_type_StackType_STCons();
 		push_value(d2);
 	}
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	mtw_mirth_elab_OpSig_OPSIGz_APPLY();
 }
 static void mw_mirth_elab_elabZ_labelZ_popZ_sigZBang (void) {
@@ -29472,7 +29472,7 @@ static void mw_mirth_elab_elabZ_labelZ_popZ_sigZBang (void) {
 		push_value(d2);
 	}
 	mp_primZ_swap();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	mtw_mirth_elab_OpSig_OPSIGz_APPLY();
 }
 static void mw_mirth_elab_elabZ_arrowZ_homZBang (void) {
@@ -30050,7 +30050,7 @@ static void mw_mirth_match_ZPlusMatch_caseZBang_2 (void) {
 			push_value(var_pat);
 			mw_mirth_match_Pattern_dom();
 			mw_mirth_match_ZPlusMatch_cod();
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			{
 				VAL d4 = pop_value();
 				mp_primZ_swap();
@@ -30163,7 +30163,7 @@ static void mw_mirth_elab_elabZ_lambdaZ_paramZAsk (void) {
 				mtw_mirth_type_StackType_STMeta();
 				mw_mirth_type_MetaVar_newZBang();
 				mtw_mirth_type_StackType_STMeta();
-				mw_mirth_type_TrueZ_ZTo();
+				mw_mirth_type_TZ_ZTo();
 				mtw_mirth_type_Type_TMorphism();
 				push_value(d4);
 			}
@@ -31108,7 +31108,7 @@ static void mw_mirth_elab_dataZ_getZ_labelZ_type (void) {
 		incref(var_tag);
 		push_value(var_tag);
 		mw_mirth_data_Tag_outputZ_type();
-		mw_mirth_type_TrueZMulZPlus();
+		mw_mirth_type_TZMulZPlus();
 		incref(var_lbl);
 		push_value(var_lbl);
 		incref(var_tag);
@@ -31133,7 +31133,7 @@ static void mw_mirth_elab_dataZ_getZ_labelZ_type (void) {
 			}
 			decref(var_f);
 		}
-		mw_mirth_type_TrueZ_ZTo();
+		mw_mirth_type_TZ_ZTo();
 		decref(var_lbl);
 		decref(var_tag);
 	}
@@ -31152,13 +31152,13 @@ static void mw_mirth_elab_dataZ_setZ_labelZ_type (void) {
 		incref(var_tag);
 		push_value(var_tag);
 		mw_mirth_data_Tag_outputZ_type();
-		mw_mirth_type_TrueZMulZPlus();
+		mw_mirth_type_TZMulZPlus();
 		mw_mirth_type_T0();
 		incref(var_tag);
 		push_value(var_tag);
 		mw_mirth_data_Tag_outputZ_type();
-		mw_mirth_type_TrueZMulZPlus();
-		mw_mirth_type_TrueZ_ZTo();
+		mw_mirth_type_TZMulZPlus();
+		mw_mirth_type_TZ_ZTo();
 		decref(var_lbl);
 		decref(var_tag);
 	}
@@ -31918,11 +31918,11 @@ static void mw_mirth_elab_elabZ_entryZ_point (void) {
 		mw_mirth_var_Ctx0();
 		mw_mirth_type_T0();
 		mw_mirth_type_RESOURCEz_WORLD();
-		mw_mirth_type_TrueZPlus();
+		mw_mirth_type_TZPlus();
 		mw_mirth_type_T0();
 		mw_mirth_type_RESOURCEz_WORLD();
-		mw_mirth_type_TrueZPlus();
-		mw_mirth_type_TrueZ_ZTo();
+		mw_mirth_type_TZPlus();
+		mw_mirth_type_TZ_ZTo();
 		push_value(d2);
 	}
 	mw_mirth_word_Word_head();
@@ -31969,7 +31969,7 @@ static void mw_mirth_elab_elabZ_embedZ_strZBang (void) {
 	mw_mirth_type_T0();
 	mw_mirth_type_TYPEz_STR();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	mw_std_lazzy_ready2();
 	{
 		VAL d2 = pop_value();
@@ -32073,7 +32073,7 @@ static void mw_mirth_elab_tableZ_newZBang (void) {
 	mw_mirth_type_T0();
 	mw_mirth_type_TYPEz_INT();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	mw_std_lazzy_ready2();
 	{
 		VAL d2 = pop_value();
@@ -32119,7 +32119,7 @@ static void mw_mirth_elab_tableZ_newZBang (void) {
 	mp_primZ_swap();
 	mtw_mirth_type_Type_TTable();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	mw_std_lazzy_ready2();
 	{
 		VAL d2 = pop_value();
@@ -32192,7 +32192,7 @@ static void mw_mirth_elab_tableZ_newZBang (void) {
 	mw_mirth_type_T1();
 	mw_mirth_type_TYPEz_INT();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	mw_std_lazzy_ready2();
 	{
 		VAL d2 = pop_value();
@@ -32235,7 +32235,7 @@ static void mw_mirth_elab_tableZ_newZBang (void) {
 	mw_mirth_type_TYPEz_INT();
 	mw_mirth_type_T1();
 	mp_primZ_swap();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	mw_std_lazzy_ready2();
 	{
 		VAL d2 = pop_value();
@@ -32276,7 +32276,7 @@ static void mw_mirth_elab_tableZ_newZBang (void) {
 	mtw_mirth_type_Type_TTable();
 	mw_mirth_type_T1();
 	mp_primZ_dup();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	mw_std_lazzy_ready2();
 	{
 		VAL d2 = pop_value();
@@ -32317,7 +32317,7 @@ static void mw_mirth_elab_tableZ_newZBang (void) {
 	mtw_mirth_type_Type_TTable();
 	mw_mirth_type_T1();
 	mp_primZ_dup();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	mw_std_lazzy_ready2();
 	{
 		VAL d2 = pop_value();
@@ -32368,10 +32368,10 @@ static void mw_mirth_elab_tableZ_newZBang (void) {
 		incref(var_t);
 		push_value(var_t);
 		mtw_mirth_type_Type_TTable();
-		mw_mirth_type_TrueZMul();
+		mw_mirth_type_TZMul();
 		incref(var_a);
 		push_value(var_a);
-		mw_mirth_type_TrueZ_ZTo();
+		mw_mirth_type_TZ_ZTo();
 		mw_mirth_type_ArrowType_ZToType();
 		{
 			static bool vready = false;
@@ -32397,15 +32397,15 @@ static void mw_mirth_elab_tableZ_newZBang (void) {
 			incref(var_t);
 			push_value(var_t);
 			mtw_mirth_type_Type_TTable();
-			mw_mirth_type_TrueZMul();
+			mw_mirth_type_TZMul();
 			incref(var_a);
 			push_value(var_a);
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			mw_mirth_type_ArrowType_ZToType();
-			mw_mirth_type_TrueZMul();
+			mw_mirth_type_TZMul();
 			incref(var_a);
 			push_value(var_a);
-			mw_mirth_type_TrueZ_ZTo();
+			mw_mirth_type_TZ_ZTo();
 			mw_std_lazzy_ready2();
 			incref(var_w);
 			push_value(var_w);
@@ -32464,7 +32464,7 @@ static void mw_mirth_elab_tableZ_newZBang (void) {
 	mp_primZ_swap();
 	mtw_mirth_type_Type_TTable();
 	mw_mirth_type_T1();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	mw_std_lazzy_ready2();
 	{
 		VAL d2 = pop_value();
@@ -33137,7 +33137,7 @@ static void mw_mirth_specializzer_abZ_buildZ_overZ_atomZBang_1 (void) {
 		LPOP(lbl_ctx);
 		LPOP(lbl_dom);
 		LPOP(lbl_cod);
-		mw_mirth_type_TrueZ_ZTo();
+		mw_mirth_type_TZ_ZTo();
 		LPOP(lbl_token);
 		LPOP(lbl_home);
 		LPOP(lbl_subst);
@@ -33328,7 +33328,7 @@ static void mw_mirth_specializzer_specializzeZ_ctxZ_type (void) {
 	LPOP(lbl_gamma);
 	mp_primZ_drop();
 	mp_primZ_swap();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	{
 		VAL d2 = pop_value();
 		mw_mirth_var_Ctx0();
@@ -41264,7 +41264,7 @@ static void mb_mirth_type_Type_isZ_physicalZAsk_1 (void) {
 	mw_std_prelude_panicZBang();
 }
 static void mb_mirth_type_TT_0 (void) {
-	mw_mirth_type_TrueZMul();
+	mw_mirth_type_TZMul();
 }
 static void mb_mirth_type_MetaVar_expand_0 (void) {
 }
@@ -42118,7 +42118,7 @@ static void mb_mirth_elab_ZPlusTypeElab_elabZ_typeZ_sigZBang_3 (void) {
 	mw_mirth_token_Token_succ();
 }
 static void mb_mirth_elab_ZPlusTypeElab_elabZ_typeZ_sigZBang_7 (void) {
-	mw_mirth_type_TrueZMul();
+	mw_mirth_type_TZMul();
 }
 static void mb_mirth_elab_ZPlusTypeElab_elabZ_typeZ_sigZ_paramsZBang_0 (void) {
 	mw_mirth_elab_ZPlusTypeElab_token();
@@ -43305,7 +43305,7 @@ static void mb_mirth_elab_dataZ_getZ_labelZ_type_0 (void) {
 	incref(var_tag);
 	push_value(var_tag);
 	mw_mirth_data_Tag_outputZ_type();
-	mw_mirth_type_TrueZMulZPlus();
+	mw_mirth_type_TZMulZPlus();
 	decref(var_tag);
 }
 static void mb_mirth_elab_elabZ_arrowZ_fwdZBang_0 (void) {
@@ -44020,7 +44020,7 @@ static void mb_mirth_elab_elabZ_dataZ_tagZBang_7 (void) {
 	mp_primZ_swap();
 	mw_mirth_data_Tag_data();
 	mw_mirth_data_Data_fullZ_type();
-	mw_mirth_type_TrueZMulZPlus();
+	mw_mirth_type_TZMulZPlus();
 	mp_primZ_swap();
 	mw_mirth_data_Tag_sigZAsk();
 	switch (get_top_data_tag()) {
@@ -44039,7 +44039,7 @@ static void mb_mirth_elab_elabZ_dataZ_tagZBang_7 (void) {
 			mp_primZ_panic();
 	}
 	mp_primZ_swap();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	{
 		VAL d2 = pop_value();
 		mw_mirth_elab_ZPlusTypeElab_ctx();
@@ -44139,7 +44139,7 @@ static void mb_mirth_elab_elabZ_dataZ_doneZBang_2 (void) {
 		push_value(var_dat);
 		mtw_mirth_type_Type_TData();
 		mw_mirth_type_T1();
-		mw_mirth_type_TrueZ_ZTo();
+		mw_mirth_type_TZ_ZTo();
 		mw_std_lazzy_ready2();
 		incref(var_ftag);
 		push_value(var_ftag);
@@ -44162,7 +44162,7 @@ static void mb_mirth_elab_elabZ_dataZ_doneZBang_4 (void) {
 	mw_mirth_data_Tag_ctxZ_type();
 	mw_mirth_type_ArrowType_unpack();
 	mp_primZ_swap();
-	mw_mirth_type_TrueZ_ZTo();
+	mw_mirth_type_TZ_ZTo();
 	mw_std_prelude_pack2();
 }
 static void mb_mirth_elab_elabZ_dataZ_doneZBang_5 (void) {
@@ -44650,29 +44650,29 @@ static void mb_mirth_elab_createZ_projectorsZBang_8 (void) {
 		mtw_mirth_type_StackType_STVar();
 		incref(var_datty);
 		push_value(var_datty);
-		mw_mirth_type_TrueZMulZPlus();
+		mw_mirth_type_TZMulZPlus();
 		incref(var_sx);
 		push_value(var_sx);
 		mtw_mirth_type_StackType_STVar();
 		incref(var_lblty);
 		push_value(var_lblty);
-		mw_mirth_type_TrueZMul();
+		mw_mirth_type_TZMul();
 		incref(var_sy);
 		push_value(var_sy);
 		mtw_mirth_type_StackType_STVar();
 		incref(var_lblty);
 		push_value(var_lblty);
-		mw_mirth_type_TrueZMul();
-		mw_mirth_type_TrueZ_ZTo();
+		mw_mirth_type_TZMul();
+		mw_mirth_type_TZ_ZTo();
 		mtw_mirth_type_Type_TMorphism();
-		mw_mirth_type_TrueZMul();
+		mw_mirth_type_TZMul();
 		incref(var_sy);
 		push_value(var_sy);
 		mtw_mirth_type_StackType_STVar();
 		incref(var_datty);
 		push_value(var_datty);
-		mw_mirth_type_TrueZMulZPlus();
-		mw_mirth_type_TrueZ_ZTo();
+		mw_mirth_type_TZMulZPlus();
+		mw_mirth_type_TZ_ZTo();
 		mw_std_prelude_pack2();
 		decref(var_datty);
 		decref(var_lblty);

--- a/src/arrow.mth
+++ b/src/arrow.mth
@@ -85,7 +85,7 @@ data(Arrow, Arrow ->
     dom:StackType
     cod:StackType
     atoms:List(Atom))
-def(Arrow.type, Arrow -- ArrowType, sip(dom) cod True->)
+def(Arrow.type, Arrow -- ArrowType, sip(dom) cod T->)
 
 data(Atom, Atom ->
     home:Home
@@ -125,7 +125,7 @@ def(Block.dom, Block -- StackType, ~dom @)
 def(Block.cod, Block -- StackType, ~cod @)
 def(Block.home, Block -- Home, ~home @)
 
-def(Block.type, Block -- ArrowType, sip(dom) cod True->)
+def(Block.type, Block -- ArrowType, sip(dom) cod T->)
 def(Block.arrow, Block -- Arrow, ~arrow force!)
 def(Block.infer-type!, Block -- ArrowType, arrow type)
 

--- a/src/data.mth
+++ b/src/data.mth
@@ -73,7 +73,7 @@ def(make-prim-data!, Str Int Mut(Data) List(Mut(Tag)) --,
 def(make-prim-tag!, Str Int List(Type) Mut(Tag) --,
     @
     dip(sip(len) TT)
-    sip(Ctx0 rotr .data TData T1 True-> ready2) sip(~ctx-type !)
+    sip(Ctx0 rotr .data TData T1 T-> ready2) sip(~ctx-type !)
     sip(~num-type-inputs !)
     sip(L0 swap ~label-inputs !)
     sip(0 >Nat swap ~num-resource-inputs !)

--- a/src/elab.mth
+++ b/src/elab.mth
@@ -64,7 +64,7 @@ def(+TypeElab.elab-type-sig!, +TypeElab -- +TypeElab ArrowType,
     elab-stack-type!
     token sig-dashes? if(token:succ elab-stack-type!, dip:T0)
     token run-end? else(token "expected right paren or comma" emit-error!)
-    dip(swap for(True*)) True->)
+    dip(swap for(T*)) T->)
 
 def(+TypeElab.elab-type-sig-params!, +TypeElab -- +TypeElab List(Type),
     token lparen? if(
@@ -639,22 +639,22 @@ def(elab-op-fresh-sig!, Op -- Subst OpSig,
 
 def(data-get-tag-type, Data -- ArrowType,
     full-type left? unwrap T1
-    TYPE_INT T1 True->)
+    TYPE_INT T1 T->)
 
 def(elab-coerce-sig!, Coerce -- OpSig,
     CoerceUnsafe ->
         MetaVar.new! STMeta dup
-        MetaVar.new! TMeta True* swap
-        MetaVar.new! TMeta True* True-> OPSIG_APPLY)
+        MetaVar.new! TMeta T* swap
+        MetaVar.new! TMeta T* T-> OPSIG_APPLY)
 
 def(elab-block-sig!, Block -- OpSig,
     VALUE_BLOCK TValue OPSIG_PUSH)
 
 def(elab-match-sig!, Match -- OpSig,
-    sip(dom) cod True-> OPSIG_APPLY)
+    sip(dom) cod T-> OPSIG_APPLY)
 
 def(elab-lambda-sig!, Lambda -- OpSig,
-    sip(dom) cod True-> OPSIG_APPLY)
+    sip(dom) cod T-> OPSIG_APPLY)
 
 def(elab-var-sig!, Var -- OpSig,
     dup auto-run? if(
@@ -664,11 +664,11 @@ def(elab-var-sig!, Var -- OpSig,
 
 def(elab-label-push-sig!, Label -- OpSig,
     dip(MetaVar.new! STMeta MetaVar.new! TMeta dup2)
-    STConsLabel dip(STCons) True-> OPSIG_APPLY)
+    STConsLabel dip(STCons) T-> OPSIG_APPLY)
 
 def(elab-label-pop-sig!, Label -- OpSig,
     dip(MetaVar.new! STMeta MetaVar.new! TMeta dup2)
-    STConsLabel dip(STCons) swap True-> OPSIG_APPLY)
+    STConsLabel dip(STCons) swap T-> OPSIG_APPLY)
 
 def(elab-arrow!, Ctx ArrowType Token Home -- Arrow,
     dip2(unpack) elab-arrow-hom!)
@@ -894,7 +894,7 @@ def(+Match.case!(mkpat,mkbod),
         Pattern rdip(thaw mkpat freeze)
     ) swap \(pat ->
         pat inner-ctx
-        pat Pattern.dom +Match.cod True->
+        pat Pattern.dom +Match.cod T->
         rotl
         +Match.home
         rdip(ab-build-hom!(dip(mkbod)))
@@ -917,7 +917,7 @@ def(elab-lambda-param?, Token -- Token Maybe(Var),
     and(dup succ pattern-var?)
     and(dup succ succ rsquare? >Bool) if(
         dup succ args-0 sip:next
-        dip(MetaVar.new! STMeta MetaVar.new! STMeta True-> TMorphism)
+        dip(MetaVar.new! STMeta MetaVar.new! STMeta T-> TMorphism)
         succ name? unwrap Var.new-auto-run! Some,
         None
     )))
@@ -1069,12 +1069,12 @@ def(elab-data-tag!, Data Token -- Data,
         True >allow-implicit-type-vars
         False >allow-type-holes
         TYPE_ELAB
-        T0 over .data full-type True*+
+        T0 over .data full-type T*+
         swap sig? match(
             None -> T0,
             Some -> token! T0 elab-stack-type-parts!
         )
-        swap True-> dip:ctx pack2 rdrop
+        swap T-> dip:ctx pack2 rdrop
     ) over ~ctx-type !
     sip(num-type-inputs-from-sig) sip(~num-type-inputs !)
     sip(num-resource-inputs-from-sig) sip(~num-resource-inputs !)
@@ -1111,7 +1111,7 @@ def(elab-data-done!, Data --,
 
         dat is-enum? then(
             dat "from-tag-unsafe" 0 data-word-new! \(ftag ->
-                Ctx0 TYPE_INT T1 dat TData T1 True-> ready2 ftag ~ctx-type !
+                Ctx0 TYPE_INT T1 dat TData T1 T-> ready2 ftag ~ctx-type !
                 ftag ab-build-word!(
                     CoerceUnsafe ab-coerce!
                 ) drop
@@ -1121,7 +1121,7 @@ def(elab-data-done!, Data --,
         dat tags /L1 match(
             Some -> \(tag ->
                 dat "/" tag name >Str cat 0 data-word-new! \(untag ->
-                    tag delay(ctx-type unpack swap True-> pack2) untag ~ctx-type !
+                    tag delay(ctx-type unpack swap T-> pack2) untag ~ctx-type !
                     untag delay(ab-build-word-arrow!(
                         untag type cod >cod
                         dat head? unwrap >body
@@ -1152,17 +1152,17 @@ def(Tag.project-input-label, Label Tag -- Maybe(Type),
 
 def(data-get-label-type, Tag Label -- ArrowType,
     \(tag lbl ->
-        T0 tag output-type True*+
+        T0 tag output-type T*+
         lbl tag project-input-label unwrap T1
-        tag .data is-resource? then(tag output-type True*+)
-        True->
+        tag .data is-resource? then(tag output-type T*+)
+        T->
     ))
 
 def(data-set-label-type, Tag Label -- ArrowType,
     \(tag lbl ->
-        lbl tag project-input-label unwrap T1 tag output-type True*+
-        T0 tag output-type True*+
-        True->
+        lbl tag project-input-label unwrap T1 tag output-type T*+
+        T0 tag output-type T*+
+        T->
     ))
 
 def(create-projectors!, Tag --,
@@ -1195,11 +1195,11 @@ def(create-projectors!, Tag --,
                 lbl tag project-input-label unwrap
                 tag output-type \(sx sy lblty datty ->
                     tag ctx /Ctx sx sy L2 cat Ctx
-                    sx STVar datty True*+
-                        sx STVar lblty True*
-                        sy STVar lblty True* True-> TMorphism True*
-                    sy STVar datty True*+
-                    True-> pack2
+                    sx STVar datty T*+
+                        sx STVar lblty T*
+                        sy STVar lblty T* T-> TMorphism T*
+                    sy STVar datty T*+
+                    T-> pack2
                 )
             ) lbl_lens ~ctx-type !
             lbl_lens delay(
@@ -1436,7 +1436,7 @@ def(elab-entry-point, QName +World -- Arrow +World,
         ) >Str cat
         emit-fatal-error!
     ) nip { Word +World }
-    dup dip(Ctx0 T0 RESOURCE_WORLD True+ T0 RESOURCE_WORLD True+ True->)
+    dup dip(Ctx0 T0 RESOURCE_WORLD T+ T0 RESOURCE_WORLD T+ T->)
     head dup HomeMain ab-build-hom!(
         dip(ab-word!)
     ))
@@ -1450,7 +1450,7 @@ def(elab-embed-str!, Token +World -- Token +World,
     dup str? unwrap-or("expected source path" emit-fatal-error!)
     >Path open-file! unwrap! read-file! close-file! nip >contents
     Word.new!
-    Ctx0 T0 TYPE_STR T1 True-> ready2 over ~ctx-type !
+    Ctx0 T0 TYPE_STR T1 T-> ready2 over ~ctx-type !
     ab-build-word!(contents> ab-str!) drop)
 
 ||| Ensure that everything so far has been typechecked.
@@ -1482,7 +1482,7 @@ def(table-new!, Token QName -- Table,
     dup "MAX" 0 table-word-new!
 
     L0 Ctx
-    T0 TYPE_INT T1 True->
+    T0 TYPE_INT T1 T->
     ready2 over ~ctx-type !
 
     ab-build-word!(
@@ -1494,7 +1494,7 @@ def(table-new!, Token QName -- Table,
     dup "nil" 0 table-word-new!
 
     L0 Ctx
-    T0 over3 TTable T1 True->
+    T0 over3 TTable T1 T->
     ready2 over ~ctx-type !
 
     ab-build-word!(
@@ -1513,7 +1513,7 @@ def(table-new!, Token QName -- Table,
     dup "index" 0 table-word-new!
 
     L0 Ctx
-    over2 TTable T1 TYPE_INT T1 True->
+    over2 TTable T1 TYPE_INT T1 T->
     ready2 over ~ctx-type !
 
     ab-build-word! (
@@ -1525,7 +1525,7 @@ def(table-new!, Token QName -- Table,
     dup "from-index" 0 table-word-new!
 
     L0 Ctx
-    over2 TTable T1 TYPE_INT T1 swap True->
+    over2 TTable T1 TYPE_INT T1 swap T->
     ready2 over ~ctx-type !
 
     ab-build-word! (
@@ -1537,7 +1537,7 @@ def(table-new!, Token QName -- Table,
     dup "succ" 0 table-word-new!
 
     L0 Ctx
-    over2 TTable T1 dup True->
+    over2 TTable T1 dup T->
     ready2 over ~ctx-type !
 
     ab-build-word! (
@@ -1558,7 +1558,7 @@ def(table-new!, Token QName -- Table,
     dup "pred" 0 table-word-new!
 
     L0 Ctx
-    over2 TTable T1 dup True->
+    over2 TTable T1 dup T->
     ready2 over ~ctx-type !
 
     ab-build-word! (
@@ -1579,10 +1579,10 @@ def(table-new!, Token QName -- Table,
 
     dup "for" 1 table-word-new!
     TYPE_STACK "*a" >Name Var.new! dup STVar
-    \(t w va a -> a t TTable True* a True-> >Type "x" >Name Var.new-auto-run!
+    \(t w va a -> a t TTable T* a T-> >Type "x" >Name Var.new-auto-run!
     \(x ->
         va Ctx1
-        a a t TTable True* a True-> >Type True* a True->
+        a a t TTable T* a T-> >Type T* a T->
         ready2 w ~ctx-type !
 
         w ab-build-word! (
@@ -1616,7 +1616,7 @@ def(table-new!, Token QName -- Table,
     dup "alloc!" 0 table-word-new!
 
     L0 Ctx
-    T0 over3 TTable T1 True->
+    T0 over3 TTable T1 T->
     ready2 over ~ctx-type !
 
     ab-build-word! (

--- a/src/prim.mth
+++ b/src/prim.mth
@@ -256,12 +256,12 @@ def(init-prims!, --,
     # monomorphic prims
     #
 
-    Ctx0 T0 T0 True->
+    Ctx0 T0 T0 T->
     dup2 PRIM_CORE_ID ctx-type!
     dup2 PRIM_CORE_DEBUG ctx-type!
     drop2
 
-    Ctx0 TYPE_INT TYPE_INT T2 TYPE_INT T1 True->
+    Ctx0 TYPE_INT TYPE_INT T2 TYPE_INT T1 T->
     dup2 PRIM_INT_ADD ctx-type!
     dup2 PRIM_INT_SUB ctx-type!
     dup2 PRIM_INT_MUL ctx-type!
@@ -274,105 +274,105 @@ def(init-prims!, --,
     dup2 PRIM_INT_SHR ctx-type!
     drop2
 
-    Ctx0 TYPE_INT TYPE_INT T2 TYPE_BOOL T1 True->
+    Ctx0 TYPE_INT TYPE_INT T2 TYPE_BOOL T1 T->
     dup2 PRIM_INT_EQ ctx-type!
     dup2 PRIM_INT_LT ctx-type!
     drop2
 
-    Ctx0 TYPE_INT T1 TYPE_STR T1 True-> PRIM_INT_TO_STR ctx-type!
+    Ctx0 TYPE_INT T1 TYPE_STR T1 T-> PRIM_INT_TO_STR ctx-type!
 
-    Ctx0 TYPE_PTR T1 TYPE_PTR T1 True-> PRIM_PTR_GET ctx-type!
-    Ctx0 TYPE_PTR T1 TYPE_U8  T1 True-> PRIM_U8_GET  ctx-type!
-    Ctx0 TYPE_PTR T1 TYPE_U16 T1 True-> PRIM_U16_GET ctx-type!
-    Ctx0 TYPE_PTR T1 TYPE_U32 T1 True-> PRIM_U32_GET ctx-type!
-    Ctx0 TYPE_PTR T1 TYPE_U64 T1 True-> PRIM_U64_GET ctx-type!
-    Ctx0 TYPE_PTR T1 TYPE_I8  T1 True-> PRIM_I8_GET  ctx-type!
-    Ctx0 TYPE_PTR T1 TYPE_I16 T1 True-> PRIM_I16_GET ctx-type!
-    Ctx0 TYPE_PTR T1 TYPE_I32 T1 True-> PRIM_I32_GET ctx-type!
-    Ctx0 TYPE_PTR T1 TYPE_I64 T1 True-> PRIM_I64_GET ctx-type!
+    Ctx0 TYPE_PTR T1 TYPE_PTR T1 T-> PRIM_PTR_GET ctx-type!
+    Ctx0 TYPE_PTR T1 TYPE_U8  T1 T-> PRIM_U8_GET  ctx-type!
+    Ctx0 TYPE_PTR T1 TYPE_U16 T1 T-> PRIM_U16_GET ctx-type!
+    Ctx0 TYPE_PTR T1 TYPE_U32 T1 T-> PRIM_U32_GET ctx-type!
+    Ctx0 TYPE_PTR T1 TYPE_U64 T1 T-> PRIM_U64_GET ctx-type!
+    Ctx0 TYPE_PTR T1 TYPE_I8  T1 T-> PRIM_I8_GET  ctx-type!
+    Ctx0 TYPE_PTR T1 TYPE_I16 T1 T-> PRIM_I16_GET ctx-type!
+    Ctx0 TYPE_PTR T1 TYPE_I32 T1 T-> PRIM_I32_GET ctx-type!
+    Ctx0 TYPE_PTR T1 TYPE_I64 T1 T-> PRIM_I64_GET ctx-type!
 
-    Ctx0 TYPE_PTR TYPE_PTR T2 T0 True-> PRIM_PTR_SET ctx-type!
-    Ctx0 TYPE_U8  TYPE_PTR T2 T0 True-> PRIM_U8_SET  ctx-type!
-    Ctx0 TYPE_U16 TYPE_PTR T2 T0 True-> PRIM_U16_SET ctx-type!
-    Ctx0 TYPE_U32 TYPE_PTR T2 T0 True-> PRIM_U32_SET ctx-type!
-    Ctx0 TYPE_U64 TYPE_PTR T2 T0 True-> PRIM_U64_SET ctx-type!
-    Ctx0 TYPE_I8  TYPE_PTR T2 T0 True-> PRIM_I8_SET  ctx-type!
-    Ctx0 TYPE_I16 TYPE_PTR T2 T0 True-> PRIM_I16_SET ctx-type!
-    Ctx0 TYPE_I32 TYPE_PTR T2 T0 True-> PRIM_I32_SET ctx-type!
-    Ctx0 TYPE_I64 TYPE_PTR T2 T0 True-> PRIM_I64_SET ctx-type!
+    Ctx0 TYPE_PTR TYPE_PTR T2 T0 T-> PRIM_PTR_SET ctx-type!
+    Ctx0 TYPE_U8  TYPE_PTR T2 T0 T-> PRIM_U8_SET  ctx-type!
+    Ctx0 TYPE_U16 TYPE_PTR T2 T0 T-> PRIM_U16_SET ctx-type!
+    Ctx0 TYPE_U32 TYPE_PTR T2 T0 T-> PRIM_U32_SET ctx-type!
+    Ctx0 TYPE_U64 TYPE_PTR T2 T0 T-> PRIM_U64_SET ctx-type!
+    Ctx0 TYPE_I8  TYPE_PTR T2 T0 T-> PRIM_I8_SET  ctx-type!
+    Ctx0 TYPE_I16 TYPE_PTR T2 T0 T-> PRIM_I16_SET ctx-type!
+    Ctx0 TYPE_I32 TYPE_PTR T2 T0 T-> PRIM_I32_SET ctx-type!
+    Ctx0 TYPE_I64 TYPE_PTR T2 T0 T-> PRIM_I64_SET ctx-type!
 
-    Ctx0 TYPE_INT TYPE_PTR TYPE_INT T3 TYPE_INT T1 True->
+    Ctx0 TYPE_INT TYPE_PTR TYPE_INT T3 TYPE_INT T1 T->
     PRIM_POSIX_READ ctx-type!
 
-    Ctx0 TYPE_INT TYPE_PTR TYPE_INT T3 TYPE_INT T1 True->
+    Ctx0 TYPE_INT TYPE_PTR TYPE_INT T3 TYPE_INT T1 T->
     PRIM_POSIX_WRITE ctx-type!
 
-    Ctx0 TYPE_PTR TYPE_INT TYPE_INT T3 TYPE_INT T1 True->
+    Ctx0 TYPE_PTR TYPE_INT TYPE_INT T3 TYPE_INT T1 T->
     PRIM_POSIX_OPEN ctx-type!
 
-    Ctx0 TYPE_INT T1 TYPE_INT T1 True->
+    Ctx0 TYPE_INT T1 TYPE_INT T1 T->
     PRIM_POSIX_CLOSE ctx-type!
 
     Ctx0
     TYPE_PTR TYPE_INT TYPE_INT TYPE_INT TYPE_INT TYPE_INT T6
-    TYPE_PTR T1 True->
+    TYPE_PTR T1 T->
     PRIM_POSIX_MMAP ctx-type!
 
-    Ctx0 T0 TYPE_PTR T1 True->
+    Ctx0 T0 TYPE_PTR T1 T->
     PRIM_PTR_NIL ctx-type!
 
-    Ctx0 TYPE_PTR TYPE_PTR T2 TYPE_BOOL T1 True->
+    Ctx0 TYPE_PTR TYPE_PTR T2 TYPE_BOOL T1 T->
     PRIM_PTR_EQ ctx-type!
 
-    Ctx0 TYPE_INT TYPE_PTR T2 TYPE_PTR T1 True->
+    Ctx0 TYPE_INT TYPE_PTR T2 TYPE_PTR T1 T->
     PRIM_PTR_ADD ctx-type!
 
-    Ctx0 T0 TYPE_INT T1 True->
+    Ctx0 T0 TYPE_INT T1 T->
     PRIM_PTR_SIZE ctx-type!
 
-    Ctx0 TYPE_INT T1 TYPE_PTR T1 True->
+    Ctx0 TYPE_INT T1 TYPE_PTR T1 T->
     PRIM_PTR_ALLOC ctx-type!
 
-    Ctx0 TYPE_PTR TYPE_INT T2 TYPE_PTR T1 True->
+    Ctx0 TYPE_PTR TYPE_INT T2 TYPE_PTR T1 T->
     PRIM_PTR_REALLOC ctx-type!
 
-    Ctx0 TYPE_PTR T1 T0 True->
+    Ctx0 TYPE_PTR T1 T0 T->
     PRIM_PTR_FREE ctx-type!
 
-    Ctx0 TYPE_PTR TYPE_INT TYPE_PTR T3 T0 True->
+    Ctx0 TYPE_PTR TYPE_INT TYPE_PTR T3 T0 T->
     PRIM_PTR_COPY ctx-type!
 
-    Ctx0 TYPE_INT TYPE_INT TYPE_PTR T3 T0 True->
+    Ctx0 TYPE_INT TYPE_INT TYPE_PTR T3 T0 T->
     PRIM_PTR_FILL ctx-type!
 
-    Ctx0 TYPE_PTR TYPE_INT T2 TYPE_STR T1 True->
+    Ctx0 TYPE_PTR TYPE_INT T2 TYPE_STR T1 T->
     PRIM_STR_COPY ctx-type!
 
-    Ctx0 TYPE_STR T1 TYPE_INT T1 True->
+    Ctx0 TYPE_STR T1 TYPE_INT T1 T->
     PRIM_STR_NUM_BYTES ctx-type!
 
-    Ctx0 TYPE_STR T1 TYPE_PTR T1 True->
+    Ctx0 TYPE_STR T1 TYPE_PTR T1 T->
     PRIM_STR_BASE ctx-type!
 
-    Ctx0 TYPE_STR TYPE_STR T2 TYPE_STR T1 True->
+    Ctx0 TYPE_STR TYPE_STR T2 TYPE_STR T1 T->
     PRIM_STR_CAT ctx-type!
 
-    Ctx0 TYPE_STR TYPE_STR T2 TYPE_INT T1 True->
+    Ctx0 TYPE_STR TYPE_STR T2 TYPE_INT T1 T->
     PRIM_STR_CMP ctx-type!
 
-    Ctx0 T0 TYPE_INT T1 True->
+    Ctx0 T0 TYPE_INT T1 T->
     PRIM_SYS_OS ctx-type!
 
-    Ctx0 T0 TYPE_INT T1 True->
+    Ctx0 T0 TYPE_INT T1 T->
     PRIM_SYS_ARCH ctx-type!
 
-    Ctx0 T0 TYPE_INT T1 True->
+    Ctx0 T0 TYPE_INT T1 T->
     PRIM_SYS_ARGC ctx-type!
 
-    Ctx0 T0 TYPE_PTR T1 True->
+    Ctx0 T0 TYPE_PTR T1 T->
     PRIM_SYS_ARGV ctx-type!
 
-    Ctx0 T0 T0 >Type T1 True->
+    Ctx0 T0 T0 >Type T1 T->
     PRIM_PACK_NIL ctx-type!
 
     #
@@ -392,72 +392,72 @@ def(init-prims!, --,
         xs STVar ys STVar
     \( ta tb tc trr tsr txs tys ->
         a Ctx1
-        ta T1 T0 True->
+        ta T1 T0 T->
         PRIM_CORE_DROP ctx-type!
 
         a Ctx1
-        ta T1 ta ta T2 True->
+        ta T1 ta ta T2 T->
         PRIM_CORE_DUP ctx-type!
 
         a b Ctx2
-        ta tb T2 tb ta T2 True->
+        ta tb T2 tb ta T2 T->
         PRIM_CORE_SWAP ctx-type!
 
         xs ys Ctx2
-        txs txs tys True-> >Type True* tys True->
+        txs txs tys T-> >Type T* tys T->
         PRIM_CORE_RUN ctx-type!
 
         xs ys Ctx2
-        txs TYPE_INT True* tys True->
+        txs TYPE_INT T* tys T->
         PRIM_POSIX_EXIT ctx-type!
 
         xs ys Ctx2
-        txs TYPE_STR True* tys True->
+        txs TYPE_STR T* tys T->
         PRIM_CORE_PANIC ctx-type!
 
         xs ys c Ctx3
-        txs tc True* txs tys True-> >Type True* tys tc True* True->
+        txs tc T* txs tys T-> >Type T* tys tc T* T->
         PRIM_CORE_DIP ctx-type!
 
         xs ys Ctx2
-        txs TYPE_BOOL True* txs tys True-> >Type sip(True*) True* tys True->
+        txs TYPE_BOOL T* txs tys T-> >Type sip(T*) T* tys T->
         PRIM_CORE_IF ctx-type!
 
         xs Ctx1
-        txs txs txs TYPE_BOOL True* True-> >Type True*
-            txs txs True-> >Type True*
-        txs True->
+        txs txs txs TYPE_BOOL T* T-> >Type T*
+            txs txs T-> >Type T*
+        txs T->
         PRIM_CORE_WHILE ctx-type!
 
         rr sr Ctx2
-        T0 trr True+ tsr True+ T0 tsr True+ trr True+ True->
+        T0 trr T+ tsr T+ T0 tsr T+ trr T+ T->
         PRIM_CORE_RSWAP ctx-type!
 
         xs ys rr Ctx3
-        txs trr True+ txs tys True-> >Type True* tys trr True+ True->
+        txs trr T+ txs tys T-> >Type T* tys trr T+ T->
         PRIM_CORE_RDIP ctx-type!
 
         xs b Ctx2
-        txs >Type tb T2 txs tb True* >Type T1 True->
+        txs >Type tb T2 txs tb T* >Type T1 T->
         PRIM_PACK_CONS ctx-type!
 
         xs b Ctx2
-        txs tb True* >Type T1 txs >Type tb T2 True->
+        txs tb T* >Type T1 txs >Type tb T2 T->
         PRIM_PACK_UNCONS ctx-type!
 
         a Ctx1
-        ta T1 ta TMut T1 True->
+        ta T1 ta TMut T1 T->
         PRIM_MUT_NEW ctx-type!
 
         a Ctx1
-        ta TMut T1 ta T1 True->
+        ta TMut T1 ta T1 T->
         PRIM_MUT_GET ctx-type!
 
         a Ctx1
-        ta ta TMut T2 T0 True->
+        ta ta TMut T2 T0 T->
         PRIM_MUT_SET ctx-type!
 
         a Ctx1
-        ta TMut T1 TYPE_BOOL T1 True->
+        ta TMut T1 TYPE_BOOL T1 T->
         PRIM_MUT_IS_SET ctx-type!
     )))

--- a/src/specializer.mth
+++ b/src/specializer.mth
@@ -113,7 +113,7 @@ def(+SPCheck.push-check-block!, Block +SPCheck -- +SPCheck,
 def(ab-build-over-atom!(f), (*a +AB -- *b +AB) *a Atom -- *b Arrow,
     /Atom
     ctx>
-    dom> cod> True->
+    dom> cod> T->
     token> home>
     subst> op> args> drop3
     ab-build-hom!(dip(f)))
@@ -171,7 +171,7 @@ def(specialize-ctx-type, SPKey Ctx ArrowType -- Ctx ArrowType,
         /ArgBlock type TMorphism unify! drop2
     )
     gamma> drop
-    swap True->
+    swap T->
     dip:Ctx0 rigidify-sig!)
 
 

--- a/src/table.mth
+++ b/src/table.mth
@@ -37,6 +37,6 @@ def(Field.value-type, Field -- Type, ~value-type force!)
 
 def(Field.dom, Field -- StackType, index-type T1)
 def(Field.cod, Field -- StackType, value-type TMut T1)
-def(Field.type, Field -- ArrowType, sip(dom) cod True->)
+def(Field.type, Field -- ArrowType, sip(dom) cod T->)
 
 def(Field.==, Field Field -- Bool, both(index) ==)

--- a/src/type.mth
+++ b/src/type.mth
@@ -105,19 +105,19 @@ def(init-types!, --,
 # Types #
 #########
 
-def(True+, StackType Resource -- StackType, STWith)
-def(True*, StackType Type -- StackType, STCons)
-def(True*+, StackType Either(Type, Resource) -- StackType, match(Left -> True*, Right -> True+))
-def(True->, StackType StackType -- ArrowType, ARROW_TYPE)
+def(T+, StackType Resource -- StackType, STWith)
+def(T*, StackType Type -- StackType, STCons)
+def(T*+, StackType Either(Type, Resource) -- StackType, match(Left -> T*, Right -> T+))
+def(T->, StackType StackType -- ArrowType, ARROW_TYPE)
 
-def(TT, List(Type) -- StackType, T0 swap for(True*))
+def(TT, List(Type) -- StackType, T0 swap for(T*))
 def(T0, StackType, STACK_TYPE_UNIT)
-def(T1, Type -- StackType, dip(T0) True*)
-def(T2, Type Type -- StackType, dip(T1) True*)
-def(T3, Type Type Type -- StackType, dip(T2) True*)
-def(T4, Type Type Type Type -- StackType, dip(T3) True*)
-def(T5, Type Type Type Type Type -- StackType, dip(T4) True*)
-def(T6, Type Type Type Type Type Type -- StackType, dip(T5) True*)
+def(T1, Type -- StackType, dip(T0) T*)
+def(T2, Type Type -- StackType, dip(T1) T*)
+def(T3, Type Type Type -- StackType, dip(T2) T*)
+def(T4, Type Type Type Type -- StackType, dip(T3) T*)
+def(T5, Type Type Type Type Type -- StackType, dip(T4) T*)
+def(T6, Type Type Type Type Type Type -- StackType, dip(T5) T*)
 
 # def(type-is-error, Type -- Bool, match(TYPE_ERROR -> True, _ -> drop False))
 # def(type-is-dont-care, Type -- Bool, match(TYPE_DONT_CARE -> True, _ -> drop False))
@@ -304,7 +304,7 @@ def(Value.unify-error!, Gamma Value -- Gamma Type,
 
 def(Type.unify-block!, Gamma Block Type -- Gamma Type,
     expand match(
-        TYPE_ERROR -> STACK_TYPE_ERROR STACK_TYPE_ERROR True-> block-unify-type! drop TYPE_ERROR,
+        TYPE_ERROR -> STACK_TYPE_ERROR STACK_TYPE_ERROR T-> block-unify-type! drop TYPE_ERROR,
         TMeta -> over dip(dip(type >Type) unify! drop) arrow type >Type,
         TMorphism -> block-unify-type! >Type,
         _ -> dip(type >Type) unify!


### PR DESCRIPTION
In #271 I accidentally renamed some words that are used to create stack types. This PR reverts that accidental change.