### PR TITLE
Package resolution: Derive package path from module path, and have a default package search path.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 C99FLAGS=-std=c99 -Wall -Wextra -Wno-unused-variable -Wno-unused-function -Wno-unused-parameter \
  -Wno-unused-value -Wno-missing-braces -Wno-overlength-strings -Wno-infinite-recursion \
  -Werror -pedantic -O0 -fmax-errors=9 -Wno-unused-command-line-argument
-MIRTHFLAGS=-p std:lib/std -p arg-parser:lib/arg-parser -p mirth:src -p examples:examples -p mirth-tests:test
 
 CC=gcc $(C99FLAGS)
 CCSAN=$(CC) -fsanitize=undefined -fsanitize=address
@@ -94,25 +93,25 @@ bin/mirth3debug: bin/mirth3debug.c
 	$(CC) -g -o bin/mirth3debug bin/mirth3debug.c
 
 bin/mirth1.c: bin/mirth0 $(SRCS)
-	bin/mirth0 $(MIRTHFLAGS) src/main.mth -o bin/mirth1.c
+	bin/mirth0 src/main.mth -o bin/mirth1.c
 
 bin/mirth2.c: bin/mirth1 $(SRCS)
-	bin/mirth1 $(MIRTHFLAGS) src/main.mth -o bin/mirth2.c
+	bin/mirth1 src/main.mth -o bin/mirth2.c
 
 bin/mirth3.c: bin/mirth2 $(SRCS)
-	bin/mirth2 $(MIRTHFLAGS) src/main.mth -o bin/mirth3.c
+	bin/mirth2 src/main.mth -o bin/mirth3.c
 
 bin/mirth1debug.c: bin/mirth0 $(SRCS)
-	bin/mirth0 $(MIRTHFLAGS) --debug src/main.mth -o bin/mirth1debug.c
+	bin/mirth0 --debug src/main.mth -o bin/mirth1debug.c
 
 bin/mirth2debug.c: bin/mirth1debug $(SRCS)
-	bin/mirth1debug $(MIRTHFLAGS) --debug src/main.mth -o bin/mirth2debug.c
+	bin/mirth1debug --debug src/main.mth -o bin/mirth2debug.c
 
 bin/mirth3debug.c: bin/mirth2debug $(SRCS)
-	bin/mirth2debug $(MIRTHFLAGS) --debug src/main.mth -o bin/mirth3debug.c
+	bin/mirth2debug --debug src/main.mth -o bin/mirth3debug.c
 
 bin/mirth3san.c: bin/mirth2san $(SRCS)
-	bin/mirth2san $(MIRTHFLAGS) src/main.mth -o bin/mirth3san.c
+	bin/mirth2san src/main.mth -o bin/mirth3san.c
 
 bin/mirth_prof.c: bin/mirth3.c
 
