### PR TITLE
New def syntax and type inference.

### DIFF
--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -1478,6 +1478,7 @@ static VAL lbl_reportZ_ambiguousZ_asZ_warning = MKNIL_C;
 static VAL lbl_qname = MKNIL_C;
 static VAL lbl_accum = MKNIL_C;
 static VAL lbl_arrow = MKNIL_C;
+static VAL lbl_word = MKNIL_C;
 static VAL lbl_ZPlusab = MKNIL_C;
 static VAL lbl_ZPluspat = MKNIL_C;
 static VAL lbl_tok = MKNIL_C;
@@ -1485,7 +1486,6 @@ static VAL lbl_f = MKNIL_C;
 static VAL lbl_hasZ_paren = MKNIL_C;
 static VAL lbl_target = MKNIL_C;
 static VAL lbl_alias = MKNIL_C;
-static VAL lbl_word = MKNIL_C;
 static VAL lbl_code = MKNIL_C;
 static VAL lbl_symbol = MKNIL_C;
 static VAL lbl_extblock = MKNIL_C;
@@ -5668,6 +5668,7 @@ static void mw_mirth_word_Word_for_1 (void);
 static void mw_mirth_word_Word_allocZBang (void);
 static void mw_mirth_word_Word_qnameZ_soft (void);
 static void mw_mirth_word_Word_qnameZ_hard (void);
+static void mw_mirth_word_Word_namespaceZ_hard (void);
 static void mw_mirth_word_Word_name (void);
 static void mw_mirth_word_Word_head (void);
 static void mw_mirth_word_Word_sig (void);
@@ -5675,6 +5676,7 @@ static void mw_mirth_word_Word_body (void);
 static void mw_mirth_word_Word_arity (void);
 static void mw_mirth_word_Word_params (void);
 static void mw_mirth_word_Word_arrow (void);
+static void mw_mirth_word_Word_inferringZ_typeZAsk (void);
 static void mw_mirth_word_Word_cname (void);
 static void mw_mirth_word_Word_ctxZ_type (void);
 static void mw_mirth_word_Word_type (void);
@@ -5704,6 +5706,7 @@ static void mw_mirth_table_Field_type (void);
 static void mw_mirth_table_Field_ZEqualZEqual (void);
 static void mw_mirth_tycon_Tycon_qnameZ_hard (void);
 static void mw_mirth_tycon_Tycon_ZEqualZEqual (void);
+static void mw_mirth_tycon_Tycon_fullZ_typeZ_fresh (void);
 static void mw_mirth_data_Data_index (void);
 static void mw_mirth_data_Data_allocZBang (void);
 static void mw_mirth_data_Data_headZAsk (void);
@@ -5860,11 +5863,14 @@ static void mw_mirth_arrow_Arrow_atoms_1 (void);
 static void mw_mirth_arrow_Arrow_cod (void);
 static void mw_mirth_arrow_Arrow_codZBang (void);
 static void mw_mirth_arrow_Arrow_dom (void);
+static void mw_mirth_arrow_Arrow_domZBang (void);
 static void mw_mirth_arrow_Arrow_ctx (void);
+static void mw_mirth_arrow_Arrow_ctxZBang (void);
 static void mw_mirth_arrow_Arrow_tokenZ_end (void);
 static void mw_mirth_arrow_Arrow_tokenZ_endZBang (void);
 static void mw_mirth_arrow_Arrow_tokenZ_start (void);
 static void mw_mirth_arrow_Arrow_home (void);
+static void mw_mirth_arrow_Arrow_ctxZ_type (void);
 static void mw_mirth_arrow_Arrow_type (void);
 static void mw_mirth_arrow_Atom_ZDivAtom (void);
 static void mw_mirth_arrow_Atom_cod (void);
@@ -5921,6 +5927,7 @@ static void mw_mirth_typedef_TypeDef_target (void);
 static void mw_mirth_typedef_TypeDef_ZEqualZEqual (void);
 static void mw_mirth_typedef_TypeDef_newZBang (void);
 static void mw_mirth_type_PrimType_tag (void);
+static void mw_mirth_type_PrimType_isZ_resourceZAsk (void);
 static void mw_mirth_type_PrimType_isZ_physicalZAsk (void);
 static void mw_mirth_type_Type_tyconZAsk (void);
 static void mw_mirth_type_PrimType_tyconZ_qname (void);
@@ -6577,6 +6584,7 @@ static void mw_mirth_elab_ZPlusAB_gamma_1 (void);
 static void mw_mirth_elab_abZ_buildZBang_1 (void);
 static void mw_mirth_elab_abZ_buildZ_homZBang_1 (void);
 static void mw_mirth_elab_abZ_buildZ_wordZ_arrowZBang_1 (void);
+static void mw_mirth_elab_guessZ_initialZ_ctxZ_type (void);
 static void mw_mirth_elab_abZ_buildZ_wordZBang_1 (void);
 static void mw_mirth_elab_abZ_unifyZ_typeZBang (void);
 static void mw_mirth_elab_abZ_atomZBang (void);
@@ -7176,6 +7184,7 @@ static void mb_mirth_token_Token_runZ_tokens_0 (void);
 static void mb_mirth_token_Token_runZ_tokens_1 (void);
 static void mb_mirth_token_Token_runZ_arrowZAsk_0 (void);
 static void mb_mirth_token_Token_patZ_tokens_0 (void);
+static void mb_mirth_data_Data_isZ_resourceZAsk_0 (void);
 static void mb_mirth_type_Type_isZ_physicalZAsk_0 (void);
 static void mb_mirth_type_Type_isZ_physicalZAsk_1 (void);
 static void mb_mirth_type_TT_0 (void);
@@ -7254,7 +7263,6 @@ static void mb_mirth_data_Data_isZ_unitZAsk_1 (void);
 static void mb_mirth_match_Match_isZ_transparentZAsk_0 (void);
 static void mb_mirth_match_Match_isZ_transparentZAsk_1 (void);
 static void mb_mirth_data_Data_isZ_transparentZAsk_0 (void);
-static void mb_mirth_data_Data_isZ_resourceZAsk_0 (void);
 static void mb_mirth_data_Data_isZ_semiZ_transparentZAsk_0 (void);
 static void mb_mirth_data_Data_isZ_semiZ_transparentZAsk_1 (void);
 static void mb_mirth_data_Tag_labelZ_inputsZ_fromZ_sig_0 (void);
@@ -7272,6 +7280,9 @@ static void mb_mirth_data_Tag_numZ_labelZ_inputs_0 (void);
 static void mb_mirth_word_Word_preferZ_inlineZAsk_0 (void);
 static void mb_std_map_Map_2_lookup_1_1 (void);
 static void mb_mirth_var_Ctx_lookup_0 (void);
+static void mb_mirth_tycon_Tycon_fullZ_typeZ_fresh_1 (void);
+static void mb_mirth_tycon_Tycon_fullZ_typeZ_fresh_2 (void);
+static void mb_mirth_word_Word_inferringZ_typeZAsk_0 (void);
 static void mb_mirth_match_Match_hasZ_defaultZ_caseZAsk_0 (void);
 static void mb_mirth_match_Match_scrutineeZ_dataZAsk_0 (void);
 static void mb_mirth_match_Match_scrutineeZ_dataZAsk_1 (void);
@@ -7372,6 +7383,7 @@ static void mb_mirth_elab_abZ_tokenZBang_0 (void);
 static void mb_mirth_elab_abZ_typeZBang_0 (void);
 static void mb_mirth_elab_abZ_buildZ_homZBang_1_1 (void);
 static void mb_mirth_elab_abZ_unifyZ_typeZBang_1 (void);
+static void mb_mirth_elab_abZ_buildZ_wordZ_arrowZBang_1_2 (void);
 static void mb_mirth_elab_abZ_buildZ_wordZBang_1_0 (void);
 static void mb_mirth_elab_abZ_buildZ_wordZBang_1_1 (void);
 static void mb_mirth_elab_abZ_atomZBang_0 (void);
@@ -7874,6 +7886,7 @@ static void mfld_mirth_word_Word_ZTildeparams (void);
 static void mfld_mirth_word_Word_ZTildearrow (void);
 static void mfld_mirth_word_Word_ZTildepreferZ_inlineZAsk (void);
 static void mfld_mirth_word_Word_ZTildecname (void);
+static void mfld_mirth_word_Word_ZTildeinferringZ_typeZAsk (void);
 static void mfld_mirth_word_Word_ZTildenumZ_blocks (void);
 static void mfld_mirth_table_Table_ZTildehead (void);
 static void mfld_mirth_table_Table_ZTildename (void);
