### PR TITLE
More build.sh stuff

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "make",
             "type": "shell",
-            "command": "tools/build.sh '${relativeFile}'",
+            "command": "bash tools/build.sh '${relativeFile}'",
             "group": {
                 "kind": "build",
                 "isDefault": true

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ checksan: bin/mirth0.c bin/mirth1.c bin/mirth2.c bin/mirth3san.c
 
 clean:
 	cp bin/mirth0.c mirth0.c
-	rm -rf bin/*.c bin/*.exe bin/eval
+	rm -rf bin/*.c bin/*.exe bin/eval bin/test
 	mv mirth0.c bin/
 
 install-vim:

--- a/test/external-fnptr.mth
+++ b/test/external-fnptr.mth
@@ -1,0 +1,13 @@
+module(mirth-tests.external-fnptr)
+
+import(std.prelude)
+import(std.posix)
+
+def-external(atexit, [ +World -- +World ] +World -- +World)
+
+def(main, +World -- +World,
+    [ "goodbye world" put line ] atexit
+    "hello world" put line)
+
+# mirth-test # pout # hello world
+# mirth-test # pout # goodbye world

--- a/tools/build.bat
+++ b/tools/build.bat
@@ -1,13 +1,13 @@
 @echo off
 
-cl /WX /MD /TC bin\mirth0.c /link /WX  || goto :error
-mirth0.exe src/main.mth -o bin/mirth1.c || goto :error
+cl /WX /MD /TC bin\mirth0.c /Fobin\wmirth0.obj  /Febin\wmirth0.exe /link /WX || goto :error
+bin\wmirth0.exe src\main.mth -o bin\wmirth1.c || goto :error
 
-cl /WX /MD /TC bin\mirth1.c /link /WX  || goto :error
-mirth1.exe src/main.mth -o bin/mirth2.c || goto :error
+cl /WX /MD /TC bin\wmirth1.c /Fobin\wmirth1.obj /Febin\wmirth1.exe /link /WX || goto :error
+bin\wmirth1.exe src\main.mth -o bin\wmirth2.c || goto :error
 
-cl /WX /W3 /MD /TC bin\mirth2.c /link /WX  || goto :error
-mirth2.exe src/main.mth -o bin/mirth3.c || goto :error
+cl /WX /W3 /MD /TC bin\wmirth2.c /Fobin\wmirth2.obj /Febin\wmirth2.exe /link /WX || goto :error
+bin\wmirth2.exe src\main.mth -o bin\wmirth3.c || goto :error
 
 goto :EOF
 

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -2,15 +2,44 @@
 
 set -euo pipefail
 
+DirName="$(dirname "$1")"
+BaseName="$(basename "$1")"
+
 make
-case "$1" in
-    test/*.mth )
-        bash tools/run.sh "$1"
+case "$DirName" in
+    test )
+        case "$BaseName" in
+            *.mth )
+                bash tools/mirth-test.sh -u "$DirName/$BaseName"
+                ;;
+        esac
         ;;
-    examples/snake.mth )
-        make play-snake
+    examples )
+        case "$BaseName" in
+            snake.mth )
+                make play-snake
+                ;;
+            *.mth )
+                bin/mirth2 -c "$DirName/$BaseName"
+                ;;
+        esac
         ;;
-    *.mth )
-        bin/mirth2 -c "$1"
+    tools )
+        case "$BaseName" in
+            mirth-test.sh )
+                bash tools/mirth-test.sh -v
+                ;;
+            build32.bat|build64.bat )
+                powershell $1
+                diff --strip-trailing-cr bin/mirth3.c bin/wmirth3.c
+                ;;
+        esac
+        ;;
+    * )
+        case "$BaseName" in
+            *.mth )
+                bin/mirth2 -c "$1"
+                ;;
+        esac
         ;;
 esac

--- a/tools/build32.bat
+++ b/tools/build32.bat
@@ -1,0 +1,1 @@
+"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars32.bat" && "tools\build.bat" || exit /b 2

--- a/tools/build64.bat
+++ b/tools/build64.bat
@@ -1,0 +1,1 @@
+"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat" && "tools\build.bat" || exit /b 2

--- a/tools/mirth-test.sh
+++ b/tools/mirth-test.sh
@@ -5,72 +5,85 @@ CC="gcc $C99FLAGS"
 
 UPDATE=0
 VERIFY=0
+PRINT=0
 
 case "$1" in
   -u ) UPDATE=1 ;;
   -v ) VERIFY=1 ;;
+  -p ) PRINT=1 ;;
   * )
-    echo "USAGE: ./mirth-test [-v|-u]"
+    echo "USAGE: ./mirth-test [-v|-u|-p] [test]"
     echo "  -v  Run tests."
     echo "  -u  Update tests."
+    echo "  -p  Print test comments."
     exit 1 ;;
 esac
+
+if [ -n "$2" ]; then
+    FILES="$2"
+else
+    FILES="$(ls test/*.mth)"
+fi
 
 set -euo pipefail
 
 readonly TMP=$(mktemp -d)
-
-make bin/mirth2debug.c > $TMP/mkout 2> $TMP/mkerr || (cat $TMP/mkout && cat $TMP/mkerr && echo "Make failed." && exit 1)
-$CC -o $TMP/mirth bin/mirth2debug.c || (echo "Mirth build failed." && exit 1)
+make bin/mirth2 > $TMP/mkout 2> $TMP/mkerr || (cat $TMP/mkout && cat $TMP/mkerr && echo "Make failed." && exit 1)
+cp bin/mirth2 $TMP/mirth
 mkdir $TMP/test
 
 FAILED=0
 
 set +e
+mkdir -p bin/test
 
-for filename in $(ls test | grep .mth)
+for filepath in $FILES
 do
+    filename="$(basename $filepath)"
+    targetname="${filename%.*}.c"
+    targetpath="bin/test/$targetname"
+
     rm -f $TMP/test/*
-    echo test/$filename
-    binary_name="${filename%.*}"
-    $TMP/mirth --debug test/$filename -o "bin/${binary_name}.c"> $TMP/test/mout 2> $TMP/test/merr
+    echo "${filepath}"
+    rm -f "${targetpath}"
+    $TMP/mirth --debug "$filepath" -o "${targetpath}"> $TMP/test/mout 2> $TMP/test/merr
     MIRTH_BUILD_FAILED=$?
     cat $TMP/test/mout | sed 's/^/# mirth-test # mout # /' >> $TMP/test/actual
     cat $TMP/test/merr | egrep ': (error|warning):' | sed 's/^[^:]*:/# mirth-test # merr # /' >> $TMP/test/actual
     if [ "$MIRTH_BUILD_FAILED" != "0" ] ; then
         echo "# mirth-test # mret # $MIRTH_BUILD_FAILED" >> $TMP/test/actual
-	rm -f bin/${binary_name}
     else
-            echo "=> bin/${binary_name}"
-            $CC -o $TMP/test/ctarget bin/${binary_name}.c > $TMP/test/cout 2> $TMP/test/cerr
-            TARGET_FAILED=$?
-            rm -f bin/${binary_name}
-            cat $TMP/test/cout | sed "s/^/# mirth-test # cout # /" >> $TMP/test/actual
-            cat $TMP/test/cerr | sed "s/^/# mirth-test # cerr # /" >> $TMP/test/actual
-            if [ "$TARGET_FAILED" != "0" ] ; then
-                echo "# mirth-test # cret # $TARGET_FAILED" >> $TMP/test/actual
-            else
-                $TMP/test/ctarget > $TMP/test/pout 2> $TMP/test/perr
-                PROGRAM_FAILED=$?
-                cat $TMP/test/pout | sed "s/^/# mirth-test # pout # /" >> $TMP/test/actual
-                cat $TMP/test/perr | sed "s/^/# mirth-test # perr # /" >> $TMP/test/actual
-                if [ "$PROGRAM_FAILED" != "0" ] ; then
-                    echo "# mirth-test # pret # $PROGRAM_FAILED" >> $TMP/test/actual
-                fi
+        echo "=> ${targetpath}"
+        $CC -o $TMP/test/ctarget ${targetpath} > $TMP/test/cout 2> $TMP/test/cerr
+        TARGET_FAILED=$?
+        cat $TMP/test/cout | sed "s/^/# mirth-test # cout # /" >> $TMP/test/actual
+        cat $TMP/test/cerr | sed "s/^/# mirth-test # cerr # /" >> $TMP/test/actual
+        if [ "$TARGET_FAILED" != "0" ] ; then
+            echo "# mirth-test # cret # $TARGET_FAILED" >> $TMP/test/actual
+        else
+            $TMP/test/ctarget > $TMP/test/pout 2> $TMP/test/perr
+            PROGRAM_FAILED=$?
+            cat $TMP/test/pout | sed "s/^/# mirth-test # pout # /" >> $TMP/test/actual
+            cat $TMP/test/perr | sed "s/^/# mirth-test # perr # /" >> $TMP/test/actual
+            if [ "$PROGRAM_FAILED" != "0" ] ; then
+                echo "# mirth-test # pret # $PROGRAM_FAILED" >> $TMP/test/actual
             fi
+        fi
     fi
 
     if [ "$VERIFY" == "1" ] ; then
-        cat test/$filename | grep "# mirth-test #" > $TMP/test/expected || echo -n
+        cat $filepath | grep "# mirth-test #" > $TMP/test/expected || echo -n
         diff --text --strip-trailing-cr $TMP/test/expected $TMP/test/actual
         DIFF_FAILED=$?
         if [ "$DIFF_FAILED" != "0" ] ; then
-            echo "test/$filename FAILED"
+            echo "-- $filepath FAILED"
             FAILED=1
         fi
     elif [ "$UPDATE" == "1" ] ; then
-        cat test/$filename | grep -v "# mirth-test #" > $TMP/test/source || echo -n
-        cat $TMP/test/source $TMP/test/actual > test/$filename
+        cat $filepath | grep -v "# mirth-test #" > $TMP/test/source || echo -n
+        cat $TMP/test/source $TMP/test/actual > $filepath
+    elif [ "$PRINT" == "1" ] ; then
+        cat $TMP/test/actual
     fi
 done
 


### PR DESCRIPTION
Also adds a test for fnptrs in def-external.

Also adds a few options to mirth-test.sh:

- `-p` option to print the golden test comments
- you can run a single test by passing a file path, e.g. `tools/mirth-test.sh -p test/hello-world.mth`