### PR TITLE
Relax visibility checks.

### DIFF
--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -4675,13 +4675,6 @@ static void mtp_mirth_elab_RejectedDef_RDz_WRONGz_ARITY (void) {
 		free(tup);
 	}
 }
-static void mtw_mirth_elab_RejectedDef_RDz_NOTz_VISIBLE (void) {
-	TUP* tup = tup_new(2);
-	tup->size = 2;
-	tup->cells[0] = MKU64(2LL);
-	tup->cells[1] = pop_value();
-	push_value(MKTUP(tup, 2));
-}
 static void mtp_mirth_elab_RejectedDef_RDz_NOTz_VISIBLE (void) {
 	VAL val = pop_value();
 	ASSERT1(IS_TUP(val),val);
@@ -6469,7 +6462,6 @@ static void mw_mirth_elab_ZPlusResolveDef_rdrop (void);
 static void mw_mirth_elab_ZPlusResolveDef_resolveZ_defZ_ambiguous (void);
 static void mw_mirth_elab_ZPlusResolveDef_resolveZ_defZ_unknown (void);
 static void mw_mirth_elab_ZPlusResolveDef_filterZ_arity (void);
-static void mw_mirth_elab_ZPlusResolveDef_filterZ_visible (void);
 static void mw_mirth_elab_ZPlusResolveDef_filterZ_qualifiers (void);
 static void mw_mirth_elab_ZPlusResolveDef_filterZ_roots (void);
 static void mw_mirth_elab_defZ_isZ_importedZ_atZ_tokenZAsk (void);
@@ -7253,8 +7245,6 @@ static void mb_mirth_elab_ZPlusResolveDef_resolveZ_defZ_ambiguous_8 (void);
 static void mb_mirth_elab_ZPlusResolveDef_resolveZ_defZ_ambiguous_11 (void);
 static void mb_mirth_elab_ZPlusResolveDef_filterZ_arity_0 (void);
 static void mb_mirth_elab_ZPlusResolveDef_filterZ_arity_1 (void);
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_visible_0 (void);
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_visible_1 (void);
 static void mb_mirth_elab_ZPlusResolveDef_filterZ_qualifiers_0 (void);
 static void mb_mirth_elab_ZPlusResolveDef_filterZ_qualifiers_1 (void);
 static void mb_mirth_elab_ZPlusResolveDef_filterZ_qualifiers_2 (void);
@@ -30999,11 +30989,6 @@ static void mw_mirth_elab_ZPlusResolveDef_filterZ_arity (void) {
 	mw_mirth_elab_ZPlusResolveDef_filter_2();
 	mp_primZ_drop();
 }
-static void mw_mirth_elab_ZPlusResolveDef_filterZ_visible (void) {
-	push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filterZ_visible_0);
-	push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filterZ_visible_1);
-	mw_mirth_elab_ZPlusResolveDef_filter_2();
-}
 static void mw_mirth_elab_ZPlusResolveDef_filterZ_qualifiers (void) {
 	mw_mirth_elab_ZPlusResolveDef_token();
 	mw_mirth_token_Token_dnameZAsk();
@@ -45325,19 +45310,6 @@ static void mb_mirth_elab_ZPlusResolveDef_filterZ_arity_0 (void) {
 static void mb_mirth_elab_ZPlusResolveDef_filterZ_arity_1 (void) {
 	mtw_mirth_elab_RejectedDef_RDz_WRONGz_ARITY();
 }
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_visible_0 (void) {
-	mw_mirth_elab_ZPlusResolveDef_token();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	mw_mirth_elab_defZ_visibleZ_fromZ_tokenZAsk();
-}
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_visible_1 (void) {
-	mtw_mirth_elab_RejectedDef_RDz_NOTz_VISIBLE();
-}
 static void mb_mirth_elab_ZPlusResolveDef_filterZ_qualifiers_0 (void) {
 	push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filterZ_qualifiers_1);
 	push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filterZ_qualifiers_2);
@@ -45601,7 +45573,6 @@ static void mb_mirth_elab_ZPlusTypeElab_resolveZ_typeZ_conZ_nameZBang_1 (void) {
 	push_fnptr(&mb_mirth_elab_ZPlusTypeElab_resolveZ_typeZ_conZ_nameZBang_3);
 	mw_mirth_elab_ZPlusResolveDef_filter_2();
 	mw_mirth_elab_ZPlusResolveDef_filterZ_arity();
-	mw_mirth_elab_ZPlusResolveDef_filterZ_visible();
 	mw_mirth_elab_ZPlusResolveDef_filterZ_qualifiers();
 	push_u64(0LL); // Nil
 	mw_mirth_elab_ZPlusResolveDef_filterZ_roots();
@@ -45781,7 +45752,6 @@ static void mb_mirth_elab_elabZ_atomZ_resolveZ_defZBang_0 (void) {
 	push_fnptr(&mb_mirth_elab_elabZ_atomZ_resolveZ_defZBang_2);
 	mw_mirth_elab_ZPlusResolveDef_filter_2();
 	mw_mirth_elab_ZPlusResolveDef_filterZ_arity();
-	mw_mirth_elab_ZPlusResolveDef_filterZ_visible();
 	mw_mirth_elab_ZPlusResolveDef_filterZ_qualifiers();
 	mw_mirth_elab_ZPlusResolveDef_token();
 	mw_mirth_token_Token_canZ_beZ_relativeZ_nameZ_orZ_dnameZAsk();
@@ -45925,7 +45895,6 @@ static void mb_mirth_elab_elabZ_patternZ_atomZBang_5 (void) {
 	push_fnptr(&mb_mirth_elab_elabZ_patternZ_atomZBang_7);
 	mw_mirth_elab_ZPlusResolveDef_filter_2();
 	mw_mirth_elab_ZPlusResolveDef_filterZ_arity();
-	mw_mirth_elab_ZPlusResolveDef_filterZ_visible();
 	mw_mirth_elab_ZPlusResolveDef_filterZ_qualifiers();
 	LPOPR(lbl_ZPluspat);
 	mw_mirth_match_ZPlusPattern_pattern();

--- a/src/elab.mth
+++ b/src/elab.mth
@@ -5,10 +5,7 @@ import(std.str)
 import(std.list)
 import(std.maybe)
 import(std.either)
-import(std.path)
 import(std.byte)
-import(std.world)
-import(std.file)
 import(std.terminal)
 
 import(mirth.mirth)
@@ -377,7 +374,6 @@ def(+TypeElab.resolve-type-con-name!, +Mirth +TypeElab -- +Mirth +TypeElab Type,
     token >token "type" >sort rdip:resolve-def(
         filter(dup rdip:defines-a-type?, RD_WRONG_SORT)
         filter-arity
-        filter-visible
         filter-qualifiers
         L0 filter-roots
     ) map:match(
@@ -799,7 +795,6 @@ def(elab-atom-resolve-def!, +Mirth +AB -- +Mirth +AB,
     >+ab resolve-def(
         filter(dup rdip:callable?, RD_WRONG_SORT)
         filter-arity
-        filter-visible
         filter-qualifiers
         token can-be-relative-name-or-dname? if(
             @+ab:ab-type@ top-types-are-fine? then(
@@ -896,7 +891,6 @@ def(elab-pattern-atom!, Token +Mirth +Pattern -- +Mirth +Pattern,
         >+pat resolve-def(
             filter(dup tag? some?, RD_WRONG_SORT)
             filter-arity
-            filter-visible
             filter-qualifiers
             @+pat:pattern mid top-types-are-fine? then(
                 @+pat:pattern mid top-namespaces

--- a/test/error-name-resolution-constructors.mth
+++ b/test/error-name-resolution-constructors.mth
@@ -7,7 +7,7 @@ data(+MyEither, Left -> Int, Right -> Str)
 data(Foo, FOO)
 data(Bar, BAR)
 
-def(constructors-not-visible, --,
+def(constructors-not-visible-but-ok, --,
     1 >I8? match(
         Some -> drop,
         None -> id
@@ -30,8 +30,6 @@ def(unknown-single, Foo --, BAR -> )
 def(unknown-multiple, Foo --, Left -> )
 
 def(main, --, id)
-# mirth-test # merr # 12:9: error: Not visible in current scope: std.maybe.Maybe/1.Some
-# mirth-test # merr # 13:9: error: Not visible in current scope: std.maybe.Maybe/1.None
 # mirth-test # merr # 23:5: error: Ambiguous constructor. Can't decide between: mirth-tests.error-name-resolution-constructors.+MyEither.Left, mirth-tests.error-name-resolution-constructors.MyEither.Left
 # mirth-test # merr # 24:5: error: Ambiguous constructor. Can't decide between: mirth-tests.error-name-resolution-constructors.+MyEither.Right, mirth-tests.error-name-resolution-constructors.MyEither.Right
 # mirth-test # merr # 29:29: error: Constructor is for a different type: mirth-tests.error-name-resolution-constructors.Bar.BAR

--- a/test/error-name-resolution-types.mth
+++ b/test/error-name-resolution-types.mth
@@ -10,7 +10,7 @@ def(ok-fn, std.prim.Int -- error-name-resolution-types.Int, 1+ drop "0" MY_INT)
 def(bad-again, badstd.Bool -- failstd.prim.Int, id)
 def(main, --, id)
 # mirth-test # merr # 5:10: error: Ambiguous type. Can't decide between: mirth-tests.error-name-resolution-types.Int, std.prim.Int
-# mirth-test # merr # 5:17: error: Not visible in current scope: std.maybe.Maybe/1
+# mirth-test # merr # 5:17: error: Not imported in current scope: std.maybe.Maybe/1
 # mirth-test # merr # 6:10: error: std.prim.Bool expects 0 arguments, but got 1.
 # mirth-test # merr # 6:24: error: Unknown type name, possibly a misspelling.
 # mirth-test # merr # 7:10: error: Expected a type, but mirth-tests.error-name-resolution-types.Foo is not a type.

--- a/test/error-name-resolution-words.mth
+++ b/test/error-name-resolution-words.mth
@@ -10,9 +10,9 @@ def(+Type2.method, +Type2 -- +Type2, id)
 def(1+, Int -- Int, 1 +)
 def(+Type2.method2, +Type2 -- +Type2, id)
 
-def(not-visible-1, --, 10 >I8? none? drop)
-def(not-visible-2, --, 10 >I8? .none? drop)
-def(not-visible-3, --, 10 >I8? Maybe.none? drop)
+def(not-visible-but-ok-1, --, 10 >I8? none? drop)
+def(not-visible-but-ok-2, --, 10 >I8? .none? drop)
+def(not-visible-not-ok-3, --, 10 >I8? Maybe.none? drop)
 def(unknown-1, --, foobarbaz)
 def(unknown-2, --, std.prelude.foo)
 def(ambiguous-1a, Type1 +Type2 -- Type1 +Type2, method)
@@ -44,9 +44,7 @@ def(error-chaining-3-detects-error-again, --, "Hello" + method2 /TYPE3)
 def(error-chaining-4-still-ambiguous, --, "Hello" 1- method2 /TYPE2 1-)
 
 def(main, --, id)
-# mirth-test # merr # 13:32: error: Not visible in current scope: std.maybe.Maybe/1.none?
-# mirth-test # merr # 14:32: error: Not visible in current scope: std.maybe.Maybe/1.none?
-# mirth-test # merr # 15:32: error: Not visible in current scope: std.maybe.Maybe/1.none?
+# mirth-test # merr # 15:39: error: Not imported in current scope: std.maybe.Maybe/1.none?
 # mirth-test # merr # 16:20: error: Unknown word name, possibly a misspelling.
 # mirth-test # merr # 17:20: error: Unknown word name, possibly a misspelling.
 # mirth-test # merr # 18:49: error: Ambiguous word. Can't decide between: mirth-tests.error-name-resolution-words.+Type2.method, mirth-tests.error-name-resolution-words.Type1.method

--- a/test/labels.mth
+++ b/test/labels.mth
@@ -22,7 +22,7 @@ def(main, +World -- +World,
         60 !bar
         @bar show; " " ; @bar:1+
         @bar show; " " ; @bar:1+
-        pop-bar shoow;
+        pop-bar show;
     )
 
     "world" +Str
@@ -31,5 +31,6 @@ def(main, +World -- +World,
     pop-mystr freeze print
 )
 
-# mirth-test # merr # 25:17: error: Unknown word name, possibly a misspelling.
-# mirth-test # mret # 1
+# mirth-test # pout # 10 30 40 20 21 22 60 61 62
+# mirth-test # pout # world!
+# mirth-test # pout # hello


### PR DESCRIPTION
This PR is a bit of an experiment to relax visibility checks somewhat.

Previously, if you tried to use a definition made in some module, you needed to have imported that module directly.

With this PR, we change name resolution so that:

- if it's a relative name, e.g. invoking a method on a type, or a constructor during pattern matching, then no direct visibility is required.

- if it's an absolute name, e.g. a type name like `List`, or a global defined in some module like `swap`, then the defining module must be imported.

- if it's a qualified name, then the root of the qualified name must be directly visible (e.g. if the root is a module, it must be directly imported; if the root is a type, its defining module must be directly imported).

Of note, these checks were all in place already. They were just shadowed by the "direct visibility" test that this PR removes.

In practice, this change means you can now use methods on a type without directly importing the module where those methods are defined. E.g. we can concatenate two strings using `cat` without importing `std.str` directly. We can also pattern match on a type's constructors without importing their defining module directly.

Regardless of these changes, any kind of ambiguity is still an error, and you can still resolve ambiguity by using a qualified name. Because this PR relaxes visibility requirements, it might introduce ambiguity where there previously was none. In most situations, all that's needed then is to qualify the name that is ambiguous.