### PR TITLE
Flexible external declaration.

### DIFF
--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -6213,6 +6213,7 @@ static void mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZ_atZBang (void);
 static void mw_mirth_mirth_ZPlusMirth_emitZ_warningZBang (void);
 static void mw_mirth_mirth_ZPlusMirth_emitZ_errorZBang (void);
 static void mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang (void);
+static void mw_mirth_mirth_ZPlusMirth_emitZ_deprecatedZBang (void);
 static void mw_mirth_mirth_ZPlusMirth_withZ_errorZ_token_1 (void);
 static void mw_mirth_mirth_ZPlusMirth_errorZBang (void);
 static void mw_mirth_mirth_ZPlusMirth_traceZ_allZ_diagnosticsZBang (void);
@@ -7043,6 +7044,7 @@ static void mb_mirth_mirth_ZPlusMirth_emitZ_diagnosticZ_atZBang_0 (void);
 static void mb_mirth_mirth_ZPlusMirth_emitZ_diagnosticZ_atZBang_1 (void);
 static void mb_mirth_mirth_ZPlusMirth_emitZ_diagnosticZ_atZBang_2 (void);
 static void mb_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZ_atZBang_0 (void);
+static void mb_mirth_mirth_ZPlusMirth_emitZ_deprecatedZBang_0 (void);
 static void mb_mirth_mirth_PropLabel_prop2_1_1 (void);
 static void mb_mirth_mirth_PropLabel_prop3_1_1 (void);
 static void mb_mirth_mirth_PropLabel_prop0_1_1 (void);
@@ -26266,6 +26268,11 @@ static void mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang (void) {
 	}
 	mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZ_atZBang();
 }
