### PR TITLE
Add way to specify tag value.

### DIFF
--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -7151,6 +7151,9 @@ static void mb_mirth_arrow_Arrow_freeZ_vars_1 (void);
 static void mb_mirth_arrow_Block_freeZ_vars_0 (void);
 static void mb_mirth_data_makeZ_primZ_dataZBang_0 (void);
 static void mb_mirth_data_Data_fullZ_type_1 (void);
+static void mb_mirth_data_Data_addZ_tagZBang_0 (void);
+static void mb_mirth_data_Data_addZ_tagZBang_3 (void);
+static void mb_mirth_data_Data_addZ_tagZBang_5 (void);
 static void mb_mirth_data_Data_isZ_unitZAsk_0 (void);
 static void mb_mirth_data_Data_isZ_transparentZAsk_0 (void);
 static void mb_mirth_data_Data_isZ_semiZ_transparentZAsk_0 (void);
@@ -7277,8 +7280,8 @@ static void mb_mirth_elab_elabZ_fieldZBang_3 (void);
 static void mb_mirth_elab_elabZ_dataZBang_2 (void);
 static void mb_mirth_elab_elabZ_embedZ_strZBang_4 (void);
 static void mb_mirth_elab_elabZ_dataZ_headerZBang_2 (void);
-static void mb_mirth_elab_elabZ_dataZ_tagZBang_7 (void);
-static void mb_mirth_elab_elabZ_dataZ_tagZBang_17 (void);
+static void mb_mirth_elab_elabZ_dataZ_tagZBang_10 (void);
+static void mb_mirth_elab_elabZ_dataZ_tagZBang_20 (void);
 static void mb_mirth_elab_elabZ_dataZ_doneZBang_0 (void);
 static void mb_mirth_elab_elabZ_dataZ_doneZBang_1 (void);
 static void mb_mirth_elab_elabZ_dataZ_doneZBang_2 (void);
@@ -7673,6 +7676,7 @@ static void mfld_mirth_data_Data_ZTildearity (void);
 static void mfld_mirth_data_Data_ZTildeparams (void);
 static void mfld_mirth_data_Data_ZTildetags (void);
 static void mfld_mirth_data_Data_ZTildectypeZAsk (void);
+static void mfld_mirth_data_Data_ZTildelastZ_tagZ_value (void);
 static void mfld_mirth_data_Data_ZTildeisZ_unitZAsk (void);
 static void mfld_mirth_data_Data_ZTildeisZ_enumZAsk (void);
 static void mfld_mirth_data_Data_ZTildeisZ_transparentZAsk (void);
