### PR TITLE
Make resource labels use + as a prefix.

### DIFF
--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -5762,11 +5762,8 @@ static void mw_std_str_ZPlusStr_firstZ_byte (void);
 static void mw_std_str_ZPlusStr_secondZ_byte (void);
 static void mw_std_str_ZPlusStr_thirdZ_byte (void);
 static void mw_std_str_ZPlusStr_firstZ_twoZ_bytes (void);
-static void mw_std_str_ZPlusStr_lastZ_twoZ_bytes (void);
 static void mw_std_str_ZPlusStr_dropZ_firstZ_byte (void);
-static void mw_std_str_ZPlusStr_dropZ_firstZ_twoZ_bytes (void);
 static void mw_std_str_ZPlusStr_dropZ_lastZ_byte (void);
-static void mw_std_str_ZPlusStr_dropZ_lastZ_twoZ_bytes (void);
 static void mw_std_str_ZPlusStr_labelZ_tokenZAsk (void);
 static void mw_std_str_ZPlusStr_labelZ_popZ_tokenZAsk (void);
 static void mw_std_str_ZPlusStr_labelZ_popZ_rZ_tokenZAsk (void);
@@ -6526,6 +6523,7 @@ static void mb_mirth_data_Tag_numZ_resourceZ_inputsZ_fromZ_sig_0 (void);
 static void mb_mirth_data_Tag_numZ_resourceZ_inputsZ_fromZ_sig_1 (void);
 static void mb_mirth_data_Tag_numZ_resourceZ_inputsZ_fromZ_sig_2 (void);
 static void mb_mirth_data_Tag_numZ_resourceZ_inputsZ_fromZ_sig_3 (void);
+static void mb_mirth_data_Tag_numZ_resourceZ_inputsZ_fromZ_sig_4 (void);
 static void mb_mirth_data_Tag_numZ_labelZ_inputs_0 (void);
 static void mb_mirth_word_Word_preferZ_inlineZAsk_0 (void);
 static void mb_std_map_Map_2_lookup_1_1 (void);