@@ -120,7 +119,7 @@ bin/mirth_prof: bin/mirth_prof.c
 	$(CC) -g -fprofile-instr-generate -o bin/mirth_prof bin/mirth_prof.c
 
 bin/snake.c: bin/mirth2 lib/std/* examples/snake.mth examples/sdl2.mth
-	bin/mirth2 --debug $(MIRTHFLAGS) examples/snake.mth -o bin/snake.c
+	bin/mirth2 --debug examples/snake.mth -o bin/snake.c
 
 bin/snake: bin/snake.c
 	$(CC) -o bin/snake bin/snake.c `pkg-config --libs sdl2`

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -4837,6 +4837,7 @@ static void mw_std_prim_Str_copyZ_partialZBang (void);
 static void mw_std_str_cstrZ_numZ_bytes (void);
 static void mw_std_prim_Str_thaw (void);
 static void mw_std_str_ZPlusStr_freezze (void);
+static void mw_std_str_ZPlusStr_rdrop (void);
 static void mw_std_str_Str_1 (void);
 static void mw_std_str_ZPlusStr_dupZBang (void);
 static void mw_std_str_ZPlusStr_numZ_bytesZAsk (void);
@@ -4853,12 +4854,16 @@ static void mw_std_prim_Str_fromZ_bytesZ_unsafe (void);
 static void mw_std_prim_Str_withZ_dataZ_cstr_1 (void);
 static void mw_std_str_clampZ_sliceZ_offsetZ_sizze (void);
 static void mw_std_prim_Str_slice (void);
+static void mw_std_prim_Str_dropZ_slice (void);
+static void mw_std_prim_Str_takeZ_slice (void);
 static void mw_std_str_ZPlusStr_slice (void);
 static void mw_std_str_ZPlusStr_offsetZ_slice (void);
 static void mw_std_str_ZPlusStr_takeZ_slice (void);
 static void mw_std_str_ZPlusStr_dropZ_slice (void);
 static void mw_std_str_ZPlusStr_splitZ_byte (void);
 static void mw_std_prim_Str_splitZ_byte (void);
+static void mw_std_str_ZPlusStr_findZ_lastZ_byte_1 (void);
+static void mw_std_prim_Str_splitZ_lastZ_byte_1 (void);
 static void mw_std_str_ZPlusStr_pushZ_showZ_byteZBang (void);
 static void mw_std_prim_Str_show (void);
 static void mw_std_list_List_1_ZDivL1 (void);
@@ -4936,9 +4941,9 @@ static void mw_std_maybe_Maybe_1_unwrapZ_or_1 (void);
 static void mw_std_maybe_Maybe_1_map_1 (void);
 static void mw_std_maybe_Maybe_1_bind_1 (void);
 static void mw_std_maybe_Maybe_1_for_1 (void);
-static void mw_std_maybe_whileZ_some_2 (void);
 static void mw_std_maybe_Maybe_1_map2_1 (void);
 static void mw_std_maybe_Maybe_1_zzip (void);
+static void mw_std_prelude_OS_tag (void);
 static void mw_std_prelude_OS_fromZ_tagZ_unsafe (void);
 static void mw_std_prim_Int_ZToOS (void);
 static void mw_std_prim_Int_inZ_range (void);
@@ -4966,8 +4971,11 @@ static void mw_std_prelude_ZAtZAsk (void);
 static void mw_std_prelude_panicZBang (void);
 static void mw_std_prelude_expectZBang_2 (void);
 static void mw_std_prelude_assertZBang_2 (void);
+static void mw_std_path_Path_ZDivPath (void);
 static void mw_std_path_Path_joinZ_with (void);
 static void mw_std_path_Path_joinZ_unix (void);
+static void mw_std_byte_Byte_isZ_pathZ_separatorZAsk (void);
+static void mw_std_path_Path_splitZ_last (void);
 static void mw_std_prim_Int_ZToFile (void);
 static void mw_std_posix_File_ZToInt (void);
 static void mw_std_posix_STDOUT (void);
@@ -5732,8 +5740,9 @@ static void mw_mirth_package_Package_allocZBang (void);
 static void mw_mirth_package_Package_name (void);
 static void mw_mirth_package_Package_qname (void);
 static void mw_mirth_package_Package_path (void);
+static void mw_mirth_package_Package_pathZBang (void);
 static void mw_mirth_package_Package_newZBang (void);
-static void mw_mirth_package_Package_newZ_orZ_setZ_pathZBang (void);
+static void mw_mirth_package_Package_newZ_orZ_pathZBang (void);
 static void mw_mirth_package_Package_find (void);
 static void mw_mirth_package_Package_findZ_orZ_newZBang (void);
 static void mw_mirth_package_Package_ZEqualZEqual (void);
@@ -6278,9 +6287,6 @@ static void mb_mirth_elab_elabZ_entryZ_point_0 (void);
 static void mb_mirth_elab_elabZ_entryZ_point_1 (void);
 static void mb_mirth_elab_elabZ_entryZ_point_4 (void);
 static void mb_mirth_main_parseZ_packageZ_def_1 (void);
-static void mb_std_str_ZPlusStr_splitZ_byte_0 (void);
-static void mb_std_list_List_1_ZDivL2_0 (void);
-static void mb_std_list_List_1_ZDivL2_1 (void);
 static void mb_mirth_main_compilerZ_parseZ_args_1 (void);
 static void mb_mirth_main_compilerZ_parseZ_args_2 (void);
 static void mb_mirth_main_compilerZ_parseZ_args_3 (void);
@@ -6330,11 +6336,9 @@ static void mb_std_list_List_1_filter_1_0 (void);
 static void mb_std_list_List_1_map2_1_0 (void);
 static void mb_std_maybe_Maybe_1_zzip_0 (void);
 static void mb_std_list_List_1_cat_0 (void);
-static void mb_std_list_List_1_len_0 (void);
-static void mb_std_list_List_1_len_1 (void);
+static void mb_std_list_List_1_ZDivL2_0 (void);
+static void mb_std_list_List_1_ZDivL2_1 (void);
 static void mb_std_list_List_1_first_0 (void);
-static void mb_std_list_ListZPlus_1_last_0 (void);
-static void mb_std_list_ListZPlus_1_last_1 (void);
 static void mb_std_list_List_1_last_0 (void);
 static void mb_std_list_List_1_reverse_0 (void);
 static void mb_std_list_List_1_fold_1_0 (void);
@@ -6375,10 +6379,13 @@ static void mb_std_prim_Str_fromZ_bytesZ_unsafe_1 (void);
 static void mb_mirth_need_ZPlusNeeds_new_0 (void);
 static void mb_std_prim_Str_withZ_dataZ_cstr_1_0 (void);
 static void mb_std_prim_Str_slice_0 (void);
+static void mb_std_str_ZPlusStr_findZ_lastZ_byte_1_3 (void);
+static void mb_std_prim_Str_splitZ_lastZ_byte_1_1 (void);
 static void mb_std_prim_Int_ZToByte_0 (void);
 static void mb_std_prim_Int_ZToByte_1 (void);
 static void mb_std_byte_Byte_zzencode_2 (void);
 static void mb_std_buffer_ZPlusBuffer_resizzeZBang_0 (void);
+static void mb_std_path_Path_splitZ_last_0 (void);
 static void mb_argZ_parser_parse_printZ_usage_0 (void);
 static void mb_argZ_parser_parse_printZ_usage_1 (void);
 static void mb_argZ_parser_parse_printZ_usage_2 (void);
@@ -6418,14 +6425,13 @@ static void mb_std_file_ZPlusFile_unsafeZ_writeZBang_5 (void);
 static void mb_std_file_ZPlusFile_unsafeZ_writeZBang_6 (void);
 static void mb_std_file_ZPlusFile_unsafeZ_readZBang_1 (void);
 static void mb_std_file_ZPlusFile_unsafeZ_readZBang_2 (void);
-static void mb_std_input_ZPlusInput_readZ_fileZBang_0 (void);
-static void mb_std_input_ZPlusInput_readZ_fileZBang_1 (void);
 static void mb_std_input_ZPlusInputOpenState_fillZ_bufferZBang_0 (void);
 static void mb_std_input_ZPlusInputOpenState_fillZ_bufferZBang_1 (void);
 static void mb_std_input_ZPlusInput_peek_0 (void);
 static void mb_std_input_ZPlusInput_moveZBang_0 (void);
 static void mb_std_input_ZPlusInput_readZ_chunkZBang_0 (void);
 static void mb_mirth_arrow_Block_qname_0 (void);
+static void mb_mirth_package_Package_pathZBang_2 (void);
 static void mb_mirth_label_Label_newZBang_0 (void);
 static void mb_mirth_def_Def_register_1 (void);
 static void mb_mirth_name_QName_defZAsk_0 (void);
@@ -6441,8 +6447,6 @@ static void mb_std_lazzy_delay0_1_0 (void);
 static void mb_std_lazzy_delay2_1_0 (void);
 static void mb_std_lazzy_delay3_1_0 (void);
 static void mb_mirth_def_Def_definingZ_moduleZAsk_0 (void);
-static void mb_mirth_def_Def_resolve_0 (void);
-static void mb_mirth_def_Def_resolve_1 (void);
 static void mb_std_str_ZPlusStr_dnameZAsk_3 (void);
 static void mb_mirth_token_TokenValue_sigZ_typeZAsk_0 (void);
 static void mb_mirth_token_TokenValue_sigZ_typeZ_conZAsk_0 (void);
@@ -6553,8 +6557,6 @@ static void mb_mirth_data_Tag_numZ_labelZ_inputs_0 (void);
 static void mb_mirth_word_Word_preferZ_inlineZAsk_0 (void);
 static void mb_std_map_Map_2_lookup_1_1 (void);
 static void mb_mirth_var_Ctx_lookup_0 (void);
-static void mb_mirth_var_Ctx_freshZ_nameZBang_0 (void);
-static void mb_mirth_var_Ctx_freshZ_nameZBang_1 (void);
 static void mb_mirth_match_Match_hasZ_defaultZ_caseZAsk_0 (void);
 static void mb_mirth_match_Match_scrutineeZ_dataZAsk_0 (void);
 static void mb_mirth_match_Match_scrutineeZ_dataZAsk_1 (void);
@@ -6576,8 +6578,6 @@ static void mb_mirth_match_ZPlusPattern_underscoreZBang_4 (void);
 static void mb_mirth_match_ZPlusPattern_tagZBang_2 (void);
 static void mb_mirth_match_ZPlusPattern_tagZBang_3 (void);
 static void mb_mirth_match_ZPlusPattern_tagZBang_4 (void);
-static void mb_mirth_lexer_lexerZ_closeZ_colonsZBang_0 (void);
-static void mb_mirth_lexer_lexerZ_closeZ_colonsZBang_1 (void);
 static void mb_mirth_lexer_lexerZ_closeZ_colonsZBang_2 (void);
 static void mb_mirth_lexer_lexerZ_prepareZ_forZ_argsZBang_0 (void);
 static void mb_std_str_ZPlusStr_labelZ_tokenZAsk_0 (void);
@@ -6692,6 +6692,8 @@ static void mb_mirth_elab_elabZ_moduleZ_declZBang_2 (void);
 static void mb_mirth_elab_elabZ_moduleZ_packageZ_name_0 (void);
 static void mb_mirth_elab_elabZ_moduleZ_packageZ_name_1 (void);
 static void mb_mirth_elab_elabZ_moduleZ_packageZ_name_2 (void);
+static void mb_mirth_elab_checkZ_moduleZ_path_1 (void);
+static void mb_mirth_elab_checkZ_moduleZ_path_2 (void);
 static void mb_mirth_elab_elabZ_aliasZBang_2 (void);
 static void mb_mirth_elab_elabZ_aliasZBang_4 (void);
 static void mb_mirth_elab_elabZ_aliasZBang_5 (void);
@@ -6781,8 +6783,6 @@ static void mb_mirth_elab_fieldZ_newZBang_0 (void);
 static void mb_mirth_elab_fieldZ_newZBang_1 (void);
 static void mb_mirth_specializzer_ZPlusSPCheck_checkZ_arrowZBang_0 (void);
 static void mb_mirth_specializzer_ZPlusSPCheck_checkZ_arrowZBang_1 (void);
-static void mb_mirth_specializzer_ZPlusSPCheck_loopZBang_0 (void);
-static void mb_mirth_specializzer_ZPlusSPCheck_loopZBang_1 (void);
 static void mb_mirth_specializzer_ZPlusSPCheck_loopZBang_2 (void);
 static void mb_mirth_specializzer_ZPlusSPCheck_checkZ_primZ_atomZBang_0 (void);
 static void mb_mirth_specializzer_ZPlusSPCheck_checkZ_wordZ_atomZBang_0 (void);
@@ -7026,8 +7026,6 @@ static void mb_mirth_need_ZPlusNeeds_needZBang_2 (void);
 static void mb_mirth_need_ZPlusNeeds_needZBang_3 (void);
 static void mb_std_set_ZPlusSet_1_insertZBang_0 (void);
 static void mb_mirth_need_ZPlusNeeds_runZ_arrowZBang_0 (void);
-static void mb_mirth_need_ZPlusNeeds_determineZ_transitiveZ_needsZBang_0 (void);
-static void mb_mirth_need_ZPlusNeeds_determineZ_transitiveZ_needsZBang_1 (void);
 static void mb_mirth_need_ZPlusNeeds_determineZ_transitiveZ_needsZBang_2 (void);
 static void mb_mirth_need_ZPlusNeeds_runZ_argsZBang_0 (void);
 static void mb_mirth_need_ZPlusNeeds_pushZ_argsZBang_0 (void);
@@ -7042,6 +7040,7 @@ static void mb_mirth_need_ZPlusNeeds_runZ_primZBang_7 (void);
 static void mb_mirth_need_ZPlusNeeds_runZ_matchZBang_0 (void);
 static void mb_mirth_need_ZPlusNeeds_runZ_patternZBang_0 (void);
 static void mb_std_set_ZPlusSet_1_offsetZ_mask_0 (void);
+static void mb_std_str_ZPlusStr_splitZ_byte_1_ZLParenstdZDotstrZDotZPlusStrZDotsplitZ_byteZDot2ZRParen_11 (void);
 static void mfld_mirth_label_Label_ZTildename (void);
 static void mfld_mirth_module_Module_ZTildepackage (void);
 static void mfld_mirth_module_Module_ZTildename (void);
@@ -9023,6 +9022,17 @@ static void mw_std_str_ZPlusStr_freezze (void) {
 			mp_primZ_panic();
 	}
 }
+static void mw_std_str_ZPlusStr_rdrop (void) {
+	switch (get_top_resource_data_tag()) {
+		case 0LL: // +Str
+			mtp_std_str_ZPlusStr_ZPlusStr();
+			mp_primZ_drop();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primZ_panic();
+	}
+}
 static void mw_std_str_Str_1 (void) {
 	{
 		VAL var_f = pop_value();
@@ -9260,6 +9270,32 @@ static void mw_std_prim_Str_slice (void) {
 	push_fnptr(&mb_std_prim_Str_slice_0);
 	mw_std_prim_Str_withZ_data_1();
 }
+static void mw_std_prim_Str_dropZ_slice (void) {
+	{
+		VAL d2 = pop_resource();
+		mw_std_prim_Str_thaw();
+		push_resource(d2);
+	}
+	mw_std_str_ZPlusStr_dropZ_slice();
+	{
+		VAL d2 = pop_resource();
+		mw_std_str_ZPlusStr_rdrop();
+		push_resource(d2);
+	}
+}
+static void mw_std_prim_Str_takeZ_slice (void) {
+	{
+		VAL d2 = pop_resource();
+		mw_std_prim_Str_thaw();
+		push_resource(d2);
+	}
+	mw_std_str_ZPlusStr_takeZ_slice();
+	{
+		VAL d2 = pop_resource();
+		mw_std_str_ZPlusStr_rdrop();
+		push_resource(d2);
+	}
+}
 static void mw_std_str_ZPlusStr_slice (void) {
 	{
 		VAL d2 = pop_resource();
@@ -9325,7 +9361,7 @@ static void mw_std_str_ZPlusStr_dropZ_slice (void) {
 	mw_std_str_ZPlusStr_slice();
 }
 static void mw_std_str_ZPlusStr_splitZ_byte (void) {
-	push_fnptr(&mb_std_str_ZPlusStr_splitZ_byte_0);
+	push_fnptr(&mb_std_str_ZPlusStr_splitZ_byte_1_ZLParenstdZDotstrZDotZPlusStrZDotsplitZ_byteZDot2ZRParen_11);
 	mw_std_list_LISTZPlus_1();
 	{
 		VAL d2 = pop_value();
@@ -9336,9 +9372,85 @@ static void mw_std_str_ZPlusStr_splitZ_byte (void) {
 static void mw_std_prim_Str_splitZ_byte (void) {
 	mw_std_prim_Str_thaw();
 	mw_std_str_ZPlusStr_splitZ_byte();
-	mw_std_str_ZPlusStr_freezze();
-	mp_primZ_drop();
-	mw_std_list_ListZPlus_1_ZDivListZPlusUnsafe();
+	mw_std_str_ZPlusStr_rdrop();
+}
+static void mw_std_str_ZPlusStr_findZ_lastZ_byte_1 (void) {
+	{
+		VAL var_p = pop_value();
+		mw_std_str_ZPlusStr_numZ_bytesZAsk();
+		mw_std_prelude_Sizze_ZDivSizze();
+		push_u64(0LL); // None
+		while(1) {
+			mp_primZ_dup();
+			mw_std_maybe_Maybe_1_ZToBool();
+			if (pop_u64()) {
+				push_u64(0LL); // False
+			} else {
+				push_u64(1LL); // True
+			}
+			if (pop_u64()) {
+				{
+					VAL d5 = pop_value();
+					mp_primZ_dup();
+					push_value(d5);
+				}
+				mp_primZ_swap();
+				mw_std_prelude_Offset_ZDivOffset();
+				push_i64(0LL);
+				mp_primZ_swap();
+				mp_primZ_intZ_lt();
+			} else {
+				push_u64(0LL); // False
+			}
+			if (! pop_u64()) break;
+			mp_primZ_drop();
+			mw_std_prelude_Offset_ZDivOffset();
+			push_i64(1LL);
+			mp_primZ_intZ_sub();
+			push_fnptr(&mb_std_str_ZPlusStr_findZ_lastZ_byte_1_3);
+			incref(var_p);
+			push_value(var_p);
+			mp_primZ_packZ_cons();
+			{
+				VAL var_f = pop_value();
+				mp_primZ_dup();
+				{
+					VAL d5 = pop_value();
+					incref(var_f);
+					run_value(var_f);
+					push_value(d5);
+				}
+				decref(var_f);
+			}
+			mp_primZ_swap();
+			if (pop_u64()) {
+				mp_primZ_dup();
+				mtw_std_maybe_Maybe_1_Some();
+			} else {
+				push_u64(0LL); // None
+			}
+		}
+		{
+			VAL d3 = pop_value();
+			mp_primZ_drop();
+			push_value(d3);
+		}
+		decref(var_p);
+	}
+}
+static void mw_std_prim_Str_splitZ_lastZ_byte_1 (void) {
+	{
+		VAL var_p = pop_value();
+		mw_std_prim_Str_thaw();
+		incref(var_p);
+		push_value(var_p);
+		mw_std_str_ZPlusStr_findZ_lastZ_byte_1();
+		mw_std_str_ZPlusStr_freezze();
+		mp_primZ_swap();
+		push_fnptr(&mb_std_prim_Str_splitZ_lastZ_byte_1_1);
+		mw_std_maybe_Maybe_1_map_1();
+		decref(var_p);
+	}
 }
 static void mw_std_str_ZPlusStr_pushZ_showZ_byteZBang (void) {
 	switch (get_top_data_tag()) {
@@ -9458,9 +9570,24 @@ static void mw_std_list_List_1_len (void) {
 	push_i64(0LL);
 	mw_std_prim_Int_ZToNat();
 	mp_primZ_swap();
-	push_fnptr(&mb_std_list_List_1_len_0);
-	push_fnptr(&mb_std_list_List_1_len_1);
-	mw_std_maybe_whileZ_some_2();
+	mw_std_list_List_1_uncons();
+	mp_primZ_swap();
+	while(1) {
+		mp_primZ_dup();
+		mw_std_maybe_Maybe_1_ZToBool();
+		if (! pop_u64()) break;
+		mw_std_maybe_Maybe_1_unwrap();
+		mp_primZ_drop();
+		{
+			VAL d3 = pop_value();
+			push_i64(1LL);
+			mp_primZ_intZ_add();
+			push_value(d3);
+		}
+		mw_std_list_List_1_uncons();
+		mp_primZ_swap();
+	}
+	mp_primZ_drop();
 	mp_primZ_drop();
 }
 static void mw_std_list_List_1_uncons (void) {
@@ -9579,9 +9706,27 @@ static void mw_std_list_ListZPlus_1_last (void) {
 			break;
 		case 1LL: // Cons
 			mtp_std_list_List_1_Cons();
-			push_fnptr(&mb_std_list_ListZPlus_1_last_0);
-			push_fnptr(&mb_std_list_ListZPlus_1_last_1);
-			mw_std_maybe_whileZ_some_2();
+			mw_std_list_List_1_uncons();
+			mp_primZ_swap();
+			while(1) {
+				mp_primZ_dup();
+				mw_std_maybe_Maybe_1_ZToBool();
+				if (! pop_u64()) break;
+				mw_std_maybe_Maybe_1_unwrap();
+				{
+					VAL d5 = pop_value();
+					{
+						VAL d6 = pop_value();
+						mp_primZ_drop();
+						push_value(d6);
+					}
+					push_value(d5);
+				}
+				mp_primZ_swap();
+				mw_std_list_List_1_uncons();
+				mp_primZ_swap();
+			}
+			mp_primZ_drop();
 			mp_primZ_drop();
 			break;
 		default:
@@ -9767,7 +9912,25 @@ static void mw_std_list_List_1_findZ_some_1 (void) {
 		incref(var_f);
 		push_value(var_f);
 		mp_primZ_packZ_cons();
-		mw_std_maybe_whileZ_some_2();
+		{
+			VAL var_g = pop_value();
+			VAL var_f = pop_value();
+			incref(var_f);
+			run_value(var_f);
+			while(1) {
+				mp_primZ_dup();
+				mw_std_maybe_Maybe_1_ZToBool();
+				if (! pop_u64()) break;
+				mw_std_maybe_Maybe_1_unwrap();
+				incref(var_g);
+				run_value(var_g);
+				incref(var_f);
+				run_value(var_f);
+			}
+			mp_primZ_drop();
+			decref(var_g);
+			decref(var_f);
+		}
 		mp_primZ_drop();
 		decref(var_f);
 	}
@@ -10522,27 +10685,6 @@ static void mw_std_maybe_Maybe_1_for_1 (void) {
 		decref(var_f);
 	}
 }
-static void mw_std_maybe_whileZ_some_2 (void) {
-	{
-		VAL var_g = pop_value();
-		VAL var_f = pop_value();
-		incref(var_f);
-		run_value(var_f);
-		while(1) {
-			mp_primZ_dup();
-			mw_std_maybe_Maybe_1_ZToBool();
-			if (! pop_u64()) break;
-			mw_std_maybe_Maybe_1_unwrap();
-			incref(var_g);
-			run_value(var_g);
-			incref(var_f);
-			run_value(var_f);
-		}
-		mp_primZ_drop();
-		decref(var_g);
-		decref(var_f);
-	}
-}
 static void mw_std_maybe_Maybe_1_map2_1 (void) {
 	{
 		VAL var_f = pop_value();
@@ -10583,6 +10725,8 @@ static void mw_std_maybe_Maybe_1_map2_1 (void) {
 static void mw_std_maybe_Maybe_1_zzip (void) {
 	push_fnptr(&mb_std_maybe_Maybe_1_zzip_0);
 	mw_std_maybe_Maybe_1_map2_1();
+}
+static void mw_std_prelude_OS_tag (void) {
 }
 static void mw_std_prelude_OS_fromZ_tagZ_unsafe (void) {
 }
@@ -10918,6 +11062,8 @@ static void mw_std_prelude_assertZBang_2 (void) {
 		decref(var_f);
 	}
 }
+static void mw_std_path_Path_ZDivPath (void) {
+}
 static void mw_std_path_Path_joinZ_with (void) {
 	{
 		VAL d2 = pop_value();
@@ -10966,6 +11112,40 @@ static void mw_std_path_Path_joinZ_unix (void) {
 		push_value(d2);
 	}
 	mw_std_path_Path_joinZ_with();
+}
+static void mw_std_byte_Byte_isZ_pathZ_separatorZAsk (void) {
+	switch (get_top_data_tag()) {
+		case 47LL: // B'/'
+			(void)pop_u64();
+			push_u64(1LL); // True
+			break;
+		case 92LL: // B'\'
+			(void)pop_u64();
+			mp_primZ_sysZ_os();
+			mw_std_prim_Int_ZToOS();
+			push_u64(1LL); // OS_WINDOWS
+			{
+				VAL d4 = pop_value();
+				mw_std_prelude_OS_tag();
+				push_value(d4);
+			}
+			mw_std_prelude_OS_tag();
+			mp_primZ_intZ_eq();
+			break;
+		default:
+			mp_primZ_drop();
+			push_u64(0LL); // False
+			break;
+	}
+}
+static void mw_std_path_Path_splitZ_last (void) {
+	mw_std_path_Path_ZDivPath();
+	push_fnptr(&mb_std_path_Path_splitZ_last_0);
+	mw_std_prim_Str_splitZ_lastZ_byte_1();
+	{
+		VAL d2 = pop_value();
+		push_value(d2);
+	}
 }
 static void mw_std_prim_Int_ZToFile (void) {
 }
@@ -12315,9 +12495,16 @@ static void mw_std_input_ZPlusInput_readZ_chunkZBang (void) {
 }
 static void mw_std_input_ZPlusInput_readZ_fileZBang (void) {
 	STRLIT("", 0);
-	push_fnptr(&mb_std_input_ZPlusInput_readZ_fileZBang_0);
-	push_fnptr(&mb_std_input_ZPlusInput_readZ_fileZBang_1);
-	mw_std_maybe_whileZ_some_2();
+	mw_std_input_ZPlusInput_readZ_chunkZBang();
+	while(1) {
+		mp_primZ_dup();
+		mw_std_maybe_Maybe_1_ZToBool();
+		if (! pop_u64()) break;
+		mw_std_maybe_Maybe_1_unwrap();
+		mp_primZ_strZ_cat();
+		mw_std_input_ZPlusInput_readZ_chunkZBang();
+	}
+	mp_primZ_drop();
 }
 static void mw_std_file_ZPlusFile_ZDivZPlusFile (void) {
 	switch (get_top_resource_data_tag()) {
@@ -13030,9 +13217,63 @@ static void mw_mirth_var_Ctx_freshZ_nameZBang (void) {
 	push_i64(1LL);
 	STRLIT("_x1", 3);
 	mw_std_prim_Str_ZToName();
-	push_fnptr(&mb_mirth_var_Ctx_freshZ_nameZBang_0);
-	push_fnptr(&mb_mirth_var_Ctx_freshZ_nameZBang_1);
-	mw_std_maybe_whileZ_some_2();
+	mp_primZ_dup();
+	{
+		VAL d2 = pop_value();
+		{
+			VAL d3 = pop_value();
+			{
+				VAL d4 = pop_value();
+				mp_primZ_dup();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			push_value(d3);
+		}
+		mp_primZ_swap();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	mw_mirth_var_Ctx_lookup();
+	while(1) {
+		mp_primZ_dup();
+		mw_std_maybe_Maybe_1_ZToBool();
+		if (! pop_u64()) break;
+		mw_std_maybe_Maybe_1_unwrap();
+		mp_primZ_drop();
+		mp_primZ_drop();
+		push_i64(1LL);
+		mp_primZ_intZ_add();
+		STRLIT("_x", 2);
+		{
+			VAL d3 = pop_value();
+			mp_primZ_dup();
+			push_value(d3);
+		}
+		mp_primZ_swap();
+		mw_std_prim_Int_show();
+		mp_primZ_strZ_cat();
+		mw_std_prim_Str_ZToName();
+		mp_primZ_dup();
+		{
+			VAL d3 = pop_value();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mp_primZ_dup();
+					push_value(d5);
+				}
+				mp_primZ_swap();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			push_value(d3);
+		}
+		mp_primZ_swap();
+		mw_mirth_var_Ctx_lookup();
+	}
+	mp_primZ_drop();
 	{
 		VAL d2 = pop_value();
 		mp_primZ_drop();
@@ -24167,9 +24408,23 @@ static void mw_mirth_def_Def_sameZ_resolvedZAsk (void) {
 	mw_mirth_def_Def_ZEqualZEqual();
 }
 static void mw_mirth_def_Def_resolve (void) {
-	push_fnptr(&mb_mirth_def_Def_resolve_0);
-	push_fnptr(&mb_mirth_def_Def_resolve_1);
-	mw_std_maybe_whileZ_some_2();
+	mp_primZ_dup();
+	mw_mirth_def_Def_aliasZAsk();
+	while(1) {
+		mp_primZ_dup();
+		mw_std_maybe_Maybe_1_ZToBool();
+		if (! pop_u64()) break;
+		mw_std_maybe_Maybe_1_unwrap();
+		{
+			VAL d3 = pop_value();
+			mp_primZ_drop();
+			push_value(d3);
+		}
+		mw_mirth_alias_Alias_target();
+		mp_primZ_dup();
+		mw_mirth_def_Def_aliasZAsk();
+	}
+	mp_primZ_drop();
 }
 static void mw_mirth_def_Def_qname (void) {
 	switch (get_top_data_tag()) {
@@ -25150,6 +25405,99 @@ static void mw_mirth_package_Package_path (void) {
 	mfld_mirth_package_Package_ZTildepath();
 	mp_primZ_mutZ_get();
 }
+static void mw_mirth_package_Package_pathZBang (void) {
+	mp_primZ_dup();
+	{
+		VAL d2 = pop_value();
+		mp_primZ_swap();
+		push_value(d2);
+	}
+	mw_mirth_package_Package_path();
+	switch (get_top_data_tag()) {
+		case 1LL: // Some
+			mtp_std_maybe_Maybe_1_Some();
+			{
+				VAL d4 = pop_value();
+				mp_primZ_dup();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			{
+				VAL d4 = pop_value();
+				mp_primZ_dup();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			{
+				VAL d4 = pop_value();
+				push_value(d4);
+			}
+			mp_primZ_strZ_cmp();
+			push_i64(0LL);
+			{
+				VAL d4 = pop_value();
+				mp_primZ_dup();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			{
+				VAL d4 = pop_value();
+				mp_primZ_dup();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			mp_primZ_intZ_eq();
+			if (pop_u64()) {
+				mp_primZ_drop();
+				mp_primZ_drop();
+				push_u64(1LL); // EQ
+			} else {
+				mp_primZ_intZ_lt();
+				if (pop_u64()) {
+					push_u64(0LL); // LT
+				} else {
+					push_u64(2LL); // GT
+				}
+			}
+			switch (get_top_data_tag()) {
+				case 0LL: // LT
+					(void)pop_u64();
+					push_u64(0LL); // False
+					break;
+				case 1LL: // EQ
+					(void)pop_u64();
+					push_u64(1LL); // True
+					break;
+				case 2LL: // GT
+					(void)pop_u64();
+					push_u64(0LL); // False
+					break;
+				default:
+					push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+					mp_primZ_panic();
+			}
+			if (pop_u64()) {
+				mp_primZ_drop();
+				mp_primZ_drop();
+				mp_primZ_drop();
+			} else {
+				push_fnptr(&mb_mirth_package_Package_pathZBang_2);
+				mw_std_str_Str_1();
+				mw_std_prelude_panicZBang();
+			}
+			break;
+		case 0LL: // None
+			(void)pop_u64();
+			mtw_std_maybe_Maybe_1_Some();
+			mp_primZ_swap();
+			mfld_mirth_package_Package_ZTildepath();
+			mp_primZ_mutZ_set();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primZ_panic();
+	}
+}
 static void mw_mirth_package_Package_newZBang (void) {
 	mw_mirth_package_Package_allocZBang();
 	mp_primZ_dup();
@@ -25172,44 +25520,24 @@ static void mw_mirth_package_Package_newZBang (void) {
 	mtw_mirth_def_Def_DefPackage();
 	mw_mirth_def_Def_register();
 }
-static void mw_mirth_package_Package_newZ_orZ_setZ_pathZBang (void) {
+static void mw_mirth_package_Package_newZ_orZ_pathZBang (void) {
 	mp_primZ_dup();
 	mw_mirth_package_Package_find();
 	switch (get_top_data_tag()) {
 		case 1LL: // Some
 			mtp_std_maybe_Maybe_1_Some();
-			mp_primZ_dup();
-			mw_mirth_package_Package_path();
-			switch (get_top_data_tag()) {
-				case 1LL: // Some
-					mtp_std_maybe_Maybe_1_Some();
-					STRLIT("Package already has path", 24);
-					mw_std_prelude_panicZBang();
-					break;
-				case 0LL: // None
-					(void)pop_u64();
-					{
-						VAL d6 = pop_value();
-						mp_primZ_drop();
-						push_value(d6);
-					}
-					mp_primZ_dup();
-					{
-						VAL d6 = pop_value();
-						{
-							VAL d7 = pop_value();
-							mtw_std_maybe_Maybe_1_Some();
-							push_value(d7);
-						}
-						mfld_mirth_package_Package_ZTildepath();
-						mp_primZ_mutZ_set();
-						push_value(d6);
-					}
-					break;
-				default:
-					push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-					mp_primZ_panic();
+			{
+				VAL d4 = pop_value();
+				mp_primZ_drop();
+				push_value(d4);
 			}
+			mp_primZ_dup();
+			{
+				VAL d4 = pop_value();
+				mp_primZ_swap();
+				push_value(d4);
+			}
+			mw_mirth_package_Package_pathZBang();
 			break;
 		case 0LL: // None
 			(void)pop_u64();
@@ -25601,9 +25929,27 @@ static void mw_mirth_lexer_lexerZ_emitZ_lcolonZBang (void) {
 	mw_mirth_lexer_lexerZ_stackZ_pushZBang();
 }
 static void mw_mirth_lexer_lexerZ_closeZ_colonsZBang (void) {
-	push_fnptr(&mb_mirth_lexer_lexerZ_closeZ_colonsZBang_0);
-	push_fnptr(&mb_mirth_lexer_lexerZ_closeZ_colonsZBang_1);
-	mw_std_maybe_whileZ_some_2();
+	mw_mirth_lexer_lexerZ_stackZ_peek();
+	push_fnptr(&mb_mirth_lexer_lexerZ_closeZ_colonsZBang_2);
+	mw_std_maybe_Maybe_1_guard_1();
+	while(1) {
+		mp_primZ_dup();
+		mw_std_maybe_Maybe_1_ZToBool();
+		if (! pop_u64()) break;
+		mw_std_maybe_Maybe_1_unwrap();
+		mw_mirth_lexer_lexerZ_stackZ_drop();
+		mp_primZ_dup();
+		mtw_mirth_token_TokenValue_TokenRColon();
+		mw_mirth_lexer_lexerZ_makeZBang();
+		mtw_mirth_token_TokenValue_TokenLColon();
+		mp_primZ_swap();
+		mfld_mirth_token_Token_ZTildevalue();
+		mp_primZ_mutZ_set();
+		mw_mirth_lexer_lexerZ_stackZ_peek();
+		push_fnptr(&mb_mirth_lexer_lexerZ_closeZ_colonsZBang_2);
+		mw_std_maybe_Maybe_1_guard_1();
+	}
+	mp_primZ_drop();
 }
 static void mw_mirth_lexer_lexerZ_prepareZ_forZ_atomZBang (void) {
 	mw_mirth_lexer_ZPlusLexer_lexerZ_lastZ_token();
@@ -29586,87 +29932,206 @@ static void mw_mirth_elab_elabZ_moduleZ_headerZBang (void) {
 }
 static void mw_mirth_elab_checkZ_moduleZ_path (void) {
 	mp_primZ_dup();
-	{
-		VAL d2 = pop_value();
-		mw_mirth_module_Module_path();
-		push_value(d2);
-	}
-	mw_mirth_module_Module_qname();
-	mw_mirth_name_QName_toZ_moduleZ_path();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	{
-		VAL d2 = pop_value();
-		push_value(d2);
-	}
-	mp_primZ_strZ_cmp();
-	push_i64(0LL);
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	mp_primZ_intZ_eq();
-	if (pop_u64()) {
-		mp_primZ_drop();
-		mp_primZ_drop();
-		push_u64(1LL); // EQ
-	} else {
-		mp_primZ_intZ_lt();
-		if (pop_u64()) {
-			push_u64(0LL); // LT
-		} else {
-			push_u64(2LL); // GT
-		}
-	}
+	mw_mirth_module_Module_path();
+	mw_std_path_Path_splitZ_last();
 	switch (get_top_data_tag()) {
-		case 0LL: // LT
+		case 0LL: // None
 			(void)pop_u64();
-			push_u64(0LL); // False
+			mp_primZ_swap();
+			mw_mirth_module_Module_qname();
+			mw_mirth_name_QName_toZ_moduleZ_path();
+			{
+				VAL d4 = pop_value();
+				mp_primZ_dup();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			{
+				VAL d4 = pop_value();
+				mp_primZ_dup();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			{
+				VAL d4 = pop_value();
+				push_value(d4);
+			}
+			mp_primZ_strZ_cmp();
+			push_i64(0LL);
+			{
+				VAL d4 = pop_value();
+				mp_primZ_dup();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			{
+				VAL d4 = pop_value();
+				mp_primZ_dup();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			mp_primZ_intZ_eq();
+			if (pop_u64()) {
+				mp_primZ_drop();
+				mp_primZ_drop();
+				push_u64(1LL); // EQ
+			} else {
+				mp_primZ_intZ_lt();
+				if (pop_u64()) {
+					push_u64(0LL); // LT
+				} else {
+					push_u64(2LL); // GT
+				}
+			}
+			switch (get_top_data_tag()) {
+				case 0LL: // LT
+					(void)pop_u64();
+					push_u64(0LL); // False
+					break;
+				case 1LL: // EQ
+					(void)pop_u64();
+					push_u64(1LL); // True
+					break;
+				case 2LL: // GT
+					(void)pop_u64();
+					push_u64(0LL); // False
+					break;
+				default:
+					push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+					mp_primZ_panic();
+			}
+			if (pop_u64()) {
+			} else {
+				STRLIT("expected module name to match path\n", 35);
+				mp_primZ_swap();
+				mp_primZ_strZ_cat();
+				STRLIT("\n", 1);
+				mp_primZ_strZ_cat();
+				mp_primZ_swap();
+				mp_primZ_strZ_cat();
+				mw_mirth_token_emitZ_fatalZ_errorZBang();
+			}
+			mp_primZ_drop();
+			mp_primZ_drop();
+			mp_primZ_drop();
 			break;
-		case 1LL: // EQ
-			(void)pop_u64();
-			push_u64(1LL); // True
-			break;
-		case 2LL: // GT
-			(void)pop_u64();
-			push_u64(0LL); // False
+		case 1LL: // Some
+			mtp_std_maybe_Maybe_1_Some();
+			push_fnptr(&mb_mirth_elab_checkZ_moduleZ_path_1);
+			mw_std_prim_Str_splitZ_lastZ_byte_1();
+			STRLIT("mth", 3);
+			mtw_std_maybe_Maybe_1_Some();
+			push_fnptr(&mb_mirth_elab_checkZ_moduleZ_path_2);
+			mw_std_maybe_Maybe_1_ZEqualZEqual_1();
+			if (pop_u64()) {
+			} else {
+				{
+					VAL d5 = pop_value();
+					{
+						VAL d6 = pop_value();
+						{
+							VAL d7 = pop_value();
+							mp_primZ_dup();
+							push_value(d7);
+						}
+						mp_primZ_swap();
+						push_value(d6);
+					}
+					mp_primZ_swap();
+					push_value(d5);
+				}
+				mp_primZ_swap();
+				STRLIT("expected .mth extension for mirth file", 38);
+				mw_mirth_token_emitZ_warningZBang();
+			}
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mp_primZ_dup();
+					push_value(d5);
+				}
+				mp_primZ_swap();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			mw_mirth_module_Module_name();
+			mw_mirth_name_Name_ZToStr();
+			mp_primZ_strZ_cmp();
+			push_i64(0LL);
+			{
+				VAL d4 = pop_value();
+				mp_primZ_dup();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			{
+				VAL d4 = pop_value();
+				mp_primZ_dup();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			mp_primZ_intZ_eq();
+			if (pop_u64()) {
+				mp_primZ_drop();
+				mp_primZ_drop();
+				push_u64(1LL); // EQ
+			} else {
+				mp_primZ_intZ_lt();
+				if (pop_u64()) {
+					push_u64(0LL); // LT
+				} else {
+					push_u64(2LL); // GT
+				}
+			}
+			switch (get_top_data_tag()) {
+				case 0LL: // LT
+					(void)pop_u64();
+					push_u64(0LL); // False
+					break;
+				case 1LL: // EQ
+					(void)pop_u64();
+					push_u64(1LL); // True
+					break;
+				case 2LL: // GT
+					(void)pop_u64();
+					push_u64(0LL); // False
+					break;
+				default:
+					push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+					mp_primZ_panic();
+			}
+			if (pop_u64()) {
+			} else {
+				{
+					VAL d5 = pop_value();
+					{
+						VAL d6 = pop_value();
+						mp_primZ_dup();
+						push_value(d6);
+					}
+					mp_primZ_swap();
+					push_value(d5);
+				}
+				mp_primZ_swap();
+				STRLIT("expected module name to match file name", 39);
+				mw_mirth_token_emitZ_fatalZ_errorZBang();
+			}
+			{
+				VAL d4 = pop_value();
+				mp_primZ_dup();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			mw_mirth_module_Module_package();
+			mw_mirth_package_Package_pathZBang();
+			mp_primZ_drop();
+			mp_primZ_drop();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primZ_panic();
 	}
-	if (pop_u64()) {
-	} else {
-		STRLIT("expected module name to match path\n", 35);
-		mp_primZ_swap();
-		mp_primZ_strZ_cat();
-		STRLIT("\n", 1);
-		mp_primZ_strZ_cat();
-		mp_primZ_swap();
-		mp_primZ_strZ_cat();
-		mw_mirth_token_emitZ_fatalZ_errorZBang();
-	}
-	mp_primZ_drop();
-	mp_primZ_drop();
-	mp_primZ_drop();
 }
 static void mw_mirth_elab_elabZ_moduleZ_declZBang (void) {
 	mp_primZ_dup();
@@ -31847,9 +32312,18 @@ static void mw_mirth_specializzer_ZPlusSPCheck_endZBang (void) {
 	}
 }
 static void mw_mirth_specializzer_ZPlusSPCheck_loopZBang (void) {
-	push_fnptr(&mb_mirth_specializzer_ZPlusSPCheck_loopZBang_0);
-	push_fnptr(&mb_mirth_specializzer_ZPlusSPCheck_loopZBang_1);
-	mw_std_maybe_whileZ_some_2();
+	push_fnptr(&mb_mirth_specializzer_ZPlusSPCheck_loopZBang_2);
+	mw_mirth_specializzer_ZPlusSPCheck_checklist_1();
+	while(1) {
+		mp_primZ_dup();
+		mw_std_maybe_Maybe_1_ZToBool();
+		if (! pop_u64()) break;
+		mw_std_maybe_Maybe_1_unwrap();
+		mw_mirth_specializzer_ZPlusSPCheck_doZ_itemZ_checkZBang();
+		push_fnptr(&mb_mirth_specializzer_ZPlusSPCheck_loopZBang_2);
+		mw_mirth_specializzer_ZPlusSPCheck_checklist_1();
+	}
+	mp_primZ_drop();
 }
 static void mw_mirth_specializzer_ZPlusSPCheck_doZ_itemZ_checkZBang (void) {
 	switch (get_top_data_tag()) {
@@ -33205,9 +33679,18 @@ static void mw_mirth_need_ZPlusNeeds_determineZ_arrowZ_needsZBang (void) {
 	mw_mirth_need_ZPlusNeeds_determineZ_transitiveZ_needsZBang();
 }
 static void mw_mirth_need_ZPlusNeeds_determineZ_transitiveZ_needsZBang (void) {
-	push_fnptr(&mb_mirth_need_ZPlusNeeds_determineZ_transitiveZ_needsZBang_0);
-	push_fnptr(&mb_mirth_need_ZPlusNeeds_determineZ_transitiveZ_needsZBang_1);
-	mw_std_maybe_whileZ_some_2();
+	push_fnptr(&mb_mirth_need_ZPlusNeeds_determineZ_transitiveZ_needsZBang_2);
+	mw_mirth_need_ZPlusNeeds_stack_1();
+	while(1) {
+		mp_primZ_dup();
+		mw_std_maybe_Maybe_1_ZToBool();
+		if (! pop_u64()) break;
+		mw_std_maybe_Maybe_1_unwrap();
+		mw_mirth_need_ZPlusNeeds_runZ_needZBang();
+		push_fnptr(&mb_mirth_need_ZPlusNeeds_determineZ_transitiveZ_needsZBang_2);
+		mw_mirth_need_ZPlusNeeds_stack_1();
+	}
+	mp_primZ_drop();
 }
 static void mw_mirth_need_ZPlusNeeds_runZ_needZBang (void) {
 	switch (get_top_data_tag()) {
@@ -36966,6 +37449,7 @@ static void mw_mirth_main_parseZ_packageZ_def (void) {
 		push_value(d2);
 	}
 	mw_std_prim_Str_splitZ_byte();
+	mw_std_list_ListZPlus_1_ZDivListZPlusUnsafe();
 	mw_std_list_List_1_ZDivL2();
 	push_fnptr(&mb_mirth_main_parseZ_packageZ_def_1);
 	mw_std_maybe_Maybe_1_unwrapZ_or_1();
@@ -37386,7 +37870,7 @@ static void mb_mirth_main_compileZBang_0 (void) {
 	mw_std_prelude_unpack2();
 	mp_primZ_swap();
 	mw_std_prim_Str_ZToName();
-	mw_mirth_package_Package_newZ_orZ_setZ_pathZBang();
+	mw_mirth_package_Package_newZ_orZ_pathZBang();
 	mp_primZ_drop();
 }
 static void mb_mirth_main_compileZBang_1 (void) {
@@ -37498,90 +37982,6 @@ static void mb_mirth_elab_elabZ_entryZ_point_4 (void) {
 static void mb_mirth_main_parseZ_packageZ_def_1 (void) {
 	STRLIT("Invalid package path definition", 31);
 	mw_std_prelude_panicZBang();
-}
-static void mb_std_str_ZPlusStr_splitZ_byte_0 (void) {
-	push_i64(0LL);
-	mp_primZ_dup();
-	while(1) {
-		mp_primZ_dup();
-		{
-			VAL d3 = pop_resource();
-			mw_std_str_ZPlusStr_numZ_bytesZAsk();
-			push_resource(d3);
-		}
-		mw_std_prelude_Sizze_ZDivSizze();
-		{
-			VAL d3 = pop_value();
-			mw_std_prelude_Offset_ZDivOffset();
-			push_value(d3);
-		}
-		mw_std_prelude_Offset_ZDivOffset();
-		mp_primZ_intZ_lt();
-		if (! pop_u64()) break;
-		{
-			VAL d3 = pop_value();
-			{
-				VAL d4 = pop_value();
-				mp_primZ_dup();
-				push_value(d4);
-			}
-			mp_primZ_swap();
-			push_value(d3);
-		}
-		mp_primZ_swap();
-		{
-			VAL d3 = pop_value();
-			mp_primZ_dup();
-			push_value(d3);
-		}
-		mp_primZ_swap();
-		{
-			VAL d3 = pop_resource();
-			mw_std_str_ZPlusStr_byteZAt();
-			push_resource(d3);
-		}
-		mw_std_byte_Byte_ZEqualZEqual();
-		if (pop_u64()) {
-			mp_primZ_dup();
-			{
-				VAL d4 = pop_value();
-				mp_primZ_swap();
-				push_value(d4);
-			}
-			{
-				VAL d4 = pop_resource();
-				push_resource(MKU64(0LL)); // +Unsafe
-				mw_std_str_ZPlusStr_offsetZ_slice();
-				mw_std_prelude_ZPlusUnsafe_ZDivZPlusUnsafe();
-				push_resource(d4);
-			}
-			mw_std_list_ZPlusList_1_pushZBang();
-			mw_std_prelude_Offset_ZDivOffset();
-			push_i64(1LL);
-			mp_primZ_intZ_add();
-			mp_primZ_dup();
-		} else {
-			mw_std_prelude_Offset_ZDivOffset();
-			push_i64(1LL);
-			mp_primZ_intZ_add();
-		}
-	}
-	{
-		VAL d2 = pop_resource();
-		push_resource(MKU64(0LL)); // +Unsafe
-		mw_std_str_ZPlusStr_offsetZ_slice();
-		mw_std_prelude_ZPlusUnsafe_ZDivZPlusUnsafe();
-		push_resource(d2);
-	}
-	mw_std_list_ZPlusList_1_pushZPlusZBang();
-}
-static void mb_std_list_List_1_ZDivL2_0 (void) {
-	mw_std_prelude_pack2();
-	mtw_std_maybe_Maybe_1_Some();
-}
-static void mb_std_list_List_1_ZDivL2_1 (void) {
-	mp_primZ_drop();
-	push_u64(0LL); // None
 }
 static void mb_mirth_main_compilerZ_parseZ_args_1 (void) {
 	mp_primZ_drop();
@@ -38013,37 +38413,16 @@ static void mb_std_list_List_1_cat_0 (void) {
 	mp_primZ_swap();
 	mtw_std_list_List_1_Cons();
 }
-static void mb_std_list_List_1_len_0 (void) {
-	mw_std_list_List_1_uncons();
-	mp_primZ_swap();
+static void mb_std_list_List_1_ZDivL2_0 (void) {
+	mw_std_prelude_pack2();
+	mtw_std_maybe_Maybe_1_Some();
 }
-static void mb_std_list_List_1_len_1 (void) {
+static void mb_std_list_List_1_ZDivL2_1 (void) {
 	mp_primZ_drop();
-	{
-		VAL d2 = pop_value();
-		push_i64(1LL);
-		mp_primZ_intZ_add();
-		push_value(d2);
-	}
+	push_u64(0LL); // None
 }
 static void mb_std_list_List_1_first_0 (void) {
 	mw_std_list_ListZPlus_1_first();
-}
-static void mb_std_list_ListZPlus_1_last_0 (void) {
-	mw_std_list_List_1_uncons();
-	mp_primZ_swap();
-}
-static void mb_std_list_ListZPlus_1_last_1 (void) {
-	{
-		VAL d2 = pop_value();
-		{
-			VAL d3 = pop_value();
-			mp_primZ_drop();
-			push_value(d3);
-		}
-		push_value(d2);
-	}
-	mp_primZ_swap();
 }
 static void mb_std_list_List_1_last_0 (void) {
 	mw_std_list_ListZPlus_1_last();
@@ -38244,7 +38623,25 @@ static void mb_std_list_collect_1_0 (void) {
 	push_value(var_f);
 	mp_primZ_packZ_cons();
 	push_fnptr(&mb_std_list_collect_1_2);
-	mw_std_maybe_whileZ_some_2();
+	{
+		VAL var_g = pop_value();
+		VAL var_f = pop_value();
+		incref(var_f);
+		run_value(var_f);
+		while(1) {
+			mp_primZ_dup();
+			mw_std_maybe_Maybe_1_ZToBool();
+			if (! pop_u64()) break;
+			mw_std_maybe_Maybe_1_unwrap();
+			incref(var_g);
+			run_value(var_g);
+			incref(var_f);
+			run_value(var_f);
+		}
+		mp_primZ_drop();
+		decref(var_g);
+		decref(var_f);
+	}
 	decref(var_f);
 }
 static void mb_std_list_collect_1_1 (void) {
@@ -38767,6 +39164,55 @@ static void mb_std_prim_Str_slice_0 (void) {
 	mw_std_prelude_Sizze_ZDivSizze();
 	mp_primZ_strZ_copy();
 }
+static void mb_std_str_ZPlusStr_findZ_lastZ_byte_1_3 (void) {
+	mp_primZ_packZ_uncons();
+	VAL var_p = pop_value();
+	pop_value();
+	mw_std_str_ZPlusStr_byteZAt();
+	{
+		VAL d2 = pop_resource();
+		incref(var_p);
+		run_value(var_p);
+		push_resource(d2);
+	}
+	decref(var_p);
+}
+static void mb_std_prim_Str_splitZ_lastZ_byte_1_1 (void) {
+	push_resource(MKU64(0LL)); // +Unsafe
+	mp_primZ_swap();
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	{
+		VAL d2 = pop_value();
+		mw_std_prelude_Offset_ZDivOffset();
+		push_i64(1LL);
+		mp_primZ_intZ_add();
+		push_value(d2);
+	}
+	mw_std_prim_Str_dropZ_slice();
+	{
+		VAL d2 = pop_value();
+		{
+			VAL d3 = pop_value();
+			mw_std_prelude_Offset_ZDivOffset();
+			mw_std_prim_Int_ZToNat();
+			push_value(d3);
+		}
+		mw_std_prim_Str_takeZ_slice();
+		push_value(d2);
+	}
+	mw_std_prelude_ZPlusUnsafe_ZDivZPlusUnsafe();
+}
 static void mb_std_prim_Int_ZToByte_0 (void) {
 	mp_primZ_dup();
 	push_i64(0LL);
@@ -38791,6 +39237,9 @@ static void mb_std_buffer_ZPlusBuffer_resizzeZBang_0 (void) {
 	mw_std_prelude_Sizze_ZDivSizze();
 	mp_primZ_ptrZ_realloc();
 	mw_std_prelude_ZPlusUnsafe_ZDivZPlusUnsafe();
+}
+static void mb_std_path_Path_splitZ_last_0 (void) {
+	mw_std_byte_Byte_isZ_pathZ_separatorZAsk();
 }
 static void mb_argZ_parser_parse_printZ_usage_0 (void) {
 	push_u64(1LL); // Bold
@@ -39076,12 +39525,6 @@ static void mb_std_file_ZPlusFile_unsafeZ_readZBang_1 (void) {
 static void mb_std_file_ZPlusFile_unsafeZ_readZBang_2 (void) {
 	STRLIT("read failed", 11);
 }
-static void mb_std_input_ZPlusInput_readZ_fileZBang_0 (void) {
-	mw_std_input_ZPlusInput_readZ_chunkZBang();
-}
-static void mb_std_input_ZPlusInput_readZ_fileZBang_1 (void) {
-	mp_primZ_strZ_cat();
-}
 static void mb_std_input_ZPlusInputOpenState_fillZ_bufferZBang_0 (void) {
 	mw_std_buffer_ZPlusBuffer_base();
 	mw_std_buffer_ZPlusBuffer_sizze();
@@ -39155,6 +39598,32 @@ static void mb_mirth_arrow_Block_qname_0 (void) {
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primZ_panic();
 	}
+}
+static void mb_mirth_package_Package_pathZBang_2 (void) {
+	STRLIT("Tried to set different path for the same package.", 49);
+	mw_std_str_ZPlusStr_pushZ_strZBang();
+	STRLIT("\n\tPackage: ", 11);
+	mw_std_str_ZPlusStr_pushZ_strZBang();
+	{
+		VAL d2 = pop_value();
+		mp_primZ_swap();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	mw_mirth_package_Package_name();
+	mw_mirth_name_Name_ZToStr();
+	mw_std_str_ZPlusStr_pushZ_strZBang();
+	STRLIT("\n\tPath 1: ", 10);
+	mw_std_str_ZPlusStr_pushZ_strZBang();
+	mp_primZ_swap();
+	mw_std_path_Path_ZDivPath();
+	mw_std_prim_Str_show();
+	mw_std_str_ZPlusStr_pushZ_strZBang();
+	STRLIT("\n\tPath 2: ", 10);
+	mw_std_str_ZPlusStr_pushZ_strZBang();
+	mw_std_path_Path_ZDivPath();
+	mw_std_prim_Str_show();
+	mw_std_str_ZPlusStr_pushZ_strZBang();
 }
 static void mb_mirth_label_Label_newZBang_0 (void) {
 	mw_mirth_label_Label_allocZBang();
@@ -39273,18 +39742,6 @@ static void mb_std_lazzy_delay3_1_0 (void) {
 }
 static void mb_mirth_def_Def_definingZ_moduleZAsk_0 (void) {
 	mw_mirth_token_Token_module();
-}
-static void mb_mirth_def_Def_resolve_0 (void) {
-	mp_primZ_dup();
-	mw_mirth_def_Def_aliasZAsk();
-}
-static void mb_mirth_def_Def_resolve_1 (void) {
-	{
-		VAL d2 = pop_value();
-		mp_primZ_drop();
-		push_value(d2);
-	}
-	mw_mirth_alias_Alias_target();
 }
 static void mb_std_str_ZPlusStr_dnameZAsk_3 (void) {
 	mw_std_prim_Str_ZToName();
@@ -40135,42 +40592,6 @@ static void mb_mirth_var_Ctx_lookup_0 (void) {
 	mw_mirth_var_Var_name();
 	mw_mirth_name_Name_ZEqualZEqual();
 }
-static void mb_mirth_var_Ctx_freshZ_nameZBang_0 (void) {
-	mp_primZ_dup();
-	{
-		VAL d2 = pop_value();
-		{
-			VAL d3 = pop_value();
-			{
-				VAL d4 = pop_value();
-				mp_primZ_dup();
-				push_value(d4);
-			}
-			mp_primZ_swap();
-			push_value(d3);
-		}
-		mp_primZ_swap();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	mw_mirth_var_Ctx_lookup();
-}
-static void mb_mirth_var_Ctx_freshZ_nameZBang_1 (void) {
-	mp_primZ_drop();
-	mp_primZ_drop();
-	push_i64(1LL);
-	mp_primZ_intZ_add();
-	STRLIT("_x", 2);
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	mw_std_prim_Int_show();
-	mp_primZ_strZ_cat();
-	mw_std_prim_Str_ZToName();
-}
 static void mb_mirth_match_Match_hasZ_defaultZ_caseZAsk_0 (void) {
 	mp_primZ_dup();
 	mw_mirth_match_Case_isZ_defaultZ_caseZAsk();
@@ -40287,21 +40708,6 @@ static void mb_mirth_match_ZPlusPattern_tagZBang_3 (void) {
 }
 static void mb_mirth_match_ZPlusPattern_tagZBang_4 (void) {
 	mtw_std_list_List_1_Cons();
-}
-static void mb_mirth_lexer_lexerZ_closeZ_colonsZBang_0 (void) {
-	mw_mirth_lexer_lexerZ_stackZ_peek();
-	push_fnptr(&mb_mirth_lexer_lexerZ_closeZ_colonsZBang_2);
-	mw_std_maybe_Maybe_1_guard_1();
-}
-static void mb_mirth_lexer_lexerZ_closeZ_colonsZBang_1 (void) {
-	mw_mirth_lexer_lexerZ_stackZ_drop();
-	mp_primZ_dup();
-	mtw_mirth_token_TokenValue_TokenRColon();
-	mw_mirth_lexer_lexerZ_makeZBang();
-	mtw_mirth_token_TokenValue_TokenLColon();
-	mp_primZ_swap();
-	mfld_mirth_token_Token_ZTildevalue();
-	mp_primZ_mutZ_set();
 }
 static void mb_mirth_lexer_lexerZ_closeZ_colonsZBang_2 (void) {
 	mp_primZ_dup();
@@ -41445,6 +41851,56 @@ static void mb_mirth_elab_elabZ_moduleZ_packageZ_name_2 (void) {
 	mp_primZ_drop();
 	STRLIT("Expected module name. (3)", 25);
 	mw_mirth_token_emitZ_fatalZ_errorZBang();
+}
+static void mb_mirth_elab_checkZ_moduleZ_path_1 (void) {
+	push_u64(46LL); // BDOT
+	mw_std_byte_Byte_ZEqualZEqual();
+}
+static void mb_mirth_elab_checkZ_moduleZ_path_2 (void) {
+	mp_primZ_strZ_cmp();
+	push_i64(0LL);
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	mp_primZ_intZ_eq();
+	if (pop_u64()) {
+		mp_primZ_drop();
+		mp_primZ_drop();
+		push_u64(1LL); // EQ
+	} else {
+		mp_primZ_intZ_lt();
+		if (pop_u64()) {
+			push_u64(0LL); // LT
+		} else {
+			push_u64(2LL); // GT
+		}
+	}
+	switch (get_top_data_tag()) {
+		case 0LL: // LT
+			(void)pop_u64();
+			push_u64(0LL); // False
+			break;
+		case 1LL: // EQ
+			(void)pop_u64();
+			push_u64(1LL); // True
+			break;
+		case 2LL: // GT
+			(void)pop_u64();
+			push_u64(0LL); // False
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primZ_panic();
+	}
 }
 static void mb_mirth_elab_elabZ_aliasZBang_2 (void) {
 	STRLIT("expected alias target, which must be a name", 43);
@@ -42853,13 +43309,6 @@ static void mb_mirth_specializzer_ZPlusSPCheck_checkZ_arrowZBang_0 (void) {
 }
 static void mb_mirth_specializzer_ZPlusSPCheck_checkZ_arrowZBang_1 (void) {
 	mw_mirth_specializzer_ZPlusSPCheck_checkZ_atomZBang();
-}
-static void mb_mirth_specializzer_ZPlusSPCheck_loopZBang_0 (void) {
-	push_fnptr(&mb_mirth_specializzer_ZPlusSPCheck_loopZBang_2);
-	mw_mirth_specializzer_ZPlusSPCheck_checklist_1();
-}
-static void mb_mirth_specializzer_ZPlusSPCheck_loopZBang_1 (void) {
-	mw_mirth_specializzer_ZPlusSPCheck_doZ_itemZ_checkZBang();
 }
 static void mb_mirth_specializzer_ZPlusSPCheck_loopZBang_2 (void) {
 	mw_std_list_List_1_uncons();
@@ -45006,13 +45455,6 @@ static void mb_std_set_ZPlusSet_1_insertZBang_0 (void) {
 static void mb_mirth_need_ZPlusNeeds_runZ_arrowZBang_0 (void) {
 	mw_mirth_need_ZPlusNeeds_runZ_atomZBang();
 }
-static void mb_mirth_need_ZPlusNeeds_determineZ_transitiveZ_needsZBang_0 (void) {
-	push_fnptr(&mb_mirth_need_ZPlusNeeds_determineZ_transitiveZ_needsZBang_2);
-	mw_mirth_need_ZPlusNeeds_stack_1();
-}
-static void mb_mirth_need_ZPlusNeeds_determineZ_transitiveZ_needsZBang_1 (void) {
-	mw_mirth_need_ZPlusNeeds_runZ_needZBang();
-}
 static void mb_mirth_need_ZPlusNeeds_determineZ_transitiveZ_needsZBang_2 (void) {
 	mw_std_list_List_1_uncons();
 }
@@ -45054,4 +45496,93 @@ static void mb_mirth_need_ZPlusNeeds_runZ_patternZBang_0 (void) {
 }
 static void mb_std_set_ZPlusSet_1_offsetZ_mask_0 (void) {
 	mw_std_buffer_ZPlusBuffer_expandZBang();
+}
+static void mb_std_str_ZPlusStr_splitZ_byte_1_ZLParenstdZDotstrZDotZPlusStrZDotsplitZ_byteZDot2ZRParen_11 (void) {
+	push_i64(0LL);
+	mp_primZ_dup();
+	while(1) {
+		mp_primZ_dup();
+		{
+			VAL d3 = pop_resource();
+			mw_std_str_ZPlusStr_numZ_bytesZAsk();
+			push_resource(d3);
+		}
+		mw_std_prelude_Sizze_ZDivSizze();
+		{
+			VAL d3 = pop_value();
+			mw_std_prelude_Offset_ZDivOffset();
+			push_value(d3);
+		}
+		mw_std_prelude_Offset_ZDivOffset();
+		mp_primZ_intZ_lt();
+		if (! pop_u64()) break;
+		mp_primZ_dup();
+		{
+			VAL d3 = pop_value();
+			mp_primZ_swap();
+			push_value(d3);
+		}
+		{
+			VAL d3 = pop_value();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_resource();
+					mw_std_str_ZPlusStr_byteZAt();
+					{
+						VAL d6 = pop_resource();
+						{
+							VAL d7 = pop_value();
+							mp_primZ_dup();
+							push_value(d7);
+						}
+						mp_primZ_swap();
+						mw_std_byte_Byte_ZEqualZEqual();
+						push_resource(d6);
+					}
+					push_resource(d5);
+				}
+				push_value(d4);
+			}
+			push_value(d3);
+		}
+		{
+			VAL d3 = pop_value();
+			mp_primZ_swap();
+			push_value(d3);
+		}
+		mp_primZ_swap();
+		if (pop_u64()) {
+			mp_primZ_dup();
+			{
+				VAL d4 = pop_value();
+				mp_primZ_swap();
+				push_value(d4);
+			}
+			{
+				VAL d4 = pop_resource();
+				push_resource(MKU64(0LL)); // +Unsafe
+				mw_std_str_ZPlusStr_offsetZ_slice();
+				mw_std_prelude_ZPlusUnsafe_ZDivZPlusUnsafe();
+				push_resource(d4);
+			}
+			mw_std_list_ZPlusList_1_pushZBang();
+			mw_std_prelude_Offset_ZDivOffset();
+			push_i64(1LL);
+			mp_primZ_intZ_add();
+			mp_primZ_dup();
+		} else {
+			mw_std_prelude_Offset_ZDivOffset();
+			push_i64(1LL);
+			mp_primZ_intZ_add();
+		}
+	}
+	{
+		VAL d2 = pop_resource();
+		push_resource(MKU64(0LL)); // +Unsafe
+		mw_std_str_ZPlusStr_offsetZ_slice();
+		mw_std_prelude_ZPlusUnsafe_ZDivZPlusUnsafe();
+		push_resource(d2);
+	}
+	mw_std_list_ZPlusList_1_pushZPlusZBang();
 }

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -4777,6 +4777,10 @@ static void mvar_mirth_data_TAGz_I8 (void) {
 	static VAL v = {0};
 	push_ptr(&v);
 }
+static void mvar_mirth_package_PACKAGEz_SEARCHz_PATH (void) {
+	static VAL v = {0};
+	push_ptr(&v);
+}
 static void mvar_mirth_elab_ZTildepreferZ_inlineZ_defsZAsk (void) {
 	static VAL v = {0};
 	push_ptr(&v);
@@ -4946,11 +4950,16 @@ static void mw_std_maybe_Maybe_1_zzip (void);
 static void mw_std_prelude_OS_tag (void);
 static void mw_std_prelude_OS_fromZ_tagZ_unsafe (void);
 static void mw_std_prim_Int_ZToOS (void);
+static void mw_std_prelude_Arch_tag (void);
+static void mw_std_prelude_Arch_fromZ_tagZ_unsafe (void);
+static void mw_std_prim_Int_ZToArch (void);
 static void mw_std_prim_Int_inZ_range (void);
 static void mw_std_prim_Int_show (void);
 static void mw_std_prelude_ZPlusUnsafe_ZDivZPlusUnsafe (void);
 static void mw_std_prim_Int_ZToU8ZAsk (void);
+static void mw_std_prim_Int_ZToU16ZAsk (void);
 static void mw_std_prim_Int_ZToU8 (void);
+static void mw_std_prim_Int_ZToU16 (void);
 static void mw_std_prim_Int_ZToI64 (void);
 static void mw_std_prelude_Nat_ZDivNatUnsafe (void);
 static void mw_std_prim_Int_ZToNat (void);
@@ -4990,6 +4999,11 @@ static void mw_std_posix_lineZ_printZBang (void);
 static void mw_std_posix_lineZ_traceZBang (void);
 static void mw_std_path_Path_traceZBang (void);
 static void mw_std_prim_Int_traceZBang (void);
+static void mw_std_prim_ZPlusWorld_isZ_directoryZAsk (void);
+static void mw_std_posix_Sz_IFMT (void);
+static void mw_std_posix_Sz_IFDIR (void);
+static void mw_std_posix_Sz_ISDIR (void);
+static void mw_std_posix_stz_modeZAt (void);
 static void mw_std_terminal_Sgr_tag (void);
 static void mw_std_terminal_SGRColor_show (void);
 static void mw_std_terminal_Sgr_show (void);
@@ -5740,6 +5754,7 @@ static void mw_mirth_package_Package_allocZBang (void);
 static void mw_mirth_package_Package_name (void);
 static void mw_mirth_package_Package_qname (void);
 static void mw_mirth_package_Package_path (void);
+static void mw_mirth_package_Package_pathZ_orZ_search (void);
 static void mw_mirth_package_Package_pathZBang (void);
 static void mw_mirth_package_Package_newZBang (void);
 static void mw_mirth_package_Package_newZ_orZ_pathZBang (void);
@@ -6329,6 +6344,7 @@ static void mb_argZ_parser_parse_parseZ_args_20 (void);
 static void mb_std_prim_Int_ZToNat_0 (void);
 static void mb_std_prim_Int_ZToNat_1 (void);
 static void mb_std_prim_Int_ZToU8_0 (void);
+static void mb_std_prim_Int_ZToU16_0 (void);
 static void mb_std_prelude_assertZBang_2_1 (void);
 static void mb_mirth_elab_ZPlusResolveDef_filter_2_0 (void);
 static void mb_mirth_elab_ZPlusResolveDef_filter_1_2 (void);
@@ -6412,6 +6428,7 @@ static void mb_std_output_ZPlusOutput_put_5 (void);
 static void mb_std_output_ZPlusOutput_put_6 (void);
 static void mb_std_output_ZPlusOutput_put_7 (void);
 static void mb_mirth_c99_ZPlusC99_line_0 (void);
+static void mb_std_prim_ZPlusWorld_isZ_directoryZAsk_0 (void);
 static void mb_std_terminal_csi_0 (void);
 static void mb_std_prim_ZPlusWorld_openZ_fileZBang_0 (void);
 static void mb_std_prim_ZPlusWorld_openZ_fileZBang_3 (void);
@@ -6431,6 +6448,9 @@ static void mb_std_input_ZPlusInput_peek_0 (void);
 static void mb_std_input_ZPlusInput_moveZBang_0 (void);
 static void mb_std_input_ZPlusInput_readZ_chunkZBang_0 (void);
 static void mb_mirth_arrow_Block_qname_0 (void);
+static void mb_mirth_package_Package_pathZ_orZ_search_0 (void);
+static void mb_mirth_package_Package_pathZ_orZ_search_1 (void);
+static void mb_mirth_package_Package_pathZ_orZ_search_2 (void);
 static void mb_mirth_package_Package_pathZBang_2 (void);
 static void mb_mirth_label_Label_newZBang_0 (void);
 static void mb_mirth_def_Def_register_1 (void);
@@ -10742,6 +10762,22 @@ static void mw_std_prim_Int_ZToOS (void) {
 		push_u64(0LL); // OS_UNKNOWN
 	}
 }
+static void mw_std_prelude_Arch_tag (void) {
+}
+static void mw_std_prelude_Arch_fromZ_tagZ_unsafe (void) {
+}
+static void mw_std_prim_Int_ZToArch (void) {
+	mp_primZ_dup();
+	push_i64(1LL);
+	push_i64(3LL);
+	mw_std_prim_Int_inZ_range();
+	if (pop_u64()) {
+		mw_std_prelude_Arch_fromZ_tagZ_unsafe();
+	} else {
+		mp_primZ_drop();
+		push_u64(0LL); // ARCH_UNKNOWN
+	}
+}
 static void mw_std_prim_Int_inZ_range (void) {
 	{
 		VAL d2 = pop_value();
@@ -10801,9 +10837,26 @@ static void mw_std_prim_Int_ZToU8ZAsk (void) {
 		push_u64(0LL); // None
 	}
 }
+static void mw_std_prim_Int_ZToU16ZAsk (void) {
+	mp_primZ_dup();
+	push_i64(0LL);
+	push_i64(65535LL);
+	mw_std_prim_Int_inZ_range();
+	if (pop_u64()) {
+		mtw_std_maybe_Maybe_1_Some();
+	} else {
+		mp_primZ_drop();
+		push_u64(0LL); // None
+	}
+}
 static void mw_std_prim_Int_ZToU8 (void) {
 	mw_std_prim_Int_ZToU8ZAsk();
 	push_fnptr(&mb_std_prim_Int_ZToU8_0);
+	mw_std_maybe_Maybe_1_unwrapZ_or_1();
+}
+static void mw_std_prim_Int_ZToU16 (void) {
+	mw_std_prim_Int_ZToU16ZAsk();
+	push_fnptr(&mb_std_prim_Int_ZToU16_0);
 	mw_std_maybe_Maybe_1_unwrapZ_or_1();
 }
 static void mw_std_prim_Int_ZToI64 (void) {
@@ -11227,6 +11280,80 @@ static void mw_std_path_Path_traceZBang (void) {
 static void mw_std_prim_Int_traceZBang (void) {
 	mw_std_prim_Int_show();
 	mw_std_prim_Str_traceZBang();
+}
+static void mw_std_prim_ZPlusWorld_isZ_directoryZAsk (void) {
+	push_i64(256LL);
+	mw_std_prim_Int_ZToNat();
+	mw_std_buffer_ZPlusBuffer_new();
+	push_fnptr(&mb_std_prim_ZPlusWorld_isZ_directoryZAsk_0);
+	mw_std_prim_Str_withZ_dataZ_cstr_1();
+	mw_std_buffer_ZPlusBuffer_rdrop();
+}
+static void mw_std_posix_Sz_IFMT (void) {
+	push_i64(61440LL);
+	mw_std_prim_Int_ZToU16();
+}
+static void mw_std_posix_Sz_IFDIR (void) {
+	push_i64(16384LL);
+	mw_std_prim_Int_ZToU16();
+}
+static void mw_std_posix_Sz_ISDIR (void) {
+	mw_std_posix_Sz_IFMT();
+	{
+		VAL d2 = pop_value();
+		push_value(d2);
+	}
+	mp_primZ_intZ_and();
+	mw_std_posix_Sz_IFDIR();
+	{
+		VAL d2 = pop_value();
+		push_value(d2);
+	}
+	mp_primZ_intZ_eq();
+}
+static void mw_std_posix_stz_modeZAt (void) {
+	mp_primZ_sysZ_os();
+	mw_std_prim_Int_ZToOS();
+	switch (get_top_data_tag()) {
+		case 2LL: // OS_LINUX
+			(void)pop_u64();
+			push_i64(24LL);
+			break;
+		case 1LL: // OS_WINDOWS
+			(void)pop_u64();
+			push_i64(6LL);
+			break;
+		case 3LL: // OS_MACOS
+			(void)pop_u64();
+			mp_primZ_sysZ_arch();
+			mw_std_prim_Int_ZToArch();
+			push_u64(3LL); // ARCH_ARM64
+			{
+				VAL d4 = pop_value();
+				mw_std_prelude_Arch_tag();
+				push_value(d4);
+			}
+			mw_std_prelude_Arch_tag();
+			mp_primZ_intZ_eq();
+			if (pop_u64()) {
+				push_i64(4LL);
+			} else {
+				push_i64(8LL);
+			}
+			break;
+		default:
+			mp_primZ_drop();
+			push_i64(8LL);
+			break;
+	}
+	mp_primZ_swap();
+	{
+		VAL d2 = pop_value();
+		mw_std_prelude_Offset_ZDivOffset();
+		push_value(d2);
+	}
+	mp_primZ_ptrZ_add();
+	mp_primZ_u16Z_get();
 }
 static void mw_std_terminal_Sgr_tag (void) {
 	{
@@ -25290,7 +25417,7 @@ static void mw_mirth_name_QName_toZ_moduleZ_path (void) {
 	switch (get_top_data_tag()) {
 		case 1LL: // NAMESPACE_PACKAGE
 			mtp_mirth_name_Namespace_NAMESPACEz_PACKAGE();
-			mw_mirth_package_Package_path();
+			mw_mirth_package_Package_pathZ_orZ_search();
 			push_fnptr(&mb_mirth_name_QName_toZ_moduleZ_path_0);
 			mw_std_maybe_Maybe_1_unwrapZ_or_1();
 			mp_primZ_swap();
@@ -25404,6 +25531,43 @@ static void mw_mirth_package_Package_qname (void) {
 static void mw_mirth_package_Package_path (void) {
 	mfld_mirth_package_Package_ZTildepath();
 	mp_primZ_mutZ_get();
+}
+static void mw_mirth_package_Package_pathZ_orZ_search (void) {
+	mp_primZ_dup();
+	mw_mirth_package_Package_path();
+	switch (get_top_data_tag()) {
+		case 1LL: // Some
+			mtp_std_maybe_Maybe_1_Some();
+			{
+				VAL d4 = pop_value();
+				mp_primZ_drop();
+				push_value(d4);
+			}
+			mtw_std_maybe_Maybe_1_Some();
+			break;
+		case 0LL: // None
+			(void)pop_u64();
+			mvar_mirth_package_PACKAGEz_SEARCHz_PATH();
+			push_fnptr(&mb_mirth_package_Package_pathZ_orZ_search_0);
+			mw_std_prelude_memoizze_1();
+			push_fnptr(&mb_mirth_package_Package_pathZ_orZ_search_1);
+			mw_std_list_List_1_map_1();
+			push_fnptr(&mb_mirth_package_Package_pathZ_orZ_search_2);
+			mw_std_list_List_1_find_1();
+			mp_primZ_dup();
+			{
+				VAL d4 = pop_value();
+				mp_primZ_swap();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			mfld_mirth_package_Package_ZTildepath();
+			mp_primZ_mutZ_set();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primZ_panic();
+	}
 }
 static void mw_mirth_package_Package_pathZBang (void) {
 	mp_primZ_dup();
@@ -38330,6 +38494,10 @@ static void mb_std_prim_Int_ZToU8_0 (void) {
 	STRLIT("U8 out of bounds", 16);
 	mw_std_prelude_panicZBang();
 }
+static void mb_std_prim_Int_ZToU16_0 (void) {
+	STRLIT("U16 out of bounds", 17);
+	mw_std_prelude_panicZBang();
+}
 static void mb_std_prelude_assertZBang_2_1 (void) {
 	mp_primZ_packZ_uncons();
 	VAL var_g = pop_value();
@@ -39430,6 +39598,21 @@ static void mb_std_output_ZPlusOutput_put_7 (void) {
 static void mb_mirth_c99_ZPlusC99_line_0 (void) {
 	mw_std_output_ZPlusOutput_line();
 }
+static void mb_std_prim_ZPlusWorld_isZ_directoryZAsk_0 (void) {
+	mw_std_buffer_ZPlusBuffer_base();
+	mext_std_posix_stat();
+	push_i64(0LL);
+	mp_primZ_intZ_eq();
+	if (pop_u64()) {
+		mw_std_buffer_ZPlusBuffer_base();
+		push_resource(MKU64(0LL)); // +Unsafe
+		mw_std_posix_stz_modeZAt();
+		mw_std_prelude_ZPlusUnsafe_ZDivZPlusUnsafe();
+		mw_std_posix_Sz_ISDIR();
+	} else {
+		push_u64(0LL); // False
+	}
+}
 static void mb_std_terminal_csi_0 (void) {
 	push_u64(27LL); // BESC
 	mw_std_str_ZPlusStr_pushZ_byteZ_unsafeZBang();
@@ -39598,6 +39781,26 @@ static void mb_mirth_arrow_Block_qname_0 (void) {
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primZ_panic();
 	}
+}
+static void mb_mirth_package_Package_pathZ_orZ_search_0 (void) {
+	STRLIT("lib", 3);
+	push_u64(0LL); // Nil
+	mtw_std_list_List_1_Cons();
+}
+static void mb_mirth_package_Package_pathZ_orZ_search_1 (void) {
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	mw_mirth_package_Package_name();
+	mw_mirth_name_Name_ZToStr();
+	mw_std_path_Path_joinZ_unix();
+}
+static void mb_mirth_package_Package_pathZ_orZ_search_2 (void) {
+	mp_primZ_dup();
+	mw_std_prim_ZPlusWorld_isZ_directoryZAsk();
 }
 static void mb_mirth_package_Package_pathZBang_2 (void) {
 	STRLIT("Tried to set different path for the same package.", 49);

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -4785,11 +4785,11 @@ static void mvar_mirth_elab_ZTildepreferZ_inlineZ_defsZAsk (void) {
 	static VAL v = {0};
 	push_ptr(&v);
 }
-int64_t stat (int64_t, int64_t);
+intptr_t stat (intptr_t, intptr_t);
 static void mext_std_posix_stat (void) {
-	int64_t x1 = pop_i64();
-	int64_t x0 = pop_i64();
-	push_i64(stat(x0, x1));
+	intptr_t x1 = (intptr_t)pop_i64();
+	intptr_t x0 = (intptr_t)pop_i64();
+	push_i64((int64_t)stat(x0, x1));
 }
 static void mw_std_either_Either_2_leftZAsk (void);
 static void mw_std_either_Either_2_map_2 (void);
@@ -36172,7 +36172,7 @@ static void mw_mirth_c99_c99Z_externalZBang (void) {
 			push_u64(1LL); // True
 		}
 		if (pop_u64()) {
-			STRLIT("int64_t ", 8);
+			STRLIT("intptr_t ", 9);
 		} else {
 			STRLIT("void ", 5);
 		}
@@ -36202,7 +36202,7 @@ static void mw_mirth_c99_c99Z_externalZBang (void) {
 	mp_primZ_swap();
 	mp_primZ_intZ_lt();
 	if (pop_u64()) {
-		STRLIT("int64_t", 7);
+		STRLIT("intptr_t", 8);
 		mw_mirth_c99_ZPlusC99_put();
 		push_i64(1LL);
 		mp_primZ_intZ_sub();
@@ -36215,7 +36215,7 @@ static void mw_mirth_c99_c99Z_externalZBang (void) {
 			if (! pop_u64()) break;
 			{
 				VAL d4 = pop_value();
-				STRLIT(", int64_t", 9);
+				STRLIT(", intptr_t", 10);
 				mw_mirth_c99_ZPlusC99_put();
 				push_value(d4);
 			}
@@ -36268,11 +36268,11 @@ static void mw_mirth_c99_c99Z_externalZBang (void) {
 			mp_primZ_dup();
 			{
 				VAL d4 = pop_value();
-				STRLIT("\tint64_t x", 10);
+				STRLIT("\tintptr_t x", 11);
 				mw_mirth_c99_ZPlusC99_put();
 				mw_std_prim_Int_show();
 				mw_mirth_c99_ZPlusC99_put();
-				STRLIT(" = pop_i64();", 13);
+				STRLIT(" = (intptr_t)pop_i64();", 23);
 				mw_mirth_c99_ZPlusC99_put();
 				mw_mirth_c99_ZPlusC99_line();
 				push_value(d4);
@@ -36290,7 +36290,7 @@ static void mw_mirth_c99_c99Z_externalZBang (void) {
 	mp_primZ_swap();
 	mp_primZ_intZ_lt();
 	if (pop_u64()) {
-		STRLIT("\tpush_i64(", 10);
+		STRLIT("\tpush_i64((int64_t)", 19);
 	} else {
 		STRLIT("\t", 1);
 	}

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -4981,8 +4981,9 @@ static void mw_std_prelude_panicZBang (void);
 static void mw_std_prelude_expectZBang_2 (void);
 static void mw_std_prelude_assertZBang_2 (void);
 static void mw_std_path_Path_ZDivPath (void);
+static void mw_std_path_PATHz_SEPARATOR (void);
 static void mw_std_path_Path_joinZ_with (void);
-static void mw_std_path_Path_joinZ_unix (void);
+static void mw_std_path_Path_join (void);
 static void mw_std_byte_Byte_isZ_pathZ_separatorZAsk (void);
 static void mw_std_path_Path_splitZ_last (void);
 static void mw_std_prim_Int_ZToFile (void);
@@ -11117,6 +11118,23 @@ static void mw_std_prelude_assertZBang_2 (void) {
 }
 static void mw_std_path_Path_ZDivPath (void) {
 }
+static void mw_std_path_PATHz_SEPARATOR (void) {
+	mp_primZ_sysZ_os();
+	mw_std_prim_Int_ZToOS();
+	push_u64(1LL); // OS_WINDOWS
+	{
+		VAL d2 = pop_value();
+		mw_std_prelude_OS_tag();
+		push_value(d2);
+	}
+	mw_std_prelude_OS_tag();
+	mp_primZ_intZ_eq();
+	if (pop_u64()) {
+		STRLIT("\\", 1);
+	} else {
+		STRLIT("/", 1);
+	}
+}
 static void mw_std_path_Path_joinZ_with (void) {
 	{
 		VAL d2 = pop_value();
@@ -11158,10 +11176,10 @@ static void mw_std_path_Path_joinZ_with (void) {
 		mp_primZ_strZ_cat();
 	}
 }
-static void mw_std_path_Path_joinZ_unix (void) {
+static void mw_std_path_Path_join (void) {
 	{
 		VAL d2 = pop_value();
-		STRLIT("/", 1);
+		mw_std_path_PATHz_SEPARATOR();
 		push_value(d2);
 	}
 	mw_std_path_Path_joinZ_with();
@@ -25425,7 +25443,7 @@ static void mw_mirth_name_QName_toZ_moduleZ_path (void) {
 			mw_mirth_name_Name_ZToStr();
 			STRLIT(".mth", 4);
 			mp_primZ_strZ_cat();
-			mw_std_path_Path_joinZ_unix();
+			mw_std_path_Path_join();
 			break;
 		default:
 			mp_primZ_drop();
@@ -39796,7 +39814,7 @@ static void mb_mirth_package_Package_pathZ_orZ_search_1 (void) {
 	mp_primZ_swap();
 	mw_mirth_package_Package_name();
 	mw_mirth_name_Name_ZToStr();
-	mw_std_path_Path_joinZ_unix();
+	mw_std_path_Path_join();
 }
 static void mb_mirth_package_Package_pathZ_orZ_search_2 (void) {
 	mp_primZ_dup();

--- a/build.bat
+++ b/build.bat
@@ -1,7 +1,7 @@
 @echo off
 
 cl /WX /MD /TC bin\mirth0.c /link /WX  || goto :error
-mirth0.exe -p std:lib/std -p arg-parser:lib/arg-parser -p mirth:src src/main.mth -o bin/mirth1.c || goto :error
+mirth0.exe src/main.mth -o bin/mirth1.c || goto :error
 
 cl /WX /MD /TC bin\mirth1.c /link /WX  || goto :error
 mirth1.exe src/main.mth -o bin/mirth2.c || goto :error

--- a/build.bat
+++ b/build.bat
@@ -4,10 +4,10 @@ cl /WX /MD /TC bin\mirth0.c /link /WX  || goto :error
 mirth0.exe -p std:lib/std -p arg-parser:lib/arg-parser -p mirth:src src/main.mth -o bin/mirth1.c || goto :error
 
 cl /WX /MD /TC bin\mirth1.c /link /WX  || goto :error
-mirth1.exe -p std:lib/std -p arg-parser:lib/arg-parser -p mirth:src src/main.mth -o bin/mirth2.c || goto :error
+mirth1.exe src/main.mth -o bin/mirth2.c || goto :error
 
 cl /WX /W3 /MD /TC bin\mirth2.c /link /WX  || goto :error
-mirth2.exe -p std:lib/std -p arg-parser:lib/arg-parser -p mirth:src src/main.mth -o bin/mirth3.c || goto :error
+mirth2.exe src/main.mth -o bin/mirth3.c || goto :error
 
 goto :EOF
 

--- a/lib/std/list.mth
+++ b/lib/std/list.mth
@@ -41,6 +41,7 @@ inline(
     def(List+.>List, List+(t) -- List(t), /List+Unsafe)
     def(List+.len, List+(t) -- Nat, /List+Unsafe len)
     def(List+./L1+, List+(t) -- Maybe(t), /List+Unsafe /L1)
+    def(List+./L2+, List+(t) -- Maybe([t t]), /List+Unsafe /L2)
 )
 
 def(List.>List+, List(t) -- Maybe(List+(t)),

--- a/lib/std/maybe.mth
+++ b/lib/std/maybe.mth
@@ -76,8 +76,13 @@ def(Maybe.filter(f), (*c a -- *c a Bool) *c Maybe(a) -- *c Maybe(a),
     None -> None,
     Some -> f if(Some, drop None))
 
-def(while-some(f,g), (*a -- *a Maybe(b), *a b -- *a) *a -- *a,
-    f while(dup some?, unwrap g f) drop)
+inline(
+    def(while-some(f,g), (*a -- *a Maybe(b), *a b -- *a) *a -- *a,
+        f while(dup some?, unwrap g f) drop)
+
+    def(while-none(f,g), (*a -- *a Maybe(b), *a -- *a) *a -- *a b,
+        f while(dup none?, drop g f) unwrap)
+)
 
 def(Maybe.map2(f), (*c x y -- *c z) *c Maybe(x) Maybe(y) -- *c Maybe(z),
     None -> drop None,

--- a/lib/std/path.mth
+++ b/lib/std/path.mth
@@ -1,7 +1,10 @@
 module(std.path)
 
-import(std.str)
 import(std.prelude)
+import(std.byte)
+import(std.str)
+import(std.list)
+import(std.maybe)
 
 data(Path, Path -> Str)
 inline(
@@ -20,3 +23,14 @@ def(Path.join-with, Path Str Path -- Path,
 
 def(Path.join, Path Path -- Path, dip(PATH_SEPARATOR) join-with)
 def(Path.join-unix, Path Path -- Path, dip("/") join-with)
+
+def(Byte.is-path-separator?, Byte -- Bool,
+    B'/' -> True,
+    B'\' -> RUNNING_OS OS_WINDOWS ==,
+    _ -> drop False)
+
+def(Path.split, Path -- List+(Str),
+    /Path split-byte(is-path-separator?))
+
+def(Path.split-last, Path -- Path Maybe(Str),
+    /Path split-last-byte(is-path-separator?) dip(Path))

--- a/lib/std/posix.mth
+++ b/lib/std/posix.mth
@@ -51,7 +51,7 @@ def(Nat.print-ln!, Nat --, show print-ln!)
 ########
 
 def-external(stat, Ptr Ptr -- Int)
-def(is-directory?, Path -- Bool,
+def(+World.is-directory?, +World Path -- +World Bool,
     256 >Size +Buffer.new
     >Str with-data-cstr(
         base stat

--- a/lib/std/posix.mth
+++ b/lib/std/posix.mth
@@ -78,6 +78,6 @@ def(st_mode@, Ptr +Unsafe -- U16 +Unsafe,
     RUNNING_OS match(
         OS_LINUX -> 24, # .. this is all terrible and brittle
         OS_WINDOWS -> 6,
-	OS_MACOS -> RUNNING_ARCH ARCH_ARM64 == if(4, 8),
+        OS_MACOS -> RUNNING_ARCH ARCH_ARM64 == if(4, 8),
         _ -> drop 8
     ) >Offset swap offset @U16)

--- a/lib/std/str.mth
+++ b/lib/std/str.mth
@@ -32,6 +32,7 @@ def(cstr-num-bytes, Ptr +Unsafe -- Size +Unsafe,
 data(+Str, +Str -> Str)
 def(Str.thaw, Str -- +Str, +Str)
 def(+Str.freeze, +Str -- Str, +Str -> id)
+def(+Str.rdrop, +Str --, +Str -> drop)
 
 def(Str(f), (*a +Str -- *b +Str) *a -- *b Str, "" thaw f freeze)
 inline:def(+Str.;, Str +Str -- +Str, push-str!)
@@ -128,6 +129,12 @@ def(Str.slice, Offset Size Str +Unsafe -- Str +Unsafe,
         swap dip(offset) Str.copy
     ))
 
+def(Str.drop-slice, Offset Str +Unsafe -- Str +Unsafe,
+    rdip:thaw +Str.drop-slice rdip:rdrop)
+
+def(Str.take-slice, Size Str +Unsafe -- Str +Unsafe,
+    rdip:thaw +Str.take-slice rdip:rdrop)
+
 def(+Str.slice, Offset Size +Str +Unsafe -- Str +Str +Unsafe,
     rdip(+Str.dup!) slice)
 
@@ -157,18 +164,38 @@ def(+Str.find, Str +Str -- Maybe(Offset) +Str,
         1+
     ) drop2)
 
-def(+Str.split-byte, Byte +Str -- List+(Str) +Str,
+inline:
+def(+Str.split-byte(p), (*a Byte -- *a Bool) *a +Str -- *a List+(Str) +Str,
     LIST+( 0 >Offset dup while(
         dup rdip(+Str.num-bytes?) >Offset <,
-        over2 over rdip(+Str.byte@) == if(
+        tuck dip2(rdip(byte@ rdip(p))) rotl if(
             tuck rdip:unsafe(+Str.offset-slice)
             ; 1+ dup,
             1+
         )
-    ) rdip:unsafe(+Str.offset-slice) ;+) nip)
+    ) rdip:unsafe(+Str.offset-slice) ;+))
 
-def(Str.split-byte, Byte Str -- List(Str),
-    thaw +Str.split-byte freeze drop >List)
+def(+Str.split-byte, Byte +Str -- List+(Str) +Str,
+    split-byte(over ==) nip)
+
+inline:
+def(Str.split-byte(p), (*a Byte -- *a Bool) *a Str -- *a List+(Str),
+    thaw +Str.split-byte(p) rdrop)
+
+def(Str.split-byte, Byte Str -- List+(Str),
+    thaw +Str.split-byte rdrop)
+
+def(+Str.find-last-byte(p), (*a Byte -- *a Bool) *a +Str -- *a Maybe(Offset) +Str,
+    num-bytes? >Offset None while(
+        dup none? and(over 0>),
+        drop 1- sip(byte@ rdip(p)) swap if(dup Some, None)
+    ) nip)
+
+def(Str.split-last-byte(p), (*a Byte -- *a Bool) *a Str -- *a Str Maybe(Str),
+    thaw find-last-byte(p) freeze swap map(unsafe(
+        swap dup2 dip:1+ drop-slice
+        dip(dip:>Size take-slice)
+    )))
 
 def(+Str.push-show-byte!, +Str Byte -- +Str,
     BQUOTE -> "\\\"" ;, B'\' -> "\\\\" ;,

--- a/magic/magic.c
+++ b/magic/magic.c
@@ -1,0 +1,18 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <stdio.h>
+
+int main (int argc, char** argv) {
+    struct stat sb;
+
+    printf("S_IFDIR: 0x%X\n", S_IFDIR);
+    printf("st_mode: %u\n", (unsigned)((uintptr_t)&sb.st_mode) - ((uintptr_t)&sb));
+
+
+    // printf("st_isdir@")
+    // st_isdir@
+
+    stat("lib\\std", &sb);
+    printf("st_mode= 0x%X\n", sb.st_mode);
+
+}

--- a/mirth-test.sh
+++ b/mirth-test.sh
@@ -33,7 +33,7 @@ do
     rm -f $TMP/test/*
     echo test/$filename
     binary_name="${filename%.*}"
-    $TMP/mirth --debug test/$filename -p std:lib/std -p arg-parser:lib/arg-parser -p mirth-tests:test -o "bin/${binary_name}.c"> $TMP/test/mout 2> $TMP/test/merr
+    $TMP/mirth --debug test/$filename -o "bin/${binary_name}.c"> $TMP/test/mout 2> $TMP/test/merr
     MIRTH_BUILD_FAILED=$?
     cat $TMP/test/mout | sed 's/^/# mirth-test # mout # /' >> $TMP/test/actual
     cat $TMP/test/merr | egrep ': (error|warning):' | sed 's/^[^:]*:/# mirth-test # merr # /' >> $TMP/test/actual

--- a/src/c99.mth
+++ b/src/c99.mth
@@ -354,7 +354,7 @@ def(c99-external!, External +C99 -- +C99,
         "can't declare external with multiple return values" panic!,
 
         dup 1 >Nat >= if(
-            "int64_t ",
+            "intptr_t ",
             "void "
         ) put
     )
@@ -362,12 +362,12 @@ def(c99-external!, External +C99 -- +C99,
     dip2(dup symbol put)
 
     " (" put
-    over dup 0> if("int64_t" put 1- repeat(", int64_t" put), drop "void" put)
+    over dup 0> if("intptr_t" put 1- repeat(", intptr_t" put), drop "void" put)
     ");" put line
 
     dip2(dup cname sig-put) " {" put line
-    over countdown("\tint64_t x" put show put " = pop_i64();" put line)
-    dup 0> if("\tpush_i64(", "\t") put
+    over countdown("\tintptr_t x" put show put " = (intptr_t)pop_i64();" put line)
+    dup 0> if("\tpush_i64((int64_t)", "\t") put
     dip2(dup symbol put)
     "(" put
     dip(dup 0> if(

--- a/src/elab.mth
+++ b/src/elab.mth
@@ -1003,7 +1003,7 @@ def(elab-module-qname, Token -- QName,
     elab-module-package-name dip(NAMESPACE_PACKAGE) QNAME0)
 
 ||| Check that the `module(M)` statement exists and save the name.
-def(elab-module-header!, Token -- Token,
+def(elab-module-header!, +World Token -- +World Token,
     # dup token-name@ name-str @ str-trace-ln!
     dup module-header? if(
         sip(next) args-1 dup elab-module-package-name
@@ -1017,7 +1017,7 @@ def(elab-module-header!, Token -- Token,
         dup "Expected module header." emit-fatal-error!
     ))
 
-def(check-module-path, Token Module --,
+def(check-module-path, Token Module +World -- +World,
     dup path split-last match(
         None ->
             swap qname to-module-path dup2 == else(

--- a/src/elab.mth
+++ b/src/elab.mth
@@ -1018,9 +1018,18 @@ def(elab-module-header!, Token -- Token,
     ))
 
 def(check-module-path, Token Module --,
-    sip(path) qname to-module-path dup2 == else(
-        "expected module name to match path\n" swap >Str cat "\n" cat swap >Str cat emit-fatal-error!
-    ) drop3)
+    dup path split-last match(
+        None ->
+            swap qname to-module-path dup2 == else(
+                "expected module name to match path\n" swap >Str cat "\n" cat swap >Str cat emit-fatal-error!
+            ) drop3,
+
+        Some ->
+            split-last-byte(BDOT ==) "mth" Some ==:==
+            else(over3 "expected .mth extension for mirth file" emit-warning!)
+            over2 name >Str == else(over2 "expected module name to match file name" emit-fatal-error!)
+            over package path! drop2
+    ))
 
 ||| Elaborate a declaration. Returns the next token.
 def(elab-module-decl!, Token +World -- Token +World,

--- a/src/main.mth
+++ b/src/main.mth
@@ -74,7 +74,7 @@ def(compile!, Arguments +World -- +World,
     "Compiling " trace!
     @input-file >Str trace-ln!
     packages> for(
-      unpack2 swap >Name Package.new-or-set-path! drop
+        unpack2 swap >Name Package.new-or-path! drop
     )
     input-file> run-lexer!
     "Building." trace-ln!
@@ -114,7 +114,7 @@ def(compile!, Arguments +World -- +World,
 
 def(parse-package-def, Str -- [Str Path],
     dip(BCOLON) split-byte
-    /L2 unwrap-or("Invalid package path definition" panic!)
+    /L2+ unwrap-or("Invalid package path definition" panic!)
     unpack2 >Path pack2)
 
 def(compiler-parse-args, +ArgumentParser(Arguments) Arguments Maybe(Str) ArgpOptionType -- +ArgumentParser(Arguments) Arguments,

--- a/src/name.mth
+++ b/src/name.mth
@@ -237,8 +237,6 @@ def(QName.to-module-path, QName +World -- Path +World,
         NAMESPACE_PACKAGE ->
             path-or-search unwrap-or("No path defined for package" panic!)
         	swap name >Str ".mth" cat >Path join,
-                # TODO use Path.join instead? Related to issue:
-                #   https://github.com/mirth-lang/mirth/issues/199
         _ -> drop "expected module name" panic!
     ))
 def(QName.mangled, QName -- Str, MKQNAME ->

--- a/src/name.mth
+++ b/src/name.mth
@@ -236,7 +236,7 @@ def(QName.to-module-path, QName +World -- Path +World,
     dup namespace match(
         NAMESPACE_PACKAGE ->
             path-or-search unwrap-or("No path defined for package" panic!)
-        	swap name >Str ".mth" cat >Path join-unix,
+        	swap name >Str ".mth" cat >Path join,
                 # TODO use Path.join instead? Related to issue:
                 #   https://github.com/mirth-lang/mirth/issues/199
         _ -> drop "expected module name" panic!

--- a/src/name.mth
+++ b/src/name.mth
@@ -232,13 +232,13 @@ def(QName.>Str, QName -- Str, MKQNAME ->
     name> >Str cat
     arity> dup 0= if(drop, dip:"/" show cat cat))
 
-def(QName.to-module-path, QName -- Path,
+def(QName.to-module-path, QName +World -- Path +World,
     dup namespace match(
         NAMESPACE_PACKAGE ->
-            path unwrap-or("No path defined for package" panic!)
+            path-or-search unwrap-or("No path defined for package" panic!)
         	swap name >Str ".mth" cat >Path join-unix,
                 # TODO use Path.join instead? Related to issue:
-                #  https://github.com/mirth-lang/mirth/issues/199
+                #   https://github.com/mirth-lang/mirth/issues/199
         _ -> drop "expected module name" panic!
     ))
 def(QName.mangled, QName -- Str, MKQNAME ->

--- a/src/package.mth
+++ b/src/package.mth
@@ -3,6 +3,7 @@ module(mirth.package)
 import(std.prelude)
 import(std.path)
 import(std.maybe)
+import(std.str)
 import(mirth.name)
 import(mirth.def)
 
@@ -14,21 +15,33 @@ def(Package.name, Package -- Name, ~name @)
 def(Package.qname, Package -- QName, NAMESPACE_ROOT swap name QNAME0)
 def(Package.path, Package -- Maybe(Path), ~path @)
 
+def(Package.path!, Path Package --,
+    tuck path match(
+        Some ->
+            dup2 == if(
+                drop3,
+                Str(
+                    "Tried to set different path for the same package." ;
+                    "\n\tPackage: " ; rotl name >Str ;
+                    "\n\tPath 1: " ; swap /Path show ;
+                    "\n\tPath 2: " ; /Path show ;
+                ) panic!
+            ),
+        None ->
+            Some swap ~path !
+    ))
+
 def(Package.new!, Maybe(Path) Name -- Package,
     Package.alloc!
     tuck ~name !
     tuck ~path !
     dup DefPackage register)
 
-def(Package.new-or-set-path!, Path Name -- Package,
-  dup Package.find match(
-    Some -> dup path match(
-      Some -> "Package already has path" panic!,
-      None -> dip(drop) dup dip(dip(Some) ~path !)
-    ),
-    None -> dip(Some) Package.new!
-  )
-)
+def(Package.new-or-path!, Path Name -- Package,
+    dup Package.find match(
+        Some -> nip tuck path!,
+        None -> dip(Some) Package.new!
+    ))
 
 def(Package.find, Name -- Maybe(Package),
     NAMESPACE_ROOT swap QNAME0 def? bind(package?))

--- a/src/package.mth
+++ b/src/package.mth
@@ -4,6 +4,8 @@ import(std.prelude)
 import(std.path)
 import(std.maybe)
 import(std.str)
+import(std.list)
+import(std.posix)
 import(mirth.name)
 import(mirth.def)
 
@@ -14,6 +16,18 @@ field(Package.~path, Package, Maybe(Path))
 def(Package.name, Package -- Name, ~name @)
 def(Package.qname, Package -- QName, NAMESPACE_ROOT swap name QNAME0)
 def(Package.path, Package -- Maybe(Path), ~path @)
+
+var(PACKAGE_SEARCH_PATH, List(Path))
+
+def(Package.path-or-search, +World Package -- +World Maybe(Path),
+    dup path match(
+        Some -> nip Some,
+        None ->
+            PACKAGE_SEARCH_PATH memoize("lib" Path L1)
+            map(over name >Str >Path join-unix)
+            find(dup is-directory?)
+            tuck swap ~path !
+    ))
 
 def(Package.path!, Path Package --,
     tuck path match(

--- a/src/package.mth
+++ b/src/package.mth
@@ -24,7 +24,7 @@ def(Package.path-or-search, +World Package -- +World Maybe(Path),
         Some -> nip Some,
         None ->
             PACKAGE_SEARCH_PATH memoize("lib" Path L1)
-            map(over name >Str >Path join-unix)
+            map(over name >Str >Path join)
             find(dup is-directory?)
             tuck swap ~path !
     ))

--- a/test/error-module-name-mismatch.mth
+++ b/test/error-module-name-mismatch.mth
@@ -2,5 +2,5 @@
 module(mirth-tests.error-module-name-mismatcg)
 
 def(main, ,)
-# mirth-test # merr # 2:8: error: expected module name to match path
+# mirth-test # merr # 2:8: error: expected module name to match file name
 # mirth-test # mret # 1

--- a/test/test-is-directory.mth
+++ b/test/test-is-directory.mth
@@ -9,7 +9,7 @@ def(should-be-directory, +World Str -- +World,
 def(should-not-be-directory, +World Str -- +World,
    >Path is-directory? if("err", "ok") put line)
 
-def(main, --,
+def(main, +World -- +World,
     "src" should-be-directory
     "bin" should-be-directory
     "tools" should-be-directory

--- a/test/test-is-directory.mth
+++ b/test/test-is-directory.mth
@@ -3,11 +3,11 @@ import(std.prelude)
 import(std.path)
 import(std.posix)
 
-def(should-be-directory, Str --,
-   >Path is-directory? if("ok", "err") trace-ln!)
+def(should-be-directory, +World Str -- +World,
+   >Path is-directory? if("ok", "err") put line)
 
-def(should-not-be-directory, Str --,
-   >Path is-directory? if("err", "ok") trace-ln!)
+def(should-not-be-directory, +World Str -- +World,
+   >Path is-directory? if("err", "ok") put line)
 
 def(main, --,
     "src" should-be-directory
@@ -17,9 +17,9 @@ def(main, --,
     "lib/std/prelude.mth" should-not-be-directory
     "nonsense" should-not-be-directory)
 
-# mirth-test # perr # ok
-# mirth-test # perr # ok
-# mirth-test # perr # ok
-# mirth-test # perr # ok
-# mirth-test # perr # ok
-# mirth-test # perr # ok
+# mirth-test # pout # ok
+# mirth-test # pout # ok
+# mirth-test # pout # ok
+# mirth-test # pout # ok
+# mirth-test # pout # ok
+# mirth-test # pout # ok


### PR DESCRIPTION
This PR implements two main changes:

- When loading a module via a module path without knowing a package path (e.g. because the module path is passed in as the command-line argument to the mirth compiler), then infer the package path from the module path. e.g. if loading module `foo.bar`, from `my/directory/bar.mth`, it will infer that package `foo`'s path is `my/directory`.

- When loading a module via its name, and you don't know where the package is, it will look for a package in a predefined list of directories -- the "package search path". Right now, the search path is hardcoded to be just the "lib" directory, but it should be easy to make package search path configurable in the future (e.g. adding a `-P` option).

Together these eliminate all the necessary uses of `-p` package flags in the mirth repo. Of course `-p` still works to specify a package path manually ... we just don't need to do it.

Also this PR fixes issue #199.