@@ -8085,6 +8089,15 @@ static void mfld_mirth_data_Data_ZTildetags (void) {
 }
 
 static void mfld_mirth_data_Data_ZTildectypeZAsk (void) {
+	size_t i = (size_t)pop_u64();
+	static struct VAL * p = 0;
+	size_t m = 524288;
+	if (! p) { p = calloc(m, sizeof *p); }
+	EXPECT(i<m, "table grew too big");
+	push_ptr(p+i);
+}
+
+static void mfld_mirth_data_Data_ZTildelastZ_tagZ_value (void) {
 	size_t i = (size_t)pop_u64();
 	static struct VAL * p = 0;
 	size_t m = 524288;
@@ -15238,7 +15251,6 @@ static void mw_mirth_data_makeZ_primZ_tagZBang (void) {
 	mfld_mirth_data_Tag_ZTildeqname();
 	mp_primZ_mutZ_set();
 	LPOP(lbl_value);
-	mw_std_prim_Int_ZToNat();
 	LPOP(lbl_tag);
 	mp_primZ_dup();
 	LPUSH(lbl_tag);
@@ -15692,26 +15704,82 @@ static void mw_mirth_data_Data_addZ_tagZBang (void) {
 		push_value(d2);
 	}
 	mp_primZ_swap();
+	mfld_mirth_data_Tag_ZTildevalue();
+	push_fnptr(&mb_mirth_data_Data_addZ_tagZBang_0);
+	mw_std_prelude_memoizze_1();
 	{
 		VAL d2 = pop_value();
 		mp_primZ_dup();
 		push_value(d2);
 	}
 	mp_primZ_swap();
-	mw_mirth_data_Data_numZ_tags();
-	mp_primZ_swap();
-	mfld_mirth_data_Tag_ZTildevalue();
-	mp_primZ_mutZ_set();
-	mp_primZ_dup();
 	mw_mirth_data_Data_tags();
-	mp_primZ_swap();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_swap();
-		push_value(d2);
+	push_fnptr(&mb_mirth_data_Data_addZ_tagZBang_3);
+	mw_std_list_List_1_find_1();
+	switch (get_top_data_tag()) {
+		case 1LL: // Some
+			mtp_std_maybe_Maybe_1_Some();
+			push_fnptr(&mb_mirth_data_Data_addZ_tagZBang_5);
+			mw_std_str_Str_1();
+			{
+				VAL d4 = pop_value();
+				{
+					VAL d5 = pop_value();
+					mp_primZ_dup();
+					push_value(d5);
+				}
+				mp_primZ_swap();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			mw_mirth_data_Data_headZAsk();
+			switch (get_top_data_tag()) {
+				case 1LL: // Some
+					mtp_std_maybe_Maybe_1_Some();
+					break;
+				case 0LL: // None
+					(void)pop_u64();
+					mw_mirth_mirth_ZPlusMirth_errorZ_token();
+					switch (get_top_data_tag()) {
+						case 1LL: // Some
+							mtp_std_maybe_Maybe_1_Some();
+							break;
+						case 0LL: // None
+							(void)pop_u64();
+							mw_std_prelude_panicZBang();
+							break;
+						default:
+							push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+							mp_primZ_panic();
+					}
+					break;
+				default:
+					push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+					mp_primZ_panic();
+			}
+			mp_primZ_swap();
+			mw_mirth_mirth_ZPlusMirth_emitZ_errorZBang();
+			break;
+		case 0LL: // None
+			(void)pop_u64();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primZ_panic();
 	}
 	{
 		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	mfld_mirth_data_Data_ZTildelastZ_tagZ_value();
+	mp_primZ_mutZ_set();
+	mp_primZ_dup();
+	{
+		VAL d2 = pop_value();
+		mw_mirth_data_Data_tags();
+		mp_primZ_swap();
 		push_u64(0LL); // Nil
 		mtw_std_list_List_1_Cons();
 		mw_std_list_List_1_cat();
@@ -37130,6 +37198,24 @@ static void mw_mirth_elab_elabZ_dataZ_paramsZBang (void) {
 	mw_mirth_var_Ctx_ZToList();
 }
 static void mw_mirth_elab_elabZ_dataZ_tagZBang (void) {
+	mp_primZ_dup();
+	mw_mirth_token_Token_intZAsk();
+	switch (get_top_data_tag()) {
+		case 1LL: // Some
+			mtp_std_maybe_Maybe_1_Some();
+			mtw_std_maybe_Maybe_1_Some();
+			LPUSH(lbl_value);
+			mw_mirth_token_Token_succ();
+			break;
+		case 0LL: // None
+			(void)pop_u64();
+			push_u64(0LL); // None
+			LPUSH(lbl_value);
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primZ_panic();
+	}
 	{
 		VAL d2 = pop_value();
 		mp_primZ_dup();
@@ -37160,6 +37246,26 @@ static void mw_mirth_elab_elabZ_dataZ_tagZBang (void) {
 	push_i64(0LL);
 	mw_mirth_data_dataZ_qname();
 	mw_mirth_data_Tag_allocZBang();
+	LPOP(lbl_value);
+	switch (get_top_data_tag()) {
+		case 1LL: // Some
+			mtp_std_maybe_Maybe_1_Some();
+			{
+				VAL d4 = pop_value();
+				mp_primZ_dup();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			mfld_mirth_data_Tag_ZTildevalue();
+			mp_primZ_mutZ_set();
+			break;
+		case 0LL: // None
+			(void)pop_u64();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primZ_panic();
+	}
 	push_u64(0LL); // None
 	{
 		VAL d2 = pop_value();
@@ -37252,7 +37358,7 @@ static void mw_mirth_elab_elabZ_dataZ_tagZBang (void) {
 	mp_primZ_dup();
 	mp_primZ_dup();
 	mtw_mirth_mirth_PropLabel_TagType();
-	push_fnptr(&mb_mirth_elab_elabZ_dataZ_tagZBang_7);
+	push_fnptr(&mb_mirth_elab_elabZ_dataZ_tagZBang_10);
 	mw_mirth_mirth_PropLabel_prop_1();
 	{
 		VAL d2 = pop_value();
@@ -37340,7 +37446,7 @@ static void mw_mirth_elab_elabZ_dataZ_tagZBang (void) {
 				mp_primZ_panic();
 		}
 		mw_mirth_token_Token_runZ_tokens();
-		push_fnptr(&mb_mirth_elab_elabZ_dataZ_tagZBang_17);
+		push_fnptr(&mb_mirth_elab_elabZ_dataZ_tagZBang_20);
 		mw_std_list_List_1_find_1();
 		switch (get_top_data_tag()) {
 			case 1LL: // Some
@@ -48354,6 +48460,68 @@ static void mb_mirth_data_Data_fullZ_type_1 (void) {
 	mtw_mirth_type_Type_TVar();
 	mtw_mirth_type_Type_TApp();
 }
+static void mb_mirth_data_Data_addZ_tagZBang_0 (void) {
+	mp_primZ_dup();
+	mfld_mirth_data_Data_ZTildelastZ_tagZ_value();
+	mw_std_prelude_ZAtZAsk();
+	switch (get_top_data_tag()) {
+		case 1LL: // Some
+			mtp_std_maybe_Maybe_1_Some();
+			push_i64(1LL);
+			mp_primZ_intZ_add();
+			break;
+		case 0LL: // None
+			(void)pop_u64();
+			push_i64(0LL);
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primZ_panic();
+	}
+}
+static void mb_mirth_data_Data_addZ_tagZBang_3 (void) {
+	mw_mirth_data_Tag_value();
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	mp_primZ_intZ_eq();
+}
+static void mb_mirth_data_Data_addZ_tagZBang_5 (void) {
+	STRLIT("Constructors ", 13);
+	mw_std_str_ZPlusStr_pushZ_strZBang();
+	mw_mirth_data_Tag_name();
+	{
+		VAL d2 = pop_resource();
+		mw_mirth_name_Name_ZToStr();
+		push_resource(d2);
+	}
+	mw_std_str_ZPlusStr_pushZ_strZBang();
+	STRLIT(" and ", 5);
+	mw_std_str_ZPlusStr_pushZ_strZBang();
+	{
+		VAL d2 = pop_value();
+		{
+			VAL d3 = pop_value();
+			mp_primZ_dup();
+			push_value(d3);
+		}
+		mp_primZ_swap();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	mw_mirth_data_Tag_name();
+	{
+		VAL d2 = pop_resource();
+		mw_mirth_name_Name_ZToStr();
+		push_resource(d2);
+	}
+	mw_std_str_ZPlusStr_pushZ_strZBang();
+	STRLIT(" have the same tag value.", 25);
+	mw_std_str_ZPlusStr_pushZ_strZBang();
+}
 static void mb_mirth_data_Data_isZ_unitZAsk_0 (void) {
 	mp_primZ_dup();
 	mw_mirth_data_Data_tags();
@@ -50029,7 +50197,7 @@ static void mb_mirth_elab_elabZ_embedZ_strZBang_4 (void) {
 static void mb_mirth_elab_elabZ_dataZ_headerZBang_2 (void) {
 	mw_mirth_elab_elabZ_dataZ_paramsZBang();
 }
-static void mb_mirth_elab_elabZ_dataZ_tagZBang_7 (void) {
+static void mb_mirth_elab_elabZ_dataZ_tagZBang_10 (void) {
 	mp_primZ_dup();
 	mw_mirth_data_Tag_data();
 	mw_mirth_data_Data_headZAsk();
@@ -50098,7 +50266,7 @@ static void mb_mirth_elab_elabZ_dataZ_tagZBang_7 (void) {
 	mw_std_prelude_pack2();
 	mw_mirth_elab_ZPlusTypeElab_rdrop();
 }
-static void mb_mirth_elab_elabZ_dataZ_tagZBang_17 (void) {
+static void mb_mirth_elab_elabZ_dataZ_tagZBang_20 (void) {
 	mp_primZ_dup();
 	mw_mirth_token_Token_sigZ_resourceZ_conZAsk();
 	if (pop_u64()) {

--- a/src/data.mth
+++ b/src/data.mth
@@ -2,6 +2,7 @@ module(mirth.data)
 
 import(std.prelude)
 import(std.list)
+import(std.str)
 import(std.maybe)
 import(std.either)
 
@@ -64,7 +65,7 @@ def(make-prim-tag!, +Mirth Str Int List(Type) Tag -- +Mirth,
     >tag >inputs >value >name
 
     @tag .data name> 0 data-word-qname @tag ~qname !
-    value> >Nat @tag ~value !
+    value> @tag ~value !
 
     @inputs len @tag ~num-type-inputs !
     0 >Nat @tag ~num-resource-inputs !
@@ -143,10 +144,25 @@ def(data-word-qname, Data Str Int -- QName,
 def(Data.==, Data Data -- Bool, both(index) ==)
 def(Data.num-tags, Data -- Nat, tags len)
 
-||| Adds constructor to data type, and gives tag its rank.
-def(Data.add-tag!, Tag Data --,
-    dup2 num-tags swap ~value !
-    dup tags rotr dip(List.snoc) ~tags !)
+field(Data.~last-tag-value, Data, Int)
+
+||| Adds constructor to data type, and gives tag its value.
+def(Data.add-tag!, +Mirth Tag Data -- +Mirth,
+    over ~value memoize(
+        dup ~last-tag-value @? if-some(1+, 0)
+    )
+    over tags find(value over ==) for(
+        Str("Constructors ";
+            name rdip:>Str ;
+            " and " ;
+            over2 name rdip:>Str ;
+            " have the same tag value." ;
+        )
+        over2 head? unwrap(error-token unwrap(panic!))
+        swap emit-error!
+    )
+    over ~last-tag-value !
+    sip(tags swap List.snoc) ~tags !)
 
 field(Data.~is-unit?, Data, Bool)
 def(Data.is-unit?, Data -- Bool,
@@ -206,7 +222,7 @@ def(Data.full-type, +Mirth Data -- +Mirth Type/Resource,
 table(Tag)
 field(Tag.~data, Tag, Data)
 field(Tag.~qname, Tag, QName)
-field(Tag.~value, Tag, Nat)
+field(Tag.~value, Tag, Int)
 field(Tag.~label-inputs, Tag, List(Label))
 field(Tag.~num-type-inputs, Tag, Nat)
 field(Tag.~num-resource-inputs, Tag, Nat)
@@ -217,7 +233,7 @@ field(Tag.~untag, Tag, Maybe(Word))
 def(Tag.data, Tag -- Data, ~data @)
 def(Tag.qname, Tag -- QName, ~qname @)
 def(Tag.name, Tag -- Name, qname name)
-def(Tag.value, Tag -- Nat, ~value @)
+def(Tag.value, Tag -- Int, ~value @)
 def(Tag.label-inputs, Tag -- List(Label), ~label-inputs @)
 def(Tag.num-type-inputs, Tag -- Nat, ~num-type-inputs @)
 def(Tag.num-resource-inputs, Tag -- Nat, ~num-resource-inputs @)

--- a/src/elab.mth
+++ b/src/elab.mth
@@ -1202,9 +1202,14 @@ def(elab-data-params!, List(Token) +Mirth -- List(Var) +Mirth,
 ||| Get a tag associated with a data type.
 ||| This looks like either "TAG" or "TAG -> TYPE1 .. TYPEN".
 def(elab-data-tag!, Data Token +Mirth -- Data +Mirth,
+    dup int? if-some(
+        Some >value succ,
+        None >value
+    )
     dup2 name? unwrap(drop "Expected constructor name." emit-fatal-error!)
     0 data-qname
     Tag.alloc!
+    value> for(over ~value !)
     None over ~untag !
     tuck ~qname !
     dup DefTag register

--- a/test/data-get-tag.mth
+++ b/test/data-get-tag.mth
@@ -6,6 +6,12 @@ data(Bar, Bar0, Bar1 -> Int)
 data(Baz, Baz -> Foo)
 data(MyStr, MyStr -> Str)
 
+data(CustomEnum,
+    1 One, Two, Three,
+    400 FourHundred, FourHundredOne,
+    -10 NegativeTen, NegativeNine, NegativeEight,
+)
+
 def(main, --,
     assert!(Foo0 tag 0 ==, "Foo0 tag 0 ==")
     assert!(Foo1 tag 1 ==, "Foo1 tag 1 ==")
@@ -19,4 +25,13 @@ def(main, --,
     assert!(Foo2 Baz tag 0 ==, "Foo2 Baz tag 0 ==")
     assert!("Hello" MyStr tag 0 ==, "\"Hello\" MyStr tag 0 ==")
     assert!("World" MyStr tag 0 ==, "\"World\" MyStr tag 0 ==")
+
+    assert!(One tag 1 ==, "One tag 1 ==")
+    assert!(Two tag 2 ==, "Two tag 2 ==")
+    assert!(Three tag 3 ==, "Three tag 3 ==")
+    assert!(FourHundred tag 400 ==, "FourHundred tag 400 ==")
+    assert!(FourHundredOne tag 401 ==, "FourHundredOne tag 401 ==")
+    assert!(NegativeTen tag -10 ==, "NegativeTen tag -10 ==")
+    assert!(NegativeNine tag -9 ==, "NegativeNine tag -9 ==")
+    assert!(NegativeEight tag -8 ==, "NegativeNine tag -8 ==")
 )

--- a/test/error-data-tag-overlap.mth
+++ b/test/error-data-tag-overlap.mth
@@ -1,0 +1,9 @@
+module(test.error-data-tag-overlap)
+
+data(Foo, Foo0a, 0 Foo0b)
+data(Bar, 11 Bar11, 10 Bar10, BarOops)
+
+def main {}
+# mirth-test # merr # 3:6: error: Constructors Foo0a and Foo0b have the same tag value.
+# mirth-test # merr # 4:6: error: Constructors Bar11 and BarOops have the same tag value.
+# mirth-test # mret # 1


### PR DESCRIPTION
This PR adds a way to specify a tag value for `data` types. This closes #233.

To use it, place an integer value *before* the tag name, e.g.:

```
data(MyData, 10 Foo, 20 Bar, 30 Baz)
```

This causes the `.tag` value for `Foo` to be 10, `Bar` to be 20, and `Baz` to be 30.

If you omit a number, it will use the number than the previous tag's number. So for example, the following are equivalent:

```
data(MyData, 10 Foo, 11 Bar, 12 Baz)
data(MyData, 10 Foo, Bar, Baz)
```
If two tag values are the same, the compiler raises an error. (Use an alias instead.)