+static void mw_mirth_mirth_ZPlusMirth_emitZ_deprecatedZBang (void) {
+	push_fnptr(&mb_mirth_mirth_ZPlusMirth_emitZ_deprecatedZBang_0);
+	mw_std_str_Str_1();
+	mw_mirth_mirth_ZPlusMirth_emitZ_warningZBang();
+}
 static void mw_mirth_mirth_ZPlusMirth_withZ_errorZ_token_1 (void) {
 	{
 		VAL var_f = pop_value();
@@ -33137,6 +33144,12 @@ static void mw_mirth_elab_elabZ_moduleZ_declZBang (void) {
 			break;
 		case 86LL: // PRIM_SYNTAX_DEF_EXTERNAL
 			(void)pop_u64();
+			mp_primZ_dup();
+			STRLIT("def-external", 12);
+			LPUSH(lbl_old);
+			STRLIT("external", 8);
+			LPUSH(lbl_new);
+			mw_mirth_mirth_ZPlusMirth_emitZ_deprecatedZBang();
 			mw_mirth_elab_elabZ_externalZBang();
 			break;
 		case 85LL: // PRIM_SYNTAX_EXTERNAL
@@ -43305,6 +43318,24 @@ static void mb_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZ_atZBang_0 (void) {
 	mw_std_str_ZPlusStr_pushZ_strZBang();
 	push_u64(0LL); // Reset
 	mw_std_terminal_Sgr_emitZThen();
+}
+static void mb_mirth_mirth_ZPlusMirth_emitZ_deprecatedZBang_0 (void) {
+	push_u64(36LL); // FGCyan
+	mw_std_terminal_Sgr_emitZThen();
+	LPOP(lbl_old);
+	mw_std_str_ZPlusStr_pushZ_strZBang();
+	push_u64(0LL); // Reset
+	mw_std_terminal_Sgr_emitZThen();
+	STRLIT(" is deprecated, please use ", 27);
+	mw_std_str_ZPlusStr_pushZ_strZBang();
+	push_u64(36LL); // FGCyan
+	mw_std_terminal_Sgr_emitZThen();
+	LPOP(lbl_new);
+	mw_std_str_ZPlusStr_pushZ_strZBang();
+	push_u64(0LL); // Reset
+	mw_std_terminal_Sgr_emitZThen();
+	STRLIT(" instead.", 9);
+	mw_std_str_ZPlusStr_pushZ_strZBang();
 }
 static void mb_mirth_mirth_PropLabel_prop2_1_1 (void) {
 	mp_primZ_packZ_uncons();

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -7379,8 +7379,10 @@ static void mb_mirth_elab_parseZ_externalZ_decl_2 (void);
 static void mb_mirth_elab_parseZ_externalZ_decl_3 (void);
 static void mb_mirth_elab_parseZ_externalZ_declZ_part_0 (void);
 static void mb_mirth_elab_parseZ_externalZ_declZ_part_1 (void);
-static void mb_mirth_elab_parseZ_externalZ_declZ_part_3 (void);
+static void mb_mirth_elab_parseZ_externalZ_declZ_part_2 (void);
+static void mb_mirth_elab_parseZ_externalZ_declZ_part_5 (void);
 static void mb_mirth_elab_parseZ_externalZ_declZ_part_6 (void);
+static void mb_mirth_elab_parseZ_externalZ_declZ_part_7 (void);
 static void mb_mirth_elab_elabZ_externalZ_defZBang_0 (void);
 static void mb_mirth_elab_elabZ_externalZ_defZBang_1 (void);
 static void mb_mirth_elab_elabZ_externalZ_defZBang_2 (void);
@@ -47183,13 +47185,6 @@ static void mb_mirth_elab_parseZ_externalZ_declZ_part_0 (void) {
 	mp_primZ_dup();
 	LPUSH(lbl_token);
 	mw_mirth_token_Token_succ();
-	mp_primZ_dup();
-	mw_mirth_token_Token_argZ_endZAsk();
-	if (pop_u64()) {
-	} else {
-		STRLIT("expected comma", 14);
-		mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
-	}
 	mtw_mirth_elab_ExternalDeclPart_EDPCode();
 }
 static void mb_mirth_elab_parseZ_externalZ_declZ_part_1 (void) {
@@ -47197,7 +47192,7 @@ static void mb_mirth_elab_parseZ_externalZ_declZ_part_1 (void) {
 	LPUSH(lbl_head);
 	mp_primZ_dup();
 	mw_mirth_token_Token_nameZ_orZ_dnameZAsk();
-	push_fnptr(&mb_mirth_elab_parseZ_externalZ_declZ_part_3);
+	push_fnptr(&mb_mirth_elab_parseZ_externalZ_declZ_part_2);
 	mw_std_maybe_Maybe_1_else_1();
 	mw_mirth_token_Token_succ();
 	mp_primZ_dup();
@@ -47206,7 +47201,7 @@ static void mb_mirth_elab_parseZ_externalZ_declZ_part_1 (void) {
 		mw_mirth_token_Token_succ();
 		mp_primZ_dup();
 		mw_mirth_token_Token_nameZAsk();
-		push_fnptr(&mb_mirth_elab_parseZ_externalZ_declZ_part_6);
+		push_fnptr(&mb_mirth_elab_parseZ_externalZ_declZ_part_5);
 		mw_std_maybe_Maybe_1_else_1();
 		mp_primZ_dup();
 		mtw_std_maybe_Maybe_1_Some();
@@ -47217,10 +47212,32 @@ static void mb_mirth_elab_parseZ_externalZ_declZ_part_1 (void) {
 		LPUSH(lbl_symbol);
 	}
 	mp_primZ_dup();
+	mw_mirth_token_Token_lsquareZAsk();
+	push_fnptr(&mb_mirth_elab_parseZ_externalZ_declZ_part_6);
+	push_fnptr(&mb_mirth_elab_parseZ_externalZ_declZ_part_7);
+	mw_std_maybe_Maybe_1_if_2();
+	mtw_mirth_elab_ExternalDeclPart_EDPDef();
+}
+static void mb_mirth_elab_parseZ_externalZ_declZ_part_2 (void) {
+	STRLIT("expected external word name", 27);
+	mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+}
+static void mb_mirth_elab_parseZ_externalZ_declZ_part_5 (void) {
+	STRLIT("expected external symbol name", 29);
+	mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+}
+static void mb_mirth_elab_parseZ_externalZ_declZ_part_6 (void) {
+	mp_primZ_dup();
+	mw_mirth_token_Token_argsZ_1();
+	LPUSH(lbl_sig);
+	mw_mirth_token_Token_next();
+}
+static void mb_mirth_elab_parseZ_externalZ_declZ_part_7 (void) {
+	mp_primZ_dup();
 	mw_mirth_token_Token_commaZAsk();
 	if (pop_u64()) {
 	} else {
-		STRLIT("expected comma before type signature", 36);
+		STRLIT("expected type signature", 23);
 		mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
 	}
 	mw_mirth_token_Token_succ();
@@ -47234,15 +47251,6 @@ static void mb_mirth_elab_parseZ_externalZ_declZ_part_1 (void) {
 	mp_primZ_dup();
 	LPUSH(lbl_sig);
 	mw_mirth_token_Token_nextZ_argZ_end();
-	mtw_mirth_elab_ExternalDeclPart_EDPDef();
-}
-static void mb_mirth_elab_parseZ_externalZ_declZ_part_3 (void) {
-	STRLIT("expected external word name", 27);
-	mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
-}
-static void mb_mirth_elab_parseZ_externalZ_declZ_part_6 (void) {
-	STRLIT("expected external symbol name", 29);
-	mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
 }
 static void mb_mirth_elab_elabZ_externalZ_defZBang_0 (void) {
 	mw_mirth_token_Token_nameZAsk();

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -1460,6 +1460,8 @@ static VAL lbl_errorZ_token = MKNIL_C;
 static VAL lbl_severity = MKNIL_C;
 static VAL lbl_message = MKNIL_C;
 static VAL lbl_location = MKNIL_C;
+static VAL lbl_old = MKNIL_C;
+static VAL lbl_new = MKNIL_C;
 static VAL lbl_label = MKNIL_C;
 static VAL lbl_module = MKNIL_C;
 static VAL lbl_row = MKNIL_C;
@@ -1520,6 +1522,10 @@ static VAL lbl_ZPlusab = MKNIL_C;
 static VAL lbl_ZPluspat = MKNIL_C;
 static VAL lbl_tok = MKNIL_C;
 static VAL lbl_f = MKNIL_C;
+static VAL lbl_code = MKNIL_C;
+static VAL lbl_symbol = MKNIL_C;
+static VAL lbl_extblock = MKNIL_C;
+static VAL lbl_external = MKNIL_C;
 static VAL lbl_contents = MKNIL_C;
 static VAL lbl_tbl = MKNIL_C;
 static VAL lbl_word = MKNIL_C;
@@ -2204,6 +2210,44 @@ static void mtw_mirth_match_PatternOp_PatOpTag (void) {
 	push_value(MKTUP(tup, 2));
 }
 static void mtp_mirth_match_PatternOp_PatOpTag (void) {
+	VAL val = pop_value();
+	ASSERT1(IS_TUP(val),val);
+	TUP* tup = VTUP(val);
+	push_value(tup->cells[1]);
+	if (tup->refs > 1) {
+		incref(tup->cells[1]);
+		decref(val);
+	} else {
+		free(tup);
+	}
+}
+static void mtw_mirth_external_ExternalBlockPart_EBPCode (void) {
+	TUP* tup = tup_new(2);
+	tup->size = 2;
+	tup->cells[0] = MKU64(0LL);
+	tup->cells[1] = pop_value();
+	push_value(MKTUP(tup, 2));
+}
+static void mtp_mirth_external_ExternalBlockPart_EBPCode (void) {
+	VAL val = pop_value();
+	ASSERT1(IS_TUP(val),val);
+	TUP* tup = VTUP(val);
+	push_value(tup->cells[1]);
+	if (tup->refs > 1) {
+		incref(tup->cells[1]);
+		decref(val);
+	} else {
+		free(tup);
+	}
+}
+static void mtw_mirth_external_ExternalBlockPart_EBPDef (void) {
+	TUP* tup = tup_new(2);
+	tup->size = 2;
+	tup->cells[0] = MKU64(1LL);
+	tup->cells[1] = pop_value();
+	push_value(MKTUP(tup, 2));
+}
+static void mtp_mirth_external_ExternalBlockPart_EBPDef (void) {
 	VAL val = pop_value();
 	ASSERT1(IS_TUP(val),val);
 	TUP* tup = VTUP(val);
@@ -4748,6 +4792,53 @@ static void mtp_mirth_elab_OpSig_OPSIGz_APPLY (void) {
 		free(tup);
 	}
 }
+static void mtw_mirth_elab_ExternalDeclPart_EDPCode (void) {
+	TUP* tup = tup_new(3);
+	tup->size = 3;
+	tup->cells[0] = MKU64(0LL);
+	tup->cells[2] = lpop(&lbl_code);
+	tup->cells[1] = lpop(&lbl_token);
+	push_value(MKTUP(tup, 3));
+}
+static void mtp_mirth_elab_ExternalDeclPart_EDPCode (void) {
+	VAL val = pop_value();
+	ASSERT1(IS_TUP(val),val);
+	TUP* tup = VTUP(val);
+	lpush(&lbl_token, tup->cells[1]);
+	lpush(&lbl_code, tup->cells[2]);
+	if (tup->refs > 1) {
+		incref(tup->cells[1]);
+		incref(tup->cells[2]);
+		decref(val);
+	} else {
+		free(tup);
+	}
+}
+static void mtw_mirth_elab_ExternalDeclPart_EDPDef (void) {
+	TUP* tup = tup_new(4);
+	tup->size = 4;
+	tup->cells[0] = MKU64(1LL);
+	tup->cells[3] = lpop(&lbl_sig);
+	tup->cells[2] = lpop(&lbl_symbol);
+	tup->cells[1] = lpop(&lbl_head);
+	push_value(MKTUP(tup, 4));
+}
+static void mtp_mirth_elab_ExternalDeclPart_EDPDef (void) {
+	VAL val = pop_value();
+	ASSERT1(IS_TUP(val),val);
+	TUP* tup = VTUP(val);
+	lpush(&lbl_head, tup->cells[1]);
+	lpush(&lbl_symbol, tup->cells[2]);
+	lpush(&lbl_sig, tup->cells[3]);
+	if (tup->refs > 1) {
+		incref(tup->cells[1]);
+		incref(tup->cells[2]);
+		incref(tup->cells[3]);
+		decref(val);
+	} else {
+		free(tup);
+	}
+}
 static void mtw_std_map_KVPair_2_KVPair (void) {
 	TUP* tup = tup_new(3);
 	tup->size = 3;
@@ -5077,6 +5168,10 @@ static void mbuf_mirth_data_Tag_NUM (void) {
 	push_ptr(&b);
 }
 static void mbuf_mirth_external_External_NUM (void) {
+	static uint8_t b[8] = {0};
+	push_ptr(&b);
+}
+static void mbuf_mirth_external_ExternalBlock_NUM (void) {
 	static uint8_t b[8] = {0};
 	push_ptr(&b);
 }
@@ -5650,6 +5745,9 @@ static void mw_mirth_external_External_ctxZ_type (void);
 static void mw_mirth_external_External_type (void);
 static void mw_mirth_external_External_ctype (void);
 static void mw_mirth_external_External_ZEqualZEqual (void);
+static void mw_mirth_external_ExternalBlock_for_1 (void);
+static void mw_mirth_external_ExternalBlock_allocZBang (void);
+static void mw_mirth_external_ExternalBlock_parts (void);
 static void mw_mirth_variable_Variable_index (void);
 static void mw_mirth_variable_Variable_for_1 (void);
 static void mw_mirth_variable_Variable_allocZBang (void);
@@ -6475,7 +6573,11 @@ static void mw_mirth_elab_checkZ_inlineZ_recursionZ_opZBang (void);
 static void mw_mirth_elab_checkZ_inlineZ_recursionZ_failedZBang (void);
 static void mw_mirth_elab_elabZ_defZ_paramsZBang (void);
 static void mw_mirth_elab_elabZ_defZ_bodyZBang (void);
-static void mw_mirth_elab_elabZ_defZ_externalZBang (void);
+static void mw_mirth_elab_parseZ_externalZ_decl (void);
+static void mw_mirth_elab_parseZ_externalZ_declZ_part (void);
+static void mw_mirth_elab_elabZ_externalZBang (void);
+static void mw_mirth_elab_elabZ_externalZ_blockZ_partZBang (void);
+static void mw_mirth_elab_elabZ_externalZ_defZBang (void);
 static void mw_mirth_elab_elabZ_defZ_externalZ_ctype (void);
 static void mw_mirth_elab_elabZ_defZ_typeZBang (void);
 static void mw_mirth_elab_elabZ_bufferZBang (void);
@@ -6657,8 +6759,9 @@ static void mw_mirth_c99_c99Z_tagZ_defZBang (void);
 static void mw_mirth_c99_c99Z_tagZ_labelZ_index (void);
 static void mw_mirth_c99_c99Z_tagZ_getZ_labelZBang (void);
 static void mw_mirth_c99_c99Z_tagZ_setZ_labelZBang (void);
-static void mw_mirth_c99_c99Z_externalsZBang (void);
-static void mw_mirth_c99_c99Z_externalZBang (void);
+static void mw_mirth_c99_c99Z_externalZ_blocksZBang (void);
+static void mw_mirth_c99_c99Z_externalZ_blockZBang (void);
+static void mw_mirth_c99_c99Z_externalZ_defZBang (void);
 static void mw_mirth_type_CType_c99Z_popZ_value (void);
 static void mw_mirth_type_CType_c99Z_popZ_resource (void);
 static void mw_mirth_type_CType_c99Z_popZ_label (void);
@@ -7216,9 +7319,7 @@ static void mb_mirth_elab_elabZ_defZBang_5 (void);
 static void mb_mirth_elab_elabZ_defZBang_6 (void);
 static void mb_mirth_elab_elabZ_defZBang_7 (void);
 static void mb_mirth_elab_elabZ_defZBang_11 (void);
-static void mb_mirth_elab_elabZ_defZ_externalZBang_3 (void);
-static void mb_mirth_elab_elabZ_defZ_externalZBang_4 (void);
-static void mb_mirth_elab_elabZ_defZ_externalZBang_6 (void);
+static void mb_mirth_elab_elabZ_externalZBang_0 (void);
 static void mb_mirth_elab_elabZ_bufferZBang_1 (void);
 static void mb_mirth_elab_elabZ_variableZBang_1 (void);
 static void mb_mirth_elab_elabZ_dataZBang_2 (void);
@@ -7271,6 +7372,17 @@ static void mb_mirth_elab_checkZ_inlineZ_recursionZ_atomZBang_2 (void);
 static void mb_mirth_elab_checkZ_inlineZ_recursionZ_opZBang_4 (void);
 static void mb_mirth_elab_checkZ_inlineZ_recursionZ_opZBang_5 (void);
 static void mb_mirth_elab_checkZ_inlineZ_recursionZ_opZBang_6 (void);
+static void mb_mirth_elab_parseZ_externalZ_decl_1 (void);
+static void mb_mirth_elab_parseZ_externalZ_decl_2 (void);
+static void mb_mirth_elab_parseZ_externalZ_decl_3 (void);
+static void mb_mirth_elab_parseZ_externalZ_declZ_part_0 (void);
+static void mb_mirth_elab_parseZ_externalZ_declZ_part_1 (void);
+static void mb_mirth_elab_parseZ_externalZ_declZ_part_3 (void);
+static void mb_mirth_elab_parseZ_externalZ_declZ_part_6 (void);
+static void mb_mirth_elab_elabZ_externalZ_defZBang_0 (void);
+static void mb_mirth_elab_elabZ_externalZ_defZBang_1 (void);
+static void mb_mirth_elab_elabZ_externalZ_defZBang_2 (void);
+static void mb_mirth_elab_elabZ_externalZ_defZBang_4 (void);
 static void mb_mirth_elab_elabZ_defZ_externalZ_ctype_0 (void);
 static void mb_mirth_elab_elabZ_defZ_externalZ_ctype_1 (void);
 static void mb_mirth_elab_tableZ_newZBang_0 (void);
@@ -7351,7 +7463,7 @@ static void mb_mirth_c99_c99Z_labelZ_defsZBang_0 (void);
 static void mb_mirth_c99_c99Z_tagZ_defsZBang_0 (void);
 static void mb_mirth_c99_c99Z_buffersZBang_0 (void);
 static void mb_mirth_c99_c99Z_variablesZBang_0 (void);
-static void mb_mirth_c99_c99Z_externalsZBang_0 (void);
+static void mb_mirth_c99_c99Z_externalZ_blocksZBang_0 (void);
 static void mb_mirth_c99_c99Z_wordZ_sigsZBang_0 (void);
 static void mb_mirth_c99_c99Z_wordZ_sigsZBang_1 (void);
 static void mb_mirth_c99_c99Z_blockZ_sigsZBang_0 (void);
@@ -7449,20 +7561,21 @@ static void mb_mirth_c99_c99Z_tagZ_setZ_labelZBang_49 (void);
 static void mb_mirth_c99_c99Z_tagZ_setZ_labelZBang_50 (void);
 static void mb_mirth_c99_c99Z_nest_1_0 (void);
 static void mb_mirth_c99_c99Z_nest_1_1 (void);
-static void mb_mirth_c99_c99Z_externalZBang_0 (void);
-static void mb_mirth_c99_c99Z_externalZBang_1 (void);
-static void mb_mirth_c99_c99Z_externalZBang_2 (void);
-static void mb_mirth_c99_c99Z_externalZBang_3 (void);
-static void mb_mirth_c99_c99Z_externalZBang_4 (void);
-static void mb_mirth_c99_c99Z_externalZBang_5 (void);
-static void mb_mirth_c99_c99Z_externalZBang_6 (void);
-static void mb_mirth_c99_c99Z_externalZBang_7 (void);
-static void mb_mirth_c99_c99Z_externalZBang_8 (void);
-static void mb_mirth_c99_c99Z_externalZBang_10 (void);
-static void mb_mirth_c99_c99Z_externalZBang_11 (void);
-static void mb_mirth_c99_c99Z_externalZBang_14 (void);
-static void mb_mirth_c99_c99Z_externalZBang_15 (void);
-static void mb_mirth_c99_c99Z_externalZBang_16 (void);
+static void mb_mirth_c99_c99Z_externalZ_blockZBang_0 (void);
+static void mb_mirth_c99_c99Z_externalZ_defZBang_0 (void);
+static void mb_mirth_c99_c99Z_externalZ_defZBang_1 (void);
+static void mb_mirth_c99_c99Z_externalZ_defZBang_2 (void);
+static void mb_mirth_c99_c99Z_externalZ_defZBang_3 (void);
+static void mb_mirth_c99_c99Z_externalZ_defZBang_4 (void);
+static void mb_mirth_c99_c99Z_externalZ_defZBang_5 (void);
+static void mb_mirth_c99_c99Z_externalZ_defZBang_6 (void);
+static void mb_mirth_c99_c99Z_externalZ_defZBang_7 (void);
+static void mb_mirth_c99_c99Z_externalZ_defZBang_8 (void);
+static void mb_mirth_c99_c99Z_externalZ_defZBang_10 (void);
+static void mb_mirth_c99_c99Z_externalZ_defZBang_11 (void);
+static void mb_mirth_c99_c99Z_externalZ_defZBang_14 (void);
+static void mb_mirth_c99_c99Z_externalZ_defZBang_15 (void);
+static void mb_mirth_c99_c99Z_externalZ_defZBang_16 (void);
 static void mb_mirth_type_CTypeStackPart_c99Z_argZ_name_0 (void);
 static void mb_mirth_type_CTypeStackPart_c99Z_argZ_name_1 (void);
 static void mb_mirth_type_CTypeStackPart_c99Z_argZ_name_2 (void);
@@ -7672,6 +7785,8 @@ static void mfld_mirth_external_External_ZTildehead (void);
 static void mfld_mirth_external_External_ZTildesig (void);
 static void mfld_mirth_external_External_ZTildectxZ_type (void);
 static void mfld_mirth_external_External_ZTildectype (void);
+static void mfld_mirth_external_ExternalBlock_ZTildetoken (void);
+static void mfld_mirth_external_ExternalBlock_ZTildeparts (void);
 static void mfld_mirth_variable_Variable_ZTildehead (void);
 static void mfld_mirth_variable_Variable_ZTildeqname (void);
 static void mfld_mirth_variable_Variable_ZTildetype (void);
@@ -8200,6 +8315,24 @@ static void mfld_mirth_external_External_ZTildectxZ_type (void) {
 }
 
 static void mfld_mirth_external_External_ZTildectype (void) {
+	size_t i = (size_t)pop_u64();
+	static struct VAL * p = 0;
+	size_t m = 524288;
+	if (! p) { p = calloc(m, sizeof *p); }
+	EXPECT(i<m, "table grew too big");
+	push_ptr(p+i);
+}
+
+static void mfld_mirth_external_ExternalBlock_ZTildetoken (void) {
+	size_t i = (size_t)pop_u64();
+	static struct VAL * p = 0;
+	size_t m = 524288;
+	if (! p) { p = calloc(m, sizeof *p); }
+	EXPECT(i<m, "table grew too big");
+	push_ptr(p+i);
+}
+
+static void mfld_mirth_external_ExternalBlock_ZTildeparts (void) {
 	size_t i = (size_t)pop_u64();
 	static struct VAL * p = 0;
 	size_t m = 524288;
@@ -16125,6 +16258,45 @@ static void mw_mirth_external_External_ZEqualZEqual (void) {
 	mw_mirth_external_External_index();
 	mp_primZ_intZ_eq();
 }
+static void mw_mirth_external_ExternalBlock_for_1 (void) {
+	{
+		VAL var_f = pop_value();
+		push_i64(1LL);
+		while(1) {
+			mp_primZ_dup();
+			mbuf_mirth_external_ExternalBlock_NUM();
+			mp_primZ_u64Z_get();
+			push_i64(1LL);
+			mp_primZ_intZ_add();
+			mp_primZ_intZ_lt();
+			if (! pop_u64()) break;
+			mp_primZ_dup();
+			{
+				VAL d4 = pop_value();
+				incref(var_f);
+				run_value(var_f);
+				push_value(d4);
+			}
+			push_i64(1LL);
+			mp_primZ_intZ_add();
+		}
+		mp_primZ_drop();
+		decref(var_f);
+	}
+}
+static void mw_mirth_external_ExternalBlock_allocZBang (void) {
+	mbuf_mirth_external_ExternalBlock_NUM();
+	mp_primZ_u64Z_get();
+	push_i64(1LL);
+	mp_primZ_intZ_add();
+	mp_primZ_dup();
+	mbuf_mirth_external_ExternalBlock_NUM();
+	mp_primZ_u64Z_set();
+}
+static void mw_mirth_external_ExternalBlock_parts (void) {
+	mfld_mirth_external_ExternalBlock_ZTildeparts();
+	mp_primZ_mutZ_get();
+}
 static void mw_mirth_variable_Variable_index (void) {
 }
 static void mw_mirth_variable_Variable_for_1 (void) {
@@ -22453,23 +22625,27 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	STRLIT("buffer", 6);
 	push_i64(-1LL);
 	mw_mirth_prim_defZ_primZBang();
-	push_u64(85LL); // PRIM_SYNTAX_DEF_EXTERNAL
+	push_u64(86LL); // PRIM_SYNTAX_DEF_EXTERNAL
 	STRLIT("def-external", 12);
 	push_i64(-1LL);
 	mw_mirth_prim_defZ_primZBang();
-	push_u64(87LL); // PRIM_SYNTAX_TABLE
+	push_u64(85LL); // PRIM_SYNTAX_EXTERNAL
+	STRLIT("external", 8);
+	push_i64(-1LL);
+	mw_mirth_prim_defZ_primZBang();
+	push_u64(88LL); // PRIM_SYNTAX_TABLE
 	STRLIT("table", 5);
 	push_i64(-1LL);
 	mw_mirth_prim_defZ_primZBang();
-	push_u64(88LL); // PRIM_SYNTAX_FIELD
+	push_u64(89LL); // PRIM_SYNTAX_FIELD
 	STRLIT("field", 5);
 	push_i64(-1LL);
 	mw_mirth_prim_defZ_primZBang();
-	push_u64(86LL); // PRIM_SYNTAX_EMBED_STR
+	push_u64(87LL); // PRIM_SYNTAX_EMBED_STR
 	STRLIT("embed-str", 9);
 	push_i64(-1LL);
 	mw_mirth_prim_defZ_primZBang();
-	push_u64(89LL); // PRIM_SYNTAX_DATA
+	push_u64(90LL); // PRIM_SYNTAX_DATA
 	STRLIT("data", 4);
 	push_i64(-1LL);
 	mw_mirth_prim_defZ_primZBang();
@@ -22477,11 +22653,11 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	STRLIT("var", 3);
 	push_i64(-1LL);
 	mw_mirth_prim_defZ_primZBang();
-	push_u64(91LL); // PRIM_SYNTAX_ARROW
+	push_u64(92LL); // PRIM_SYNTAX_ARROW
 	STRLIT("->", 2);
 	push_i64(-1LL);
 	mw_mirth_prim_defZ_primZBang();
-	push_u64(90LL); // PRIM_SYNTAX_DASHES
+	push_u64(91LL); // PRIM_SYNTAX_DASHES
 	STRLIT("--", 2);
 	push_i64(-1LL);
 	mw_mirth_prim_defZ_primZBang();
@@ -32959,9 +33135,13 @@ static void mw_mirth_elab_elabZ_moduleZ_declZBang (void) {
 			(void)pop_u64();
 			mw_mirth_elab_elabZ_defZ_typeZBang();
 			break;
-		case 85LL: // PRIM_SYNTAX_DEF_EXTERNAL
+		case 86LL: // PRIM_SYNTAX_DEF_EXTERNAL
 			(void)pop_u64();
-			mw_mirth_elab_elabZ_defZ_externalZBang();
+			mw_mirth_elab_elabZ_externalZBang();
+			break;
+		case 85LL: // PRIM_SYNTAX_EXTERNAL
+			(void)pop_u64();
+			mw_mirth_elab_elabZ_externalZBang();
 			break;
 		case 83LL: // PRIM_SYNTAX_BUFFER
 			(void)pop_u64();
@@ -32971,19 +33151,19 @@ static void mw_mirth_elab_elabZ_moduleZ_declZBang (void) {
 			(void)pop_u64();
 			mw_mirth_elab_elabZ_variableZBang();
 			break;
-		case 87LL: // PRIM_SYNTAX_TABLE
+		case 88LL: // PRIM_SYNTAX_TABLE
 			(void)pop_u64();
 			mw_mirth_elab_elabZ_tableZBang();
 			break;
-		case 88LL: // PRIM_SYNTAX_FIELD
+		case 89LL: // PRIM_SYNTAX_FIELD
 			(void)pop_u64();
 			mw_mirth_elab_elabZ_fieldZBang();
 			break;
-		case 89LL: // PRIM_SYNTAX_DATA
+		case 90LL: // PRIM_SYNTAX_DATA
 			(void)pop_u64();
 			mw_mirth_elab_elabZ_dataZBang();
 			break;
-		case 86LL: // PRIM_SYNTAX_EMBED_STR
+		case 87LL: // PRIM_SYNTAX_EMBED_STR
 			(void)pop_u64();
 			mw_mirth_elab_elabZ_embedZ_strZBang();
 			break;
@@ -34145,106 +34325,149 @@ static void mw_mirth_elab_elabZ_defZ_bodyZBang (void) {
 	push_fnptr(&mb_mirth_elab_elabZ_defZ_bodyZBang_1);
 	mw_std_maybe_Maybe_1_if_2();
 }
-static void mw_mirth_elab_elabZ_defZ_externalZBang (void) {
+static void mw_mirth_elab_parseZ_externalZ_decl (void) {
 	mp_primZ_dup();
 	{
 		VAL d2 = pop_value();
 		mw_mirth_token_Token_next();
 		push_value(d2);
 	}
-	mw_mirth_token_Token_argsZ_2();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	mp_primZ_dup();
-	mw_mirth_elab_elabZ_defZ_qnameZ_undefined();
-	mp_primZ_swap();
 	mw_mirth_token_Token_succ();
 	mp_primZ_dup();
-	mw_mirth_token_Token_commaZAsk();
-	if (pop_u64()) {
-		mp_primZ_drop();
-		mp_primZ_dup();
-		mw_mirth_name_QName_name();
-	} else {
-		mw_mirth_elab_expectZ_tokenZ_arrow();
-		mw_mirth_token_Token_succ();
-		mp_primZ_dup();
-		mw_mirth_token_Token_nameZAsk();
-		push_fnptr(&mb_mirth_elab_elabZ_defZ_externalZBang_3);
-		mw_std_maybe_Maybe_1_unwrapZ_or_1();
-		{
-			VAL d3 = pop_value();
-			mp_primZ_drop();
-			push_value(d3);
-		}
-	}
-	mw_mirth_name_Name_ZToStr();
-	mp_primZ_swap();
-	mw_mirth_external_External_allocZBang();
+	mw_mirth_token_Token_lparenZ_orZ_lcolonZAsk();
+	push_fnptr(&mb_mirth_elab_parseZ_externalZ_decl_1);
+	mw_std_maybe_Maybe_1_else_1();
+	push_fnptr(&mb_mirth_elab_parseZ_externalZ_decl_3);
+	mw_std_list_LIST_1();
+}
+static void mw_mirth_elab_parseZ_externalZ_declZ_part (void) {
 	mp_primZ_dup();
+	mw_mirth_token_Token_strZAsk();
+	push_fnptr(&mb_mirth_elab_parseZ_externalZ_declZ_part_0);
+	push_fnptr(&mb_mirth_elab_parseZ_externalZ_declZ_part_1);
+	mw_std_maybe_Maybe_1_ifZ_some_2();
 	{
 		VAL d2 = pop_value();
-		mp_primZ_swap();
+		mp_primZ_dup();
+		mw_mirth_token_Token_commaZAsk();
+		if (pop_u64()) {
+			mw_mirth_token_Token_succ();
+		} else {
+		}
 		push_value(d2);
 	}
+}
+static void mw_mirth_elab_elabZ_externalZBang (void) {
+	mp_primZ_dup();
+	LPUSH(lbl_token);
+	mw_mirth_elab_parseZ_externalZ_decl();
+	push_fnptr(&mb_mirth_elab_elabZ_externalZBang_0);
+	mw_std_list_List_1_map_1();
+	LPUSH(lbl_parts);
+	mw_mirth_external_ExternalBlock_allocZBang();
+	LPUSH(lbl_extblock);
+	LPOP(lbl_token);
+	LPOP(lbl_extblock);
+	mp_primZ_dup();
+	LPUSH(lbl_extblock);
+	mfld_mirth_external_ExternalBlock_ZTildetoken();
+	mp_primZ_mutZ_set();
+	LPOP(lbl_parts);
+	LPOP(lbl_extblock);
+	mp_primZ_dup();
+	LPUSH(lbl_extblock);
+	mfld_mirth_external_ExternalBlock_ZTildeparts();
+	mp_primZ_mutZ_set();
+	LPOP(lbl_extblock);
+	mp_primZ_drop();
+}
+static void mw_mirth_elab_elabZ_externalZ_blockZ_partZBang (void) {
+	switch (get_top_data_tag()) {
+		case 0LL: // EDPCode
+			mtp_mirth_elab_ExternalDeclPart_EDPCode();
+			LPOP(lbl_token);
+			mp_primZ_drop();
+			LPOP(lbl_code);
+			mtw_mirth_external_ExternalBlockPart_EBPCode();
+			break;
+		case 1LL: // EDPDef
+			mtp_mirth_elab_ExternalDeclPart_EDPDef();
+			mw_mirth_elab_elabZ_externalZ_defZBang();
+			mtw_mirth_external_ExternalBlockPart_EBPDef();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primZ_panic();
+	}
+}
+static void mw_mirth_elab_elabZ_externalZ_defZBang (void) {
+	LPOP(lbl_head);
+	mp_primZ_dup();
+	LPUSH(lbl_head);
+	mw_mirth_elab_elabZ_defZ_qnameZ_undefined();
+	LPUSH(lbl_qname);
+	LPOP(lbl_symbol);
+	push_fnptr(&mb_mirth_elab_elabZ_externalZ_defZBang_0);
+	push_fnptr(&mb_mirth_elab_elabZ_externalZ_defZBang_1);
+	mw_std_maybe_Maybe_1_ifZ_some_2();
+	mw_mirth_name_Name_ZToStr();
+	LPUSH(lbl_symbol);
+	mw_mirth_external_External_allocZBang();
+	LPUSH(lbl_external);
+	LPOP(lbl_qname);
+	LPOP(lbl_external);
+	mp_primZ_dup();
+	LPUSH(lbl_external);
 	mfld_mirth_external_External_ZTildeqname();
 	mp_primZ_mutZ_set();
+	LPOP(lbl_symbol);
+	LPOP(lbl_external);
 	mp_primZ_dup();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_swap();
-		push_value(d2);
-	}
+	LPUSH(lbl_external);
 	mfld_mirth_external_External_ZTildesymbol();
 	mp_primZ_mutZ_set();
+	LPOP(lbl_sig);
+	LPOP(lbl_external);
 	mp_primZ_dup();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_swap();
-		push_value(d2);
-	}
+	LPUSH(lbl_external);
 	mfld_mirth_external_External_ZTildesig();
 	mp_primZ_mutZ_set();
+	LPOP(lbl_head);
+	LPOP(lbl_external);
 	mp_primZ_dup();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_swap();
-		push_value(d2);
-	}
+	LPUSH(lbl_external);
 	mfld_mirth_external_External_ZTildehead();
 	mp_primZ_mutZ_set();
+	LPOP(lbl_external);
 	mp_primZ_dup();
+	LPUSH(lbl_external);
 	mp_primZ_dup();
 	mtw_mirth_mirth_PropLabel_ExternalType();
-	push_fnptr(&mb_mirth_elab_elabZ_defZ_externalZBang_4);
+	push_fnptr(&mb_mirth_elab_elabZ_externalZ_defZBang_2);
 	mw_mirth_mirth_PropLabel_prop_1();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
+	LPOP(lbl_external);
+	mp_primZ_dup();
+	LPUSH(lbl_external);
 	mfld_mirth_external_External_ZTildectxZ_type();
 	mp_primZ_mutZ_set();
+	LPOP(lbl_external);
 	mp_primZ_dup();
+	LPUSH(lbl_external);
 	mp_primZ_dup();
 	mtw_mirth_mirth_PropLabel_ExternalCType();
-	push_fnptr(&mb_mirth_elab_elabZ_defZ_externalZBang_6);
+	push_fnptr(&mb_mirth_elab_elabZ_externalZ_defZBang_4);
 	mw_mirth_mirth_PropLabel_prop_1();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
+	LPOP(lbl_external);
+	mp_primZ_dup();
+	LPUSH(lbl_external);
 	mfld_mirth_external_External_ZTildectype();
 	mp_primZ_mutZ_set();
+	LPOP(lbl_external);
+	mp_primZ_dup();
+	LPUSH(lbl_external);
 	mtw_mirth_def_Def_DefExternal();
 	mw_mirth_def_Def_register();
+	LPOP(lbl_external);
 }
 static void mw_mirth_elab_elabZ_defZ_externalZ_ctype (void) {
 	mp_primZ_dup();
@@ -37146,7 +37369,7 @@ static void mw_mirth_c99_runZ_outputZ_c99ZBang (void) {
 		mw_mirth_c99_c99Z_tagZ_defsZBang();
 		mw_mirth_c99_c99Z_buffersZBang();
 		mw_mirth_c99_c99Z_variablesZBang();
-		mw_mirth_c99_c99Z_externalsZBang();
+		mw_mirth_c99_c99Z_externalZ_blocksZBang();
 		mw_mirth_c99_c99Z_wordZ_sigsZBang();
 		mw_mirth_c99_c99Z_blockZ_sigsZBang();
 		mw_mirth_c99_c99Z_fieldZ_sigsZBang();
@@ -38995,16 +39218,21 @@ static void mw_mirth_c99_c99Z_tagZ_setZ_labelZBang (void) {
 		decref(var_tag);
 	}
 }
-static void mw_mirth_c99_c99Z_externalsZBang (void) {
-	push_fnptr(&mb_mirth_c99_c99Z_externalsZBang_0);
-	mw_mirth_external_External_for_1();
+static void mw_mirth_c99_c99Z_externalZ_blocksZBang (void) {
+	push_fnptr(&mb_mirth_c99_c99Z_externalZ_blocksZBang_0);
+	mw_mirth_external_ExternalBlock_for_1();
 }
-static void mw_mirth_c99_c99Z_externalZBang (void) {
+static void mw_mirth_c99_c99Z_externalZ_blockZBang (void) {
+	mw_mirth_external_ExternalBlock_parts();
+	push_fnptr(&mb_mirth_c99_c99Z_externalZ_blockZBang_0);
+	mw_std_list_List_1_for_1();
+}
+static void mw_mirth_c99_c99Z_externalZ_defZBang (void) {
 	LPUSH(lbl_ext);
 	LPOP(lbl_ext);
 	mp_primZ_dup();
 	LPUSH(lbl_ext);
-	push_fnptr(&mb_mirth_c99_c99Z_externalZBang_0);
+	push_fnptr(&mb_mirth_c99_c99Z_externalZ_defZBang_0);
 	mw_mirth_c99_ZPlusC99_ZPlusmirth_1();
 	LPUSH(lbl_cty);
 	LPOP(lbl_cty);
@@ -39012,14 +39240,14 @@ static void mw_mirth_c99_c99Z_externalZBang (void) {
 	LPUSH(lbl_cty);
 	mw_mirth_type_CTypeArrow_cod();
 	mw_mirth_type_CTypeStack_parts();
-	push_fnptr(&mb_mirth_c99_c99Z_externalZBang_1);
+	push_fnptr(&mb_mirth_c99_c99Z_externalZ_defZBang_1);
 	mw_std_list_List_1_find_1();
 	LPUSH(lbl_outty);
 	LPOP(lbl_outty);
 	mp_primZ_dup();
 	LPUSH(lbl_outty);
-	push_fnptr(&mb_mirth_c99_c99Z_externalZBang_2);
-	push_fnptr(&mb_mirth_c99_c99Z_externalZBang_3);
+	push_fnptr(&mb_mirth_c99_c99Z_externalZ_defZBang_2);
+	push_fnptr(&mb_mirth_c99_c99Z_externalZ_defZBang_3);
 	mw_std_maybe_Maybe_1_ifZ_some_2();
 	mw_mirth_type_CType_cname();
 	mw_mirth_c99_ZPlusC99_put();
@@ -39037,7 +39265,7 @@ static void mw_mirth_c99_c99Z_externalZBang (void) {
 	LPUSH(lbl_cty);
 	mw_mirth_type_CTypeArrow_dom();
 	mw_mirth_type_CTypeStack_parts();
-	push_fnptr(&mb_mirth_c99_c99Z_externalZBang_4);
+	push_fnptr(&mb_mirth_c99_c99Z_externalZ_defZBang_4);
 	mw_std_list_List_1_filter_1();
 	switch (get_top_data_tag()) {
 		case 0LL: // Nil
@@ -39046,8 +39274,8 @@ static void mw_mirth_c99_c99Z_externalZBang (void) {
 			mw_mirth_c99_ZPlusC99_put();
 			break;
 		default:
-			push_fnptr(&mb_mirth_c99_c99Z_externalZBang_5);
-			push_fnptr(&mb_mirth_c99_c99Z_externalZBang_6);
+			push_fnptr(&mb_mirth_c99_c99Z_externalZ_defZBang_5);
+			push_fnptr(&mb_mirth_c99_c99Z_externalZ_defZBang_6);
 			mw_std_list_List_1_for_2();
 			break;
 	}
@@ -39057,7 +39285,7 @@ static void mw_mirth_c99_c99Z_externalZBang (void) {
 	LPOP(lbl_ext);
 	mp_primZ_dup();
 	LPUSH(lbl_ext);
-	push_fnptr(&mb_mirth_c99_c99Z_externalZBang_7);
+	push_fnptr(&mb_mirth_c99_c99Z_externalZ_defZBang_7);
 	mw_mirth_c99_ZPlusC99_ZPlusmirth_1();
 	mw_mirth_c99_ZPlusC99_sigZ_put();
 	STRLIT(" {", 2);
@@ -39071,14 +39299,14 @@ static void mw_mirth_c99_c99Z_externalZBang (void) {
 	mp_primZ_dup();
 	mw_std_list_List_1_len();
 	LPUSH(lbl_argZ_index);
-	push_fnptr(&mb_mirth_c99_c99Z_externalZBang_8);
+	push_fnptr(&mb_mirth_c99_c99Z_externalZ_defZBang_8);
 	mw_std_list_List_1_reverseZ_for_1();
 	STRLIT("\t", 1);
 	mw_mirth_c99_ZPlusC99_put();
 	LPOP(lbl_outty);
 	mp_primZ_dup();
 	LPUSH(lbl_outty);
-	push_fnptr(&mb_mirth_c99_c99Z_externalZBang_10);
+	push_fnptr(&mb_mirth_c99_c99Z_externalZ_defZBang_10);
 	mw_std_maybe_Maybe_1_for_1();
 	LPOP(lbl_ext);
 	mp_primZ_dup();
@@ -39097,10 +39325,10 @@ static void mw_mirth_c99_c99Z_externalZBang (void) {
 	LPUSH(lbl_cty);
 	mw_mirth_type_CTypeArrow_dom();
 	mw_mirth_type_CTypeStack_parts();
-	push_fnptr(&mb_mirth_c99_c99Z_externalZBang_11);
+	push_fnptr(&mb_mirth_c99_c99Z_externalZ_defZBang_11);
 	mw_std_list_List_1_filterZ_some_1();
-	push_fnptr(&mb_mirth_c99_c99Z_externalZBang_14);
-	push_fnptr(&mb_mirth_c99_c99Z_externalZBang_15);
+	push_fnptr(&mb_mirth_c99_c99Z_externalZ_defZBang_14);
+	push_fnptr(&mb_mirth_c99_c99Z_externalZ_defZBang_15);
 	mw_std_list_List_1_for_2();
 	STRLIT(");", 2);
 	mw_mirth_c99_ZPlusC99_put();
@@ -39110,7 +39338,7 @@ static void mw_mirth_c99_c99Z_externalZBang (void) {
 	LPUSH(lbl_cty);
 	mw_mirth_type_CTypeArrow_cod();
 	mw_mirth_type_CTypeStack_parts();
-	push_fnptr(&mb_mirth_c99_c99Z_externalZBang_16);
+	push_fnptr(&mb_mirth_c99_c99Z_externalZ_defZBang_16);
 	mw_std_list_List_1_for_1();
 	STRLIT("}", 1);
 	mw_mirth_c99_ZPlusC99_put();
@@ -43145,12 +43373,12 @@ static void mb_mirth_token_TokenValue_sigZ_resourceZ_conZAsk_0 (void) {
 	mw_mirth_name_Name_couldZ_beZ_resourceZ_con();
 }
 static void mb_mirth_token_TokenValue_sigZ_dashesZAsk_0 (void) {
-	push_u64(90LL); // PRIM_SYNTAX_DASHES
+	push_u64(91LL); // PRIM_SYNTAX_DASHES
 	mw_mirth_prim_Prim_name();
 	mw_mirth_name_Name_ZEqualZEqual();
 }
 static void mb_mirth_token_TokenValue_patZ_arrowZAsk_0 (void) {
-	push_u64(91LL); // PRIM_SYNTAX_ARROW
+	push_u64(92LL); // PRIM_SYNTAX_ARROW
 	mw_mirth_prim_Prim_name();
 	mw_mirth_name_Name_ZEqualZEqual();
 }
@@ -45869,24 +46097,8 @@ static void mb_mirth_elab_elabZ_defZBang_7 (void) {
 static void mb_mirth_elab_elabZ_defZBang_11 (void) {
 	mw_mirth_elab_elabZ_defZ_bodyZBang();
 }
-static void mb_mirth_elab_elabZ_defZ_externalZBang_3 (void) {
-	STRLIT("expected external symbol name", 29);
-	mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
-}
-static void mb_mirth_elab_elabZ_defZ_externalZBang_4 (void) {
-	mw_mirth_external_External_sig();
-	mw_mirth_elab_ZPlusTypeElab_typeZ_sigZ_startZBang();
-	mw_mirth_elab_ZPlusTypeElab_elabZ_typeZ_sigZBang();
-	{
-		VAL d2 = pop_value();
-		mw_mirth_elab_ZPlusTypeElab_ctx();
-		push_value(d2);
-	}
-	mw_std_prelude_pack2();
-	mw_mirth_elab_ZPlusTypeElab_rdrop();
-}
-static void mb_mirth_elab_elabZ_defZ_externalZBang_6 (void) {
-	mw_mirth_elab_elabZ_defZ_externalZ_ctype();
+static void mb_mirth_elab_elabZ_externalZBang_0 (void) {
+	mw_mirth_elab_elabZ_externalZ_blockZ_partZBang();
 }
 static void mb_mirth_elab_elabZ_bufferZBang_1 (void) {
 	STRLIT("expected buffer size", 20);
@@ -46899,6 +47111,133 @@ static void mb_mirth_elab_checkZ_inlineZ_recursionZ_opZBang_6 (void) {
 	mw_mirth_match_Case_body();
 	mw_mirth_elab_checkZ_inlineZ_recursionZ_arrowZBang();
 }
+static void mb_mirth_elab_parseZ_externalZ_decl_1 (void) {
+	mw_mirth_token_Token_pred();
+	push_fnptr(&mb_mirth_elab_parseZ_externalZ_decl_2);
+	mw_std_str_Str_1();
+	mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+}
+static void mb_mirth_elab_parseZ_externalZ_decl_2 (void) {
+	push_u64(36LL); // FGCyan
+	mw_std_terminal_Sgr_emitZThen();
+	STRLIT("external", 8);
+	mw_std_str_ZPlusStr_pushZ_strZBang();
+	push_u64(0LL); // Reset
+	mw_std_terminal_Sgr_emitZThen();
+	STRLIT(" requires arguments", 19);
+	mw_std_str_ZPlusStr_pushZ_strZBang();
+}
+static void mb_mirth_elab_parseZ_externalZ_decl_3 (void) {
+	mw_mirth_token_Token_succ();
+	while(1) {
+		mp_primZ_dup();
+		mw_mirth_token_Token_argsZ_endZAsk();
+		if (pop_u64()) {
+			push_u64(0LL); // False
+		} else {
+			push_u64(1LL); // True
+		}
+		if (! pop_u64()) break;
+		{
+			VAL d3 = pop_resource();
+			mw_mirth_elab_parseZ_externalZ_declZ_part();
+			push_resource(d3);
+		}
+		mw_std_list_ZPlusList_1_pushZBang();
+	}
+	mp_primZ_drop();
+}
+static void mb_mirth_elab_parseZ_externalZ_declZ_part_0 (void) {
+	LPUSH(lbl_code);
+	mp_primZ_dup();
+	LPUSH(lbl_token);
+	mw_mirth_token_Token_succ();
+	mp_primZ_dup();
+	mw_mirth_token_Token_argZ_endZAsk();
+	if (pop_u64()) {
+	} else {
+		STRLIT("expected comma", 14);
+		mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+	}
+	mtw_mirth_elab_ExternalDeclPart_EDPCode();
+}
+static void mb_mirth_elab_parseZ_externalZ_declZ_part_1 (void) {
+	mp_primZ_dup();
+	LPUSH(lbl_head);
+	mp_primZ_dup();
+	mw_mirth_token_Token_nameZ_orZ_dnameZAsk();
+	push_fnptr(&mb_mirth_elab_parseZ_externalZ_declZ_part_3);
+	mw_std_maybe_Maybe_1_else_1();
+	mw_mirth_token_Token_succ();
+	mp_primZ_dup();
+	mw_mirth_token_Token_patZ_arrowZAsk();
+	if (pop_u64()) {
+		mw_mirth_token_Token_succ();
+		mp_primZ_dup();
+		mw_mirth_token_Token_nameZAsk();
+		push_fnptr(&mb_mirth_elab_parseZ_externalZ_declZ_part_6);
+		mw_std_maybe_Maybe_1_else_1();
+		mp_primZ_dup();
+		mtw_std_maybe_Maybe_1_Some();
+		LPUSH(lbl_symbol);
+		mw_mirth_token_Token_succ();
+	} else {
+		push_u64(0LL); // None
+		LPUSH(lbl_symbol);
+	}
+	mp_primZ_dup();
+	mw_mirth_token_Token_commaZAsk();
+	if (pop_u64()) {
+	} else {
+		STRLIT("expected comma before type signature", 36);
+		mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+	}
+	mw_mirth_token_Token_succ();
+	mp_primZ_dup();
+	mw_mirth_token_Token_argZ_endZAsk();
+	if (pop_u64()) {
+		STRLIT("expected type signature", 23);
+		mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+	} else {
+	}
+	mp_primZ_dup();
+	LPUSH(lbl_sig);
+	mw_mirth_token_Token_nextZ_argZ_end();
+	mtw_mirth_elab_ExternalDeclPart_EDPDef();
+}
+static void mb_mirth_elab_parseZ_externalZ_declZ_part_3 (void) {
+	STRLIT("expected external word name", 27);
+	mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+}
+static void mb_mirth_elab_parseZ_externalZ_declZ_part_6 (void) {
+	STRLIT("expected external symbol name", 29);
+	mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+}
+static void mb_mirth_elab_elabZ_externalZ_defZBang_0 (void) {
+	mw_mirth_token_Token_nameZAsk();
+	mw_std_maybe_Maybe_1_unwrap();
+}
+static void mb_mirth_elab_elabZ_externalZ_defZBang_1 (void) {
+	LPOP(lbl_qname);
+	mp_primZ_dup();
+	LPUSH(lbl_qname);
+	mw_mirth_name_QName_name();
+}
+static void mb_mirth_elab_elabZ_externalZ_defZBang_2 (void) {
+	mw_mirth_external_External_sig();
+	mw_mirth_elab_ZPlusTypeElab_typeZ_sigZ_startZBang();
+	mw_mirth_elab_ZPlusTypeElab_elabZ_typeZ_sigZBang();
+	{
+		VAL d2 = pop_value();
+		mw_mirth_elab_ZPlusTypeElab_ctx();
+		push_value(d2);
+	}
+	mw_std_prelude_pack2();
+	mw_mirth_elab_ZPlusTypeElab_rdrop();
+}
+static void mb_mirth_elab_elabZ_externalZ_defZBang_4 (void) {
+	mw_mirth_elab_elabZ_defZ_externalZ_ctype();
+}
 static void mb_mirth_elab_elabZ_defZ_externalZ_ctype_0 (void) {
 	mw_mirth_external_External_type();
 	mw_mirth_type_ArrowType_ctype();
@@ -47485,8 +47824,8 @@ static void mb_mirth_c99_c99Z_buffersZBang_0 (void) {
 static void mb_mirth_c99_c99Z_variablesZBang_0 (void) {
 	mw_mirth_c99_c99Z_variableZBang();
 }
-static void mb_mirth_c99_c99Z_externalsZBang_0 (void) {
-	mw_mirth_c99_c99Z_externalZBang();
+static void mb_mirth_c99_c99Z_externalZ_blocksZBang_0 (void) {
+	mw_mirth_c99_c99Z_externalZ_blockZBang();
 }
 static void mb_mirth_c99_c99Z_wordZ_sigsZBang_0 (void) {
 	mp_primZ_dup();
@@ -48706,10 +49045,26 @@ static void mb_mirth_c99_c99Z_nest_1_1 (void) {
 	mp_primZ_intZ_sub();
 	mw_std_prim_Int_ZToNat();
 }
-static void mb_mirth_c99_c99Z_externalZBang_0 (void) {
+static void mb_mirth_c99_c99Z_externalZ_blockZBang_0 (void) {
+	switch (get_top_data_tag()) {
+		case 0LL: // EBPCode
+			mtp_mirth_external_ExternalBlockPart_EBPCode();
+			mw_mirth_c99_ZPlusC99_put();
+			mw_mirth_c99_ZPlusC99_line();
+			break;
+		case 1LL: // EBPDef
+			mtp_mirth_external_ExternalBlockPart_EBPDef();
+			mw_mirth_c99_c99Z_externalZ_defZBang();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primZ_panic();
+	}
+}
+static void mb_mirth_c99_c99Z_externalZ_defZBang_0 (void) {
 	mw_mirth_external_External_ctype();
 }
-static void mb_mirth_c99_c99Z_externalZBang_1 (void) {
+static void mb_mirth_c99_c99Z_externalZ_defZBang_1 (void) {
 	mp_primZ_dup();
 	mw_mirth_type_CTypeStackPart_ctype();
 	mw_mirth_type_CType_phantomZAsk();
@@ -48719,13 +49074,13 @@ static void mb_mirth_c99_c99Z_externalZBang_1 (void) {
 		push_u64(1LL); // True
 	}
 }
-static void mb_mirth_c99_c99Z_externalZBang_2 (void) {
+static void mb_mirth_c99_c99Z_externalZ_defZBang_2 (void) {
 	mw_mirth_type_CTypeStackPart_ctype();
 }
-static void mb_mirth_c99_c99Z_externalZBang_3 (void) {
+static void mb_mirth_c99_c99Z_externalZ_defZBang_3 (void) {
 	push_u64(3LL); // Phantom
 }
-static void mb_mirth_c99_c99Z_externalZBang_4 (void) {
+static void mb_mirth_c99_c99Z_externalZ_defZBang_4 (void) {
 	mp_primZ_dup();
 	mw_mirth_type_CTypeStackPart_ctype();
 	mw_mirth_type_CType_phantomZAsk();
@@ -48735,19 +49090,19 @@ static void mb_mirth_c99_c99Z_externalZBang_4 (void) {
 		push_u64(1LL); // True
 	}
 }
-static void mb_mirth_c99_c99Z_externalZBang_5 (void) {
+static void mb_mirth_c99_c99Z_externalZ_defZBang_5 (void) {
 	mw_mirth_type_CTypeStackPart_ctype();
 	mw_mirth_type_CType_cname();
 	mw_mirth_c99_ZPlusC99_put();
 }
-static void mb_mirth_c99_c99Z_externalZBang_6 (void) {
+static void mb_mirth_c99_c99Z_externalZ_defZBang_6 (void) {
 	STRLIT(", ", 2);
 	mw_mirth_c99_ZPlusC99_put();
 }
-static void mb_mirth_c99_c99Z_externalZBang_7 (void) {
+static void mb_mirth_c99_c99Z_externalZ_defZBang_7 (void) {
 	mw_mirth_external_External_cname();
 }
-static void mb_mirth_c99_c99Z_externalZBang_8 (void) {
+static void mb_mirth_c99_c99Z_externalZ_defZBang_8 (void) {
 	mp_primZ_dup();
 	mw_mirth_type_CTypeStackPart_ctype();
 	mw_mirth_type_CType_phantomZAsk();
@@ -48777,14 +49132,14 @@ static void mb_mirth_c99_c99Z_externalZBang_8 (void) {
 	mw_std_prim_Int_ZToNat();
 	LPUSH(lbl_argZ_index);
 }
-static void mb_mirth_c99_c99Z_externalZBang_10 (void) {
+static void mb_mirth_c99_c99Z_externalZ_defZBang_10 (void) {
 	mw_mirth_type_CTypeStackPart_ctype();
 	mw_mirth_type_CType_cname();
 	mw_mirth_c99_ZPlusC99_put();
 	STRLIT(" Y = ", 5);
 	mw_mirth_c99_ZPlusC99_put();
 }
-static void mb_mirth_c99_c99Z_externalZBang_11 (void) {
+static void mb_mirth_c99_c99Z_externalZ_defZBang_11 (void) {
 	mp_primZ_dup();
 	mw_mirth_type_CTypeStackPart_ctype();
 	mw_mirth_type_CType_phantomZAsk();
@@ -48800,14 +49155,14 @@ static void mb_mirth_c99_c99Z_externalZBang_11 (void) {
 	mp_primZ_intZ_add();
 	LPUSH(lbl_argZ_index);
 }
-static void mb_mirth_c99_c99Z_externalZBang_14 (void) {
+static void mb_mirth_c99_c99Z_externalZ_defZBang_14 (void) {
 	mw_mirth_c99_ZPlusC99_put();
 }
-static void mb_mirth_c99_c99Z_externalZBang_15 (void) {
+static void mb_mirth_c99_c99Z_externalZ_defZBang_15 (void) {
 	STRLIT(", ", 2);
 	mw_mirth_c99_ZPlusC99_put();
 }
-static void mb_mirth_c99_c99Z_externalZBang_16 (void) {
+static void mb_mirth_c99_c99Z_externalZ_defZBang_16 (void) {
 	STRLIT("\t", 1);
 	mw_mirth_c99_ZPlusC99_put();
 	{

--- a/examples/sdl2.mth
+++ b/examples/sdl2.mth
@@ -7,9 +7,11 @@ import(std.ctypes)
 # SDL2 Bindings #
 #################
 
-external(+Unsafe.SDL_Init -> SDL_Init, +Unsafe SDL_InitFlags -- +Unsafe CInt)
-external(+Unsafe.SDL_Quit -> SDL_Quit, +Unsafe -- +Unsafe)
-external(+Unsafe.SDL_GetError -> SDL_GetError, +Unsafe -- +Unsafe CStr)
+external (
+    +Unsafe.SDL_Init [ +Unsafe SDL_InitFlags -- +Unsafe CInt ]
+    +Unsafe.SDL_Quit [ +Unsafe -- +Unsafe ]
+    +Unsafe.SDL_GetError [ +Unsafe -- +Unsafe CStr ]
+)
 
 data(+SDL, SDL!)
 data(+SDL?, OK! -> +SDL, ERROR! -> Str)
@@ -51,16 +53,16 @@ def(SDL_INIT_EVERYTHING, SDL_InitFlags,
     SDL_INIT_EVENTS |
     SDL_INIT_SENSOR |)
 
-external(+SDL.delay! -> SDL_Delay, +SDL SDL_Ticks -- +SDL)
-external(+SDL.get-ticks! -> SDL_GetTicks, +SDL -- +SDL SDL_Ticks)
+external(+SDL.delay! -> SDL_Delay [ +SDL SDL_Ticks -- +SDL ] )
+external(+SDL.get-ticks! -> SDL_GetTicks [ +SDL -- +SDL SDL_Ticks ])
 def-type(SDL_Ticks, U32)
 def(ms, Int -- SDL_Ticks, >U32)
 
 data(+SDL_Window, SDL_WINDOW! -> unsafe-ptr:Ptr)
 data(+SDL_Window?, OK! -> +SDL_Window, ERROR! -> Str)
 def(+SDL_Window?.unwrap!, +SDL_Window? -- +SDL_Window, OK! -> id, ERROR! -> panic!)
-external(+Unsafe.SDL_CreateWindow -> SDL_CreateWindow, +SDL +Unsafe title:CStr x:CInt y:CInt w:CInt h:CInt flags:SDL_WindowFlags -- +SDL +Unsafe Ptr)
-external(+SDL_Window.destroy! -> SDL_DestroyWindow, +SDL +SDL_Window -- +SDL)
+external(+Unsafe.SDL_CreateWindow -> SDL_CreateWindow [ +SDL +Unsafe title:CStr x:CInt y:CInt w:CInt h:CInt flags:SDL_WindowFlags -- +SDL +Unsafe Ptr ])
+external(+SDL_Window.destroy! -> SDL_DestroyWindow [ +SDL +SDL_Window -- +SDL ])
 def(+SDL.create-window!,
         +SDL title:Str
         x:Int y:Int
@@ -111,9 +113,9 @@ def(SDL_WINDOW_TOOLTIP, SDL_WindowFlags, 1 18 << >SDL_WindowFlags)
 def(SDL_WINDOW_POPUP_MENU, SDL_WindowFlags, 1 19 << >SDL_WindowFlags)
 def(SDL_WINDOW_VULKAN, SDL_WindowFlags, 1 28 << >SDL_WindowFlags)
 
-external(+Unsafe.SDL_ShowWindow -> SDL_ShowWindow, Ptr --)
-external(+Unsafe.SDL_HideWindow -> SDL_HideWindow, Ptr --)
-external(+Unsafe.SDL_RaiseWindow -> SDL_RaiseWindow, Ptr --)
+external(+Unsafe.SDL_ShowWindow [Ptr --])
+external(+Unsafe.SDL_HideWindow [Ptr --])
+external(+Unsafe.SDL_RaiseWindow [Ptr --])
 def(+SDL_Window.show!, +SDL_Window -- +SDL_Window, .unsafe-ptr unsafe(.SDL_ShowWindow))
 def(+SDL_Window.hide!, +SDL_Window -- +SDL_Window, .unsafe-ptr unsafe(.SDL_HideWindow))
 def(+SDL_Window.raise!, +SDL_Window -- +SDL_Window, .unsafe-ptr unsafe(.SDL_RaiseWindow))
@@ -122,8 +124,8 @@ data(+SDL_Renderer, SDL_RENDERER! -> unsafe-ptr:Ptr)
 data(+SDL_Renderer?, OK! -> +SDL_Renderer, ERROR! -> Str)
 def(+SDL_Renderer?.unwrap!, +SDL_Renderer? -- +SDL_Renderer, OK! -> id, ERROR! -> panic!)
 
-external(+Unsafe.SDL_CreateRenderer, Ptr CInt SDL_RendererFlags -- Ptr)
-external(+Unsafe.SDL_DestroyRenderer, Ptr --)
+external(+Unsafe.SDL_CreateRenderer [Ptr CInt SDL_RendererFlags -- Ptr])
+external(+Unsafe.SDL_DestroyRenderer [Ptr --])
 
 def(+SDL_Window.create-renderer!,
         +SDL +SDL_Window index:Int flags:SDL_RendererFlags
@@ -145,10 +147,12 @@ def(SDL_RENDERER_ACCELERATED, SDL_RendererFlags, 0x2 >U32)
 def(SDL_RENDERER_PRESENTVSYNC, SDL_RendererFlags, 0x4 >U32)
 def(SDL_RENDERER_TARGETTEXTURE, SDL_RendererFlags, 0x8 >U32)
 
-external(SDL_RenderClear, SDL_Renderer* --)
-external(SDL_RenderPresent, SDL_Renderer* --)
-external(SDL_SetRenderDrawColor, SDL_Renderer* CInt CInt CInt CInt --)
-external(SDL_RenderFillRect, SDL_Renderer* SDL_Rect* --)
+external(
+    SDL_RenderClear [SDL_Renderer* --]
+    SDL_RenderPresent [SDL_Renderer* --]
+    SDL_SetRenderDrawColor [SDL_Renderer* CInt CInt CInt CInt --]
+    SDL_RenderFillRect [SDL_Renderer* SDL_Rect* --]
+)
 def-type(SDL_Rect*, Ptr)
 
 # Size of SDL_Event structure.
@@ -158,7 +162,7 @@ data(SDL_Event, WRAP_SDL_EVENT -> Ptr)
 def(SDL_Event.unwrap, SDL_Event -- Ptr, WRAP_SDL_EVENT -> id)
 def(Ptr.>SDL_Event, Ptr -- SDL_Event, WRAP_SDL_EVENT)
 def(SDL_Event.>Ptr, SDL_Event -- Ptr, unwrap)
-external(SDL_PollEvent, SDL_Event -- CInt)
+external(SDL_PollEvent [SDL_Event -- CInt])
 
 data(SDL_EventType, WRAP_SDL_EVENTTYPE -> U32)
 def(U32.>SDL_EventType, U32 -- SDL_EventType, WRAP_SDL_EVENTTYPE)
@@ -524,13 +528,15 @@ def(SDL_JoystickID.>, SDL_JoystickID SDL_JoystickID -- Bool, both(>Int) >)
 def(SDL_JoystickID.1+, SDL_JoystickID -- SDL_JoystickID, >Int 1+ >SDL_JoystickID)
 def(SDL_JoystickID.==, SDL_JoystickID SDL_JoystickID -- Bool, both(>Int) ==)
 
-external(+Unsafe.SDL_NumJoysticks, CInt)
-external(+Unsafe.SDL_IsGameController, CInt -- Bool)
-external(+Unsafe.SDL_GameControllerOpen, CInt -- Ptr)
-external(+Unsafe.SDL_GameControllerClose, Ptr --)
+external(
+    SDL_NumJoysticks        [+Unsafe      -- CInt +Unsafe]
+    SDL_IsGameController    [+Unsafe CInt -- Bool +Unsafe]
+    SDL_GameControllerOpen  [+Unsafe CInt -- Ptr  +Unsafe]
+    SDL_GameControllerClose [+Unsafe Ptr  --      +Unsafe]
+)
 
-def(+SDL.num-joysticks, +SDL -- +SDL Int, unsafe(.SDL_NumJoysticks) >Int)
-def(+SDL.is-game-controller, +SDL Int -- +SDL Bool, CInt unsafe(.SDL_IsGameController))
+def(+SDL.num-joysticks, +SDL -- +SDL Int, unsafe(SDL_NumJoysticks) >Int)
+def(+SDL.is-game-controller, +SDL Int -- +SDL Bool, CInt unsafe(SDL_IsGameController))
 
 data(+SDL_GameController, SDL_GAME_CONTROLLER! -> unsafe-ptr:Ptr)
 data(+SDL_GameController?, OK! -> +SDL_GameController, ERROR! -> Str)
@@ -543,13 +549,13 @@ def(+SDL_GameController?.for!(f), (*a +SDL_GameController -- *a) *a +SDL_GameCon
     ERROR! -> drop)
 
 def(+SDL.game-controller-open!, +SDL Int -- +SDL +SDL_GameController?,
-    CInt unsafe(.SDL_GameControllerOpen)
+    CInt unsafe(SDL_GameControllerOpen)
     dup is-null if(
         drop get-error! +SDL_GameController?.ERROR!,
         >unsafe-ptr SDL_GAME_CONTROLLER! +SDL_GameController?.OK!
     ))
 def(+SDL_GameController.close!, +SDL +SDL_GameController -- +SDL,
-    /SDL_GAME_CONTROLLER! unsafe-ptr> unsafe(.SDL_GameControllerClose))
+    /SDL_GAME_CONTROLLER! unsafe-ptr> unsafe(SDL_GameControllerClose))
 
 data(SDL_GameControllerButton,
     SDL_CONTROLLER_BUTTON_A,

--- a/examples/sdl2.mth
+++ b/examples/sdl2.mth
@@ -7,9 +7,9 @@ import(std.ctypes)
 # SDL2 Bindings #
 #################
 
-def-external(+Unsafe.SDL_Init -> SDL_Init, +Unsafe SDL_InitFlags -- +Unsafe CInt)
-def-external(+Unsafe.SDL_Quit -> SDL_Quit, +Unsafe -- +Unsafe)
-def-external(+Unsafe.SDL_GetError -> SDL_GetError, +Unsafe -- +Unsafe CStr)
+external(+Unsafe.SDL_Init -> SDL_Init, +Unsafe SDL_InitFlags -- +Unsafe CInt)
+external(+Unsafe.SDL_Quit -> SDL_Quit, +Unsafe -- +Unsafe)
+external(+Unsafe.SDL_GetError -> SDL_GetError, +Unsafe -- +Unsafe CStr)
 
 data(+SDL, SDL!)
 data(+SDL?, OK! -> +SDL, ERROR! -> Str)
@@ -51,16 +51,16 @@ def(SDL_INIT_EVERYTHING, SDL_InitFlags,
     SDL_INIT_EVENTS |
     SDL_INIT_SENSOR |)
 
-def-external(+SDL.delay! -> SDL_Delay, +SDL SDL_Ticks -- +SDL)
-def-external(+SDL.get-ticks! -> SDL_GetTicks, +SDL -- +SDL SDL_Ticks)
+external(+SDL.delay! -> SDL_Delay, +SDL SDL_Ticks -- +SDL)
+external(+SDL.get-ticks! -> SDL_GetTicks, +SDL -- +SDL SDL_Ticks)
 def-type(SDL_Ticks, U32)
 def(ms, Int -- SDL_Ticks, >U32)
 
 data(+SDL_Window, SDL_WINDOW! -> unsafe-ptr:Ptr)
 data(+SDL_Window?, OK! -> +SDL_Window, ERROR! -> Str)
 def(+SDL_Window?.unwrap!, +SDL_Window? -- +SDL_Window, OK! -> id, ERROR! -> panic!)
-def-external(+Unsafe.SDL_CreateWindow -> SDL_CreateWindow, +SDL +Unsafe title:CStr x:CInt y:CInt w:CInt h:CInt flags:SDL_WindowFlags -- +SDL +Unsafe Ptr)
-def-external(+SDL_Window.destroy! -> SDL_DestroyWindow, +SDL +SDL_Window -- +SDL)
+external(+Unsafe.SDL_CreateWindow -> SDL_CreateWindow, +SDL +Unsafe title:CStr x:CInt y:CInt w:CInt h:CInt flags:SDL_WindowFlags -- +SDL +Unsafe Ptr)
+external(+SDL_Window.destroy! -> SDL_DestroyWindow, +SDL +SDL_Window -- +SDL)
 def(+SDL.create-window!,
         +SDL title:Str
         x:Int y:Int
@@ -111,9 +111,9 @@ def(SDL_WINDOW_TOOLTIP, SDL_WindowFlags, 1 18 << >SDL_WindowFlags)
 def(SDL_WINDOW_POPUP_MENU, SDL_WindowFlags, 1 19 << >SDL_WindowFlags)
 def(SDL_WINDOW_VULKAN, SDL_WindowFlags, 1 28 << >SDL_WindowFlags)
 
-def-external(+Unsafe.SDL_ShowWindow -> SDL_ShowWindow, Ptr --)
-def-external(+Unsafe.SDL_HideWindow -> SDL_HideWindow, Ptr --)
-def-external(+Unsafe.SDL_RaiseWindow -> SDL_RaiseWindow, Ptr --)
+external(+Unsafe.SDL_ShowWindow -> SDL_ShowWindow, Ptr --)
+external(+Unsafe.SDL_HideWindow -> SDL_HideWindow, Ptr --)
+external(+Unsafe.SDL_RaiseWindow -> SDL_RaiseWindow, Ptr --)
 def(+SDL_Window.show!, +SDL_Window -- +SDL_Window, .unsafe-ptr unsafe(.SDL_ShowWindow))
 def(+SDL_Window.hide!, +SDL_Window -- +SDL_Window, .unsafe-ptr unsafe(.SDL_HideWindow))
 def(+SDL_Window.raise!, +SDL_Window -- +SDL_Window, .unsafe-ptr unsafe(.SDL_RaiseWindow))
@@ -122,8 +122,8 @@ data(+SDL_Renderer, SDL_RENDERER! -> unsafe-ptr:Ptr)
 data(+SDL_Renderer?, OK! -> +SDL_Renderer, ERROR! -> Str)
 def(+SDL_Renderer?.unwrap!, +SDL_Renderer? -- +SDL_Renderer, OK! -> id, ERROR! -> panic!)
 
-def-external(+Unsafe.SDL_CreateRenderer, Ptr CInt SDL_RendererFlags -- Ptr)
-def-external(+Unsafe.SDL_DestroyRenderer, Ptr --)
+external(+Unsafe.SDL_CreateRenderer, Ptr CInt SDL_RendererFlags -- Ptr)
+external(+Unsafe.SDL_DestroyRenderer, Ptr --)
 
 def(+SDL_Window.create-renderer!,
         +SDL +SDL_Window index:Int flags:SDL_RendererFlags
@@ -145,10 +145,10 @@ def(SDL_RENDERER_ACCELERATED, SDL_RendererFlags, 0x2 >U32)
 def(SDL_RENDERER_PRESENTVSYNC, SDL_RendererFlags, 0x4 >U32)
 def(SDL_RENDERER_TARGETTEXTURE, SDL_RendererFlags, 0x8 >U32)
 
-def-external(SDL_RenderClear, SDL_Renderer* --)
-def-external(SDL_RenderPresent, SDL_Renderer* --)
-def-external(SDL_SetRenderDrawColor, SDL_Renderer* CInt CInt CInt CInt --)
-def-external(SDL_RenderFillRect, SDL_Renderer* SDL_Rect* --)
+external(SDL_RenderClear, SDL_Renderer* --)
+external(SDL_RenderPresent, SDL_Renderer* --)
+external(SDL_SetRenderDrawColor, SDL_Renderer* CInt CInt CInt CInt --)
+external(SDL_RenderFillRect, SDL_Renderer* SDL_Rect* --)
 def-type(SDL_Rect*, Ptr)
 
 # Size of SDL_Event structure.
@@ -158,7 +158,7 @@ data(SDL_Event, WRAP_SDL_EVENT -> Ptr)
 def(SDL_Event.unwrap, SDL_Event -- Ptr, WRAP_SDL_EVENT -> id)
 def(Ptr.>SDL_Event, Ptr -- SDL_Event, WRAP_SDL_EVENT)
 def(SDL_Event.>Ptr, SDL_Event -- Ptr, unwrap)
-def-external(SDL_PollEvent, SDL_Event -- CInt)
+external(SDL_PollEvent, SDL_Event -- CInt)
 
 data(SDL_EventType, WRAP_SDL_EVENTTYPE -> U32)
 def(U32.>SDL_EventType, U32 -- SDL_EventType, WRAP_SDL_EVENTTYPE)
@@ -524,10 +524,10 @@ def(SDL_JoystickID.>, SDL_JoystickID SDL_JoystickID -- Bool, both(>Int) >)
 def(SDL_JoystickID.1+, SDL_JoystickID -- SDL_JoystickID, >Int 1+ >SDL_JoystickID)
 def(SDL_JoystickID.==, SDL_JoystickID SDL_JoystickID -- Bool, both(>Int) ==)
 
-def-external(+Unsafe.SDL_NumJoysticks, CInt)
-def-external(+Unsafe.SDL_IsGameController, CInt -- Bool)
-def-external(+Unsafe.SDL_GameControllerOpen, CInt -- Ptr)
-def-external(+Unsafe.SDL_GameControllerClose, Ptr --)
+external(+Unsafe.SDL_NumJoysticks, CInt)
+external(+Unsafe.SDL_IsGameController, CInt -- Bool)
+external(+Unsafe.SDL_GameControllerOpen, CInt -- Ptr)
+external(+Unsafe.SDL_GameControllerClose, Ptr --)
 
 def(+SDL.num-joysticks, +SDL -- +SDL Int, unsafe(.SDL_NumJoysticks) >Int)
 def(+SDL.is-game-controller, +SDL Int -- +SDL Bool, CInt unsafe(.SDL_IsGameController))

--- a/examples/snake.mth
+++ b/examples/snake.mth
@@ -305,7 +305,7 @@ def(+SnakeLogic.update!, +World +SnakeLogic -- +World +SnakeLogic,
 
 def(+SnakeLogic.desired-length, +SnakeLogic -- +SnakeLogic Nat, points 5 + >Nat)
 
-def-external(libc-rand -> rand, +World -- +World CInt)
+external(libc-rand -> rand, +World -- +World CInt)
 def(random-position, +World -- +World Position,
     libc-rand >Int SNAKE_W % >x
     libc-rand >Int SNAKE_H % >y

--- a/examples/snake.mth
+++ b/examples/snake.mth
@@ -305,7 +305,7 @@ def(+SnakeLogic.update!, +World +SnakeLogic -- +World +SnakeLogic,
 
 def(+SnakeLogic.desired-length, +SnakeLogic -- +SnakeLogic Nat, points 5 + >Nat)
 
-external(libc-rand -> rand, +World -- +World CInt)
+external(libc-rand -> rand [+World -- +World CInt])
 def(random-position, +World -- +World Position,
     libc-rand >Int SNAKE_W % >x
     libc-rand >Int SNAKE_H % >y

--- a/lib/std/ctypes.mth
+++ b/lib/std/ctypes.mth
@@ -62,5 +62,5 @@ inline(
     def(CPtr.>CStr, CPtr(CConst(CChar)) -- CStr, CStr)
     def(CStr.>CPtr, CStr -- CPtr(CConst(CChar)), CStr -> id)
     def(CStr.>Ptr, CStr -- Ptr, >CPtr /CPtr)
-    def-external(CStr.num-bytes -> strlen, +Unsafe CStr -- +Unsafe CUSize)
+    external(CStr.num-bytes -> strlen, +Unsafe CStr -- +Unsafe CUSize)
 )

--- a/lib/std/ctypes.mth
+++ b/lib/std/ctypes.mth
@@ -62,5 +62,5 @@ inline(
     def(CPtr.>CStr, CPtr(CConst(CChar)) -- CStr, CStr)
     def(CStr.>CPtr, CStr -- CPtr(CConst(CChar)), CStr -> id)
     def(CStr.>Ptr, CStr -- Ptr, >CPtr /CPtr)
-    external(CStr.num-bytes -> strlen, +Unsafe CStr -- +Unsafe CUSize)
+    external(CStr.num-bytes -> strlen [ +Unsafe CStr -- +Unsafe CUSize ])
 )

--- a/lib/std/posix.mth
+++ b/lib/std/posix.mth
@@ -51,7 +51,7 @@ def(Nat.print-ln!, Nat --, show print-ln!)
 # STAT #
 ########
 
-def-external(posix-stat -> stat, +Unsafe CStr Ptr -- +Unsafe CInt)
+external(posix-stat -> stat, +Unsafe CStr Ptr -- +Unsafe CInt)
 def(+World.is-directory?, +World Path -- +World Bool,
     256 >Size +Buffer.new
     >Str with-cstr(

--- a/lib/std/posix.mth
+++ b/lib/std/posix.mth
@@ -51,7 +51,7 @@ def(Nat.print-ln!, Nat --, show print-ln!)
 # STAT #
 ########
 
-external(posix-stat -> stat, +Unsafe CStr Ptr -- +Unsafe CInt)
+external(posix-stat -> stat [+Unsafe CStr Ptr -- +Unsafe CInt])
 def(+World.is-directory?, +World Path -- +World Bool,
     256 >Size +Buffer.new
     >Str with-cstr(

--- a/src/c99.mth
+++ b/src/c99.mth
@@ -78,7 +78,7 @@ def(run-output-c99!, Arrow C99_Options +World +Mirth -- +World +Mirth,
         c99-tag-defs!
         c99-buffers!
         c99-variables!
-        c99-externals!
+        c99-external-blocks!
         c99-word-sigs!
         c99-block-sigs!
         c99-field-sigs!
@@ -395,10 +395,16 @@ def(c99-tag-set-label!, Tag Label +C99 -- +C99, \(tag lbl ->
             )
     )))
 
-def(c99-externals!, +C99 -- +C99,
-    External.for(c99-external!))
+def(c99-external-blocks!, +C99 -- +C99,
+    ExternalBlock.for(c99-external-block!))
 
-def(c99-external!, External +C99 -- +C99,
+def(c99-external-block!, ExternalBlock +C99 -- +C99,
+    parts for(match(
+        EBPCode -> put line,
+        EBPDef -> c99-external-def!
+    )))
+
+def(c99-external-def!, External +C99 -- +C99,
     >ext
     @ext +mirth:ctype >cty
 

--- a/src/elab.mth
+++ b/src/elab.mth
@@ -1510,13 +1510,7 @@ def(parse-external-decl-part, +Mirth Token -- +Mirth Token ExternalDeclPart,
     )
     dip(dup comma? then(succ)))
 
-# external(
-#     "#include <SDL.h>",
-#     SDL_Init :: +SDL flags:U32 -- +SDL?
-#     SDL_Quit :: +SDL +SDL_
-# )
-
-||| Elaborate an external declaration `external(w -> sym, t)` or `external(w -> sym, t, code)`
+||| Elaborate an external declaration.
 def(elab-external!, +Mirth Token -- +Mirth Token,
     dup >token
     parse-external-decl

--- a/src/elab.mth
+++ b/src/elab.mth
@@ -1036,7 +1036,7 @@ def(elab-module-decl!, Token +World +Mirth -- Token +World +Mirth,
         PRIM_SYNTAX_DEF_MISSING -> elab-def-missing!,
         PRIM_SYNTAX_DEF_TYPE -> elab-def-type!,
         PRIM_SYNTAX_DEF_EXTERNAL ->
-            # dup "def-external" >old "external" >new emit-deprecated!
+            dup "def-external" >old "external" >new emit-deprecated!
             elab-external!,
         PRIM_SYNTAX_EXTERNAL -> elab-external!,
         PRIM_SYNTAX_BUFFER -> elab-buffer!,

--- a/src/elab.mth
+++ b/src/elab.mth
@@ -1484,7 +1484,6 @@ def(parse-external-decl-part, +Mirth Token -- +Mirth Token ExternalDeclPart,
     dup str? if-some(
         >code dup >token
         succ
-        dup arg-end? else("expected comma" emit-fatal-error!)
         EDPCode,
 
         dup >head
@@ -1497,11 +1496,16 @@ def(parse-external-decl-part, +Mirth Token -- +Mirth Token ExternalDeclPart,
 
             None >symbol
         )
-        dup comma? else("expected comma before type signature" emit-fatal-error!)
-        succ
-        dup arg-end? then("expected type signature" emit-fatal-error!)
-        dup >sig
-        next-arg-end
+        dup lsquare? if(
+            dup args-1 >sig
+            next,
+
+            dup comma? else("expected type signature" emit-fatal-error!)
+            succ
+            dup arg-end? then("expected type signature" emit-fatal-error!)
+            dup >sig
+            next-arg-end
+        )
         EDPDef
     )
     dip(dup comma? then(succ)))

--- a/src/elab.mth
+++ b/src/elab.mth
@@ -9,6 +9,7 @@ import(std.path)
 import(std.byte)
 import(std.posix)
 import(std.file)
+import(std.terminal)
 
 import(mirth.mirth)
 import(mirth.name)
@@ -1034,7 +1035,10 @@ def(elab-module-decl!, Token +World +Mirth -- Token +World +Mirth,
         PRIM_SYNTAX_DEF -> elab-def!,
         PRIM_SYNTAX_DEF_MISSING -> elab-def-missing!,
         PRIM_SYNTAX_DEF_TYPE -> elab-def-type!,
-        PRIM_SYNTAX_DEF_EXTERNAL -> elab-def-external!,
+        PRIM_SYNTAX_DEF_EXTERNAL ->
+            # dup "def-external" >old "external" >new emit-deprecated!
+            elab-external!,
+        PRIM_SYNTAX_EXTERNAL -> elab-external!,
         PRIM_SYNTAX_BUFFER -> elab-buffer!,
         PRIM_SYNTAX_VARIABLE -> elab-variable!,
         PRIM_SYNTAX_TABLE -> elab-table!,
@@ -1456,29 +1460,94 @@ def(elab-def-body!, StackType +Mirth +AB -- StackType +Mirth +AB,
         elab-atoms!
     ))
 
-||| Elaborate an external declaration `def-external(w, t)` or `def-external(w -> sym, t)`
-def(elab-def-external!, +Mirth Token -- +Mirth Token,
-    sip(next) args-2
-    over dup elab-def-qname-undefined
-    swap succ dup comma? if(
-        drop dup name,
-        expect-token-arrow succ
-        dup name? unwrap-or("expected external symbol name" emit-fatal-error!) nip
-    ) >Str swap
+data(ExternalDeclPart,
+    EDPCode -> token:Token code:Str,
+    EDPDef  -> head:Token symbol:Maybe(Token) sig:Token)
 
-    External.alloc!
-    tuck ~qname !
-    tuck ~symbol !
-    tuck ~sig !
-    tuck ~head !
-    dup dup ExternalType prop(
+def(parse-external-decl, +Mirth Token -- +Mirth Token List(ExternalDeclPart),
+    sip(next)
+    succ dup lparen-or-lcolon? else(
+        pred Str(
+            FGCyan emit; "external"; Reset emit;
+            " requires arguments";
+        )
+        emit-fatal-error!
+    )
+    LIST(
+        succ
+        while(dup args-end? not,
+            rdip(parse-external-decl-part) ;)
+        drop
+    ))
+
+def(parse-external-decl-part, +Mirth Token -- +Mirth Token ExternalDeclPart,
+    dup str? if-some(
+        >code dup >token
+        succ
+        dup arg-end? else("expected comma" emit-fatal-error!)
+        EDPCode,
+
+        dup >head
+        dup name-or-dname? else("expected external word name" emit-fatal-error!)
+        succ
+        dup pat-arrow? if(
+            succ dup name? else("expected external symbol name" emit-fatal-error!)
+            dup Some >symbol
+            succ,
+
+            None >symbol
+        )
+        dup comma? else("expected comma before type signature" emit-fatal-error!)
+        succ
+        dup arg-end? then("expected type signature" emit-fatal-error!)
+        dup >sig
+        next-arg-end
+        EDPDef
+    )
+    dip(dup comma? then(succ)))
+
+# external(
+#     "#include <SDL.h>",
+#     SDL_Init :: +SDL flags:U32 -- +SDL?
+#     SDL_Quit :: +SDL +SDL_
+# )
+
+||| Elaborate an external declaration `external(w -> sym, t)` or `external(w -> sym, t, code)`
+def(elab-external!, +Mirth Token -- +Mirth Token,
+    dup >token
+    parse-external-decl
+    map(elab-external-block-part!) >parts
+    ExternalBlock.alloc! >extblock
+    token> @extblock ~token !
+    parts> @extblock ~parts !
+    extblock> drop)
+
+def(elab-external-block-part!, +Mirth ExternalDeclPart -- +Mirth ExternalBlockPart,
+    EDPCode -> token> drop code> EBPCode,
+    EDPDef -> elab-external-def! EBPDef)
+
+def(elab-external-def!, +Mirth head:Token symbol:Maybe(Token) sig:Token -- +Mirth External,
+    @head elab-def-qname-undefined >qname
+
+    symbol> if-some(
+        name? unwrap,
+        @qname name
+    ) >Str >symbol
+
+    External.alloc! >external
+    qname> @external ~qname !
+    symbol> @external ~symbol !
+    sig> @external ~sig !
+    head> @external ~head !
+    @external dup ExternalType prop(
         sig +TypeElab.type-sig-start!
         elab-type-sig! dip:ctx pack2 rdrop
-    ) over ~ctx-type !
-    dup dup ExternalCType prop(
+    ) @external ~ctx-type !
+    @external dup ExternalCType prop(
         elab-def-external-ctype
-    ) over ~ctype !
-    DefExternal register)
+    ) @external ~ctype !
+    @external DefExternal register
+    external>)
 
 def(elab-def-external-ctype, +Mirth External -- +Mirth CTypeArrow,
     dup head with-error-token(

--- a/src/external.mth
+++ b/src/external.mth
@@ -33,6 +33,7 @@ def(External.==, External External -- Bool, both(index) ==)
 table(ExternalBlock)
 field(ExternalBlock.~token, ExternalBlock, Token)
 field(ExternalBlock.~parts, ExternalBlock, List(ExternalBlockPart))
+def(ExternalBlock.parts, ExternalBlock -- List(ExternalBlockPart), ~parts @)
 
 data(ExternalBlockPart,
     EBPCode -> Str,

--- a/src/external.mth
+++ b/src/external.mth
@@ -1,6 +1,7 @@
 module(mirth.external)
 
 import(std.prelude)
+import(std.list)
 
 import(mirth.type)
 import(mirth.token)
@@ -28,3 +29,11 @@ def(External.type, +Mirth External -- +Mirth ArrowType, ctx-type nip)
 def(External.ctype, +Mirth External -- +Mirth CTypeArrow, ~ctype force!)
 
 def(External.==, External External -- Bool, both(index) ==)
+
+table(ExternalBlock)
+field(ExternalBlock.~token, ExternalBlock, Token)
+field(ExternalBlock.~parts, ExternalBlock, List(ExternalBlockPart))
+
+data(ExternalBlockPart,
+    EBPCode -> Str,
+    EBPDef -> External)

--- a/src/mirth.mth
+++ b/src/mirth.mth
@@ -160,6 +160,12 @@ def(+Mirth.emit-error!, Token Str +Mirth -- +Mirth,
 def(+Mirth.emit-fatal-error!, *a Token Str +Mirth -- *b +Mirth,
     dip(location) emit-fatal-error-at!)
 
+def(+Mirth.emit-deprecated!, Token old:Str new:Str +Mirth -- +Mirth,
+    Str(FGCyan emit; old> ; Reset emit;
+        " is deprecated, please use ";
+        FGCyan emit; new> ; Reset emit;
+        " instead.";) emit-warning!)
+
 def(+Mirth.with-error-token(f), (*a +Mirth -- *b +Mirth)
         *a Token +Mirth -- *b +Mirth,
     error-token dip(Some error-token! f) error-token!)

--- a/src/prim.mth
+++ b/src/prim.mth
@@ -108,6 +108,7 @@ data(Prim,
     PRIM_SYNTAX_DEF_TYPE,
     PRIM_SYNTAX_BUFFER,
     PRIM_SYNTAX_VARIABLE,
+    PRIM_SYNTAX_EXTERNAL,
     PRIM_SYNTAX_DEF_EXTERNAL,
     PRIM_SYNTAX_EMBED_STR,
     PRIM_SYNTAX_TABLE,
@@ -155,6 +156,7 @@ def(init-prims!, +Mirth -- +Mirth,
     PRIM_SYNTAX_DEF_MISSING "def-missing" -1 def-prim!
     PRIM_SYNTAX_BUFFER "buffer" -1 def-prim!
     PRIM_SYNTAX_DEF_EXTERNAL "def-external" -1 def-prim!
+    PRIM_SYNTAX_EXTERNAL "external" -1 def-prim!
     PRIM_SYNTAX_TABLE "table" -1 def-prim!
     PRIM_SYNTAX_FIELD "field" -1 def-prim!
     PRIM_SYNTAX_EMBED_STR "embed-str" -1 def-prim!

--- a/test/external-block.mth
+++ b/test/external-block.mth
@@ -1,0 +1,10 @@
+module(test.external-block)
+
+external(
+    "#include <stdio.h>",
+    "void go (void) { printf(\"Hello, world!\\n\"); }",
+    go, +World -- +World
+)
+
+def(main, +World -- +World, go)
+# mirth-test # pout # Hello, world!

--- a/test/external-block.mth
+++ b/test/external-block.mth
@@ -1,9 +1,9 @@
 module(test.external-block)
 
 external(
-    "#include <stdio.h>",
-    "void go (void) { printf(\"Hello, world!\\n\"); }",
-    go, +World -- +World
+    "#include <stdio.h>"
+    "void go (void) { printf(\"Hello, world!\\n\"); }"
+    go [+World -- +World]
 )
 
 def(main, +World -- +World, go)

--- a/test/external-deprecated-def.mth
+++ b/test/external-deprecated-def.mth
@@ -1,0 +1,8 @@
+module(test.external-deprecated-def)
+
+import(std.ctypes)
+def-external(my-exit -> exit, *a CInt +World -- *b)
+
+def(main, +World -- +World, 10 CInt my-exit)
+# mirth-test # merr # 4:1: warning: [36mdef-external[0m is deprecated, please use [36mexternal[0m instead.
+# mirth-test # pret # 10

--- a/test/external-fnptr.mth
+++ b/test/external-fnptr.mth
@@ -3,7 +3,9 @@ module(mirth-tests.external-fnptr)
 import(std.prelude)
 import(std.posix)
 
-external(atexit, [ +World -- +World ] +World -- +World)
+external(
+    atexit [ +World [ +World -- +World ] -- +World ]
+)
 
 def(main, +World -- +World,
     [ "goodbye world" put line ] atexit

--- a/test/external-fnptr.mth
+++ b/test/external-fnptr.mth
@@ -3,7 +3,7 @@ module(mirth-tests.external-fnptr)
 import(std.prelude)
 import(std.posix)
 
-def-external(atexit, [ +World -- +World ] +World -- +World)
+external(atexit, [ +World -- +World ] +World -- +World)
 
 def(main, +World -- +World,
     [ "goodbye world" put line ] atexit

--- a/test/external-labelled-argument.mth
+++ b/test/external-labelled-argument.mth
@@ -4,9 +4,8 @@ import(std.prelude)
 import(std.str)
 import(std.ctypes)
 
-external
-    my-puts -> puts,
-    weird-name: CStr +World -- +World CInt
+external(
+    my-puts -> puts [+World weird-name:CStr -- +World CInt]
 )
 
 def(main, +World -- +World,

--- a/test/external-labelled-argument.mth
+++ b/test/external-labelled-argument.mth
@@ -4,7 +4,7 @@ import(std.prelude)
 import(std.str)
 import(std.ctypes)
 
-def-external(
+external
     my-puts -> puts,
     weird-name: CStr +World -- +World CInt
 )


### PR DESCRIPTION
This PR expands and replaces `def-external` with `external`. The new `external` declaration can be used the same way as `def-external`, but it also allows you to make C declarations directly. E.g.,

```
external(
   "#include <stdio.h>"
   "void printint(int x) { printf(\"%d\", x); }"
   printint [ +World CInt -- +World ]
)
```
This example has both raw C declarations (the string literals), and an external function declaration `printint [ +World CInt -- +World ]`.

Note the new syntax for declaring an external function, where the type signature is passed in the brackets:
```
name [ type-sig ]
name -> symbol [ type-sig ]
```
The old syntax (passing the type signature as a separate argument) is still supported, but not recommended.