@@ -8133,6 +8146,15 @@ static void mfld_mirth_word_Word_ZTildepreferZ_inlineZAsk (void) {
 }
 
 static void mfld_mirth_word_Word_ZTildecname (void) {
+	size_t i = (size_t)pop_u64();
+	static struct VAL * p = 0;
+	size_t m = 524288;
+	if (! p) { p = calloc(m, sizeof *p); }
+	EXPECT(i<m, "table grew too big");
+	push_ptr(p+i);
+}
+
+static void mfld_mirth_word_Word_ZTildeinferringZ_typeZAsk (void) {
 	size_t i = (size_t)pop_u64();
 	static struct VAL * p = 0;
 	size_t m = 524288;
@@ -14629,6 +14651,10 @@ static void mw_mirth_word_Word_qnameZ_hard (void) {
 	mfld_mirth_word_Word_ZTildeqname();
 	mw_mirth_mirth_Prop_1_forceZBang();
 }
+static void mw_mirth_word_Word_namespaceZ_hard (void) {
+	mw_mirth_word_Word_qnameZ_hard();
+	mw_mirth_name_QName_namespace();
+}
 static void mw_mirth_word_Word_name (void) {
 	mfld_mirth_word_Word_ZTildename();
 	mp_primZ_mutZ_get();
@@ -14656,6 +14682,12 @@ static void mw_mirth_word_Word_params (void) {
 static void mw_mirth_word_Word_arrow (void) {
 	mfld_mirth_word_Word_ZTildearrow();
 	mw_mirth_mirth_Prop_1_forceZBang();
+}
+static void mw_mirth_word_Word_inferringZ_typeZAsk (void) {
+	mfld_mirth_word_Word_ZTildeinferringZ_typeZAsk();
+	mw_std_prelude_ZAtZAsk();
+	push_fnptr(&mb_mirth_word_Word_inferringZ_typeZAsk_0);
+	mw_std_maybe_Maybe_1_unwrapZ_or_1();
 }
 static void mw_mirth_word_Word_cname (void) {
 	mp_primZ_dup();
@@ -14973,6 +15005,47 @@ static void mw_mirth_tycon_Tycon_ZEqualZEqual (void) {
 					push_u64(0LL); // False
 					break;
 			}
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primZ_panic();
+	}
+}
+static void mw_mirth_tycon_Tycon_fullZ_typeZ_fresh (void) {
+	switch (get_top_data_tag()) {
+		case 0LL: // TYCON_DATA
+			mtp_mirth_tycon_Tycon_TYCONz_DATA();
+			{
+				VAL d4 = pop_value();
+				push_u64(0LL); // SUBST_NIL
+				push_value(d4);
+			}
+			mw_mirth_data_Data_fullZ_type();
+			push_fnptr(&mb_mirth_tycon_Tycon_fullZ_typeZ_fresh_1);
+			push_fnptr(&mb_mirth_tycon_Tycon_fullZ_typeZ_fresh_2);
+			mw_std_either_Either_2_map_2();
+			{
+				VAL d4 = pop_value();
+				mp_primZ_drop();
+				push_value(d4);
+			}
+			break;
+		case 2LL: // TYCON_PRIM
+			mtp_mirth_tycon_Tycon_TYCONz_PRIM();
+			mp_primZ_dup();
+			mw_mirth_type_PrimType_isZ_resourceZAsk();
+			if (pop_u64()) {
+				mtw_mirth_type_Type_TPrim();
+				mtw_std_either_Either_2_Right();
+			} else {
+				mtw_mirth_type_Type_TPrim();
+				mtw_std_either_Either_2_Left();
+			}
+			break;
+		case 1LL: // TYCON_TABLE
+			mtp_mirth_tycon_Tycon_TYCONz_TABLE();
+			mtw_mirth_type_Type_TTable();
+			mtw_std_either_Either_2_Left();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -17122,6 +17195,30 @@ static void mw_mirth_arrow_Arrow_dom (void) {
 	decref(v);
 	push_value(u);
 }
+static void mw_mirth_arrow_Arrow_domZBang (void) {
+	VAL v = pop_value();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	if (VTUP(v)->refs == 1) {
+		VAL* p = &VTUP(v)->cells[5];
+		VAL t = *p; *p = u; decref(t);
+		push_value(v);
+	} else {
+		TUP *tup = tup_new(8);
+		tup->size = 8;
+		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
+		tup->cells[1] = VTUP(v)->cells[1]; incref(tup->cells[1]);
+		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
+		tup->cells[3] = VTUP(v)->cells[3]; incref(tup->cells[3]);
+		tup->cells[4] = VTUP(v)->cells[4]; incref(tup->cells[4]);
+		tup->cells[5] = u;
+		tup->cells[6] = VTUP(v)->cells[6]; incref(tup->cells[6]);
+		tup->cells[7] = VTUP(v)->cells[7]; incref(tup->cells[7]);
+		decref(v);
+		push_value(MKTUP(tup,8));
+	}
+}
 static void mw_mirth_arrow_Arrow_ctx (void) {
 	VAL v = pop_value();
 	ASSERT1(IS_TUP(v), v);
@@ -17131,6 +17228,30 @@ static void mw_mirth_arrow_Arrow_ctx (void) {
 	incref(u);
 	decref(v);
 	push_value(u);
+}
+static void mw_mirth_arrow_Arrow_ctxZBang (void) {
+	VAL v = pop_value();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 8, v);
+	if (VTUP(v)->refs == 1) {
+		VAL* p = &VTUP(v)->cells[4];
+		VAL t = *p; *p = u; decref(t);
+		push_value(v);
+	} else {
+		TUP *tup = tup_new(8);
+		tup->size = 8;
+		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
+		tup->cells[1] = VTUP(v)->cells[1]; incref(tup->cells[1]);
+		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
+		tup->cells[3] = VTUP(v)->cells[3]; incref(tup->cells[3]);
+		tup->cells[4] = u;
+		tup->cells[5] = VTUP(v)->cells[5]; incref(tup->cells[5]);
+		tup->cells[6] = VTUP(v)->cells[6]; incref(tup->cells[6]);
+		tup->cells[7] = VTUP(v)->cells[7]; incref(tup->cells[7]);
+		decref(v);
+		push_value(MKTUP(tup,8));
+	}
 }
 static void mw_mirth_arrow_Arrow_tokenZ_end (void) {
 	VAL v = pop_value();
@@ -17185,6 +17306,15 @@ static void mw_mirth_arrow_Arrow_home (void) {
 	incref(u);
 	decref(v);
 	push_value(u);
+}
+static void mw_mirth_arrow_Arrow_ctxZ_type (void) {
+	mp_primZ_dup();
+	{
+		VAL d2 = pop_value();
+		mw_mirth_arrow_Arrow_ctx();
+		push_value(d2);
+	}
+	mw_mirth_arrow_Arrow_type();
 }
 static void mw_mirth_arrow_Arrow_type (void) {
 	mp_primZ_dup();
@@ -17993,6 +18123,18 @@ static void mw_mirth_typedef_TypeDef_newZBang (void) {
 	mw_mirth_def_Def_register();
 }
 static void mw_mirth_type_PrimType_tag (void) {
+}
+static void mw_mirth_type_PrimType_isZ_resourceZAsk (void) {
+	switch (get_top_data_tag()) {
+		case 6LL: // PRIM_TYPE_WORLD
+			(void)pop_u64();
+			push_u64(1LL); // True
+			break;
+		default:
+			mp_primZ_drop();
+			push_u64(0LL); // False
+			break;
+	}
 }
 static void mw_mirth_type_PrimType_isZ_physicalZAsk (void) {
 	switch (get_top_data_tag()) {
@@ -32038,23 +32180,281 @@ static void mw_mirth_elab_abZ_buildZ_wordZ_arrowZBang_1 (void) {
 	{
 		VAL var_f = pop_value();
 		mp_primZ_dup();
-		{
-			VAL d3 = pop_value();
-			mw_mirth_word_Word_ctxZ_type();
-			push_value(d3);
+		mfld_mirth_word_Word_ZTildectxZ_type();
+		mw_mirth_mirth_Prop_1_tryZ_forceZBang();
+		switch (get_top_data_tag()) {
+			case 1LL: // Some
+				mtp_std_maybe_Maybe_1_Some();
+				mw_std_prelude_unpack2();
+				{
+					VAL d5 = pop_value();
+					mp_primZ_swap();
+					push_value(d5);
+				}
+				mp_primZ_swap();
+				mp_primZ_dup();
+				{
+					VAL d5 = pop_value();
+					mw_mirth_word_Word_body();
+					push_value(d5);
+				}
+				mtw_mirth_arrow_Home_HomeWord();
+				incref(var_f);
+				push_value(var_f);
+				mw_mirth_elab_abZ_buildZ_homZBang_1();
+				break;
+			case 0LL: // None
+				(void)pop_u64();
+				push_fnptr(&mb_mirth_elab_abZ_buildZ_wordZ_arrowZBang_1_2);
+				incref(var_f);
+				push_value(var_f);
+				mp_primZ_packZ_cons();
+				{
+					VAL var_f = pop_value();
+					mp_primZ_dup();
+					{
+						VAL d6 = pop_value();
+						incref(var_f);
+						run_value(var_f);
+						push_value(d6);
+					}
+					decref(var_f);
+				}
+				LPUSH(lbl_word);
+				LPUSH(lbl_arrow);
+				LPOP(lbl_arrow);
+				mp_primZ_dup();
+				LPUSH(lbl_arrow);
+				mw_mirth_arrow_Arrow_ctxZ_type();
+				mw_mirth_type_ArrowType_rigidifyZ_sigZBang();
+				{
+					VAL d5 = pop_value();
+					mp_primZ_dup();
+					push_value(d5);
+				}
+				mp_primZ_swap();
+				{
+					VAL d5 = pop_value();
+					mp_primZ_dup();
+					push_value(d5);
+				}
+				mp_primZ_swap();
+				mw_std_prelude_pack2();
+				LPOP(lbl_word);
+				mp_primZ_dup();
+				LPUSH(lbl_word);
+				mtw_mirth_mirth_PropLabel_WordType();
+				mw_mirth_mirth_PropLabel_prop();
+				LPOP(lbl_word);
+				mp_primZ_dup();
+				LPUSH(lbl_word);
+				mfld_mirth_word_Word_ZTildectxZ_type();
+				mp_primZ_mutZ_set();
+				push_u64(0LL); // False
+				LPOP(lbl_word);
+				mp_primZ_dup();
+				LPUSH(lbl_word);
+				mfld_mirth_word_Word_ZTildeinferringZ_typeZAsk();
+				mp_primZ_mutZ_set();
+				LPOP(lbl_word);
+				mp_primZ_drop();
+				mw_mirth_type_ArrowType_unpack();
+				LPOP(lbl_arrow);
+				mw_mirth_arrow_Arrow_codZBang();
+				mw_mirth_arrow_Arrow_domZBang();
+				mw_mirth_arrow_Arrow_ctxZBang();
+				break;
+			default:
+				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+				mp_primZ_panic();
 		}
-		mp_primZ_dup();
-		{
-			VAL d3 = pop_value();
-			mw_mirth_word_Word_body();
-			push_value(d3);
-		}
-		mtw_mirth_arrow_Home_HomeWord();
-		incref(var_f);
-		push_value(var_f);
-		mw_mirth_elab_abZ_buildZ_homZBang_1();
 		decref(var_f);
 	}
+}
+static void mw_mirth_elab_guessZ_initialZ_ctxZ_type (void) {
+	LPUSH(lbl_word);
+	mw_mirth_var_Ctx0();
+	LPUSH(lbl_ctx);
+	mw_mirth_type_MetaVar_newZBang();
+	mtw_mirth_type_StackType_STMeta();
+	LPUSH(lbl_dom);
+	mw_mirth_type_MetaVar_newZBang();
+	mtw_mirth_type_StackType_STMeta();
+	LPUSH(lbl_cod);
+	LPOP(lbl_word);
+	mp_primZ_dup();
+	LPUSH(lbl_word);
+	mw_mirth_word_Word_namespaceZ_hard();
+	switch (get_top_data_tag()) {
+		case 3LL: // NAMESPACE_TYCON
+			mtp_mirth_name_Namespace_NAMESPACEz_TYCON();
+			mw_mirth_tycon_Tycon_fullZ_typeZ_fresh();
+			LPOP(lbl_word);
+			mp_primZ_dup();
+			LPUSH(lbl_word);
+			mw_mirth_word_Word_name();
+			mw_mirth_name_Name_canZ_beZ_relativeZAsk();
+			if (pop_u64()) {
+				LPOP(lbl_dom);
+				mp_primZ_swap();
+				mw_mirth_type_TZMulZPlus();
+				LPUSH(lbl_dom);
+			} else {
+				LPOP(lbl_cod);
+				mp_primZ_swap();
+				mw_mirth_type_TZMulZPlus();
+				LPUSH(lbl_cod);
+			}
+			break;
+		case 2LL: // NAMESPACE_MODULE
+			mtp_mirth_name_Namespace_NAMESPACEz_MODULE();
+			mp_primZ_drop();
+			LPOP(lbl_word);
+			mp_primZ_dup();
+			LPUSH(lbl_word);
+			mw_mirth_word_Word_name();
+			mw_mirth_name_Name_ZToStr();
+			STRLIT("main", 4);
+			mp_primZ_strZ_cmp();
+			push_i64(0LL);
+			{
+				VAL d4 = pop_value();
+				mp_primZ_dup();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			{
+				VAL d4 = pop_value();
+				mp_primZ_dup();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			mp_primZ_intZ_eq();
+			if (pop_u64()) {
+				mp_primZ_drop();
+				mp_primZ_drop();
+				push_u64(1LL); // EQ
+			} else {
+				mp_primZ_intZ_lt();
+				if (pop_u64()) {
+					push_u64(0LL); // LT
+				} else {
+					push_u64(2LL); // GT
+				}
+			}
+			switch (get_top_data_tag()) {
+				case 0LL: // LT
+					(void)pop_u64();
+					push_u64(0LL); // False
+					break;
+				case 1LL: // EQ
+					(void)pop_u64();
+					push_u64(1LL); // True
+					break;
+				case 2LL: // GT
+					(void)pop_u64();
+					push_u64(0LL); // False
+					break;
+				default:
+					push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+					mp_primZ_panic();
+			}
+			if (pop_u64()) {
+				mw_mirth_type_T0();
+				mw_mirth_type_RESOURCEz_WORLD();
+				mw_mirth_type_TZPlus();
+				LPOP(lbl_dom);
+				mp_primZ_drop();
+				LPUSH(lbl_dom);
+				mw_mirth_type_T0();
+				mw_mirth_type_RESOURCEz_WORLD();
+				mw_mirth_type_TZPlus();
+				LPOP(lbl_cod);
+				mp_primZ_drop();
+				LPUSH(lbl_cod);
+			} else {
+			}
+			break;
+		default:
+			mp_primZ_drop();
+			break;
+	}
+	LPOP(lbl_word);
+	mp_primZ_dup();
+	LPUSH(lbl_word);
+	mw_mirth_word_Word_arity();
+	mw_std_prim_Int_ZToNat();
+	push_i64(0LL);
+	mw_std_prim_Int_ZToNat();
+	mp_primZ_swap();
+	while(1) {
+		mp_primZ_dup();
+		push_i64(0LL);
+		mp_primZ_swap();
+		mp_primZ_intZ_lt();
+		if (! pop_u64()) break;
+		{
+			VAL d3 = pop_value();
+			mp_primZ_dup();
+			{
+				VAL d4 = pop_value();
+				mp_primZ_drop();
+				LPOP(lbl_dom);
+				mw_mirth_type_MetaVar_newZBang();
+				mtw_mirth_type_StackType_STMeta();
+				mw_mirth_type_MetaVar_newZBang();
+				mtw_mirth_type_StackType_STMeta();
+				mw_mirth_type_TZ_ZTo();
+				mw_mirth_type_ArrowType_ZToType();
+				mw_mirth_type_TZMul();
+				LPUSH(lbl_dom);
+				push_value(d4);
+			}
+			push_i64(1LL);
+			mp_primZ_intZ_add();
+			push_value(d3);
+		}
+		push_i64(1LL);
+		mp_primZ_intZ_sub();
+		mw_std_prim_Int_ZToNat();
+	}
+	mp_primZ_drop();
+	mp_primZ_drop();
+	LPOP(lbl_ctx);
+	LPOP(lbl_dom);
+	LPOP(lbl_cod);
+	mw_mirth_type_TZ_ZTo();
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	mw_std_prelude_pack2();
+	LPOP(lbl_word);
+	mp_primZ_dup();
+	LPUSH(lbl_word);
+	mtw_mirth_mirth_PropLabel_WordType();
+	mw_mirth_mirth_PropLabel_prop();
+	LPOP(lbl_word);
+	mp_primZ_dup();
+	LPUSH(lbl_word);
+	mfld_mirth_word_Word_ZTildectxZ_type();
+	mp_primZ_mutZ_set();
+	push_u64(1LL); // True
+	LPOP(lbl_word);
+	mp_primZ_dup();
+	LPUSH(lbl_word);
+	mfld_mirth_word_Word_ZTildeinferringZ_typeZAsk();
+	mp_primZ_mutZ_set();
+	LPOP(lbl_word);
+	mp_primZ_drop();
 }
 static void mw_mirth_elab_abZ_buildZ_wordZBang_1 (void) {
 	{
@@ -32624,8 +33024,14 @@ static void mw_mirth_elab_elabZ_opZ_freshZ_sigZBang (void) {
 			break;
 		case 2LL: // OpWord
 			mtp_mirth_arrow_Op_OpWord();
-			mw_mirth_word_Word_type();
-			mw_mirth_type_ArrowType_freshenZ_sig();
+			mp_primZ_dup();
+			mw_mirth_word_Word_inferringZ_typeZAsk();
+			if (pop_u64()) {
+				mw_mirth_word_Word_type();
+			} else {
+				mw_mirth_word_Word_type();
+				mw_mirth_type_ArrowType_freshenZ_sig();
+			}
 			mtw_mirth_elab_OpSig_OPSIGz_APPLY();
 			break;
 		case 1LL: // OpPrim
@@ -44420,6 +44826,11 @@ static void mb_mirth_token_Token_patZ_tokens_0 (void) {
 		push_u64(1LL); // True
 	}
 }
+static void mb_mirth_data_Data_isZ_resourceZAsk_0 (void) {
+	mp_primZ_dup();
+	mw_mirth_data_Data_name();
+	mw_mirth_name_Name_couldZ_beZ_resourceZ_con();
+}
 static void mb_mirth_type_Type_isZ_physicalZAsk_0 (void) {
 	mw_mirth_type_Type_isZ_physicalZAsk();
 }
@@ -45118,11 +45529,6 @@ static void mb_mirth_data_Data_isZ_transparentZAsk_0 (void) {
 		}
 	}
 }
-static void mb_mirth_data_Data_isZ_resourceZAsk_0 (void) {
-	mp_primZ_dup();
-	mw_mirth_data_Data_name();
-	mw_mirth_name_Name_couldZ_beZ_resourceZ_con();
-}
 static void mb_mirth_data_Data_isZ_semiZ_transparentZAsk_0 (void) {
 	mp_primZ_dup();
 	mw_mirth_data_Data_tags();
@@ -45251,6 +45657,15 @@ static void mb_mirth_var_Ctx_lookup_0 (void) {
 	mp_primZ_swap();
 	mw_mirth_var_Var_name();
 	mw_mirth_name_Name_ZEqualZEqual();
+}
+static void mb_mirth_tycon_Tycon_fullZ_typeZ_fresh_1 (void) {
+	mw_mirth_type_Type_freshen();
+}
+static void mb_mirth_tycon_Tycon_fullZ_typeZ_fresh_2 (void) {
+	mw_mirth_type_Resource_freshen();
+}
+static void mb_mirth_word_Word_inferringZ_typeZAsk_0 (void) {
+	push_u64(0LL); // False
 }
 static void mb_mirth_match_Match_hasZ_defaultZ_caseZAsk_0 (void) {
 	mp_primZ_dup();
@@ -46475,6 +46890,28 @@ static void mb_mirth_elab_abZ_buildZ_homZBang_1_1 (void) {
 static void mb_mirth_elab_abZ_unifyZ_typeZBang_1 (void) {
 	mw_mirth_type_StackType_unifyZBang();
 }
+static void mb_mirth_elab_abZ_buildZ_wordZ_arrowZBang_1_2 (void) {
+	mp_primZ_packZ_uncons();
+	VAL var_f = pop_value();
+	pop_value();
+	mp_primZ_dup();
+	{
+		VAL d2 = pop_value();
+		mw_mirth_elab_guessZ_initialZ_ctxZ_type();
+		push_value(d2);
+	}
+	mp_primZ_dup();
+	{
+		VAL d2 = pop_value();
+		mw_mirth_word_Word_body();
+		push_value(d2);
+	}
+	mtw_mirth_arrow_Home_HomeWord();
+	incref(var_f);
+	push_value(var_f);
+	mw_mirth_elab_abZ_buildZ_homZBang_1();
+	decref(var_f);
+}
 static void mb_mirth_elab_abZ_buildZ_wordZBang_1_0 (void) {
 	mp_primZ_packZ_uncons();
 	VAL var_f = pop_value();
@@ -46948,17 +47385,36 @@ static void mb_mirth_elab_elabZ_aliasZBang_6 (void) {
 	mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
 }
 static void mb_mirth_elab_elabZ_defZBang_0 (void) {
+	mp_primZ_dup();
 	mw_mirth_word_Word_sig();
-	mw_std_maybe_Maybe_1_unwrap();
-	mw_mirth_elab_ZPlusTypeElab_typeZ_sigZ_startZBang();
-	mw_mirth_elab_ZPlusTypeElab_elabZ_typeZ_sigZBang();
-	{
-		VAL d2 = pop_value();
-		mw_mirth_elab_ZPlusTypeElab_ctx();
-		push_value(d2);
+	switch (get_top_data_tag()) {
+		case 1LL: // Some
+			mtp_std_maybe_Maybe_1_Some();
+			{
+				VAL d4 = pop_value();
+				mp_primZ_drop();
+				push_value(d4);
+			}
+			mw_mirth_elab_ZPlusTypeElab_typeZ_sigZ_startZBang();
+			mw_mirth_elab_ZPlusTypeElab_elabZ_typeZ_sigZBang();
+			{
+				VAL d4 = pop_value();
+				mw_mirth_elab_ZPlusTypeElab_ctx();
+				push_value(d4);
+			}
+			mw_std_prelude_pack2();
+			mw_mirth_elab_ZPlusTypeElab_rdrop();
+			break;
+		case 0LL: // None
+			(void)pop_u64();
+			mw_mirth_word_Word_arrow();
+			mw_mirth_arrow_Arrow_ctxZ_type();
+			mw_std_prelude_pack2();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primZ_panic();
 	}
-	mw_std_prelude_pack2();
-	mw_mirth_elab_ZPlusTypeElab_rdrop();
 }
 static void mb_mirth_elab_elabZ_defZBang_2 (void) {
 	mw_mirth_elab_elabZ_defZ_paramsZBang();

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -1485,13 +1485,13 @@ static VAL lbl_f = MKNIL_C;
 static VAL lbl_hasZ_paren = MKNIL_C;
 static VAL lbl_target = MKNIL_C;
 static VAL lbl_alias = MKNIL_C;
+static VAL lbl_word = MKNIL_C;
 static VAL lbl_code = MKNIL_C;
 static VAL lbl_symbol = MKNIL_C;
 static VAL lbl_extblock = MKNIL_C;
 static VAL lbl_external = MKNIL_C;
 static VAL lbl_contents = MKNIL_C;
 static VAL lbl_tbl = MKNIL_C;
-static VAL lbl_word = MKNIL_C;
 static VAL lbl_va = MKNIL_C;
 static VAL lbl_vx = MKNIL_C;
 static VAL lbl_valueZ_type = MKNIL_C;
@@ -6095,6 +6095,7 @@ static void mw_mirth_token_TokenValue_lsquareZ_openZAsk (void);
 static void mw_mirth_token_TokenValue_lsquareZAsk (void);
 static void mw_mirth_token_TokenValue_rsquareZAsk (void);
 static void mw_mirth_token_TokenValue_lcurlyZ_openZAsk (void);
+static void mw_mirth_token_TokenValue_lcurlyZAsk (void);
 static void mw_mirth_token_TokenValue_lcolonZ_openZAsk (void);
 static void mw_mirth_token_TokenValue_lcolonZAsk (void);
 static void mw_mirth_token_TokenValue_lparenZ_orZ_lcolonZAsk (void);
@@ -6137,6 +6138,7 @@ static void mw_mirth_token_Token_lsquareZ_openZAsk (void);
 static void mw_mirth_token_Token_lsquareZAsk (void);
 static void mw_mirth_token_Token_rsquareZAsk (void);
 static void mw_mirth_token_Token_lcurlyZ_openZAsk (void);
+static void mw_mirth_token_Token_lcurlyZAsk (void);
 static void mw_mirth_token_Token_lcolonZ_openZAsk (void);
 static void mw_mirth_token_Token_lcolonZAsk (void);
 static void mw_mirth_token_Token_lparenZ_orZ_lcolonZAsk (void);
@@ -6671,11 +6673,11 @@ static void mw_mirth_elab_dataZ_getZ_labelZ_type (void);
 static void mw_mirth_elab_dataZ_setZ_labelZ_type (void);
 static void mw_mirth_elab_createZ_projectorsZBang (void);
 static void mw_mirth_elab_expectZ_tokenZ_arrow (void);
-static void mw_mirth_elab_tokenZ_defZ_args (void);
 static void mw_mirth_elab_parseZ_alias (void);
 static void mw_mirth_elab_elabZ_aliasZBang (void);
 static void mw_mirth_elab_elabZ_defZ_missingZBang (void);
 static void mw_mirth_elab_elabZ_inlineZBang (void);
+static void mw_mirth_elab_parseZ_def (void);
 static void mw_mirth_elab_elabZ_defZBang (void);
 static void mw_mirth_elab_checkZ_inlineZ_recursionZ_arrowZBang (void);
 static void mw_mirth_elab_checkZ_inlineZ_recursionZ_atomZBang (void);
@@ -7420,11 +7422,11 @@ static void mb_mirth_elab_elabZ_aliasZBang_2 (void);
 static void mb_mirth_elab_elabZ_aliasZBang_3 (void);
 static void mb_mirth_elab_elabZ_aliasZBang_5 (void);
 static void mb_mirth_elab_elabZ_aliasZBang_6 (void);
+static void mb_mirth_elab_elabZ_defZBang_0 (void);
+static void mb_mirth_elab_elabZ_defZBang_2 (void);
 static void mb_mirth_elab_elabZ_defZBang_3 (void);
-static void mb_mirth_elab_elabZ_defZBang_5 (void);
-static void mb_mirth_elab_elabZ_defZBang_6 (void);
-static void mb_mirth_elab_elabZ_defZBang_7 (void);
-static void mb_mirth_elab_elabZ_defZBang_11 (void);
+static void mb_mirth_elab_elabZ_defZBang_4 (void);
+static void mb_mirth_elab_elabZ_defZBang_8 (void);
 static void mb_mirth_elab_elabZ_defZ_typeZBang_2 (void);
 static void mb_mirth_elab_elabZ_externalZBang_0 (void);
 static void mb_mirth_elab_elabZ_bufferZBang_1 (void);
@@ -7479,6 +7481,9 @@ static void mb_mirth_data_Tag_outputZ_typeZ_exceptZ_field_1 (void);
 static void mb_mirth_elab_parseZ_alias_3 (void);
 static void mb_mirth_elab_parseZ_alias_4 (void);
 static void mb_mirth_elab_elabZ_defZ_qname_0 (void);
+static void mb_mirth_elab_parseZ_def_2 (void);
+static void mb_mirth_elab_parseZ_def_3 (void);
+static void mb_mirth_elab_parseZ_def_4 (void);
 static void mb_mirth_elab_elabZ_defZ_paramsZBang_1 (void);
 static void mb_mirth_elab_elabZ_defZ_paramsZBang_5 (void);
 static void mb_mirth_elab_elabZ_defZ_bodyZBang_0 (void);
@@ -24577,6 +24582,18 @@ static void mw_mirth_token_TokenValue_lcurlyZ_openZAsk (void) {
 			break;
 	}
 }
+static void mw_mirth_token_TokenValue_lcurlyZAsk (void) {
+	switch (get_top_data_tag()) {
+		case 9LL: // TokenLCurly
+			mtp_mirth_token_TokenValue_TokenLCurly();
+			mtw_std_maybe_Maybe_1_Some();
+			break;
+		default:
+			mp_primZ_drop();
+			push_u64(0LL); // None
+			break;
+	}
+}
 static void mw_mirth_token_TokenValue_lcolonZ_openZAsk (void) {
 	switch (get_top_data_tag()) {
 		case 11LL: // TokenLColonOpen
@@ -24962,6 +24979,10 @@ static void mw_mirth_token_Token_rsquareZAsk (void) {
 static void mw_mirth_token_Token_lcurlyZ_openZAsk (void) {
 	mw_mirth_token_Token_value();
 	mw_mirth_token_TokenValue_lcurlyZ_openZAsk();
+}
+static void mw_mirth_token_Token_lcurlyZAsk (void) {
+	mw_mirth_token_Token_value();
+	mw_mirth_token_TokenValue_lcurlyZAsk();
 }
 static void mw_mirth_token_Token_lcolonZ_openZAsk (void) {
 	mw_mirth_token_Token_value();
@@ -34169,7 +34190,6 @@ static void mw_mirth_elab_elabZ_dataZ_headerZBang (void) {
 		STRLIT("Expected type name.", 19);
 		mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
 	}
-	LPOP(lbl_head);
 	mw_mirth_elab_elabZ_defZ_head();
 	LPOP(lbl_head);
 	mp_primZ_dup();
@@ -34815,38 +34835,6 @@ static void mw_mirth_elab_expectZ_tokenZ_arrow (void) {
 		mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
 	}
 }
-static void mw_mirth_elab_tokenZ_defZ_args (void) {
-	mp_primZ_dup();
-	mw_mirth_token_Token_args();
-	mp_primZ_dup();
-	mw_std_list_List_1_len();
-	push_i64(3LL);
-	mw_std_prim_Int_ZToNat();
-	{
-		VAL d2 = pop_value();
-		push_value(d2);
-	}
-	mp_primZ_intZ_lt();
-	if (pop_u64()) {
-		mp_primZ_drop();
-		STRLIT("def expects at least three arguments", 36);
-		mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
-	} else {
-	}
-	{
-		VAL d2 = pop_value();
-		mp_primZ_drop();
-		push_value(d2);
-	}
-	mw_std_list_List_1_ZToListZPlus();
-	mw_std_maybe_Maybe_1_unwrap();
-	mw_std_list_ListZPlus_1_uncons();
-	mw_std_list_List_1_ZToListZPlus();
-	mw_std_maybe_Maybe_1_unwrap();
-	mw_std_list_ListZPlus_1_uncons();
-	mw_std_list_List_1_ZToListZPlus();
-	mw_std_maybe_Maybe_1_unwrap();
-}
 static void mw_mirth_elab_parseZ_alias (void) {
 	mp_primZ_dup();
 	mw_mirth_token_Token_succ();
@@ -34928,7 +34916,6 @@ static void mw_mirth_elab_parseZ_alias (void) {
 }
 static void mw_mirth_elab_elabZ_aliasZBang (void) {
 	mw_mirth_elab_parseZ_alias();
-	LPOP(lbl_head);
 	mw_mirth_elab_elabZ_defZ_head();
 	mw_mirth_alias_Alias_newZBang();
 	mp_primZ_dup();
@@ -35014,14 +35001,93 @@ static void mw_mirth_elab_elabZ_inlineZBang (void) {
 	mp_primZ_drop();
 	mw_mirth_mirth_ZPlusMirth_preferZ_inlineZ_defsZBang();
 }
-static void mw_mirth_elab_elabZ_defZBang (void) {
+static void mw_mirth_elab_parseZ_def (void) {
 	mp_primZ_dup();
-	{
-		VAL d2 = pop_value();
+	mw_mirth_token_Token_args();
+	mw_std_list_List_1_emptyZAsk();
+	if (pop_u64()) {
 		mw_mirth_token_Token_next();
-		push_value(d2);
+		mp_primZ_dup();
+		LPUSH(lbl_head);
+		mw_mirth_token_Token_next();
+		mp_primZ_dup();
+		mw_mirth_token_Token_lsquareZAsk();
+		push_fnptr(&mb_mirth_elab_parseZ_def_2);
+		push_fnptr(&mb_mirth_elab_parseZ_def_3);
+		mw_std_maybe_Maybe_1_if_2();
+		mp_primZ_dup();
+		mw_mirth_token_Token_lcurlyZAsk();
+		push_fnptr(&mb_mirth_elab_parseZ_def_4);
+		mw_std_maybe_Maybe_1_else_1();
+		mp_primZ_dup();
+		mw_mirth_token_Token_argsZPlus();
+		LPUSH(lbl_body);
+		mw_mirth_token_Token_next();
+	} else {
+		mp_primZ_dup();
+		{
+			VAL d3 = pop_value();
+			mw_mirth_token_Token_next();
+			push_value(d3);
+		}
+		mp_primZ_dup();
+		mw_mirth_token_Token_args();
+		mp_primZ_dup();
+		mw_std_list_List_1_len();
+		push_i64(3LL);
+		mw_std_prim_Int_ZToNat();
+		{
+			VAL d3 = pop_value();
+			push_value(d3);
+		}
+		mp_primZ_intZ_lt();
+		if (pop_u64()) {
+			mp_primZ_drop();
+			STRLIT("def(...) expects at least three arguments", 41);
+			mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+		} else {
+		}
+		{
+			VAL d3 = pop_value();
+			mp_primZ_drop();
+			push_value(d3);
+		}
+		mw_std_list_List_1_ZToListZPlus();
+		mw_std_maybe_Maybe_1_unwrap();
+		mw_std_list_ListZPlus_1_uncons();
+		{
+			VAL d3 = pop_value();
+			LPUSH(lbl_head);
+			push_value(d3);
+		}
+		mw_std_list_List_1_ZToListZPlus();
+		mw_std_maybe_Maybe_1_unwrap();
+		mw_std_list_ListZPlus_1_uncons();
+		{
+			VAL d3 = pop_value();
+			mtw_std_maybe_Maybe_1_Some();
+			LPUSH(lbl_sig);
+			push_value(d3);
+		}
+		mw_std_list_List_1_ZToListZPlus();
+		mw_std_maybe_Maybe_1_unwrap();
+		LPUSH(lbl_body);
+		LPOP(lbl_head);
+		mp_primZ_dup();
+		LPUSH(lbl_head);
+		mw_mirth_token_Token_next();
+		mw_mirth_token_Token_argZ_endZAsk();
+		if (pop_u64()) {
+		} else {
+			LPOP(lbl_head);
+			mp_primZ_dup();
+			LPUSH(lbl_head);
+			mw_mirth_token_Token_next();
+			STRLIT("expected comma after word name", 30);
+			mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+		}
 	}
-	mw_mirth_elab_tokenZ_defZ_args();
+	LPOP(lbl_body);
 	mw_std_list_ListZPlus_1_uncons();
 	mw_std_list_List_1_emptyZAsk();
 	if (pop_u64()) {
@@ -35037,65 +35103,73 @@ static void mw_mirth_elab_elabZ_defZBang (void) {
 		mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
 	}
 	LPUSH(lbl_body);
-	mtw_std_maybe_Maybe_1_Some();
-	LPUSH(lbl_sig);
+}
+static void mw_mirth_elab_elabZ_defZBang (void) {
+	mw_mirth_elab_parseZ_def();
 	mw_mirth_elab_elabZ_defZ_head();
 	mw_mirth_word_Word_newZBang();
+	LPUSH(lbl_word);
+	LPOP(lbl_word);
 	mp_primZ_dup();
+	LPUSH(lbl_word);
 	mtw_mirth_mirth_PropLabel_WordQName();
 	LPUSH(lbl_label);
 	mtw_mirth_mirth_Prop_1_Prop();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
+	LPOP(lbl_word);
+	mp_primZ_dup();
+	LPUSH(lbl_word);
 	mfld_mirth_word_Word_ZTildeqname();
 	mp_primZ_mutZ_set();
 	mw_mirth_mirth_ZPlusMirth_preferZ_inlineZ_defs();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
+	LPOP(lbl_word);
+	mp_primZ_dup();
+	LPUSH(lbl_word);
 	mfld_mirth_word_Word_ZTildepreferZ_inlineZAsk();
 	mp_primZ_mutZ_set();
+	LPOP(lbl_word);
 	mp_primZ_dup();
+	LPUSH(lbl_word);
+	LPOP(lbl_word);
 	mp_primZ_dup();
+	LPUSH(lbl_word);
 	mtw_mirth_mirth_PropLabel_WordType();
-	push_fnptr(&mb_mirth_elab_elabZ_defZBang_3);
+	push_fnptr(&mb_mirth_elab_elabZ_defZBang_0);
 	mw_mirth_mirth_PropLabel_prop_1();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
+	LPOP(lbl_word);
+	mp_primZ_dup();
+	LPUSH(lbl_word);
 	mfld_mirth_word_Word_ZTildectxZ_type();
 	mp_primZ_mutZ_set();
+	LPOP(lbl_word);
 	mp_primZ_dup();
+	LPUSH(lbl_word);
+	LPOP(lbl_word);
 	mp_primZ_dup();
+	LPUSH(lbl_word);
 	mtw_mirth_mirth_PropLabel_WordParams();
-	push_fnptr(&mb_mirth_elab_elabZ_defZBang_5);
+	push_fnptr(&mb_mirth_elab_elabZ_defZBang_2);
 	mw_mirth_mirth_PropLabel_prop_1();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
+	LPOP(lbl_word);
+	mp_primZ_dup();
+	LPUSH(lbl_word);
 	mfld_mirth_word_Word_ZTildeparams();
 	mp_primZ_mutZ_set();
+	LPOP(lbl_word);
 	mp_primZ_dup();
+	LPUSH(lbl_word);
+	LPOP(lbl_word);
 	mp_primZ_dup();
+	LPUSH(lbl_word);
 	mtw_mirth_mirth_PropLabel_WordArrow();
-	push_fnptr(&mb_mirth_elab_elabZ_defZBang_6);
+	push_fnptr(&mb_mirth_elab_elabZ_defZBang_3);
 	mw_mirth_mirth_PropLabel_prop_1();
-	mp_primZ_swap();
+	LPOP(lbl_word);
+	mp_primZ_dup();
+	LPUSH(lbl_word);
 	mfld_mirth_word_Word_ZTildearrow();
 	mp_primZ_mutZ_set();
+	LPOP(lbl_word);
+	mp_primZ_drop();
 }
 static void mw_mirth_elab_checkZ_inlineZ_recursionZ_arrowZBang (void) {
 	mw_mirth_arrow_Arrow_atoms();
@@ -35331,7 +35405,6 @@ static void mw_mirth_elab_elabZ_externalZ_blockZ_partZBang (void) {
 	}
 }
 static void mw_mirth_elab_elabZ_externalZ_defZBang (void) {
-	LPOP(lbl_head);
 	mw_mirth_elab_elabZ_defZ_head();
 	LPOP(lbl_symbol);
 	push_fnptr(&mb_mirth_elab_elabZ_externalZ_defZBang_0);
@@ -35442,7 +35515,6 @@ static void mw_mirth_elab_elabZ_defZ_typeZBang (void) {
 		STRLIT("expected type constructor", 25);
 		mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
 	}
-	LPOP(lbl_head);
 	mw_mirth_elab_elabZ_defZ_head();
 	LPOP(lbl_head);
 	mtw_std_maybe_Maybe_1_Some();
@@ -35533,16 +35605,23 @@ static void mw_mirth_elab_elabZ_tableZBang (void) {
 		push_value(d2);
 	}
 	mw_mirth_token_Token_argsZ_1();
+	LPUSH(lbl_head);
+	LPOP(lbl_head);
 	mp_primZ_dup();
+	LPUSH(lbl_head);
 	mw_mirth_token_Token_sigZ_typeZ_conZAsk();
 	if (pop_u64()) {
 	} else {
 		STRLIT("expected type name", 18);
 		mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
 	}
+	LPOP(lbl_head);
 	mp_primZ_dup();
+	LPUSH(lbl_head);
 	mw_mirth_token_Token_argsZ_0();
+	LPOP(lbl_head);
 	mp_primZ_dup();
+	LPUSH(lbl_head);
 	mw_mirth_token_Token_succ();
 	mw_mirth_token_Token_argZ_endZAsk();
 	if (pop_u64()) {
@@ -35597,6 +35676,7 @@ static void mw_mirth_elab_elabZ_embedZ_strZBang (void) {
 	}
 	mw_mirth_token_Token_argsZ_2();
 	mp_primZ_swap();
+	LPUSH(lbl_head);
 	mw_mirth_elab_elabZ_defZ_head();
 	LPOP(lbl_arity);
 	mp_primZ_dup();
@@ -36173,9 +36253,9 @@ static void mw_mirth_elab_elabZ_defZ_qnameZ_undefined (void) {
 	}
 }
 static void mw_mirth_elab_elabZ_defZ_head (void) {
+	LPOP(lbl_head);
 	mp_primZ_dup();
 	LPUSH(lbl_head);
-	mp_primZ_dup();
 	mw_mirth_token_Token_nameZ_orZ_dnameZAsk();
 	push_fnptr(&mb_mirth_elab_elabZ_defZ_head_0);
 	mw_std_maybe_Maybe_1_unwrapZ_or_1();
@@ -36183,9 +36263,14 @@ static void mw_mirth_elab_elabZ_defZ_head (void) {
 	push_fnptr(&mb_mirth_elab_elabZ_defZ_head_2);
 	mw_std_either_Either_2_either_2();
 	LPUSH(lbl_name);
+	LPOP(lbl_head);
 	mp_primZ_dup();
+	LPUSH(lbl_head);
 	mw_mirth_token_Token_numZ_args();
 	LPUSH(lbl_arity);
+	LPOP(lbl_head);
+	mp_primZ_dup();
+	LPUSH(lbl_head);
 	push_fnptr(&mb_mirth_elab_elabZ_defZ_head_3);
 	mtw_mirth_mirth_PropState_1_PSDelay();
 	LPUSH(lbl_state);
@@ -36214,7 +36299,6 @@ static void mw_mirth_elab_parseZ_field (void) {
 }
 static void mw_mirth_elab_elabZ_fieldZBang (void) {
 	mw_mirth_elab_parseZ_field();
-	LPOP(lbl_head);
 	mw_mirth_elab_elabZ_defZ_head();
 	mw_mirth_table_Field_allocZBang();
 	LPUSH(lbl_fld);
@@ -46863,7 +46947,7 @@ static void mb_mirth_elab_elabZ_aliasZBang_6 (void) {
 	STRLIT("Alias points to itself, circular aliases are not allowed.", 57);
 	mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
 }
-static void mb_mirth_elab_elabZ_defZBang_3 (void) {
+static void mb_mirth_elab_elabZ_defZBang_0 (void) {
 	mw_mirth_word_Word_sig();
 	mw_std_maybe_Maybe_1_unwrap();
 	mw_mirth_elab_ZPlusTypeElab_typeZ_sigZ_startZBang();
@@ -46876,13 +46960,13 @@ static void mb_mirth_elab_elabZ_defZBang_3 (void) {
 	mw_std_prelude_pack2();
 	mw_mirth_elab_ZPlusTypeElab_rdrop();
 }
-static void mb_mirth_elab_elabZ_defZBang_5 (void) {
+static void mb_mirth_elab_elabZ_defZBang_2 (void) {
 	mw_mirth_elab_elabZ_defZ_paramsZBang();
 }
-static void mb_mirth_elab_elabZ_defZBang_6 (void) {
+static void mb_mirth_elab_elabZ_defZBang_3 (void) {
 	mp_primZ_dup();
 	mp_primZ_dup();
-	push_fnptr(&mb_mirth_elab_elabZ_defZBang_7);
+	push_fnptr(&mb_mirth_elab_elabZ_defZBang_4);
 	mw_mirth_elab_abZ_buildZ_wordZ_arrowZBang_1();
 	mp_primZ_dup();
 	{
@@ -46892,7 +46976,7 @@ static void mb_mirth_elab_elabZ_defZBang_6 (void) {
 	}
 	mw_mirth_elab_checkZ_inlineZ_recursionZ_arrowZBang();
 }
-static void mb_mirth_elab_elabZ_defZBang_7 (void) {
+static void mb_mirth_elab_elabZ_defZBang_4 (void) {
 	mp_primZ_swap();
 	{
 		VAL d2 = pop_resource();
@@ -46905,11 +46989,11 @@ static void mb_mirth_elab_elabZ_defZBang_7 (void) {
 		mp_primZ_drop();
 		mw_mirth_elab_elabZ_defZ_bodyZBang();
 	} else {
-		push_fnptr(&mb_mirth_elab_elabZ_defZBang_11);
+		push_fnptr(&mb_mirth_elab_elabZ_defZBang_8);
 		mw_mirth_elab_abZ_lambdaZBang_1();
 	}
 }
-static void mb_mirth_elab_elabZ_defZBang_11 (void) {
+static void mb_mirth_elab_elabZ_defZBang_8 (void) {
 	mw_mirth_elab_elabZ_defZ_bodyZBang();
 }
 static void mb_mirth_elab_elabZ_defZ_typeZBang_2 (void) {
@@ -47299,6 +47383,9 @@ static void mb_mirth_elab_elabZ_dataZ_doneZBang_11 (void) {
 	decref(var_dat);
 }
 static void mb_mirth_elab_elabZ_defZ_head_0 (void) {
+	LPOP(lbl_head);
+	mp_primZ_dup();
+	LPUSH(lbl_head);
 	STRLIT("expected name", 13);
 	mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
 }
@@ -47872,6 +47959,21 @@ static void mb_mirth_elab_parseZ_alias_4 (void) {
 }
 static void mb_mirth_elab_elabZ_defZ_qname_0 (void) {
 	STRLIT("expected name", 13);
+	mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+}
+static void mb_mirth_elab_parseZ_def_2 (void) {
+	mp_primZ_dup();
+	mw_mirth_token_Token_argsZ_1();
+	mtw_std_maybe_Maybe_1_Some();
+	LPUSH(lbl_sig);
+	mw_mirth_token_Token_next();
+}
+static void mb_mirth_elab_parseZ_def_3 (void) {
+	push_u64(0LL); // None
+	LPUSH(lbl_sig);
+}
+static void mb_mirth_elab_parseZ_def_4 (void) {
+	STRLIT("expected { ... }", 16);
 	mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
 }
 static void mb_mirth_elab_elabZ_defZ_paramsZBang_1 (void) {

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -36018,6 +36018,9 @@ static void mw_mirth_elab_elabZ_tableZBang (void) {
 	mw_mirth_token_Token_sigZ_typeZ_conZAsk();
 	if (pop_u64()) {
 	} else {
+		LPOP(lbl_head);
+		mp_primZ_dup();
+		LPUSH(lbl_head);
 		STRLIT("expected type name", 18);
 		mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
 	}
@@ -36032,6 +36035,9 @@ static void mw_mirth_elab_elabZ_tableZBang (void) {
 	mw_mirth_token_Token_argZ_endZAsk();
 	if (pop_u64()) {
 	} else {
+		LPOP(lbl_head);
+		mp_primZ_dup();
+		LPUSH(lbl_head);
 		mw_mirth_token_Token_succ();
 		STRLIT("expected end of argument after table name", 41);
 		mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();

--- a/src/arrow.mth
+++ b/src/arrow.mth
@@ -87,6 +87,7 @@ data(Arrow, Arrow ->
     dom:StackType
     cod:StackType
     atoms:List(Atom))
+def(Arrow.ctx-type, Arrow -- Ctx ArrowType, sip(ctx) type)
 def(Arrow.type, Arrow -- ArrowType, sip(dom) cod T->)
 
 data(Atom, Atom ->

--- a/src/elab.mth
+++ b/src/elab.mth
@@ -1102,7 +1102,7 @@ def(elab-data-header!, Data Token +Mirth -- Data +Mirth,
     >head >data
     @head last-name? and-some(could-be-type-or-resource-con)
         else(@head "Expected type name." emit-fatal-error!)
-    head> elab-def-head
+    elab-def-head
     @head Some @data ~head? !
     arity> @data ~arity !
     name> @data ~name !
@@ -1345,16 +1345,6 @@ def(create-projectors!, +Mirth Tag -- +Mirth,
 def(expect-token-arrow, +Mirth Token -- +Mirth Token,
     dup pat-arrow? else("Expected arrow." emit-fatal-error!))
 
-||| Break apart the arguments for `def` into three categories:
-|||     - head: the name of the definition, plus params
-|||     - sig: the type signature
-|||     - body: a nonempty list of body arguments
-def(token-def-args, +Mirth Token -- +Mirth Token Token List+(Token),
-    dup args dup len 3 >Nat < then(drop "def expects at least three arguments" emit-fatal-error!) nip
-    >List+ unwrap uncons
-    >List+ unwrap uncons
-    >List+ unwrap)
-
 ||| Parse an alias declaration.
 ||| Either `alias(head, target)` or `alias head target`.
 ||| Both `head` and `target` are names (or dnames), with `head` taking
@@ -1376,7 +1366,7 @@ def(parse-alias, +Mirth Token -- +Mirth Token head:Token target:Token,
 
 ||| Elaborate an alias declaration.
 def(elab-alias!, +Mirth Token -- +Mirth Token,
-    parse-alias head> elab-def-head Alias.new!
+    parse-alias elab-def-head Alias.new!
     dup AliasQName >label Prop over ~qname !
 
     target> over dup AliasTarget prop2(
@@ -1418,32 +1408,66 @@ def(elab-inline!, Token +World +Mirth -- Token +World +Mirth,
     while(dup arg-end? not, elab-module-decl!)
     drop prefer-inline-defs!)
 
+||| Parse a word definition! It will look like one of these:
+|||
+|||     def(word, sig, body...)
+|||     def word [ sig ] { body... }
+|||     def word { body... }
+|||
+||| Returns the next token after the definition.
+def parse-def [ +Mirth Token -- +Mirth Token
+                head: Token sig: Maybe(Token) body: Token ]
+{
+    dup args empty? if(
+        next
+        dup >head next
+        dup lsquare? if(dup args-1 Some >sig next, None >sig)
+        dup lcurly? else("expected { ... }" emit-fatal-error!)
+        dup args+ >body
+        next,
+
+        sip(next)
+        dup args dup len 3 >Nat <
+            then(drop
+                 "def(...) expects at least three arguments"
+                 emit-fatal-error!)
+            nip
+        >List+ unwrap uncons dip(>head)
+        >List+ unwrap uncons dip(Some >sig)
+        >List+ unwrap >body
+
+        @head next arg-end? else(
+            @head next "expected comma after word name" emit-fatal-error!
+        )
+    )
+    body> uncons empty? or(dup run-arrow? >Bool)
+        else("expected match case" emit-fatal-error!) >body
+}
+
 ||| Elaborate a word definition `def(w, t, b...)`.
 def(elab-def!, +Mirth Token -- +Mirth Token,
-    sip(next) token-def-args
-    uncons empty? or(dup run-arrow? >Bool) else("expected match case" emit-fatal-error!) >body
-    Some >sig
-    elab-def-head Word.new!
-    dup WordQName >label Prop over ~qname !
+    parse-def elab-def-head Word.new! >word
+    @word WordQName >label Prop @word ~qname !
 
-    prefer-inline-defs over ~prefer-inline? !
+    prefer-inline-defs @word ~prefer-inline? !
 
-    dup dup WordType prop(
+    @word @word WordType prop(
         sig unwrap
         +TypeElab.type-sig-start!
         elab-type-sig!
         dip:ctx pack2
         rdrop
-    ) over ~ctx-type !
-    dup dup WordParams prop(elab-def-params!) over ~params !
-    dup dup WordArrow prop(
+    ) @word ~ctx-type !
+    @word @word WordParams prop(elab-def-params!) @word ~params !
+    @word @word WordArrow prop(
         dup dup ab-build-word-arrow!(
             swap rdip:params dup empty? if(
                 drop elab-def-body!,
                 ab-lambda!(elab-def-body!)
             )
         ) tuck check-inline-recursion-arrow!
-    ) swap ~arrow !)
+    ) @word ~arrow !
+    word> drop)
 
 def(check-inline-recursion-arrow!, +Mirth Word Arrow -- +Mirth,
     atoms for(dip:dup check-inline-recursion-atom!) drop)
@@ -1565,7 +1589,7 @@ def(elab-external-block-part!, +Mirth ExternalDeclPart -- +Mirth ExternalBlockPa
     EDPDef -> elab-external-def! EBPDef)
 
 def(elab-external-def!, +Mirth head:Token symbol:Maybe(Token) sig:Token -- +Mirth External,
-    head> elab-def-head
+    elab-def-head
 
     symbol> if-some(name? unwrap, @name) >Str >symbol
 
@@ -1608,7 +1632,7 @@ def(elab-def-type!, +Mirth Token -- +Mirth Token,
     sip(next) args-2 >target >head
     @head args-0
     @head sig-type-con? else("expected type constructor" emit-fatal-error!)
-    head> elab-def-head @head:Some
+    elab-def-head @head:Some
     arity> drop
     TypeDef.new!
     target> over TypeDefTarget prop(elab-simple-type-arg!) swap ~target !)
@@ -1629,10 +1653,10 @@ def(elab-variable!, +Mirth Token -- +Mirth Token,
 
 ||| Elaborate a table definition `table(True)`.
 def(elab-table!, +Mirth Token -- +Mirth Token,
-    sip(next) args-1
-    dup sig-type-con? else("expected type name" emit-fatal-error!)
-    dup args-0
-    dup succ arg-end? else(succ "expected end of argument after table name" emit-fatal-error!)
+    sip(next) args-1 >head
+    @head sig-type-con? else("expected type name" emit-fatal-error!)
+    @head args-0
+    @head succ arg-end? else(succ "expected end of argument after table name" emit-fatal-error!)
     elab-def-head
     arity> drop
     table-new! drop)
@@ -1655,7 +1679,7 @@ def(elab-entry-point, QName +Mirth -- Arrow +Mirth,
 ||| The path is relative to compiler's cwd, not source root.
 def(elab-embed-str!, Token +World +Mirth -- Token +World +Mirth,
     sip:next args-2 swap
-    elab-def-head
+    >head elab-def-head
     @arity 0= else(@head "expected no arguments" emit-fatal-error!)
     dup >body None >sig
     dup str? unwrap-or("expected source path" emit-fatal-error!)
@@ -1914,14 +1938,13 @@ def(elab-def-qname-undefined, +Mirth Token -- +Mirth QName,
 ||| We defer the full resolution of the qualified name, but otherwise
 ||| we collect arity and (simple) name data from the head token.
 def(elab-def-head,
-        +Mirth Token --
+        +Mirth head:Token --
         +Mirth head:Token name:Name arity:Int state:PropState(QName),
-    dup >head
-    dup name-or-dname?
-        unwrap-or("expected name" emit-fatal-error!)
+    @head name-or-dname?
+        unwrap-or(@head "expected name" emit-fatal-error!)
         either(id, parts last) >name
-    dup num-args >arity
-    [elab-def-qname-undefined] PSDelay >state)
+    @head num-args >arity
+    @head [elab-def-qname-undefined] PSDelay >state)
 
 ||| Parse a field definition, `field(f, T1, T2)`
 def(parse-field,
@@ -1933,7 +1956,7 @@ def(parse-field,
 
 ||| Elaborate a field definition `field(f, T1, T2)`.
 def(elab-field!, +Mirth Token -- +Mirth Token,
-    parse-field head> elab-def-head
+    parse-field elab-def-head
     Field.alloc! >fld
     name> @fld ~name !
     head> @fld ~head !

--- a/src/elab.mth
+++ b/src/elab.mth
@@ -508,8 +508,66 @@ def(ab-build-hom!(f), (*a StackType +Mirth +AB -- *b StackType +Mirth +AB)
         *a Ctx ArrowType Token Home +Mirth -- *b Arrow +Mirth,
     dip2(unpack rotr)
     ab-build!(f ab-unify-type!))
+
+||| Build the arrow for a word. If the word type and context are available, use that.
+||| Otherwise, we are in a situation where type and context were not given, so we infer them.
+|||
+||| To infer ctx-type, we start with an initial guess based on the word head (with lots
+||| of metavariables). We temporarily set that as our ctx-type. Then we elaborate the word
+||| body. After elaboration, we rigidify the type to obtain a generalized definition, by
+||| replacing any free metavariables with universally quantified variables.
 def(ab-build-word-arrow!(f), (*a StackType +Mirth +AB -- *b StackType +Mirth +AB) *a Word +Mirth -- *b Arrow +Mirth,
-    sip(ctx-type) sip(body) HomeWord ab-build-hom!(f))
+    dup ~ctx-type try-force! match(
+        Some ->
+            unpack2 rotl sip(body) HomeWord ab-build-hom!(f),
+        None ->
+            sip(
+                sip(guess-initial-ctx-type)
+                sip(body) HomeWord ab-build-hom!(f)
+            )
+            >word >arrow
+
+            @arrow Arrow.ctx-type rigidify-sig!
+
+            dup2 pack2 @word WordType prop @word ~ctx-type !
+            False @word ~inferring-type? !
+            word> drop
+
+            unpack arrow> cod! dom! ctx!
+    ))
+
+def(guess-initial-ctx-type, +Mirth Word -- +Mirth Ctx ArrowType,
+    >word
+    Ctx0 >ctx
+    MetaVar.new! STMeta >dom
+    MetaVar.new! STMeta >cod
+    @word namespace-hard match(
+        NAMESPACE_TYCON ->
+            full-type-fresh
+            @word name can-be-relative? if(
+                @dom(swap T*+),
+                @cod(swap T*+)
+            ),
+        NAMESPACE_MODULE ->
+            drop
+            @word name >Str "main" == then(
+                T0 RESOURCE_WORLD T+ !dom
+                T0 RESOURCE_WORLD T+ !cod
+            ),
+        _ ->
+            drop
+    )
+    @word arity >Nat count(
+        drop @dom(
+            MetaVar.new! STMeta
+            MetaVar.new! STMeta T-> >Type T*
+        )
+    )
+    ctx> dom> cod> T->
+    dup2 pack2 @word WordType prop @word ~ctx-type !
+    True @word ~inferring-type? !
+    word> drop)
+
 def(ab-build-word!(f), (*a +Mirth +AB -- *b +Mirth +AB) *a Word +Mirth -- *b Word +Mirth,
     sip(ab-build-word-arrow!(dip(f))) sip(WordArrow prop)
     tuck ~arrow !)
@@ -659,7 +717,7 @@ def(elab-op-fresh-sig!, +Mirth Op -- +Mirth Subst OpSig,
         OpBuffer -> drop TYPE_PTR OPSIG_PUSH,
         OpVariable -> type TMut OPSIG_PUSH,
         OpTag -> type freshen-sig OPSIG_APPLY,
-        OpWord -> type freshen-sig OPSIG_APPLY,
+        OpWord -> dup inferring-type? if(type, type freshen-sig) OPSIG_APPLY,
         OpPrim -> type freshen-sig OPSIG_APPLY,
         OpExternal -> type freshen-sig OPSIG_APPLY,
         OpField -> type freshen-sig OPSIG_APPLY,
@@ -1452,11 +1510,16 @@ def(elab-def!, +Mirth Token -- +Mirth Token,
     prefer-inline-defs @word ~prefer-inline? !
 
     @word @word WordType prop(
-        sig unwrap
-        +TypeElab.type-sig-start!
-        elab-type-sig!
-        dip:ctx pack2
-        rdrop
+        dup sig match(
+            Some ->
+                nip
+                +TypeElab.type-sig-start!
+                elab-type-sig!
+                dip:ctx pack2
+                rdrop,
+            None ->
+                arrow ctx-type pack2
+        )
     ) @word ~ctx-type !
     @word @word WordParams prop(elab-def-params!) @word ~params !
     @word @word WordArrow prop(

--- a/src/elab.mth
+++ b/src/elab.mth
@@ -1717,9 +1717,9 @@ def(elab-variable!, +Mirth Token -- +Mirth Token,
 ||| Elaborate a table definition `table(True)`.
 def(elab-table!, +Mirth Token -- +Mirth Token,
     sip(next) args-1 >head
-    @head sig-type-con? else("expected type name" emit-fatal-error!)
+    @head sig-type-con? else(@head "expected type name" emit-fatal-error!)
     @head args-0
-    @head succ arg-end? else(succ "expected end of argument after table name" emit-fatal-error!)
+    @head succ arg-end? else(@head succ "expected end of argument after table name" emit-fatal-error!)
     elab-def-head
     arity> drop
     table-new! drop)

--- a/src/tycon.mth
+++ b/src/tycon.mth
@@ -2,6 +2,7 @@ module(mirth.tycon)
 
 import(std.prelude)
 import(std.maybe)
+import(std.either)
 
 import(mirth.name)
 import(mirth.data)
@@ -36,3 +37,8 @@ def(Tycon.>Type, Tycon -- Type,
     TYCON_DATA -> TData,
     TYCON_TABLE -> TTable,
     TYCON_PRIM -> TPrim)
+
+def(Tycon.full-type-fresh, +Mirth Tycon -- +Mirth Type/Resource,
+    TYCON_DATA -> dip:SUBST_NIL full-type map(freshen, freshen) nip,
+    TYCON_PRIM -> dup is-resource? if(TPrim Resource Right, TPrim Left),
+    TYCON_TABLE -> TTable Left)

--- a/src/type.mth
+++ b/src/type.mth
@@ -51,6 +51,11 @@ data(PrimType,
     PRIM_TYPE_WORLD,
     )
 
+def PrimType.is-resource? [ PrimType -- Bool ] {
+    PRIM_TYPE_WORLD -> True,
+    _ -> drop False
+}
+
 def(PrimType.is-physical?, PrimType -- Bool,
     PRIM_TYPE_TYPE -> False,
     PRIM_TYPE_STACK -> False,

--- a/src/word.mth
+++ b/src/word.mth
@@ -24,6 +24,7 @@ field(Word.~params, Word, Prop(List(Var)))
 field(Word.~arrow, Word, Prop(Arrow))
 field(Word.~prefer-inline?, Word, Bool)
 field(Word.~cname, Word, Str)
+field(Word.~inferring-type?, Word, Bool)
 
 def(Word.qname-soft, Word -- Maybe(QName), ~qname @? bind(ready?))
 def(Word.qname-hard, Word +Mirth -- QName +Mirth, ~qname force!)
@@ -36,6 +37,8 @@ def(Word.body, Word -- Token, ~body @)
 def(Word.arity, Word -- Int, ~arity @)
 def(Word.params, Word +Mirth -- List(Var) +Mirth, ~params force!)
 def(Word.arrow, Word +Mirth -- Arrow +Mirth, ~arrow force!)
+def(Word.inferring-type?, Word -- Bool,
+    ~inferring-type? @? unwrap-or(False))
 
 def(Word.cname, Word +Mirth -- Str +Mirth,
     dup ~cname memoize(

--- a/test/def-syntax.mth
+++ b/test/def-syntax.mth
@@ -5,11 +5,14 @@ import(std.maybe)
 import(std.world)
 
 def square [ Int -- Int ] { dup * }
+
 def my-map(f) [ (a -- b) Maybe(a) -- Maybe(b) ] {
     None -> None,
     Some -> f Some,
 }
+
 def noop [--] {}
+
 def main [+World -- +World] {
     "hello" print
 }

--- a/test/def-syntax.mth
+++ b/test/def-syntax.mth
@@ -1,0 +1,17 @@
+module(test.def-syntax)
+
+import(std.prelude)
+import(std.maybe)
+import(std.world)
+
+def square [ Int -- Int ] { dup * }
+def my-map(f) [ (a -- b) Maybe(a) -- Maybe(b) ] {
+    None -> None,
+    Some -> f Some,
+}
+def noop [--] {}
+def main [+World -- +World] {
+    "hello" print
+}
+
+# mirth-test # pout # hello

--- a/test/error-def-expects-three-arguments.mth
+++ b/test/error-def-expects-three-arguments.mth
@@ -1,4 +1,4 @@
 module(mirth-tests.error-def-expects-three-arguments)
 def(main, --, )
-# mirth-test # merr # 2:1: error: def expects at least three arguments
+# mirth-test # merr # 2:1: error: def(...) expects at least three arguments
 # mirth-test # mret # 1

--- a/test/type-inference.mth
+++ b/test/type-inference.mth
@@ -1,0 +1,46 @@
+module(test.type-inference)
+
+import(std.prelude)
+import(std.world)
+import(std.maybe)
+import(std.list)
+
+def zero { 0 }
+def Int.square { dup * }
+def Maybe.nothing? { none? }
+def Maybe.Zero { 0 None }
+def List.map(f,g) {
+    uncons dip(map(f))
+    swap dip(map(dip(g) f))
+    for(swap cons)
+}
+
+def Maybe.another-map(f) {
+    None -> None,
+    Some -> f Some
+}
+
+def fact  { 1 swap fact* }
+def fact* {
+    dup 1 < if(
+        drop,
+        tuck * swap 1- fact*
+    )
+}
+
+def fib {
+    dup 2 < if(
+        id,
+        dup dip(1- fib) dip'(2 - fib) Int.+
+    )
+}
+
+def main {
+    "Hello world!" print
+    print("[ "; 1 to: 10 for(fact show; " ";) "]";)
+    print("[ "; 1 to: 15 for(fib  show; " ";) "]";)
+}
+
+# mirth-test # pout # Hello world!
+# mirth-test # pout # [ 1 2 6 24 120 720 5040 40320 362880 3628800 ]
+# mirth-test # pout # [ 1 1 2 3 5 8 13 21 34 55 89 144 233 377 610 ]


### PR DESCRIPTION
This PR adds a new `def` syntax:

```
def word [ type-sig ] { body }
```

which is sugar for `def(word, type-sig, body)`.

In addition, the `[type-sig]` is optional, in which case a bit of type inference is implemented.

Because mirth is contextual, the type inference makes a few useful assumptions based on the name:

- if you're writing a type-qualified word that looks like a method, e.g. `List.my-method`, then it assumes that qualifying type is the top input: `*? List(?) -- *?`

- if you're writing a type-qualified word that looks like a constructor, e.g. `List.SuperCons`, then it assumes that qualifying type is the top output, `*? -- *? List(?)`. (By the way, "looks like a constructor" means it's a qualified word that starts with an uppercase letter. "Looks like a method" is everything else.)

- if you're writing a word called `main` within a module, it assumes you want the type signature `+World -- +World`.

- if your word takes parameters, it adds those to the type signature, e.g. `foo(f)` would get a type signature `(*? -- *?) *? -- *?`

These asumptions help us avoid the need to write explicit type annotations in many situations, because having a little bit of type information (e.g. when defining a method) helps a lot with name resolution.

Ultimately the goal here isn't to get the most general type, it's to get the type the user wants most of the time. If the user wants something else, they can always write a type signature.

Also there is some support for recursive definitions. But it's always going to be much harder to infer those, especially because of stack polymorphism. Again, one can always write a type signature.