### PR TITLE
add syntactic sugar for match and match cases

### DIFF
--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -5452,6 +5452,7 @@ static void mw_std_maybe_Maybe_1_ifZ_some_2 (void);
 static void mw_std_maybe_Maybe_1_then_1 (void);
 static void mw_std_maybe_Maybe_1_thenZ_some_1 (void);
 static void mw_std_maybe_Maybe_1_else_1 (void);
+static void mw_std_maybe_Maybe_1_or_1 (void);
 static void mw_std_maybe_Maybe_1_orZ_some_1 (void);
 static void mw_std_maybe_Maybe_1_and_1 (void);
 static void mw_std_maybe_Maybe_1_andZ_some_1 (void);
@@ -6651,6 +6652,8 @@ static void mw_mirth_elab_elabZ_atomZ_assertZBang (void);
 static void mw_mirth_elab_elabZ_atomZ_matchZBang (void);
 static void mw_mirth_elab_elabZ_matchZ_atZBang (void);
 static void mw_mirth_elab_elabZ_matchZ_casesZBang (void);
+static void mw_mirth_elab_elabZ_matchZ_casesZ_curlyZBang (void);
+static void mw_mirth_elab_elabZ_matchZ_casesZ_argsZBang (void);
 static void mw_mirth_elab_elabZ_matchZ_caseZBang (void);
 static void mw_mirth_elab_elabZ_patternZBang (void);
 static void mw_mirth_elab_elabZ_patternZ_atomZBang (void);
@@ -7398,9 +7401,15 @@ static void mb_mirth_elab_elabZ_argsZBang_0 (void);
 static void mb_mirth_elab_elabZ_atomZ_resolveZ_defZBang_0 (void);
 static void mb_mirth_elab_elabZ_atomZ_resolveZ_defZBang_1 (void);
 static void mb_mirth_elab_elabZ_atomZ_resolveZ_defZBang_2 (void);
+static void mb_mirth_elab_elabZ_atomZ_matchZBang_0 (void);
+static void mb_mirth_elab_elabZ_atomZ_matchZBang_1 (void);
 static void mb_mirth_elab_elabZ_atomZ_lambdaZBang_1 (void);
 static void mb_mirth_elab_elabZ_atomZ_lambdaZBang_5 (void);
 static void mb_mirth_elab_elabZ_matchZ_atZBang_0 (void);
+static void mb_mirth_elab_elabZ_matchZ_casesZBang_0 (void);
+static void mb_mirth_elab_elabZ_matchZ_casesZBang_1 (void);
+static void mb_mirth_elab_elabZ_matchZ_casesZ_curlyZBang_0 (void);
+static void mb_mirth_elab_elabZ_matchZ_casesZ_curlyZBang_1 (void);
 static void mb_mirth_elab_elabZ_matchZ_caseZBang_0 (void);
 static void mb_mirth_elab_elabZ_matchZ_caseZBang_8 (void);
 static void mb_mirth_elab_elabZ_matchZ_caseZBang_9 (void);
@@ -7499,7 +7508,6 @@ static void mb_mirth_elab_parseZ_def_4 (void);
 static void mb_mirth_elab_elabZ_defZ_paramsZBang_1 (void);
 static void mb_mirth_elab_elabZ_defZ_paramsZBang_5 (void);
 static void mb_mirth_elab_elabZ_defZ_bodyZBang_0 (void);
-static void mb_mirth_elab_elabZ_defZ_bodyZBang_1 (void);
 static void mb_mirth_elab_checkZ_inlineZ_recursionZ_arrowZBang_0 (void);
 static void mb_mirth_elab_checkZ_inlineZ_recursionZ_atomZBang_2 (void);
 static void mb_mirth_elab_checkZ_inlineZ_recursionZ_opZBang_4 (void);
@@ -11500,6 +11508,25 @@ static void mw_std_maybe_Maybe_1_else_1 (void) {
 				mp_primZ_panic();
 		}
 		decref(var_f);