@@ -26743,8 +26741,29 @@ static void mw_mirth_name_Name_canZ_beZ_relativeZAsk (void) {
 	}
 }
 static void mw_mirth_name_Name_couldZ_beZ_labelZ_nameZAsk (void) {
+	mp_primZ_dup();
 	mw_mirth_name_Name_head();
 	mw_std_byte_Byte_isZ_lower();
+	if (pop_u64()) {
+		push_u64(1LL); // True
+	} else {
+		mp_primZ_dup();
+		mw_mirth_name_Name_head();
+		push_u64(43LL); // B'+'
+		mw_std_byte_Byte_ZEqualZEqual();
+		if (pop_u64()) {
+			mp_primZ_dup();
+			mw_mirth_name_Name_tailZ_head();
+			mw_std_byte_Byte_isZ_lower();
+		} else {
+			push_u64(0LL); // False
+		}
+	}
+	{
+		VAL d2 = pop_value();
+		mp_primZ_drop();
+		push_value(d2);
+	}
 }
 static void mw_mirth_name_Name_couldZ_beZ_type (void) {
 	mw_mirth_name_Name_head();
@@ -28192,44 +28211,8 @@ static void mw_std_str_ZPlusStr_firstZ_twoZ_bytes (void) {
 	mw_std_prim_Int_ZToNat();
 	mw_std_str_ZPlusStr_takeZ_slice();
 }
-static void mw_std_str_ZPlusStr_lastZ_twoZ_bytes (void) {
-	{
-		VAL d2 = pop_resource();
-		mw_std_str_ZPlusStr_numZ_bytesZAsk();
-		push_resource(d2);
-	}
-	mw_std_prelude_Sizze_ZDivSizze();
-	push_i64(2LL);
-	mp_primZ_swap();
-	mp_primZ_intZ_lt();
-	if (pop_u64()) {
-		{
-			VAL d3 = pop_resource();
-			mw_std_str_ZPlusStr_numZ_bytesZAsk();
-			push_resource(d3);
-		}
-		mw_std_prelude_Sizze_ZDivSizze();
-		mw_std_prelude_Offset_ZDivOffset();
-		push_i64(1LL);
-		mp_primZ_intZ_sub();
-		mw_std_prelude_Offset_ZDivOffset();
-		push_i64(1LL);
-		mp_primZ_intZ_sub();
-		mw_std_str_ZPlusStr_dropZ_slice();
-	} else {
-		{
-			VAL d3 = pop_resource();
-			mw_std_str_ZPlusStr_dupZBang();
-			push_resource(d3);
-		}
-	}
-}
 static void mw_std_str_ZPlusStr_dropZ_firstZ_byte (void) {
 	push_i64(1LL);
-	mw_std_str_ZPlusStr_dropZ_slice();
-}
-static void mw_std_str_ZPlusStr_dropZ_firstZ_twoZ_bytes (void) {
-	push_i64(2LL);
 	mw_std_str_ZPlusStr_dropZ_slice();
 }
 static void mw_std_str_ZPlusStr_dropZ_lastZ_byte (void) {
@@ -28248,44 +28231,6 @@ static void mw_std_str_ZPlusStr_dropZ_lastZ_byte (void) {
 			mw_std_str_ZPlusStr_numZ_bytesZAsk();
 			push_resource(d3);
 		}
-		mw_std_prelude_Sizze_ZDivSizze();
-		push_i64(1LL);
-		mp_primZ_intZ_sub();
-		mw_std_prim_Int_ZToNat();
-		mw_std_str_ZPlusStr_takeZ_slice();
-	} else {
-		{
-			static bool vready = false;
-			static VAL v;
-			if (! vready) {
-				v = mkstr("", 0);
-				vready = true;
-			}
-			push_value(v);
-			incref(v);
-		}
-	}
-}
-static void mw_std_str_ZPlusStr_dropZ_lastZ_twoZ_bytes (void) {
-	{
-		VAL d2 = pop_resource();
-		mw_std_str_ZPlusStr_numZ_bytesZAsk();
-		push_resource(d2);
-	}
-	mw_std_prelude_Sizze_ZDivSizze();
-	push_i64(2LL);
-	mp_primZ_swap();
-	mp_primZ_intZ_lt();
-	if (pop_u64()) {
-		{
-			VAL d3 = pop_resource();
-			mw_std_str_ZPlusStr_numZ_bytesZAsk();
-			push_resource(d3);
-		}
-		mw_std_prelude_Sizze_ZDivSizze();
-		push_i64(1LL);
-		mp_primZ_intZ_sub();
-		mw_std_prim_Int_ZToNat();
 		mw_std_prelude_Sizze_ZDivSizze();
 		push_i64(1LL);
 		mp_primZ_intZ_sub();
@@ -28341,71 +28286,24 @@ static void mw_std_str_ZPlusStr_labelZ_popZ_tokenZAsk (void) {
 }
 static void mw_std_str_ZPlusStr_labelZ_popZ_rZ_tokenZAsk (void) {
 	mw_std_str_ZPlusStr_firstZ_byte();
-	mw_std_byte_Byte_isZ_lower();
+	push_u64(43LL); // B'+'
+	mw_std_byte_Byte_ZEqualZEqual();
 	if (pop_u64()) {
-		push_resource(MKU64(0LL)); // +Unsafe
-		mw_std_str_ZPlusStr_lastZ_twoZ_bytes();
-		mw_std_prelude_ZPlusUnsafe_ZDivZPlusUnsafe();
-		{
-			static bool vready = false;
-			static VAL v;
-			if (! vready) {
-				v = mkstr(">+", 2);
-				vready = true;
-			}
-			push_value(v);
-			incref(v);
-		}
-		mp_primZ_strZ_cmp();
-		push_i64(0LL);
-		{
-			VAL d3 = pop_value();
-			mp_primZ_dup();
-			push_value(d3);
-		}
-		mp_primZ_swap();
-		{
-			VAL d3 = pop_value();
-			mp_primZ_dup();
-			push_value(d3);
-		}
-		mp_primZ_swap();
-		mp_primZ_intZ_eq();
+		mw_std_str_ZPlusStr_secondZ_byte();
+		mw_std_byte_Byte_isZ_lower();
 		if (pop_u64()) {
-			mp_primZ_drop();
-			mp_primZ_drop();
-			push_u64(1LL); // EQ
+			mw_std_str_ZPlusStr_lastZ_byte();
+			push_u64(62LL); // B'>'
+			mw_std_byte_Byte_ZEqualZEqual();
 		} else {
-			mp_primZ_intZ_lt();
-			if (pop_u64()) {
-				push_u64(0LL); // LT
-			} else {
-				push_u64(2LL); // GT
-			}
-		}
-		switch (get_top_data_tag()) {
-			case 0LL: // LT
-				(void)pop_u64();
-				push_u64(0LL); // False
-				break;
-			case 1LL: // EQ
-				(void)pop_u64();
-				push_u64(1LL); // True
-				break;
-			case 2LL: // GT
-				(void)pop_u64();
-				push_u64(0LL); // False
-				break;
-			default:
-				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-				mp_primZ_panic();
+			push_u64(0LL); // False
 		}
 	} else {
 		push_u64(0LL); // False
 	}
 	if (pop_u64()) {
 		push_resource(MKU64(0LL)); // +Unsafe
-		mw_std_str_ZPlusStr_dropZ_lastZ_twoZ_bytes();
+		mw_std_str_ZPlusStr_dropZ_lastZ_byte();
 		mw_std_prelude_ZPlusUnsafe_ZDivZPlusUnsafe();
 		mw_std_prim_Str_ZToName();
 		mw_mirth_label_Label_newZBang();
@@ -28445,7 +28343,7 @@ static void mw_std_str_ZPlusStr_labelZ_pushZ_rZ_tokenZAsk (void) {
 		static bool vready = false;
 		static VAL v;
 		if (! vready) {
-			v = mkstr("+>", 2);
+			v = mkstr(">+", 2);
 			vready = true;
 		}
 		push_value(v);
@@ -28503,7 +28401,7 @@ static void mw_std_str_ZPlusStr_labelZ_pushZ_rZ_tokenZAsk (void) {
 	}
 	if (pop_u64()) {
 		push_resource(MKU64(0LL)); // +Unsafe
-		mw_std_str_ZPlusStr_dropZ_firstZ_twoZ_bytes();
+		mw_std_str_ZPlusStr_dropZ_firstZ_byte();
 		mw_std_prelude_ZPlusUnsafe_ZDivZPlusUnsafe();
 		mw_std_prim_Str_ZToName();
 		mw_mirth_label_Label_newZBang();
@@ -28520,6 +28418,19 @@ static void mw_std_str_ZPlusStr_labelZ_getZ_tokenZAsk (void) {
 	if (pop_u64()) {
 		mw_std_str_ZPlusStr_secondZ_byte();
 		mw_std_byte_Byte_isZ_lower();
+		if (pop_u64()) {
+			push_u64(1LL); // True
+		} else {
+			mw_std_str_ZPlusStr_secondZ_byte();
+			push_u64(43LL); // B'+'
+			mw_std_byte_Byte_ZEqualZEqual();
+			if (pop_u64()) {
+				mw_std_str_ZPlusStr_thirdZ_byte();
+				mw_std_byte_Byte_isZ_lower();
+			} else {
+				push_u64(0LL); // False
+			}
+		}
 	} else {
 		push_u64(0LL); // False
 	}
@@ -44079,8 +43990,10 @@ static void mb_mirth_data_Tag_numZ_typeZ_inputsZ_fromZ_sig_1 (void) {
 static void mb_mirth_data_Tag_numZ_resourceZ_inputsZ_fromZ_sig_0 (void) {
 	mw_mirth_token_Token_runZ_tokens();
 	push_fnptr(&mb_mirth_data_Tag_numZ_resourceZ_inputsZ_fromZ_sig_2);
-	mw_std_list_List_1_filterZ_some_1();
+	mw_std_list_List_1_filter_1();
 	push_fnptr(&mb_mirth_data_Tag_numZ_resourceZ_inputsZ_fromZ_sig_3);
+	mw_std_list_List_1_filterZ_some_1();
+	push_fnptr(&mb_mirth_data_Tag_numZ_resourceZ_inputsZ_fromZ_sig_4);
 	mw_std_list_List_1_filter_1();
 	mw_std_list_List_1_len();
 }
@@ -44089,9 +44002,18 @@ static void mb_mirth_data_Tag_numZ_resourceZ_inputsZ_fromZ_sig_1 (void) {
 	mw_std_prim_Int_ZToNat();
 }
 static void mb_mirth_data_Tag_numZ_resourceZ_inputsZ_fromZ_sig_2 (void) {
-	mw_mirth_token_Token_nameZAsk();
+	mp_primZ_dup();
+	mw_mirth_token_Token_couldZ_beZ_sigZ_labelZAsk();
+	if (pop_u64()) {
+		push_u64(0LL); // False
+	} else {
+		push_u64(1LL); // True
+	}
 }
 static void mb_mirth_data_Tag_numZ_resourceZ_inputsZ_fromZ_sig_3 (void) {
+	mw_mirth_token_Token_nameZAsk();
+}
+static void mb_mirth_data_Tag_numZ_resourceZ_inputsZ_fromZ_sig_4 (void) {
 	mp_primZ_dup();
 	mw_mirth_name_Name_couldZ_beZ_resourceZ_var();
 	if (pop_u64()) {

--- a/debug.sh
+++ b/debug.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
-set -uo pipefail
-make bin/mirth2debug && bin/mirth2debug --debug -p std:src/std -p posix:src/posix -p mirth:src/mirth -p args:src/args -p snake:src/snake -p mirth-tests:src/mirth-tests --debug -o bin/test.c $1 && gcc -g -o bin/test bin/test.c && bin/test
+set -euo pipefail
+make bin/mirth2debug
+bin/mirth2debug -p std:lib/std -p mirth:src -p arg-parser:lib/arg-parser \
+           -p examples:examples -p mirth-tests:test --debug -o bin/test.c $1
+echo "Compiling."
+gcc -o bin/test bin/test.c
+echo "Running."
+bin/test

--- a/src/data.mth
+++ b/src/data.mth
@@ -188,7 +188,7 @@ def(Tag.num-type-inputs-from-sig, Tag -- Nat,
 
 def(Tag.num-resource-inputs-from-sig, Tag -- Nat,
     sig? if-some(
-        run-tokens filter-some(name?)
+        run-tokens filter(dup could-be-sig-label? not) filter-some(name?)
         filter(dup could-be-resource-var or(dup could-be-resource-con))
         len,
         0 >Nat

--- a/src/lexer.mth
+++ b/src/lexer.mth
@@ -240,8 +240,8 @@ def(+Str.label-pop-token?, +Str -- Maybe(TokenValue) +Str,
     ))
 
 def(+Str.label-pop-r-token?, +Str -- Maybe(TokenValue) +Str,
-    first-byte is-lower and(unsafe(+Str.last-two-bytes) ">+" ==) if(
-        unsafe(+Str.drop-last-two-bytes) >Name Label.new! TokenLabelPopR Some,
+    first-byte B'+' == and(second-byte is-lower and(last-byte B'>' ==)) if(
+        unsafe(+Str.drop-last-byte) >Name Label.new! TokenLabelPopR Some,
         None
     ))
 
@@ -252,13 +252,13 @@ def(+Str.label-push-token?, +Str -- Maybe(TokenValue) +Str,
     ))
 
 def(+Str.label-push-r-token?, +Str -- Maybe(TokenValue) +Str,
-    unsafe(+Str.first-two-bytes) "+>" == and(third-byte is-lower) if(
-        unsafe(+Str.drop-first-two-bytes) >Name Label.new! TokenLabelPushR Some,
+    unsafe(+Str.first-two-bytes) ">+" == and(third-byte is-lower) if(
+        unsafe(+Str.drop-first-byte) >Name Label.new! TokenLabelPushR Some,
         None
     ))
 
 def(+Str.label-get-token?, +Str -- Maybe(TokenValue) +Str,
-    first-byte B'@' == and(second-byte is-lower) if(
+    first-byte B'@' == and(second-byte is-lower or(second-byte B'+' == and(third-byte is-lower))) if(
         unsafe(+Str.drop-first-byte) >Name Label.new! TokenLabelGet Some,
         None
     ))

--- a/src/name.mth
+++ b/src/name.mth
@@ -92,7 +92,7 @@ def(Name.tail, Name -- Name,
     ) >Name)
 
 def(Name.can-be-relative?, Name -- Bool, head is-upper not)
-def(Name.could-be-label-name?, Name -- Bool, head is-lower)
+def(Name.could-be-label-name?, Name -- Bool, dup head is-lower or(dup head B'+' == and(dup tail-head is-lower)) nip)
 def(Name.could-be-type, Name -- Bool, head is-alpha)
 def(Name.could-be-pattern-var?, Name -- Bool, head is-lower)
 def(Name.could-be-type-var, Name -- Bool, head is-lower)

--- a/test/data-labels.mth
+++ b/test/data-labels.mth
@@ -4,8 +4,8 @@ import(std.posix)
 
 data(Person, PERSON -> age:Int name:Str)
 data(Mixed, MIXED -> msg:Str Str)
-data(+MyWorld, +MyWorld -> age:Int msg:Int name:Str world:+World)
-data(+Deep, +Deep -> myworld:+MyWorld)
+data(+MyWorld, +MyWorld -> age:Int msg:Int name:Str +world:+World)
+data(+Deep, +Deep -> +myworld:+MyWorld)
 
 def(Person.greet!, Person +World -- Person +World,
     "Hello, " trace!
@@ -26,20 +26,20 @@ def(main, +World -- +World,
     MIXED msg trace-ln!
 
     99 >age 101 >msg "me" >name
-    +>world
+    >+world
     +MyWorld
     "<<<" trace-ln!
     age trace-ln!
-    +>myworld +Deep
+    >+myworld +Deep
     "<<<<<" trace-ln!
-    myworld:msg trace-ln!
-    myworld rdip(name) trace-ln! myworld!
+    +myworld:msg trace-ln!
+    +myworld rdip(name) trace-ln! +myworld!
     ">>>>>" trace-ln!
-    /+Deep myworld>+
+    /+Deep +myworld>
     name trace-ln!
     ">>>" trace-ln!
     /+MyWorld
-    world>+
+    +world>
     age> drop
     msg> drop
     name> drop

--- a/test/labels.mth
+++ b/test/labels.mth
@@ -7,8 +7,8 @@ def(pop-foo, foo:x -- x, foo>)
 def(pop-bar, bar:x -- x, bar>)
 def(push-foo, x -- foo:x, >foo)
 def(push-bar, y -- bar:y, >bar)
-def(pop-mystr, mystr:+a -- +a, mystr>+)
-def(push-mystr, +a -- mystr:+a, +>mystr)
+def(pop-mystr, +mystr:+a -- +a, +mystr>)
+def(push-mystr, +a -- +mystr:+a, >+mystr)
 
 def(main, +World -- +World,
     10 20 30 >foo >bar show put " " put


### PR DESCRIPTION
Changes the syntax of resource labels slightly (see #276):

- Resource labels must begin with a `+`, e.g. `+foo: +MyResource` as part of a type signature, says that the resource `+MyResource` is pushed on the `+foo` resource label.

- Because resource labels start with`+`, and value labels do not, they can be immediately distinguished.
  Thus the push and pop syntax for resource labels has been simplified to be more similar to value labels:

  - `>+foo` pushes a resource onto `+foo`
  - `+foo>` pops a resource from `+foo`
  
  Because the names are disjoint, no ambiguity arises about whether we're pushing/popping from the resource stack or the value stack.
  
- Of the three label access functions defined in #276 (see last part), only `@+foo(f)` is defined for resource labels.