### PR TITLE
Handle string nontermination and escaped newlines in strings correctly.

### DIFF
--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -32595,7 +32595,19 @@ static void mw_mirth_lexer_lexerZ_emitZ_stringZBang (void) {
 		mw_mirth_lexer_lexerZ_moveZBang();
 		mw_mirth_lexer_lexerZ_peek();
 	}
-	mp_primZ_drop();
+	push_u64(34LL); // BQUOTE
+	mw_std_byte_Byte_ZEqualZEqual();
+	if (pop_u64()) {
+	} else {
+		STRLIT("String literal is missing end quote (\").", 40);
+		mp_primZ_rswap();
+		{
+			VAL d3 = pop_resource();
+			mw_mirth_lexer_lexerZ_emitZ_fatalZ_errorZBang();
+			push_resource(d3);
+		}
+		mp_primZ_rswap();
+	}
 	{
 		VAL d2 = pop_resource();
 		mw_std_str_ZPlusStr_freezze();
@@ -32627,6 +32639,7 @@ static void mw_mirth_lexer_lexerZ_pushZ_stringZ_escapeZ_byteZBang (void) {
 	switch (get_top_data_tag()) {
 		case 10LL: // BLF
 			(void)pop_u64();
+			mw_mirth_lexer_lexerZ_newlineZBang();
 			break;
 		case 110LL: // B'n'
 			(void)pop_u64();

--- a/src/lexer.mth
+++ b/src/lexer.mth
@@ -415,7 +415,10 @@ def(lexer-emit-string!, +Mirth +Lexer -- +Mirth +Lexer,
         lexer-move!
         lexer-peek
     )
-    drop
+    BQUOTE == else(
+        "String literal is missing end quote (\")."
+        rdip':lexer-emit-fatal-error!
+    )
 
     rdip(freeze TokenStr)
     swap ~value !)
@@ -425,7 +428,7 @@ def(lexer-push-string-byte!, +Mirth +Str +Lexer Byte -- +Mirth +Str +Lexer,
     _ -> rdip(push-byte-unsafe!))
 
 def(lexer-push-string-escape-byte!, +Mirth +Str +Lexer Byte -- +Mirth +Str +Lexer,
-    BLF -> id,
+    BLF -> lexer-newline!,
     B'n' -> BLF rdip(push-byte-ascii!),
     B'r' -> BCR rdip(push-byte-ascii!),
     B't' -> BHT rdip(push-byte-ascii!),

--- a/test/error-string-literal-unfinished.mth
+++ b/test/error-string-literal-unfinished.mth
@@ -1,0 +1,9 @@
+module(test.error-string-literal-unfinished)
+
+def main {
+    "Hello, world!
+    "
+    print
+}
+# mirth-test # merr # 4:19: error: String literal is missing end quote (").
+# mirth-test # mret # 1

--- a/test/string-continuation.mth
+++ b/test/string-continuation.mth
@@ -1,0 +1,16 @@
+module(test.string-continuation)
+import(std.prelude)
+import(std.world)
+
+def main {
+    "Hello, \
+world!"
+    print
+}
+
+# Use a recursive inline word because it generates a warning,
+# and we want to check that the line numbers are handled correctly
+inline ( def recursive { recursive } )
+
+# mirth-test # merr # 13:14: warning: recursive word cannot be inlined
+# mirth-test # pout # Hello, world!


### PR DESCRIPTION
Fixes #307 by making it a fatal error for a string to not be terminated (like other syntactic errors), and fixes a related bug where escaped newlines in strings would not update the line number either. Adds tests for both.