+	}
+}
+static void mw_std_maybe_Maybe_1_or_1 (void) {
+	{
+		VAL var_p = pop_value();
+		mw_std_maybe_Maybe_1_ZToBool();
+		incref(var_p);
+		push_value(var_p);
+		{
+			VAL var_p = pop_value();
+			if (pop_u64()) {
+				push_u64(1LL); // True
+			} else {
+				incref(var_p);
+				run_value(var_p);
+			}
+			decref(var_p);
+		}
+		decref(var_p);
 	}
 }
 static void mw_std_maybe_Maybe_1_orZ_some_1 (void) {
@@ -33758,13 +33785,11 @@ static void mw_mirth_elab_elabZ_atomZ_matchZBang (void) {
 	mtw_mirth_type_StackType_STMeta();
 	LPUSH(lbl_cod);
 	mw_mirth_elab_abZ_tokenZAt();
-	{
-		VAL d2 = pop_resource();
-		mw_mirth_token_Token_argsZPlus();
-		push_resource(d2);
-	}
-	mw_std_list_ListZPlus_1_first();
-	LPUSH(lbl_body);
+	mw_mirth_token_Token_succ();
+	mw_mirth_token_Token_lcurlyZAsk();
+	push_fnptr(&mb_mirth_elab_elabZ_atomZ_matchZBang_0);
+	push_fnptr(&mb_mirth_elab_elabZ_atomZ_matchZBang_1);
+	mw_std_maybe_Maybe_1_if_2();
 	mw_mirth_elab_elabZ_matchZ_atZBang();
 }
 static void mw_mirth_elab_elabZ_matchZ_atZBang (void) {
@@ -33772,6 +33797,19 @@ static void mw_mirth_elab_elabZ_matchZ_atZBang (void) {
 	mw_mirth_elab_abZ_matchZBang_1();
 }
 static void mw_mirth_elab_elabZ_matchZ_casesZBang (void) {
+	mw_mirth_match_ZPlusMatch_body();
+	mw_mirth_token_Token_lcurlyZAsk();
+	push_fnptr(&mb_mirth_elab_elabZ_matchZ_casesZBang_0);
+	push_fnptr(&mb_mirth_elab_elabZ_matchZ_casesZBang_1);
+	mw_std_maybe_Maybe_1_if_2();
+}
+static void mw_mirth_elab_elabZ_matchZ_casesZ_curlyZBang (void) {
+	mw_mirth_match_ZPlusMatch_body();
+	mw_mirth_token_Token_runZ_tokens();
+	push_fnptr(&mb_mirth_elab_elabZ_matchZ_casesZ_curlyZBang_0);
+	mw_std_list_List_1_for_1();
+}
+static void mw_mirth_elab_elabZ_matchZ_casesZ_argsZBang (void) {
 	mw_mirth_match_ZPlusMatch_body();
 	while(1) {
 		mp_primZ_dup();
@@ -35732,8 +35770,16 @@ static void mw_mirth_elab_elabZ_defZ_bodyZBang (void) {
 	mw_mirth_elab_abZ_tokenZAt();
 	mw_mirth_token_Token_runZ_arrowZAsk();
 	push_fnptr(&mb_mirth_elab_elabZ_defZ_bodyZBang_0);
-	push_fnptr(&mb_mirth_elab_elabZ_defZ_bodyZBang_1);
-	mw_std_maybe_Maybe_1_if_2();
+	mw_std_maybe_Maybe_1_or_1();
+	if (pop_u64()) {
+		mp_primZ_dup();
+		LPUSH(lbl_cod);
+		mw_mirth_elab_abZ_tokenZAt();
+		LPUSH(lbl_body);
+		mw_mirth_elab_elabZ_matchZ_atZBang();
+	} else {
+		mw_mirth_elab_elabZ_atomsZBang();
+	}
 }
 static void mw_mirth_elab_parseZ_externalZ_decl (void) {
 	mp_primZ_dup();
@@ -47061,6 +47107,25 @@ static void mb_mirth_elab_elabZ_atomZ_resolveZ_defZBang_1 (void) {
 static void mb_mirth_elab_elabZ_atomZ_resolveZ_defZBang_2 (void) {
 	mtw_mirth_elab_RejectedDef_RDz_WRONGz_SORT();
 }
+static void mb_mirth_elab_elabZ_atomZ_matchZBang_0 (void) {
+	mw_mirth_elab_abZ_tokenZAt();
+	mw_mirth_token_Token_succ();
+	mw_mirth_token_Token_succ();
+	LPUSH(lbl_body);
+	mw_mirth_elab_abZ_tokenZAt();
+	mw_mirth_token_Token_succ();
+	mw_mirth_elab_abZ_tokenZBang();
+}
+static void mb_mirth_elab_elabZ_atomZ_matchZBang_1 (void) {
+	mw_mirth_elab_abZ_tokenZAt();
+	{
+		VAL d2 = pop_resource();
+		mw_mirth_token_Token_argsZPlus();
+		push_resource(d2);
+	}
+	mw_std_list_ListZPlus_1_first();
+	LPUSH(lbl_body);
+}
 static void mb_mirth_elab_elabZ_atomZ_lambdaZBang_1 (void) {
 	{
 		VAL d2 = pop_resource();
@@ -47074,6 +47139,33 @@ static void mb_mirth_elab_elabZ_atomZ_lambdaZBang_5 (void) {
 static void mb_mirth_elab_elabZ_matchZ_atZBang_0 (void) {
 	mw_mirth_elab_elabZ_matchZ_casesZBang();
 	mw_mirth_elab_elabZ_matchZ_exhaustiveZBang();
+}
+static void mb_mirth_elab_elabZ_matchZ_casesZBang_0 (void) {
+	mw_mirth_elab_elabZ_matchZ_casesZ_curlyZBang();
+}
+static void mb_mirth_elab_elabZ_matchZ_casesZBang_1 (void) {
+	mw_mirth_elab_elabZ_matchZ_casesZ_argsZBang();
+}
+static void mb_mirth_elab_elabZ_matchZ_casesZ_curlyZBang_0 (void) {
+	mp_primZ_dup();
+	mw_mirth_token_Token_lcurlyZAsk();
+	push_fnptr(&mb_mirth_elab_elabZ_matchZ_casesZ_curlyZBang_1);
+	mw_std_maybe_Maybe_1_else_1();
+	{
+		VAL d2 = pop_resource();
+		mw_mirth_token_Token_argsZ_1();
+		push_resource(d2);
+	}
+	mw_mirth_elab_elabZ_matchZ_caseZBang();
+	mp_primZ_drop();
+}
+static void mb_mirth_elab_elabZ_matchZ_casesZ_curlyZBang_1 (void) {
+	STRLIT("Expected a match case of the form { ... -> ... }", 48);
+	{
+		VAL d2 = pop_resource();
+		mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+		push_resource(d2);
+	}
 }
 static void mb_mirth_elab_elabZ_matchZ_caseZBang_0 (void) {
 	STRLIT("expected arrow end", 18);
@@ -48486,14 +48578,9 @@ static void mb_mirth_elab_elabZ_defZ_paramsZBang_5 (void) {
 	mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
 }
 static void mb_mirth_elab_elabZ_defZ_bodyZBang_0 (void) {
-	mp_primZ_dup();
-	LPUSH(lbl_cod);
 	mw_mirth_elab_abZ_tokenZAt();
-	LPUSH(lbl_body);
-	mw_mirth_elab_elabZ_matchZ_atZBang();
-}
-static void mb_mirth_elab_elabZ_defZ_bodyZBang_1 (void) {
-	mw_mirth_elab_elabZ_atomsZBang();
+	mw_mirth_token_Token_lcurlyZAsk();
+	mw_std_maybe_Maybe_1_ZToBool();
 }
 static void mb_mirth_elab_checkZ_inlineZ_recursionZ_arrowZBang_0 (void) {
 	{

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -47160,7 +47160,7 @@ static void mb_mirth_elab_elabZ_matchZ_casesZ_curlyZBang_0 (void) {
 	mp_primZ_drop();
 }
 static void mb_mirth_elab_elabZ_matchZ_casesZ_curlyZBang_1 (void) {
-	STRLIT("Expected a match case of the form { ... -> ... }", 48);
+	STRLIT("Expected a pattern match case of the form { ... -> ... }", 56);
 	{
 		VAL d2 = pop_resource();
 		mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
@@ -47168,7 +47168,7 @@ static void mb_mirth_elab_elabZ_matchZ_casesZ_curlyZBang_1 (void) {
 	}
 }
 static void mb_mirth_elab_elabZ_matchZ_caseZBang_0 (void) {
-	STRLIT("expected arrow end", 18);
+	STRLIT("Expected pattern match case ... -> ...", 38);
 	{
 		VAL d2 = pop_resource();
 		mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();

--- a/src/elab.mth
+++ b/src/elab.mth
@@ -933,7 +933,11 @@ def(elab-atom-assert!, +Mirth +AB -- +Mirth +AB,
 
 def(elab-atom-match!, +Mirth +AB -- +Mirth +AB,
     MetaVar.new! STMeta >cod
-    ab-token@ rdip:args+ first >body
+    ab-token@ succ lcurly? if(
+        ab-token@ succ succ >body
+        ab-token@ succ ab-token!,
+        ab-token@ rdip:args+ first >body
+    )
     elab-match-at!)
 
 ||| Elaborate a match body within AB. Takes the output stack type,
@@ -947,7 +951,23 @@ def(elab-match-at!, cod:StackType body:Token +Mirth +AB -- +Mirth +AB,
 
 ||| Elaborate match cases.
 def(elab-match-cases!, +Mirth +Match -- +Mirth +Match,
-    body while(dup args-end? not, elab-match-case!) drop)
+    body lcurly? if(
+        elab-match-cases-curly!,
+        elab-match-cases-args!
+    ))
+
+def elab-match-cases-curly! [ +Mirth +Match -- +Mirth +Match ] {
+    body run-tokens for(
+        dup lcurly?
+        else("Expected a match case of the form { ... -> ... }" rdip:emit-fatal-error!)
+        rdip:args-1 elab-match-case!
+        drop
+    )
+}
+
+def elab-match-cases-args! [ +Mirth +Match -- +Mirth +Match ] {
+    body while(dup args-end? not, elab-match-case!) drop
+}
 
 ||| Elaborate match case based on starting token.
 def(elab-match-case!, Token +Mirth +Match -- Token +Mirth +Match,
@@ -1582,7 +1602,7 @@ def(elab-def-params!, +Mirth Word -- +Mirth List(Var),
 ||| Elaborate the body of a `def`. Takes the codomain from the stack,
 ||| and the rest from the AB environment.
 def(elab-def-body!, StackType +Mirth +AB -- StackType +Mirth +AB,
-    ab-token@ run-arrow? if(
+    ab-token@ run-arrow? or(ab-token@ lcurly? some?) if(
         dup >cod ab-token@ >body elab-match-at!,
         elab-atoms!
     ))

--- a/src/elab.mth
+++ b/src/elab.mth
@@ -959,7 +959,7 @@ def(elab-match-cases!, +Mirth +Match -- +Mirth +Match,
 def elab-match-cases-curly! [ +Mirth +Match -- +Mirth +Match ] {
     body run-tokens for(
         dup lcurly?
-        else("Expected a match case of the form { ... -> ... }" rdip:emit-fatal-error!)
+        else("Expected a pattern match case of the form { ... -> ... }" rdip:emit-fatal-error!)
         rdip:args-1 elab-match-case!
         drop
     )
@@ -971,7 +971,7 @@ def elab-match-cases-args! [ +Mirth +Match -- +Mirth +Match ] {
 
 ||| Elaborate match case based on starting token.
 def(elab-match-case!, Token +Mirth +Match -- Token +Mirth +Match,
-    dup run-arrow? unwrap-or("expected arrow end" rdip:emit-fatal-error!)
+    dup run-arrow? unwrap-or("Expected pattern match case ... -> ..." rdip:emit-fatal-error!)
     dup2 == then("expected pattern" rdip:emit-fatal-error!)
     dup2 prev == else("multi-part pattern not supported" rdip:emit-fatal-error!)
     dip:pat-tokens sip:prev succ +Match.case!(

--- a/test/match-syntax.mth
+++ b/test/match-syntax.mth
@@ -1,0 +1,34 @@
+module(test.match-syntax)
+
+import(std.prelude)
+import(std.maybe)
+import(std.list)
+
+def(Maybe.sum, Maybe(Int) -- Int, { None -> 0 } { Some -> id })
+def List.sum {
+    { Nil -> 0 }
+    { Cons -> dip'(sum) + }
+}
+
+def List.very-slow-reverse {
+    match {
+        { Nil -> Nil }
+        { Cons -> swap dip(very-slow-reverse) List.snoc }
+    }
+}
+
+def Maybe.another-match-1 {
+    match (
+        { Some -> Some }
+        { None -> None }
+    )
+}
+
+def Maybe.another-match-2 {
+    match {
+        Some -> Some,
+        None -> None
+    }
+}
+
+def main {}

--- a/test/stack-assertions.mth
+++ b/test/stack-assertions.mth
@@ -2,55 +2,64 @@ module(mirth-tests.stack-assertions)
 import(std.prelude)
 
 def(ok-1, Int Str -- Str Int Str,
+    id
     {Int Str} swap {Str Int} swap {Int Str} tuck {Str Int Str})
 
 def(ok-2, a b -- b a b,
+    id
     {a b} swap {b a} swap {a b} tuck {b a b})
 
 def(ok-3, a b -- b a b,
+    id
     {a _} swap {_ a} swap {_ b} tuck {b _ b})
 
 def(ok-4, a b -- b a b,
+    id
     {a ?myb} swap {? a} swap {?foo b} tuck {b ?bar b})
 
 def(bad-1, Int Str -- Str Int Str,
+    id
     {Int Str} swap {Int Int} swap {Int Str} tuck {Str Str Str})
 
 def(bad-2, a b -- b a b,
+    id
     {a b} swap {a a} swap {a b} tuck {b b b})
 
 def(bad-3, a b -- b a b,
+    id
     {a _} swap {a a} swap {_ _} tuck {b b b})
 
 def(non-exhaustive, a b c d -- a b c d,
+    id
     {a b c d}
     {b c d}
     {c d}
     {d})
 
 def(non-exhaustive-reverse, a b c d -- a b c d,
+    id
     {a b c d}
     {a b c}
     {a b}
     {a})
 
 def(main, --, id)
-# mirth-test # merr # 17:20: error: Failed to unify Str with Int
-# mirth-test # merr # 17:50: error: Failed to unify Int with Str
-# mirth-test # merr # 20:16: error: Failed to unify b with a
-# mirth-test # merr # 20:38: error: Failed to unify a with b
-# mirth-test # merr # 23:16: error: Failed to unify b with a
-# mirth-test # merr # 23:38: error: Failed to unify a with b
-# mirth-test # merr # 27:5: error: Failed to unify [a] with []
-# mirth-test # merr # 28:5: error: Failed to unify [a b] with []
-# mirth-test # merr # 29:5: error: Failed to unify [a b c] with []
-# mirth-test # merr # 33:5: error: Failed to unify [a] with []
-# mirth-test # merr # 33:5: error: Failed to unify b with a
-# mirth-test # merr # 33:5: error: Failed to unify c with b
-# mirth-test # merr # 33:5: error: Failed to unify d with c
-# mirth-test # merr # 34:5: error: Failed to unify [a b] with []
-# mirth-test # merr # 34:5: error: Failed to unify c with a
-# mirth-test # merr # 34:5: error: Failed to unify d with b
-# mirth-test # merr # 35:5: error: Failed to unify [a b c] with []
-# mirth-test # merr # 35:5: error: Failed to unify d with a
+# mirth-test # merr # 22:20: error: Failed to unify Str with Int
+# mirth-test # merr # 22:50: error: Failed to unify Int with Str
+# mirth-test # merr # 26:16: error: Failed to unify b with a
+# mirth-test # merr # 26:38: error: Failed to unify a with b
+# mirth-test # merr # 30:16: error: Failed to unify b with a
+# mirth-test # merr # 30:38: error: Failed to unify a with b
+# mirth-test # merr # 35:5: error: Failed to unify [a] with []
+# mirth-test # merr # 36:5: error: Failed to unify [a b] with []
+# mirth-test # merr # 37:5: error: Failed to unify [a b c] with []
+# mirth-test # merr # 42:5: error: Failed to unify [a] with []
+# mirth-test # merr # 42:5: error: Failed to unify b with a
+# mirth-test # merr # 42:5: error: Failed to unify c with b
+# mirth-test # merr # 42:5: error: Failed to unify d with c
+# mirth-test # merr # 43:5: error: Failed to unify [a b] with []
+# mirth-test # merr # 43:5: error: Failed to unify c with a
+# mirth-test # merr # 43:5: error: Failed to unify d with b
+# mirth-test # merr # 44:5: error: Failed to unify [a b c] with []
+# mirth-test # merr # 44:5: error: Failed to unify d with a
 # mirth-test # mret # 1

--- a/test/test-prelude.mth
+++ b/test/test-prelude.mth
@@ -134,6 +134,7 @@ def(test-stack-assertions, --,
 )
 
 def(test-stack-assertions-var, a b -- a b,
+    id
     { a b }
     swap
     { b a }
@@ -149,6 +150,7 @@ def(test-stack-assertions-var-2, a b -- a b,
 )
 
 def(test-stack-assertions-dont-care, a b -- a b,
+    id
     { a b }
     { a _ }
     { _ b }


### PR DESCRIPTION
This PR adds syntactic sugar to match. In particular:

- you can use curly braces around the cases, instead of round ones, so `match { ... }` is equivalent to `match ( ... )`

- instead of writing the match cases as comma-separated arguments, you can write each case enclosed in curly braces. e.g. `match( { A -> B } { C -> D } )` is the same as `match( A -> B, C -> D )`.

So the following are equivalent:

```
match ( A -> B, C -> D )
match { A -> B, C -> D }
match ( { A -> B } { C -> D } )
match { { A -> B } { C -> D } }
```

In addition the new cases syntax carries over to definitions, so for example you can write,

```
def foo {
   { A -> B }
   { C -> D }
}
```