### PR TITLE
Add new syntax for data, & add struct declarations.

### DIFF
--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -1482,6 +1482,11 @@ static VAL lbl_word = MKNIL_C;
 static VAL lbl_ZPlusab = MKNIL_C;
 static VAL lbl_ZPluspat = MKNIL_C;
 static VAL lbl_tok = MKNIL_C;
+static VAL lbl_header = MKNIL_C;
+static VAL lbl_valueZAsk = MKNIL_C;
+static VAL lbl_sigZAsk = MKNIL_C;
+static VAL lbl_syn = MKNIL_C;
+static VAL lbl_dat = MKNIL_C;
 static VAL lbl_f = MKNIL_C;
 static VAL lbl_hasZ_paren = MKNIL_C;
 static VAL lbl_target = MKNIL_C;
@@ -4597,7 +4602,7 @@ static void mtp_mirth_lexer_ZPlusLexer_ZPlusLexer (void) {
 		free(tup);
 	}
 }
-static void mtw_mirth_elab_ZPlusTypeElab_TYPEz_ELAB (void) {
+static void mtw_mirth_elab_ZPlusTypeElab_ZPlusTypeElab (void) {
 	TUP* tup = tup_new(5);
 	tup->size = 5;
 	tup->cells[0] = MKU64(0LL);
@@ -4607,7 +4612,7 @@ static void mtw_mirth_elab_ZPlusTypeElab_TYPEz_ELAB (void) {
 	tup->cells[1] = lpop(&lbl_ctx);
 	push_resource(MKTUP(tup, 5));
 }
-static void mtp_mirth_elab_ZPlusTypeElab_TYPEz_ELAB (void) {
+static void mtp_mirth_elab_ZPlusTypeElab_ZPlusTypeElab (void) {
 	VAL val = pop_resource();
 	ASSERT1(IS_TUP(val),val);
 	TUP* tup = VTUP(val);
@@ -4625,7 +4630,7 @@ static void mtp_mirth_elab_ZPlusTypeElab_TYPEz_ELAB (void) {
 		free(tup);
 	}
 }
-static void mtw_mirth_elab_ZPlusResolveDef_RESOLVEz_DEF (void) {
+static void mtw_mirth_elab_ZPlusResolveDef_ZPlusResolveDef (void) {
 	TUP* tup = tup_new(7);
 	tup->size = 7;
 	tup->cells[0] = MKU64(0LL);
@@ -4637,7 +4642,7 @@ static void mtw_mirth_elab_ZPlusResolveDef_RESOLVEz_DEF (void) {
 	tup->cells[1] = lpop(&lbl_sort);
 	push_resource(MKTUP(tup, 7));
 }
-static void mtp_mirth_elab_ZPlusResolveDef_RESOLVEz_DEF (void) {
+static void mtp_mirth_elab_ZPlusResolveDef_ZPlusResolveDef (void) {
 	VAL val = pop_resource();
 	ASSERT1(IS_TUP(val),val);
 	TUP* tup = VTUP(val);
@@ -4804,10 +4809,10 @@ static void mtp_mirth_elab_RejectedDef_RDz_METHODz_WRONGz_TYPE (void) {
 		free(tup);
 	}
 }
-static void mtw_mirth_elab_ZPlusAB_MKAB (void) {
+static void mtw_mirth_elab_ZPlusAB_ZPlusAB (void) {
 	push_resource(lpop(&lbl_arrow));
 }
-static void mtp_mirth_elab_ZPlusAB_MKAB (void) {
+static void mtp_mirth_elab_ZPlusAB_ZPlusAB (void) {
 	VAL val = pop_resource();
 	lpush(&lbl_arrow, val);
 }
@@ -4848,6 +4853,44 @@ static void mtp_mirth_elab_OpSig_OPSIGz_APPLY (void) {
 	} else {
 		free(tup);
 	}
+}
+static void mtw_mirth_elab_SyntaxData_SyntaxData (void) {
+	TUP* tup = tup_new(3);
+	tup->size = 3;
+	tup->cells[0] = MKU64(0LL);
+	tup->cells[2] = lpop(&lbl_tags);
+	tup->cells[1] = lpop(&lbl_header);
+	push_value(MKTUP(tup, 3));
+}
+static void mtp_mirth_elab_SyntaxData_SyntaxData (void) {
+	VAL val = pop_value();
+	ASSERT1(IS_TUP(val),val);
+	TUP* tup = VTUP(val);
+	lpush(&lbl_header, tup->cells[1]);
+	lpush(&lbl_tags, tup->cells[2]);
+	if (tup->refs > 1) {
+		incref(tup->cells[1]);
+		incref(tup->cells[2]);
+		decref(val);
+	} else {
+		free(tup);
+	}
+}
+static void mtw_mirth_elab_SyntaxDataHeader_SyntaxDataHeader (void) {
+	push_value(lpop(&lbl_head));
+}
+static void mtp_mirth_elab_SyntaxDataHeader_SyntaxDataHeader (void) {
+	VAL val = pop_value();
+	lpush(&lbl_head, val);
+}
+static void mtw_mirth_elab_SyntaxDataTag_SyntaxDataTag (void) {
+	TUP* tup = tup_new(4);
+	tup->size = 4;
+	tup->cells[0] = MKU64(0LL);
+	tup->cells[3] = lpop(&lbl_sigZAsk);
+	tup->cells[2] = lpop(&lbl_name);
+	tup->cells[1] = lpop(&lbl_valueZAsk);
+	push_value(MKTUP(tup, 4));
 }
 static void mtw_mirth_elab_ExternalDeclPart_EDPCode (void) {
 	TUP* tup = tup_new(3);
@@ -6081,11 +6124,13 @@ static void mw_mirth_token_TokenValue_noneZAsk (void);
 static void mw_mirth_token_TokenValue_commaZAsk (void);
 static void mw_mirth_token_TokenValue_lparenZ_openZAsk (void);
 static void mw_mirth_token_TokenValue_lparenZAsk (void);
+static void mw_mirth_token_TokenValue_rparenZAsk (void);
 static void mw_mirth_token_TokenValue_lsquareZ_openZAsk (void);
 static void mw_mirth_token_TokenValue_lsquareZAsk (void);
 static void mw_mirth_token_TokenValue_rsquareZAsk (void);
 static void mw_mirth_token_TokenValue_lcurlyZ_openZAsk (void);
 static void mw_mirth_token_TokenValue_lcurlyZAsk (void);
+static void mw_mirth_token_TokenValue_rcurlyZAsk (void);
 static void mw_mirth_token_TokenValue_lcolonZ_openZAsk (void);
 static void mw_mirth_token_TokenValue_lcolonZAsk (void);
 static void mw_mirth_token_TokenValue_lparenZ_orZ_lcolonZAsk (void);
@@ -6108,7 +6153,7 @@ static void mw_mirth_token_TokenValue_sigZ_stackZ_varZAsk (void);
 static void mw_mirth_token_TokenValue_sigZ_resourceZ_varZAsk (void);
 static void mw_mirth_token_TokenValue_sigZ_resourceZ_conZAsk (void);
 static void mw_mirth_token_TokenValue_sigZ_dashesZAsk (void);
-static void mw_mirth_token_TokenValue_patZ_arrowZAsk (void);
+static void mw_mirth_token_TokenValue_arrowZAsk (void);
 static void mw_mirth_token_TokenValue_patZ_underscoreZAsk (void);
 static void mw_mirth_token_TokenValue_moduleZ_headerZAsk (void);
 static void mw_mirth_token_Token_index (void);
@@ -6124,11 +6169,13 @@ static void mw_mirth_token_Token_noneZAsk (void);
 static void mw_mirth_token_Token_commaZAsk (void);
 static void mw_mirth_token_Token_lparenZ_openZAsk (void);
 static void mw_mirth_token_Token_lparenZAsk (void);
+static void mw_mirth_token_Token_rparenZAsk (void);
 static void mw_mirth_token_Token_lsquareZ_openZAsk (void);
 static void mw_mirth_token_Token_lsquareZAsk (void);
 static void mw_mirth_token_Token_rsquareZAsk (void);
 static void mw_mirth_token_Token_lcurlyZ_openZAsk (void);
 static void mw_mirth_token_Token_lcurlyZAsk (void);
+static void mw_mirth_token_Token_rcurlyZAsk (void);
 static void mw_mirth_token_Token_lcolonZ_openZAsk (void);
 static void mw_mirth_token_Token_lcolonZAsk (void);
 static void mw_mirth_token_Token_lparenZ_orZ_lcolonZAsk (void);
@@ -6150,7 +6197,7 @@ static void mw_mirth_token_Token_sigZ_stackZ_varZAsk (void);
 static void mw_mirth_token_Token_sigZ_resourceZ_varZAsk (void);
 static void mw_mirth_token_Token_sigZ_resourceZ_conZAsk (void);
 static void mw_mirth_token_Token_sigZ_dashesZAsk (void);
-static void mw_mirth_token_Token_patZ_arrowZAsk (void);
+static void mw_mirth_token_Token_arrowZAsk (void);
 static void mw_mirth_token_Token_patZ_underscoreZAsk (void);
 static void mw_mirth_token_Token_moduleZ_headerZAsk (void);
 static void mw_mirth_token_Token_canZ_takeZ_argsZAsk (void);
@@ -6380,7 +6427,7 @@ static void mw_mirth_name_Name_isZ_underscore (void);
 static void mw_mirth_name_Name_couldZ_beZ_stackZ_var (void);
 static void mw_mirth_name_Name_couldZ_beZ_resourceZ_var (void);
 static void mw_mirth_name_Name_couldZ_beZ_resourceZ_con (void);
-static void mw_mirth_name_Name_couldZ_beZ_typeZ_orZ_resourceZ_con (void);
+static void mw_mirth_name_Name_couldZ_beZ_constructor (void);
 static void mw_mirth_name_Name_mangleZ_computeZBang (void);
 static void mw_mirth_name_Namespace_ZEqualZEqual (void);
 static void mw_mirth_name_Namespace_qname (void);
@@ -6494,7 +6541,7 @@ static void mw_mirth_lexer_lexerZ_moveZBang (void);
 static void mw_mirth_lexer_lexerZ_location (void);
 static void mw_mirth_lexer_lexerZ_emitZ_warningZBang (void);
 static void mw_mirth_lexer_lexerZ_emitZ_fatalZ_errorZBang (void);
-static void mw_mirth_elab_ZPlusTypeElab_ZDivTYPEz_ELAB (void);
+static void mw_mirth_elab_ZPlusTypeElab_ZDivZPlusTypeElab (void);
 static void mw_mirth_elab_ZPlusTypeElab_allowZ_implicitZ_typeZ_vars (void);
 static void mw_mirth_elab_ZPlusTypeElab_allowZ_typeZ_holes (void);
 static void mw_mirth_elab_ZPlusTypeElab_token (void);
@@ -6518,7 +6565,7 @@ static void mw_mirth_elab_ZPlusTypeElab_elabZ_typeZ_varZBang (void);
 static void mw_mirth_elab_ZPlusTypeElab_elabZ_resourceZ_varZBang (void);
 static void mw_mirth_elab_ZPlusTypeElab_gamma_1 (void);
 static void mw_mirth_elab_ZPlusTypeElab_elabZ_implicitZ_varZBang (void);
-static void mw_mirth_elab_ZPlusResolveDef_ZDivRESOLVEz_DEF (void);
+static void mw_mirth_elab_ZPlusResolveDef_ZDivZPlusResolveDef (void);
 static void mw_mirth_elab_ZPlusResolveDef_reportZ_ambiguousZ_asZ_warning (void);
 static void mw_mirth_elab_ZPlusResolveDef_ignoreZ_lastZ_name (void);
 static void mw_mirth_elab_ZPlusResolveDef_rejected (void);
@@ -6528,8 +6575,6 @@ static void mw_mirth_elab_ZPlusResolveDef_candidates (void);
 static void mw_mirth_elab_ZPlusResolveDef_candidatesZBang (void);
 static void mw_mirth_elab_ZPlusResolveDef_token (void);
 static void mw_mirth_elab_ZPlusResolveDef_sort (void);
-static void mw_mirth_elab_ZPlusResolveDef_filter_1 (void);
-static void mw_mirth_elab_ZPlusResolveDef_filter_2 (void);
 static void mw_mirth_elab_resolveZ_def_1 (void);
 static void mw_mirth_elab_ZPlusResolveDef_rdrop (void);
 static void mw_mirth_elab_ZPlusResolveDef_resolveZ_defZ_ambiguous (void);
@@ -6553,7 +6598,7 @@ static void mw_mirth_elab_ZPlusTypeElab_elabZ_typeZ_quoteZBang (void);
 static void mw_mirth_elab_elabZ_typeZ_unifyZBang (void);
 static void mw_mirth_elab_elabZ_stackZ_typeZ_unifyZBang (void);
 static void mw_mirth_elab_elabZ_simpleZ_typeZ_argZBang (void);
-static void mw_mirth_elab_ZPlusAB_ZDivMKAB (void);
+static void mw_mirth_elab_ZPlusAB_ZDivZPlusAB (void);
 static void mw_mirth_elab_ZPlusAB_arrow (void);
 static void mw_mirth_elab_ZPlusAB_arrowZBang (void);
 static void mw_mirth_elab_ZPlusAB_arrow_1 (void);
@@ -6653,7 +6698,21 @@ static void mw_mirth_elab_checkZ_moduleZ_path (void);
 static void mw_mirth_elab_elabZ_moduleZ_declZBang (void);
 static void mw_mirth_elab_loadZ_module (void);
 static void mw_mirth_elab_elabZ_moduleZ_importZBang (void);
+static void mw_mirth_elab_parseZ_data (void);
+static void mw_mirth_elab_parseZ_dataZ_header (void);
+static void mw_mirth_elab_parseZ_dataZ_tags (void);
+static void mw_mirth_elab_parseZ_dataZ_tag (void);
+static void mw_mirth_elab_parseZ_struct (void);
+static void mw_mirth_elab_parseZ_structZ_tag (void);
+static void mw_mirth_elab_SyntaxData_ZDivSyntaxData (void);
+static void mw_mirth_elab_SyntaxDataHeader_ZDivSyntaxDataHeader (void);
+static void mw_mirth_elab_SyntaxDataHeader_head (void);
+static void mw_mirth_elab_SyntaxDataTag_sigZAsk (void);
+static void mw_mirth_elab_SyntaxDataTag_name (void);
+static void mw_mirth_elab_SyntaxDataTag_valueZAsk (void);
 static void mw_mirth_elab_elabZ_dataZBang (void);
+static void mw_mirth_elab_elabZ_structZBang (void);
+static void mw_mirth_elab_elabZ_dataZ_auxZBang (void);
 static void mw_mirth_elab_elabZ_dataZ_headerZBang (void);
 static void mw_mirth_elab_elabZ_dataZ_paramsZBang (void);
 static void mw_mirth_elab_elabZ_dataZ_tagZBang (void);
@@ -7202,26 +7261,14 @@ static void mb_mirth_elab_ZPlusResolveDef_resolveZ_defZ_ambiguous_5 (void);
 static void mb_mirth_elab_ZPlusResolveDef_resolveZ_defZ_ambiguous_8 (void);
 static void mb_mirth_elab_ZPlusResolveDef_resolveZ_defZ_ambiguous_11 (void);
 static void mb_mirth_elab_ZPlusResolveDef_filterZ_sort_1_1 (void);
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_arity_0 (void);
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_arity_1 (void);
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_qualifiers_1 (void);
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_qualifiers_2 (void);
 static void mb_mirth_name_QName_climbZ_upZ_dnameZAsk_5 (void);
 static void mb_mirth_name_QName_climbZ_upZ_dnameZAsk_6 (void);
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_roots_1 (void);
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_roots_2 (void);
 static void mb_mirth_elab_ZPlusResolveDef_filterZ_roots_4 (void);
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_roots_16 (void);
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_roots_17 (void);
 static void mb_mirth_elab_ZPlusResolveDef_filterZ_roots_19 (void);
 static void mb_mirth_elab_ZPlusResolveDef_filterZ_roots_20 (void);
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_roots_23 (void);
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_roots_24 (void);
 static void mb_mirth_elab_ZPlusResolveDef_filterZ_roots_26 (void);
 static void mb_mirth_name_QName_climbZ_upZ_nameZAsk_2 (void);
 static void mb_mirth_elab_ZPlusTypeElab_resolveZ_typeZ_conZ_nameZBang_1 (void);
-static void mb_mirth_elab_ZPlusTypeElab_resolveZ_typeZ_conZ_nameZBang_2 (void);
-static void mb_mirth_elab_ZPlusTypeElab_resolveZ_typeZ_conZ_nameZBang_3 (void);
 static void mb_mirth_elab_ZPlusTypeElab_elabZ_typeZ_argsZBang_3 (void);
 static void mb_mirth_elab_abZ_tokenZBang_0 (void);
 static void mb_mirth_elab_abZ_typeZBang_0 (void);
@@ -7240,8 +7287,6 @@ static void mb_mirth_elab_elabZ_atomZ_assertZBang_3 (void);
 static void mb_mirth_elab_elabZ_blockZ_atZBang_1 (void);
 static void mb_mirth_elab_elabZ_argsZBang_0 (void);
 static void mb_mirth_elab_elabZ_atomZ_resolveZ_defZBang_0 (void);
-static void mb_mirth_elab_elabZ_atomZ_resolveZ_defZBang_1 (void);
-static void mb_mirth_elab_elabZ_atomZ_resolveZ_defZBang_2 (void);
 static void mb_mirth_elab_elabZ_atomZ_lambdaZBang_1 (void);
 static void mb_mirth_elab_elabZ_atomZ_lambdaZBang_5 (void);
 static void mb_mirth_elab_elabZ_matchZ_atZBang_0 (void);
@@ -7252,18 +7297,12 @@ static void mb_mirth_match_ZPlusMatch_caseZBang_2_3 (void);
 static void mb_mirth_elab_elabZ_patternZBang_0 (void);
 static void mb_mirth_elab_elabZ_patternZ_atomZBang_0 (void);
 static void mb_mirth_elab_elabZ_patternZ_atomZBang_5 (void);
-static void mb_mirth_elab_elabZ_patternZ_atomZBang_6 (void);
-static void mb_mirth_elab_elabZ_patternZ_atomZBang_7 (void);
-static void mb_mirth_elab_elabZ_patternZ_atomZBang_11 (void);
-static void mb_mirth_elab_elabZ_patternZ_atomZBang_12 (void);
 static void mb_mirth_elab_elabZ_patternZ_atomZBang_14 (void);
 static void mb_mirth_elab_elabZ_patternZ_atomZBang_16 (void);
 static void mb_mirth_elab_elabZ_moduleZ_declZBang_1 (void);
 static void mb_mirth_elab_checkZ_moduleZ_path_2 (void);
 static void mb_mirth_elab_elabZ_aliasZBang_0 (void);
 static void mb_mirth_elab_elabZ_aliasZBang_1 (void);
-static void mb_mirth_elab_elabZ_aliasZBang_2 (void);
-static void mb_mirth_elab_elabZ_aliasZBang_3 (void);
 static void mb_mirth_elab_elabZ_aliasZBang_6 (void);
 static void mb_mirth_elab_elabZ_defZBang_0 (void);
 static void mb_mirth_elab_elabZ_defZBang_2 (void);
@@ -7277,11 +7316,13 @@ static void mb_mirth_elab_elabZ_fieldZBang_0 (void);
 static void mb_mirth_elab_elabZ_fieldZBang_1 (void);
 static void mb_mirth_elab_elabZ_fieldZBang_2 (void);
 static void mb_mirth_elab_elabZ_fieldZBang_3 (void);
-static void mb_mirth_elab_elabZ_dataZBang_2 (void);
 static void mb_mirth_elab_elabZ_embedZ_strZBang_4 (void);
+static void mb_mirth_elab_parseZ_dataZ_tags_0 (void);
+static void mb_mirth_elab_parseZ_dataZ_tags_1 (void);
+static void mb_mirth_elab_elabZ_dataZ_auxZBang_0 (void);
 static void mb_mirth_elab_elabZ_dataZ_headerZBang_2 (void);
-static void mb_mirth_elab_elabZ_dataZ_tagZBang_10 (void);
-static void mb_mirth_elab_elabZ_dataZ_tagZBang_20 (void);
+static void mb_mirth_elab_elabZ_dataZ_tagZBang_1 (void);
+static void mb_mirth_elab_elabZ_dataZ_tagZBang_5 (void);
 static void mb_mirth_elab_elabZ_dataZ_doneZBang_0 (void);
 static void mb_mirth_elab_elabZ_dataZ_doneZBang_1 (void);
 static void mb_mirth_elab_elabZ_dataZ_doneZBang_2 (void);
@@ -7638,6 +7679,26 @@ static void mb_mirth_need_ZPlusNeeds_pushZ_argsZBang_0 (void);
 static void mb_mirth_need_ZPlusNeeds_runZ_matchZBang_0 (void);
 static void mb_mirth_need_ZPlusNeeds_runZ_patternZBang_0 (void);
 static void mb_std_set_ZPlusSet_1_offsetZ_mask_0 (void);
+static void mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot105ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot123ZRParen_2 (void);
+static void mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot105ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot123ZRParenZDot0ZRParen_0 (void);
+static void mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot78ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot93ZRParen_2 (void);
+static void mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot78ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot93ZRParenZDot0ZRParen_0 (void);
+static void mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot6ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot27ZRParen_2 (void);
+static void mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot6ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot27ZRParenZDot0ZRParen_0 (void);
+static void mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_qualifiersZDot6ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_qualifiersZDot15ZRParen_2 (void);
+static void mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_qualifiersZDot6ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_qualifiersZDot15ZRParenZDot0ZRParen_0 (void);
+static void mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_arityZDot4ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_arityZDot11ZRParen_2 (void);
+static void mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_arityZDot4ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_arityZDot11ZRParenZDot0ZRParen_0 (void);
+static void mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotZPlusTypeElabZDotresolveZ_typeZ_conZ_nameZBangZDot14ZCommamirthZDotelabZDotZPlusTypeElabZDotresolveZ_typeZ_conZ_nameZBangZDot20ZRParen_2 (void);
+static void mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotZPlusTypeElabZDotresolveZ_typeZ_conZ_nameZBangZDot14ZCommamirthZDotelabZDotZPlusTypeElabZDotresolveZ_typeZ_conZ_nameZBangZDot20ZRParenZDot0ZRParen_0 (void);
+static void mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotelabZ_patternZ_atomZBangZDot59ZCommamirthZDotelabZDotelabZ_patternZ_atomZBangZDot71ZRParen_2 (void);
+static void mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotelabZ_patternZ_atomZBangZDot59ZCommamirthZDotelabZDotelabZ_patternZ_atomZBangZDot71ZRParenZDot0ZRParen_0 (void);
+static void mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotelabZ_patternZ_atomZBangZDot31ZCommamirthZDotelabZDotelabZ_patternZ_atomZBangZDot35ZRParen_2 (void);
+static void mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotelabZ_patternZ_atomZBangZDot31ZCommamirthZDotelabZDotelabZ_patternZ_atomZBangZDot35ZRParenZDot0ZRParen_0 (void);
+static void mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotelabZ_atomZ_resolveZ_defZBangZDot15ZCommamirthZDotelabZDotelabZ_atomZ_resolveZ_defZBangZDot21ZRParen_2 (void);
+static void mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotelabZ_atomZ_resolveZ_defZBangZDot15ZCommamirthZDotelabZDotelabZ_atomZ_resolveZ_defZBangZDot21ZRParenZDot0ZRParen_0 (void);
+static void mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotelabZ_aliasZBangZDot32ZCommamirthZDotelabZDotelabZ_aliasZBangZDot39ZRParen_2 (void);
+static void mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotelabZ_aliasZBangZDot32ZCommamirthZDotelabZDotelabZ_aliasZBangZDot39ZRParenZDot0ZRParen_0 (void);
 static void mb_std_str_ZPlusStr_splitZ_byte_1_ZLParenstdZDotstrZDotZPlusStrZDotsplitZ_byteZDot2ZRParen_11 (void);
 static void mfld_mirth_label_Label_ZTildename (void);
 static void mfld_mirth_var_Var_ZTildename (void);
@@ -24139,15 +24200,19 @@ static void mw_mirth_prim_initZ_primsZBang (void) {
 	STRLIT("data", 4);
 	push_i64(-1LL);
 	mw_mirth_prim_defZ_primZBang();
+	push_u64(85LL); // PRIM_SYNTAX_STRUCT
+	STRLIT("struct", 6);
+	push_i64(-1LL);
+	mw_mirth_prim_defZ_primZBang();
 	push_u64(78LL); // PRIM_SYNTAX_VARIABLE
 	STRLIT("var", 3);
 	push_i64(-1LL);
 	mw_mirth_prim_defZ_primZBang();
-	push_u64(86LL); // PRIM_SYNTAX_ARROW
+	push_u64(87LL); // PRIM_SYNTAX_ARROW
 	STRLIT("->", 2);
 	push_i64(-1LL);
 	mw_mirth_prim_defZ_primZBang();
-	push_u64(85LL); // PRIM_SYNTAX_DASHES
+	push_u64(86LL); // PRIM_SYNTAX_DASHES
 	STRLIT("--", 2);
 	push_i64(-1LL);
 	mw_mirth_prim_defZ_primZBang();
@@ -25395,6 +25460,18 @@ static void mw_mirth_token_TokenValue_lparenZAsk (void) {
 			break;
 	}
 }
+static void mw_mirth_token_TokenValue_rparenZAsk (void) {
+	switch (get_top_data_tag()) {
+		case 4LL: // TokenRParen
+			mtp_mirth_token_TokenValue_TokenRParen();
+			mtw_std_maybe_Maybe_1_Some();
+			break;
+		default:
+			mp_primZ_drop();
+			push_u64(0LL); // None
+			break;
+	}
+}
 static void mw_mirth_token_TokenValue_lsquareZ_openZAsk (void) {
 	switch (get_top_data_tag()) {
 		case 5LL: // TokenLSquareOpen
@@ -25447,6 +25524,18 @@ static void mw_mirth_token_TokenValue_lcurlyZAsk (void) {
 	switch (get_top_data_tag()) {
 		case 9LL: // TokenLCurly
 			mtp_mirth_token_TokenValue_TokenLCurly();
+			mtw_std_maybe_Maybe_1_Some();
+			break;
+		default:
+			mp_primZ_drop();
+			push_u64(0LL); // None
+			break;
+	}
+}
+static void mw_mirth_token_TokenValue_rcurlyZAsk (void) {
+	switch (get_top_data_tag()) {
+		case 10LL: // TokenRCurly
+			mtp_mirth_token_TokenValue_TokenRCurly();
 			mtw_std_maybe_Maybe_1_Some();
 			break;
 		default:
@@ -25805,7 +25894,7 @@ static void mw_mirth_token_TokenValue_sigZ_dashesZAsk (void) {
 	switch (get_top_data_tag()) {
 		case 1LL: // Some
 			mtp_std_maybe_Maybe_1_Some();
-			push_u64(85LL); // PRIM_SYNTAX_DASHES
+			push_u64(86LL); // PRIM_SYNTAX_DASHES
 			mw_mirth_prim_Prim_name();
 			mw_mirth_name_Name_ZEqualZEqual();
 			break;
@@ -25818,12 +25907,12 @@ static void mw_mirth_token_TokenValue_sigZ_dashesZAsk (void) {
 			mp_primZ_panic();
 	}
 }
-static void mw_mirth_token_TokenValue_patZ_arrowZAsk (void) {
+static void mw_mirth_token_TokenValue_arrowZAsk (void) {
 	mw_mirth_token_TokenValue_nameZAsk();
 	switch (get_top_data_tag()) {
 		case 1LL: // Some
 			mtp_std_maybe_Maybe_1_Some();
-			push_u64(86LL); // PRIM_SYNTAX_ARROW
+			push_u64(87LL); // PRIM_SYNTAX_ARROW
 			mw_mirth_prim_Prim_name();
 			mw_mirth_name_Name_ZEqualZEqual();
 			break;
@@ -25984,6 +26073,10 @@ static void mw_mirth_token_Token_lparenZAsk (void) {
 	mw_mirth_token_Token_value();
 	mw_mirth_token_TokenValue_lparenZAsk();
 }
+static void mw_mirth_token_Token_rparenZAsk (void) {
+	mw_mirth_token_Token_value();
+	mw_mirth_token_TokenValue_rparenZAsk();
+}
 static void mw_mirth_token_Token_lsquareZ_openZAsk (void) {
 	mw_mirth_token_Token_value();
 	mw_mirth_token_TokenValue_lsquareZ_openZAsk();
@@ -26003,6 +26096,10 @@ static void mw_mirth_token_Token_lcurlyZ_openZAsk (void) {
 static void mw_mirth_token_Token_lcurlyZAsk (void) {
 	mw_mirth_token_Token_value();
 	mw_mirth_token_TokenValue_lcurlyZAsk();
+}
+static void mw_mirth_token_Token_rcurlyZAsk (void) {
+	mw_mirth_token_Token_value();
+	mw_mirth_token_TokenValue_rcurlyZAsk();
 }
 static void mw_mirth_token_Token_lcolonZ_openZAsk (void) {
 	mw_mirth_token_Token_value();
@@ -26088,9 +26185,9 @@ static void mw_mirth_token_Token_sigZ_dashesZAsk (void) {
 	mw_mirth_token_Token_value();
 	mw_mirth_token_TokenValue_sigZ_dashesZAsk();
 }
-static void mw_mirth_token_Token_patZ_arrowZAsk (void) {
+static void mw_mirth_token_Token_arrowZAsk (void) {
 	mw_mirth_token_Token_value();
-	mw_mirth_token_TokenValue_patZ_arrowZAsk();
+	mw_mirth_token_TokenValue_arrowZAsk();
 }
 static void mw_mirth_token_Token_patZ_underscoreZAsk (void) {
 	mw_mirth_token_Token_value();
@@ -30207,19 +30304,23 @@ static void mw_mirth_name_Name_couldZ_beZ_resourceZ_con (void) {
 		push_u64(0LL); // False
 	}
 }
-static void mw_mirth_name_Name_couldZ_beZ_typeZ_orZ_resourceZ_con (void) {
+static void mw_mirth_name_Name_couldZ_beZ_constructor (void) {
 	mp_primZ_dup();
-	mw_mirth_name_Name_couldZ_beZ_typeZ_con();
-	if (pop_u64()) {
-		push_u64(1LL); // True
-	} else {
-		mp_primZ_dup();
-		mw_mirth_name_Name_couldZ_beZ_resourceZ_con();
-	}
-	{
-		VAL d2 = pop_value();
-		mp_primZ_drop();
-		push_value(d2);
+	mw_mirth_name_Name_head();
+	switch (get_top_data_tag()) {
+		case 43LL: // B'+'
+			(void)pop_u64();
+			mw_mirth_name_Name_tailZ_head();
+			mw_std_byte_Byte_isZ_upper();
+			break;
+		default:
+			{
+				VAL d4 = pop_value();
+				mp_primZ_drop();
+				push_value(d4);
+			}
+			mw_std_byte_Byte_isZ_upper();
+			break;
 	}
 }
 static void mw_mirth_name_Name_mangleZ_computeZBang (void) {
@@ -32794,10 +32895,10 @@ static void mw_mirth_lexer_lexerZ_emitZ_fatalZ_errorZBang (void) {
 	mp_primZ_rswap();
 	mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZ_atZBang();
 }
-static void mw_mirth_elab_ZPlusTypeElab_ZDivTYPEz_ELAB (void) {
+static void mw_mirth_elab_ZPlusTypeElab_ZDivZPlusTypeElab (void) {
 	switch (get_top_resource_data_tag()) {
-		case 0LL: // TYPE_ELAB
-			mtp_mirth_elab_ZPlusTypeElab_TYPEz_ELAB();
+		case 0LL: // +TypeElab
+			mtp_mirth_elab_ZPlusTypeElab_ZPlusTypeElab();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -32896,10 +32997,10 @@ static void mw_mirth_elab_ZPlusTypeElab_typeZ_sigZ_startZBang (void) {
 	LPUSH(lbl_allowZ_typeZ_holes);
 	push_u64(1LL); // True
 	LPUSH(lbl_allowZ_implicitZ_typeZ_vars);
-	mtw_mirth_elab_ZPlusTypeElab_TYPEz_ELAB();
+	mtw_mirth_elab_ZPlusTypeElab_ZPlusTypeElab();
 }
 static void mw_mirth_elab_ZPlusTypeElab_rdrop (void) {
-	mw_mirth_elab_ZPlusTypeElab_ZDivTYPEz_ELAB();
+	mw_mirth_elab_ZPlusTypeElab_ZDivZPlusTypeElab();
 	LPOP(lbl_ctx);
 	LPOP(lbl_token);
 	mp_primZ_drop();
@@ -33392,10 +33493,10 @@ static void mw_mirth_elab_ZPlusTypeElab_elabZ_implicitZ_varZBang (void) {
 	push_fnptr(&mb_mirth_elab_ZPlusTypeElab_elabZ_implicitZ_varZBang_7);
 	mw_mirth_elab_ZPlusTypeElab_token_1();
 }
-static void mw_mirth_elab_ZPlusResolveDef_ZDivRESOLVEz_DEF (void) {
+static void mw_mirth_elab_ZPlusResolveDef_ZDivZPlusResolveDef (void) {
 	switch (get_top_resource_data_tag()) {
-		case 0LL: // RESOLVE_DEF
-			mtp_mirth_elab_ZPlusResolveDef_RESOLVEz_DEF();
+		case 0LL: // +ResolveDef
+			mtp_mirth_elab_ZPlusResolveDef_ZPlusResolveDef();
 			break;
 		default:
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
@@ -33492,39 +33593,6 @@ static void mw_mirth_elab_ZPlusResolveDef_sort (void) {
 	push_resource(v);
 	push_value(u);
 }
-static void mw_mirth_elab_ZPlusResolveDef_filter_1 (void) {
-	{
-		VAL var_p = pop_value();
-		mw_mirth_elab_ZPlusResolveDef_candidates();
-		incref(var_p);
-		push_value(var_p);
-		mw_std_list_List_1_partitionZ_either_1();
-		{
-			VAL d3 = pop_value();
-			push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_1_2);
-			mw_mirth_elab_ZPlusResolveDef_rejected_1();
-			push_value(d3);
-		}
-		mw_mirth_elab_ZPlusResolveDef_candidatesZBang();
-		decref(var_p);
-	}
-}
-static void mw_mirth_elab_ZPlusResolveDef_filter_2 (void) {
-	{
-		VAL var_q = pop_value();
-		VAL var_p = pop_value();
-		push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_2_0);
-		incref(var_p);
-		push_value(var_p);
-		mp_primZ_packZ_cons();
-		incref(var_q);
-		push_value(var_q);
-		mp_primZ_packZ_cons();
-		mw_mirth_elab_ZPlusResolveDef_filter_1();
-		decref(var_q);
-		decref(var_p);
-	}
-}
 static void mw_mirth_elab_resolveZ_def_1 (void) {
 	{
 		VAL var_f = pop_value();
@@ -33559,7 +33627,7 @@ static void mw_mirth_elab_resolveZ_def_1 (void) {
 		LPUSH(lbl_candidates);
 		push_u64(0LL); // Nil
 		LPUSH(lbl_rejected);
-		mtw_mirth_elab_ZPlusResolveDef_RESOLVEz_DEF();
+		mtw_mirth_elab_ZPlusResolveDef_ZPlusResolveDef();
 		incref(var_f);
 		run_value(var_f);
 		mw_mirth_elab_ZPlusResolveDef_candidates();
@@ -33604,7 +33672,7 @@ static void mw_mirth_elab_resolveZ_def_1 (void) {
 	}
 }
 static void mw_mirth_elab_ZPlusResolveDef_rdrop (void) {
-	mw_mirth_elab_ZPlusResolveDef_ZDivRESOLVEz_DEF();
+	mw_mirth_elab_ZPlusResolveDef_ZDivZPlusResolveDef();
 	LPOP(lbl_sort);
 	LPOP(lbl_token);
 	mp_primZ_drop();
@@ -33658,16 +33726,50 @@ static void mw_mirth_elab_ZPlusResolveDef_filterZ_sort_1 (void) {
 		incref(var_p);
 		push_value(var_p);
 		push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filterZ_sort_1_1);
-		mw_mirth_elab_ZPlusResolveDef_filter_2();
+		{
+			VAL var_q = pop_value();
+			VAL var_p = pop_value();
+			push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_2_0);
+			incref(var_p);
+			push_value(var_p);
+			mp_primZ_packZ_cons();
+			incref(var_q);
+			push_value(var_q);
+			mp_primZ_packZ_cons();
+			{
+				VAL var_p = pop_value();
+				mw_mirth_elab_ZPlusResolveDef_candidates();
+				incref(var_p);
+				push_value(var_p);
+				mw_std_list_List_1_partitionZ_either_1();
+				{
+					VAL d5 = pop_value();
+					push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_1_2);
+					mw_mirth_elab_ZPlusResolveDef_rejected_1();
+					push_value(d5);
+				}
+				mw_mirth_elab_ZPlusResolveDef_candidatesZBang();
+				decref(var_p);
+			}
+			decref(var_q);
+			decref(var_p);
+		}
 		decref(var_p);
 	}
 }
 static void mw_mirth_elab_ZPlusResolveDef_filterZ_arity (void) {
 	mw_mirth_elab_ZPlusResolveDef_token();
 	mw_mirth_token_Token_numZ_args();
-	push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filterZ_arity_0);
-	push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filterZ_arity_1);
-	mw_mirth_elab_ZPlusResolveDef_filter_2();
+	mw_mirth_elab_ZPlusResolveDef_candidates();
+	push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_arityZDot4ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_arityZDot11ZRParen_2);
+	mw_std_list_List_1_partitionZ_either_1();
+	{
+		VAL d2 = pop_value();
+		push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_arityZDot4ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_arityZDot11ZRParenZDot0ZRParen_0);
+		mw_mirth_elab_ZPlusResolveDef_rejected_1();
+		push_value(d2);
+	}
+	mw_mirth_elab_ZPlusResolveDef_candidatesZBang();
 	mp_primZ_drop();
 }
 static void mw_mirth_elab_ZPlusResolveDef_filterZ_qualifiers (void) {
@@ -33676,9 +33778,16 @@ static void mw_mirth_elab_ZPlusResolveDef_filterZ_qualifiers (void) {
 	switch (get_top_data_tag()) {
 		case 1LL: // Some
 			mtp_std_maybe_Maybe_1_Some();
-			push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filterZ_qualifiers_1);
-			push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filterZ_qualifiers_2);
-			mw_mirth_elab_ZPlusResolveDef_filter_2();
+			mw_mirth_elab_ZPlusResolveDef_candidates();
+			push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_qualifiersZDot6ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_qualifiersZDot15ZRParen_2);
+			mw_std_list_List_1_partitionZ_either_1();
+			{
+				VAL d4 = pop_value();
+				push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_qualifiersZDot6ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_qualifiersZDot15ZRParenZDot0ZRParen_0);
+				mw_mirth_elab_ZPlusResolveDef_rejected_1();
+				push_value(d4);
+			}
+			mw_mirth_elab_ZPlusResolveDef_candidatesZBang();
 			mp_primZ_drop();
 			break;
 		case 0LL: // None
@@ -33696,9 +33805,16 @@ static void mw_mirth_elab_ZPlusResolveDef_filterZ_roots (void) {
 		case 1LL: // Some
 			mtp_std_maybe_Maybe_1_Some();
 			mp_primZ_drop();
-			push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filterZ_roots_1);
-			push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filterZ_roots_2);
-			mw_mirth_elab_ZPlusResolveDef_filter_2();
+			mw_mirth_elab_ZPlusResolveDef_candidates();
+			push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot6ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot27ZRParen_2);
+			mw_std_list_List_1_partitionZ_either_1();
+			{
+				VAL d4 = pop_value();
+				push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot6ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot27ZRParenZDot0ZRParen_0);
+				mw_mirth_elab_ZPlusResolveDef_rejected_1();
+				push_value(d4);
+			}
+			mw_mirth_elab_ZPlusResolveDef_candidatesZBang();
 			break;
 		case 0LL: // None
 			(void)pop_u64();
@@ -33725,13 +33841,27 @@ static void mw_mirth_elab_ZPlusResolveDef_filterZ_roots (void) {
 				push_u64(0LL); // False
 			}
 			if (pop_u64()) {
-				push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filterZ_roots_16);
-				push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filterZ_roots_17);
-				mw_mirth_elab_ZPlusResolveDef_filter_2();
+				mw_mirth_elab_ZPlusResolveDef_candidates();
+				push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot78ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot93ZRParen_2);
+				mw_std_list_List_1_partitionZ_either_1();
+				{
+					VAL d5 = pop_value();
+					push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot78ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot93ZRParenZDot0ZRParen_0);
+					mw_mirth_elab_ZPlusResolveDef_rejected_1();
+					push_value(d5);
+				}
+				mw_mirth_elab_ZPlusResolveDef_candidatesZBang();
 			} else {
-				push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filterZ_roots_23);
-				push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filterZ_roots_24);
-				mw_mirth_elab_ZPlusResolveDef_filter_2();
+				mw_mirth_elab_ZPlusResolveDef_candidates();
+				push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot105ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot123ZRParen_2);
+				mw_std_list_List_1_partitionZ_either_1();
+				{
+					VAL d5 = pop_value();
+					push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot105ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot123ZRParenZDot0ZRParen_0);
+					mw_mirth_elab_ZPlusResolveDef_rejected_1();
+					push_value(d5);
+				}
+				mw_mirth_elab_ZPlusResolveDef_candidatesZBang();
 			}
 			mp_primZ_drop();
 			break;
@@ -34247,12 +34377,12 @@ static void mw_mirth_elab_elabZ_simpleZ_typeZ_argZBang (void) {
 	LPUSH(lbl_allowZ_typeZ_holes);
 	push_u64(0LL); // False
 	LPUSH(lbl_allowZ_implicitZ_typeZ_vars);
-	mtw_mirth_elab_ZPlusTypeElab_TYPEz_ELAB();
+	mtw_mirth_elab_ZPlusTypeElab_ZPlusTypeElab();
 	mw_mirth_elab_ZPlusTypeElab_elabZ_typeZ_argZBang();
 	mw_mirth_elab_ZPlusTypeElab_rdrop();
 }
-static void mw_mirth_elab_ZPlusAB_ZDivMKAB (void) {
-	mtp_mirth_elab_ZPlusAB_MKAB();
+static void mw_mirth_elab_ZPlusAB_ZDivZPlusAB (void) {
+	mtp_mirth_elab_ZPlusAB_ZPlusAB();
 }
 static void mw_mirth_elab_ZPlusAB_arrow (void) {
 	VAL v = top_resource();
@@ -34333,10 +34463,10 @@ static void mw_mirth_elab_abZ_buildZBang_1 (void) {
 		LPUSH(lbl_atoms);
 		mtw_mirth_arrow_Arrow_Arrow();
 		LPUSH(lbl_arrow);
-		mtw_mirth_elab_ZPlusAB_MKAB();
+		mtw_mirth_elab_ZPlusAB_ZPlusAB();
 		incref(var_f);
 		run_value(var_f);
-		mw_mirth_elab_ZPlusAB_ZDivMKAB();
+		mw_mirth_elab_ZPlusAB_ZDivZPlusAB();
 		LPOP(lbl_arrow);
 		decref(var_f);
 	}
@@ -35950,7 +36080,7 @@ static void mw_mirth_elab_elabZ_atomZ_assertZBang (void) {
 	LPUSH(lbl_allowZ_typeZ_holes);
 	push_u64(0LL); // False
 	LPUSH(lbl_allowZ_implicitZ_typeZ_vars);
-	mtw_mirth_elab_ZPlusTypeElab_TYPEz_ELAB();
+	mtw_mirth_elab_ZPlusTypeElab_ZPlusTypeElab();
 	mp_primZ_rswap();
 	{
 		VAL d2 = pop_resource();
@@ -37018,6 +37148,10 @@ static void mw_mirth_elab_elabZ_moduleZ_declZBang (void) {
 			(void)pop_u64();
 			mw_mirth_elab_elabZ_dataZBang();
 			break;
+		case 85LL: // PRIM_SYNTAX_STRUCT
+			(void)pop_u64();
+			mw_mirth_elab_elabZ_structZBang();
+			break;
 		case 81LL: // PRIM_SYNTAX_EMBED_STR
 			(void)pop_u64();
 			mw_mirth_elab_elabZ_embedZ_strZBang();
@@ -37089,37 +37223,490 @@ static void mw_mirth_elab_elabZ_moduleZ_importZBang (void) {
 	}
 	mw_mirth_module_Module_addZ_importZBang();
 }
-static void mw_mirth_elab_elabZ_dataZBang (void) {
+static void mw_mirth_elab_parseZ_data (void) {
 	mp_primZ_dup();
+	mw_mirth_token_Token_numZ_args();
+	push_i64(0LL);
+	mp_primZ_swap();
+	mp_primZ_intZ_lt();
+	if (pop_u64()) {
+		mw_mirth_token_Token_succ();
+		mp_primZ_dup();
+		mw_mirth_token_Token_lparenZAsk();
+		switch (get_top_data_tag()) {
+			case 1LL: // Some
+				mtp_std_maybe_Maybe_1_Some();
+				mp_primZ_drop();
+				break;
+			case 0LL: // None
+				(void)pop_u64();
+				STRLIT("expected left parenthesis '('", 29);
+				mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+				break;
+			default:
+				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+				mp_primZ_panic();
+		}
+		mw_mirth_token_Token_succ();
+		mw_mirth_elab_parseZ_dataZ_header();
+		LPUSH(lbl_header);
+		mp_primZ_dup();
+		mw_mirth_token_Token_commaZAsk();
+		if (pop_u64()) {
+			mw_mirth_token_Token_succ();
+		} else {
+		}
+		mw_mirth_elab_parseZ_dataZ_tags();
+		LPUSH(lbl_tags);
+		mp_primZ_dup();
+		mw_mirth_token_Token_rparenZAsk();
+		switch (get_top_data_tag()) {
+			case 1LL: // Some
+				mtp_std_maybe_Maybe_1_Some();
+				mp_primZ_drop();
+				break;
+			case 0LL: // None
+				(void)pop_u64();
+				STRLIT("expected right parenthesis ')'", 30);
+				mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+				break;
+			default:
+				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+				mp_primZ_panic();
+		}
+		mw_mirth_token_Token_succ();
+	} else {
+		mw_mirth_token_Token_succ();
+		mw_mirth_elab_parseZ_dataZ_header();
+		LPUSH(lbl_header);
+		mp_primZ_dup();
+		mw_mirth_token_Token_lcurlyZAsk();
+		switch (get_top_data_tag()) {
+			case 1LL: // Some
+				mtp_std_maybe_Maybe_1_Some();
+				mp_primZ_drop();
+				break;
+			case 0LL: // None
+				(void)pop_u64();
+				STRLIT("expected left curly brace '{'", 29);
+				mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+				break;
+			default:
+				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+				mp_primZ_panic();
+		}
+		mw_mirth_token_Token_succ();
+		mw_mirth_elab_parseZ_dataZ_tags();
+		LPUSH(lbl_tags);
+		mp_primZ_dup();
+		mw_mirth_token_Token_rcurlyZAsk();
+		switch (get_top_data_tag()) {
+			case 1LL: // Some
+				mtp_std_maybe_Maybe_1_Some();
+				mp_primZ_drop();
+				break;
+			case 0LL: // None
+				(void)pop_u64();
+				STRLIT("expected right curly brace '}'", 30);
+				mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+				break;
+			default:
+				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+				mp_primZ_panic();
+		}
+		mw_mirth_token_Token_succ();
+	}
+	mtw_mirth_elab_SyntaxData_SyntaxData();
+}
+static void mw_mirth_elab_parseZ_dataZ_header (void) {
+	mp_primZ_dup();
+	LPUSH(lbl_head);
+	mw_mirth_token_Token_next();
+	LPOP(lbl_head);
+	mp_primZ_dup();
+	LPUSH(lbl_head);
+	mw_mirth_token_Token_lastZ_nameZAsk();
+	switch (get_top_data_tag()) {
+		case 1LL: // Some
+			mtp_std_maybe_Maybe_1_Some();
+			mw_mirth_name_Name_couldZ_beZ_constructor();
+			break;
+		case 0LL: // None
+			(void)pop_u64();
+			push_u64(0LL); // False
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primZ_panic();
+	}
+	if (pop_u64()) {
+	} else {
+		LPOP(lbl_head);
+		mp_primZ_dup();
+		LPUSH(lbl_head);
+		STRLIT("Expected type name.", 19);
+		mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+	}
+	mtw_mirth_elab_SyntaxDataHeader_SyntaxDataHeader();
+}
+static void mw_mirth_elab_parseZ_dataZ_tags (void) {
+	push_fnptr(&mb_mirth_elab_parseZ_dataZ_tags_0);
+	push_fnptr(&mb_mirth_elab_parseZ_dataZ_tags_1);
+	mw_std_list_collectZ_while_2();
+}
+static void mw_mirth_elab_parseZ_dataZ_tag (void) {
+	mp_primZ_dup();
+	mw_mirth_token_Token_intZAsk();
+	mp_primZ_dup();
+	LPUSH(lbl_valueZAsk);
+	switch (get_top_data_tag()) {
+		case 1LL: // Some
+			mtp_std_maybe_Maybe_1_Some();
+			mp_primZ_drop();
+			mw_mirth_token_Token_succ();
+			break;
+		case 0LL: // None
+			(void)pop_u64();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primZ_panic();
+	}
+	mp_primZ_dup();
+	mw_mirth_token_Token_nameZAsk();
+	switch (get_top_data_tag()) {
+		case 1LL: // Some
+			mtp_std_maybe_Maybe_1_Some();
+			mp_primZ_dup();
+			{
+				VAL d4 = pop_value();
+				mw_mirth_name_Name_couldZ_beZ_constructor();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			if (pop_u64()) {
+				mtw_std_maybe_Maybe_1_Some();
+			} else {
+				mp_primZ_drop();
+				push_u64(0LL); // None
+			}
+			break;
+		case 0LL: // None
+			(void)pop_u64();
+			push_u64(0LL); // None
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primZ_panic();
+	}
+	switch (get_top_data_tag()) {
+		case 1LL: // Some
+			mtp_std_maybe_Maybe_1_Some();
+			break;
+		case 0LL: // None
+			(void)pop_u64();
+			STRLIT("Expected constructor name.", 26);
+			mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primZ_panic();
+	}
+	LPUSH(lbl_name);
+	mw_mirth_token_Token_succ();
+	mp_primZ_dup();
+	mw_mirth_token_Token_arrowZAsk();
+	if (pop_u64()) {
+		mw_mirth_token_Token_succ();
+		mp_primZ_dup();
+		mtw_std_maybe_Maybe_1_Some();
+		LPUSH(lbl_sigZAsk);
+		mw_mirth_token_Token_sigZ_nextZ_stackZ_end();
+		mp_primZ_dup();
+		mw_mirth_token_Token_argZ_endZAsk();
+		if (pop_u64()) {
+		} else {
+			STRLIT("Expected comma.", 15);
+			mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+		}
+	} else {
+		mp_primZ_dup();
+		mw_mirth_token_Token_lsquareZAsk();
+		switch (get_top_data_tag()) {
+			case 1LL: // Some
+				mtp_std_maybe_Maybe_1_Some();
+				mp_primZ_drop();
+				mw_mirth_token_Token_succ();
+				mp_primZ_dup();
+				mtw_std_maybe_Maybe_1_Some();
+				LPUSH(lbl_sigZAsk);
+				mw_mirth_token_Token_sigZ_nextZ_stackZ_end();
+				mp_primZ_dup();
+				mw_mirth_token_Token_rsquareZAsk();
+				switch (get_top_data_tag()) {
+					case 1LL: // Some
+						mtp_std_maybe_Maybe_1_Some();
+						mp_primZ_drop();
+						break;
+					case 0LL: // None
+						(void)pop_u64();
+						STRLIT("Expected right square bracket ']'", 33);
+						mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+						break;
+					default:
+						push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+						mp_primZ_panic();
+				}
+				mw_mirth_token_Token_succ();
+				break;
+			case 0LL: // None
+				(void)pop_u64();
+				push_u64(0LL); // None
+				LPUSH(lbl_sigZAsk);
+				break;
+			default:
+				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+				mp_primZ_panic();
+		}
+	}
+	mp_primZ_dup();
+	mw_mirth_token_Token_commaZAsk();
+	if (pop_u64()) {
+		mw_mirth_token_Token_succ();
+	} else {
+	}
+	mtw_mirth_elab_SyntaxDataTag_SyntaxDataTag();
+}
+static void mw_mirth_elab_parseZ_struct (void) {
+	mp_primZ_dup();
+	mw_mirth_token_Token_numZ_args();
+	push_i64(0LL);
+	mp_primZ_swap();
+	mp_primZ_intZ_lt();
+	if (pop_u64()) {
+		mw_mirth_token_Token_succ();
+		mp_primZ_dup();
+		mw_mirth_token_Token_lparenZAsk();
+		switch (get_top_data_tag()) {
+			case 1LL: // Some
+				mtp_std_maybe_Maybe_1_Some();
+				mp_primZ_drop();
+				STRLIT("Expected left parenthesis '('", 29);
+				mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+				break;
+			case 0LL: // None
+				(void)pop_u64();
+				break;
+			default:
+				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+				mp_primZ_panic();
+		}
+		mw_mirth_token_Token_succ();
+		mw_mirth_elab_parseZ_dataZ_header();
+		LPUSH(lbl_header);
+		mp_primZ_dup();
+		mw_mirth_token_Token_commaZAsk();
+		if (pop_u64()) {
+			mw_mirth_token_Token_succ();
+		} else {
+		}
+		mw_mirth_elab_parseZ_structZ_tag();
+		push_u64(0LL); // Nil
+		mtw_std_list_List_1_Cons();
+		LPUSH(lbl_tags);
+		mp_primZ_dup();
+		mw_mirth_token_Token_rparenZAsk();
+		switch (get_top_data_tag()) {
+			case 1LL: // Some
+				mtp_std_maybe_Maybe_1_Some();
+				mp_primZ_drop();
+				STRLIT("Expected right parenthesis ')'", 30);
+				mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+				break;
+			case 0LL: // None
+				(void)pop_u64();
+				break;
+			default:
+				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+				mp_primZ_panic();
+		}
+		mw_mirth_token_Token_succ();
+	} else {
+		mw_mirth_token_Token_succ();
+		mw_mirth_elab_parseZ_dataZ_header();
+		LPUSH(lbl_header);
+		mp_primZ_dup();
+		mw_mirth_token_Token_lcurlyZAsk();
+		switch (get_top_data_tag()) {
+			case 1LL: // Some
+				mtp_std_maybe_Maybe_1_Some();
+				mp_primZ_drop();
+				break;
+			case 0LL: // None
+				(void)pop_u64();
+				STRLIT("expected left curly brace '{'", 29);
+				mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+				break;
+			default:
+				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+				mp_primZ_panic();
+		}
+		mw_mirth_token_Token_succ();
+		mw_mirth_elab_parseZ_structZ_tag();
+		push_u64(0LL); // Nil
+		mtw_std_list_List_1_Cons();
+		LPUSH(lbl_tags);
+		mp_primZ_dup();
+		mw_mirth_token_Token_rcurlyZAsk();
+		switch (get_top_data_tag()) {
+			case 1LL: // Some
+				mtp_std_maybe_Maybe_1_Some();
+				mp_primZ_drop();
+				break;
+			case 0LL: // None
+				(void)pop_u64();
+				STRLIT("expected right curly brace '}'", 30);
+				mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+				break;
+			default:
+				push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+				mp_primZ_panic();
+		}
+		mw_mirth_token_Token_succ();
+	}
+	mtw_mirth_elab_SyntaxData_SyntaxData();
+}
+static void mw_mirth_elab_parseZ_structZ_tag (void) {
+	LPOP(lbl_header);
+	mp_primZ_dup();
+	LPUSH(lbl_header);
+	mw_mirth_elab_SyntaxDataHeader_head();
+	mw_mirth_token_Token_lastZ_nameZAsk();
+	switch (get_top_data_tag()) {
+		case 1LL: // Some
+			mtp_std_maybe_Maybe_1_Some();
+			mp_primZ_dup();
+			{
+				VAL d4 = pop_value();
+				mw_mirth_name_Name_couldZ_beZ_constructor();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			if (pop_u64()) {
+				mtw_std_maybe_Maybe_1_Some();
+			} else {
+				mp_primZ_drop();
+				push_u64(0LL); // None
+			}
+			break;
+		case 0LL: // None
+			(void)pop_u64();
+			push_u64(0LL); // None
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primZ_panic();
+	}
+	switch (get_top_data_tag()) {
+		case 1LL: // Some
+			mtp_std_maybe_Maybe_1_Some();
+			break;
+		case 0LL: // None
+			(void)pop_u64();
+			LPOP(lbl_header);
+			mp_primZ_dup();
+			LPUSH(lbl_header);
+			mw_mirth_elab_SyntaxDataHeader_head();
+			STRLIT("expected constructor name", 25);
+			mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primZ_panic();
+	}
+	LPUSH(lbl_name);
+	push_u64(0LL); // None
+	LPUSH(lbl_valueZAsk);
+	mp_primZ_dup();
+	mtw_std_maybe_Maybe_1_Some();
+	LPUSH(lbl_sigZAsk);
+	mw_mirth_token_Token_sigZ_nextZ_stackZ_end();
+	mtw_mirth_elab_SyntaxDataTag_SyntaxDataTag();
+}
+static void mw_mirth_elab_SyntaxData_ZDivSyntaxData (void) {
+	switch (get_top_data_tag()) {
+		case 0LL: // SyntaxData
+			mtp_mirth_elab_SyntaxData_SyntaxData();
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primZ_panic();
+	}
+}
+static void mw_mirth_elab_SyntaxDataHeader_ZDivSyntaxDataHeader (void) {
+	mtp_mirth_elab_SyntaxDataHeader_SyntaxDataHeader();
+}
+static void mw_mirth_elab_SyntaxDataHeader_head (void) {
+}
+static void mw_mirth_elab_SyntaxDataTag_sigZAsk (void) {
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 4, v);
+	VAL* p = &VTUP(v)->cells[3];
+	VAL u = *p;
+	incref(u);
+	decref(v);
+	push_value(u);
+}
+static void mw_mirth_elab_SyntaxDataTag_name (void) {
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 4, v);
+	VAL* p = &VTUP(v)->cells[2];
+	VAL u = *p;
+	incref(u);
+	decref(v);
+	push_value(u);
+}
+static void mw_mirth_elab_SyntaxDataTag_valueZAsk (void) {
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 4, v);
+	VAL* p = &VTUP(v)->cells[1];
+	VAL u = *p;
+	incref(u);
+	decref(v);
+	push_value(u);
+}
+static void mw_mirth_elab_elabZ_dataZBang (void) {
+	mw_mirth_elab_parseZ_data();
+	mw_mirth_elab_elabZ_dataZ_auxZBang();
+}
+static void mw_mirth_elab_elabZ_structZBang (void) {
+	mw_mirth_elab_parseZ_struct();
+	mw_mirth_elab_elabZ_dataZ_auxZBang();
+}
+static void mw_mirth_elab_elabZ_dataZ_auxZBang (void) {
+	mw_mirth_elab_SyntaxData_ZDivSyntaxData();
+	mw_mirth_data_Data_allocZBang();
+	push_u64(0LL); // Nil
 	{
 		VAL d2 = pop_value();
-		mw_mirth_data_Data_allocZBang();
-		push_u64(0LL); // Nil
-		{
-			VAL d3 = pop_value();
-			mp_primZ_dup();
-			push_value(d3);
-		}
-		mp_primZ_swap();
-		mfld_mirth_data_Data_ZTildetags();
-		mp_primZ_mutZ_set();
-		mp_primZ_swap();
-		mw_mirth_token_Token_argsZPlus();
-		mw_std_list_ListZPlus_1_uncons();
-		{
-			VAL d3 = pop_value();
-			mw_mirth_elab_elabZ_dataZ_headerZBang();
-			push_value(d3);
-		}
-		push_fnptr(&mb_mirth_elab_elabZ_dataZBang_2);
-		mw_std_list_List_1_for_1();
-		mw_mirth_elab_elabZ_dataZ_doneZBang();
+		mp_primZ_dup();
 		push_value(d2);
 	}
-	mw_mirth_token_Token_next();
+	mp_primZ_swap();
+	mfld_mirth_data_Data_ZTildetags();
+	mp_primZ_mutZ_set();
+	LPOP(lbl_header);
+	mw_mirth_elab_elabZ_dataZ_headerZBang();
+	LPOP(lbl_tags);
+	push_fnptr(&mb_mirth_elab_elabZ_dataZ_auxZBang_0);
+	mw_std_list_List_1_for_1();
+	mw_mirth_elab_elabZ_dataZ_doneZBang();
 }
 static void mw_mirth_elab_elabZ_dataZ_headerZBang (void) {
-	LPUSH(lbl_head);
+	mw_mirth_elab_SyntaxDataHeader_ZDivSyntaxDataHeader();
 	LPUSH(lbl_data);
 	LPOP(lbl_head);
 	mp_primZ_dup();
@@ -37128,7 +37715,7 @@ static void mw_mirth_elab_elabZ_dataZ_headerZBang (void) {
 	switch (get_top_data_tag()) {
 		case 1LL: // Some
 			mtp_std_maybe_Maybe_1_Some();
-			mw_mirth_name_Name_couldZ_beZ_typeZ_orZ_resourceZ_con();
+			mw_mirth_name_Name_couldZ_beZ_constructor();
 			break;
 		case 0LL: // None
 			(void)pop_u64();
@@ -37211,64 +37798,43 @@ static void mw_mirth_elab_elabZ_dataZ_paramsZBang (void) {
 	mw_mirth_var_Ctx_ZToList();
 }
 static void mw_mirth_elab_elabZ_dataZ_tagZBang (void) {
+	LPUSH(lbl_syn);
+	LPUSH(lbl_dat);
+	mw_mirth_data_Tag_allocZBang();
+	LPUSH(lbl_tag);
+	LPOP(lbl_dat);
 	mp_primZ_dup();
-	mw_mirth_token_Token_intZAsk();
-	switch (get_top_data_tag()) {
-		case 1LL: // Some
-			mtp_std_maybe_Maybe_1_Some();
-			mtw_std_maybe_Maybe_1_Some();
-			LPUSH(lbl_value);
-			mw_mirth_token_Token_succ();
-			break;
-		case 0LL: // None
-			(void)pop_u64();
-			push_u64(0LL); // None
-			LPUSH(lbl_value);
-			break;
-		default:
-			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-			mp_primZ_panic();
-	}
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	mw_mirth_token_Token_nameZAsk();
-	switch (get_top_data_tag()) {
-		case 1LL: // Some
-			mtp_std_maybe_Maybe_1_Some();
-			break;
-		case 0LL: // None
-			(void)pop_u64();
-			mp_primZ_drop();
-			STRLIT("Expected constructor name.", 26);
-			mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
-			break;
-		default:
-			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-			mp_primZ_panic();
-	}
+	LPUSH(lbl_dat);
+	LPOP(lbl_syn);
+	mp_primZ_dup();
+	LPUSH(lbl_syn);
+	mw_mirth_elab_SyntaxDataTag_name();
 	push_i64(0LL);
 	mw_mirth_data_dataZ_qname();
-	mw_mirth_data_Tag_allocZBang();
-	LPOP(lbl_value);
+	LPOP(lbl_tag);
+	mp_primZ_dup();
+	LPUSH(lbl_tag);
+	mfld_mirth_data_Tag_ZTildeqname();
+	mp_primZ_mutZ_set();
+	LPOP(lbl_syn);
+	mp_primZ_dup();
+	LPUSH(lbl_syn);
+	mw_mirth_elab_SyntaxDataTag_sigZAsk();
+	LPOP(lbl_tag);
+	mp_primZ_dup();
+	LPUSH(lbl_tag);
+	mfld_mirth_data_Tag_ZTildesigZAsk();
+	mp_primZ_mutZ_set();
+	LPOP(lbl_syn);
+	mp_primZ_dup();
+	LPUSH(lbl_syn);
+	mw_mirth_elab_SyntaxDataTag_valueZAsk();
 	switch (get_top_data_tag()) {
 		case 1LL: // Some
 			mtp_std_maybe_Maybe_1_Some();
-			{
-				VAL d4 = pop_value();
-				mp_primZ_dup();
-				push_value(d4);
-			}
-			mp_primZ_swap();
+			LPOP(lbl_tag);
+			mp_primZ_dup();
+			LPUSH(lbl_tag);
 			mfld_mirth_data_Tag_ZTildevalue();
 			mp_primZ_mutZ_set();
 			break;
@@ -37279,160 +37845,79 @@ static void mw_mirth_elab_elabZ_dataZ_tagZBang (void) {
 			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 			mp_primZ_panic();
 	}
-	push_u64(0LL); // None
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	mfld_mirth_data_Tag_ZTildeuntag();
-	mp_primZ_mutZ_set();
+	LPOP(lbl_dat);
 	mp_primZ_dup();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_swap();
-		push_value(d2);
-	}
-	mfld_mirth_data_Tag_ZTildeqname();
-	mp_primZ_mutZ_set();
+	LPUSH(lbl_dat);
+	LPOP(lbl_tag);
 	mp_primZ_dup();
-	mtw_mirth_def_Def_DefTag();
-	mw_mirth_def_Def_register();
-	{
-		VAL d2 = pop_value();
-		{
-			VAL d3 = pop_value();
-			mp_primZ_dup();
-			push_value(d3);
-		}
-		mp_primZ_swap();
-		push_value(d2);
-	}
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
+	LPUSH(lbl_tag);
 	mfld_mirth_data_Tag_ZTildedata();
 	mp_primZ_mutZ_set();
+	LPOP(lbl_tag);
 	mp_primZ_dup();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_swap();
-		push_value(d2);
-	}
-	{
-		VAL d2 = pop_value();
-		mw_mirth_data_Data_addZ_tagZBang();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	mw_mirth_token_Token_succ();
+	LPUSH(lbl_tag);
+	LPOP(lbl_dat);
 	mp_primZ_dup();
-	mw_mirth_token_Token_patZ_arrowZAsk();
-	if (pop_u64()) {
-		mw_mirth_token_Token_succ();
-		mtw_std_maybe_Maybe_1_Some();
-		{
-			VAL d3 = pop_value();
-			mp_primZ_dup();
-			push_value(d3);
-		}
-		mp_primZ_swap();
-		mfld_mirth_data_Tag_ZTildesigZAsk();
-		mp_primZ_mutZ_set();
-	} else {
-		mp_primZ_dup();
-		mw_mirth_token_Token_runZ_endZAsk();
-		if (pop_u64()) {
-			mp_primZ_drop();
-			push_u64(0LL); // None
-			{
-				VAL d4 = pop_value();
-				mp_primZ_dup();
-				push_value(d4);
-			}
-			mp_primZ_swap();
-			mfld_mirth_data_Tag_ZTildesigZAsk();
-			mp_primZ_mutZ_set();
-		} else {
-			STRLIT("Expected arrow, comma, or right paren.", 38);
-			mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang();
-		}
-	}
+	LPUSH(lbl_dat);
+	mw_mirth_data_Data_addZ_tagZBang();
+	LPOP(lbl_tag);
 	mp_primZ_dup();
+	LPUSH(lbl_tag);
+	mtw_mirth_def_Def_DefTag();
+	mw_mirth_def_Def_register();
+	LPOP(lbl_tag);
 	mp_primZ_dup();
+	LPUSH(lbl_tag);
+	LPOP(lbl_tag);
+	mp_primZ_dup();
+	LPUSH(lbl_tag);
 	mtw_mirth_mirth_PropLabel_TagType();
-	push_fnptr(&mb_mirth_elab_elabZ_dataZ_tagZBang_10);
+	push_fnptr(&mb_mirth_elab_elabZ_dataZ_tagZBang_1);
 	mw_mirth_mirth_PropLabel_prop_1();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
+	LPOP(lbl_tag);
+	mp_primZ_dup();
+	LPUSH(lbl_tag);
 	mfld_mirth_data_Tag_ZTildectxZ_type();
 	mp_primZ_mutZ_set();
+	LPOP(lbl_tag);
 	mp_primZ_dup();
-	{
-		VAL d2 = pop_value();
-		mw_mirth_data_Tag_numZ_typeZ_inputsZ_fromZ_sig();
-		push_value(d2);
-	}
+	LPUSH(lbl_tag);
+	mw_mirth_data_Tag_numZ_typeZ_inputsZ_fromZ_sig();
+	LPOP(lbl_tag);
 	mp_primZ_dup();
-	{
-		VAL d2 = pop_value();
-		mfld_mirth_data_Tag_ZTildenumZ_typeZ_inputs();
-		mp_primZ_mutZ_set();
-		push_value(d2);
-	}
+	LPUSH(lbl_tag);
+	mfld_mirth_data_Tag_ZTildenumZ_typeZ_inputs();
+	mp_primZ_mutZ_set();
+	LPOP(lbl_tag);
 	mp_primZ_dup();
-	{
-		VAL d2 = pop_value();
-		mw_mirth_data_Tag_numZ_resourceZ_inputsZ_fromZ_sig();
-		push_value(d2);
-	}
+	LPUSH(lbl_tag);
+	mw_mirth_data_Tag_numZ_resourceZ_inputsZ_fromZ_sig();
+	LPOP(lbl_tag);
 	mp_primZ_dup();
-	{
-		VAL d2 = pop_value();
-		mfld_mirth_data_Tag_ZTildenumZ_resourceZ_inputs();
-		mp_primZ_mutZ_set();
-		push_value(d2);
-	}
+	LPUSH(lbl_tag);
+	mfld_mirth_data_Tag_ZTildenumZ_resourceZ_inputs();
+	mp_primZ_mutZ_set();
+	LPOP(lbl_tag);
 	mp_primZ_dup();
-	{
-		VAL d2 = pop_value();
-		mw_mirth_data_Tag_labelZ_inputsZ_fromZ_sig();
-		push_value(d2);
-	}
+	LPUSH(lbl_tag);
+	mw_mirth_data_Tag_labelZ_inputsZ_fromZ_sig();
+	LPOP(lbl_tag);
 	mp_primZ_dup();
-	{
-		VAL d2 = pop_value();
-		mfld_mirth_data_Tag_ZTildelabelZ_inputs();
-		mp_primZ_mutZ_set();
-		push_value(d2);
-	}
+	LPUSH(lbl_tag);
+	mfld_mirth_data_Tag_ZTildelabelZ_inputs();
+	mp_primZ_mutZ_set();
+	LPOP(lbl_tag);
 	mp_primZ_dup();
+	LPUSH(lbl_tag);
 	mw_mirth_data_Tag_outputsZ_resourceZAsk();
 	if (pop_u64()) {
 		push_u64(0LL); // False
 	} else {
 		push_u64(1LL); // True
 	}
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
+	LPOP(lbl_tag);
+	mp_primZ_dup();
+	LPUSH(lbl_tag);
 	mw_mirth_data_Tag_numZ_resourceZ_inputs();
 	push_i64(0LL);
 	mp_primZ_swap();
@@ -37443,7 +37928,9 @@ static void mw_mirth_elab_elabZ_dataZ_tagZBang (void) {
 		push_u64(0LL); // False
 	}
 	if (pop_u64()) {
+		LPOP(lbl_tag);
 		mp_primZ_dup();
+		LPUSH(lbl_tag);
 		mw_mirth_data_Tag_sigZAsk();
 		switch (get_top_data_tag()) {
 			case 1LL: // Some
@@ -37459,7 +37946,7 @@ static void mw_mirth_elab_elabZ_dataZ_tagZBang (void) {
 				mp_primZ_panic();
 		}
 		mw_mirth_token_Token_runZ_tokens();
-		push_fnptr(&mb_mirth_elab_elabZ_dataZ_tagZBang_20);
+		push_fnptr(&mb_mirth_elab_elabZ_dataZ_tagZBang_5);
 		mw_std_list_List_1_find_1();
 		switch (get_top_data_tag()) {
 			case 1LL: // Some
@@ -37478,7 +37965,11 @@ static void mw_mirth_elab_elabZ_dataZ_tagZBang (void) {
 		mw_mirth_mirth_ZPlusMirth_emitZ_errorZBang();
 	} else {
 	}
+	LPOP(lbl_tag);
+	LPOP(lbl_syn);
 	mp_primZ_drop();
+	mp_primZ_drop();
+	LPOP(lbl_dat);
 }
 static void mw_mirth_elab_dataZ_wordZ_newZBang (void) {
 	mp_primZ_dup();
@@ -37906,7 +38397,7 @@ static void mw_mirth_elab_createZ_projectorsZBang (void) {
 }
 static void mw_mirth_elab_expectZ_tokenZ_arrow (void) {
 	mp_primZ_dup();
-	mw_mirth_token_Token_patZ_arrowZAsk();
+	mw_mirth_token_Token_arrowZAsk();
 	if (pop_u64()) {
 	} else {
 		STRLIT("Expected arrow.", 15);
@@ -38635,7 +39126,7 @@ static void mw_mirth_elab_parseZ_externalZ_declZ_part (void) {
 			}
 			mw_mirth_token_Token_succ();
 			mp_primZ_dup();
-			mw_mirth_token_Token_patZ_arrowZAsk();
+			mw_mirth_token_Token_arrowZAsk();
 			if (pop_u64()) {
 				mw_mirth_token_Token_succ();
 				mp_primZ_dup();
@@ -48128,10 +48619,10 @@ static void mb_mirth_token_Token_runZ_tokens_1 (void) {
 	}
 }
 static void mb_mirth_token_Token_runZ_arrowZAsk_0 (void) {
-	mw_mirth_token_Token_patZ_arrowZAsk();
+	mw_mirth_token_Token_arrowZAsk();
 }
 static void mb_mirth_token_Token_patZ_tokens_0 (void) {
-	mw_mirth_token_Token_patZ_arrowZAsk();
+	mw_mirth_token_Token_arrowZAsk();
 	if (pop_u64()) {
 		push_u64(0LL); // False
 	} else {
@@ -49305,58 +49796,6 @@ static void mb_mirth_elab_ZPlusResolveDef_resolveZ_defZ_ambiguous_11 (void) {
 static void mb_mirth_elab_ZPlusResolveDef_filterZ_sort_1_1 (void) {
 	mtw_mirth_elab_RejectedDef_RDz_WRONGz_SORT();
 }
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_arity_0 (void) {
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	{
-		VAL d2 = pop_resource();
-		mw_mirth_def_Def_arity();
-		push_resource(d2);
-	}
-	mw_mirth_elab_arityZ_compatibleZAsk();
-}
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_arity_1 (void) {
-	mtw_mirth_elab_RejectedDef_RDz_WRONGz_ARITY();
-}
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_qualifiers_1 (void) {
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	{
-		VAL d2 = pop_resource();
-		mw_mirth_def_Def_qnameZ_hard();
-		push_resource(d2);
-	}
-	mw_mirth_name_QName_climbZ_upZ_dnameZAsk();
-	mw_std_list_List_1_emptyZAsk();
-	if (pop_u64()) {
-		push_u64(0LL); // False
-	} else {
-		push_u64(1LL); // True
-	}
-}
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_qualifiers_2 (void) {
-	mtw_mirth_elab_RejectedDef_RDz_WRONGz_QUALIFIER();
-}
 static void mb_mirth_name_QName_climbZ_upZ_dnameZAsk_5 (void) {
 	mp_primZ_swap();
 	push_fnptr(&mb_mirth_name_QName_climbZ_upZ_dnameZAsk_6);
@@ -49396,139 +49835,8 @@ static void mb_mirth_name_QName_climbZ_upZ_dnameZAsk_6 (void) {
 			mp_primZ_panic();
 	}
 }
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_roots_1 (void) {
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	{
-		VAL d2 = pop_resource();
-		mw_mirth_def_Def_qnameZ_hard();
-		push_resource(d2);
-	}
-	mw_mirth_name_QName_namespace();
-	mp_primZ_swap();
-	push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filterZ_roots_4);
-	mw_std_list_List_1_member_1();
-	if (pop_u64()) {
-		push_u64(1LL); // True
-	} else {
-		mw_mirth_elab_ZPlusResolveDef_token();
-		{
-			VAL d3 = pop_value();
-			mp_primZ_dup();
-			push_value(d3);
-		}
-		mp_primZ_swap();
-		{
-			VAL d3 = pop_resource();
-			mw_mirth_elab_defZ_isZ_importedZ_atZ_tokenZAsk();
-			push_resource(d3);
-		}
-	}
-}
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_roots_2 (void) {
-	mp_primZ_dup();
-	{
-		VAL d2 = pop_resource();
-		mw_mirth_def_Def_qnameZ_hard();
-		push_resource(d2);
-	}
-	mw_mirth_name_QName_namespace();
-	switch (get_top_data_tag()) {
-		case 3LL: // NAMESPACE_TYCON
-			mtp_mirth_name_Namespace_NAMESPACEz_TYCON();
-			mp_primZ_drop();
-			mw_mirth_elab_ZPlusResolveDef_token();
-			mw_mirth_token_Token_nameZAsk();
-			switch (get_top_data_tag()) {
-				case 1LL: // Some
-					mtp_std_maybe_Maybe_1_Some();
-					break;
-				case 0LL: // None
-					(void)pop_u64();
-					STRLIT("tried to unwrap None", 20);
-					mw_std_prelude_panicZBang();
-					break;
-				default:
-					push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-					mp_primZ_panic();
-			}
-			mw_mirth_name_Name_canZ_beZ_relativeZAsk();
-			if (pop_u64()) {
-				{
-					VAL d5 = pop_value();
-					mp_primZ_dup();
-					push_value(d5);
-				}
-				mp_primZ_swap();
-				mw_std_list_List_1_emptyZAsk();
-				if (pop_u64()) {
-					mtw_mirth_elab_RejectedDef_RDz_METHODz_NOTz_AVAILABLE();
-				} else {
-					mtw_mirth_elab_RejectedDef_RDz_METHODz_WRONGz_TYPE();
-				}
-			} else {
-				mtw_mirth_elab_RejectedDef_RDz_NOTz_IMPORTED();
-			}
-			break;
-		default:
-			mp_primZ_drop();
-			mtw_mirth_elab_RejectedDef_RDz_NOTz_IMPORTED();
-			break;
-	}
-}
 static void mb_mirth_elab_ZPlusResolveDef_filterZ_roots_4 (void) {
 	mw_mirth_name_Namespace_ZEqualZEqual();
-}
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_roots_16 (void) {
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	{
-		VAL d2 = pop_resource();
-		mw_mirth_def_Def_qnameZ_hard();
-		push_resource(d2);
-	}
-	mw_mirth_name_QName_climbZ_upZ_dnameZAsk();
-	push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filterZ_roots_19);
-	mw_std_list_List_1_has_1();
-}
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_roots_17 (void) {
-	{
-		VAL d2 = pop_value();
-		{
-			VAL d3 = pop_value();
-			mp_primZ_dup();
-			push_value(d3);
-		}
-		mp_primZ_swap();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	mw_std_list_List_1_emptyZAsk();
-	if (pop_u64()) {
-		mtw_mirth_elab_RejectedDef_RDz_METHODz_NOTz_AVAILABLE();
-	} else {
-		mtw_mirth_elab_RejectedDef_RDz_METHODz_WRONGz_TYPE();
-	}
 }
 static void mb_mirth_elab_ZPlusResolveDef_filterZ_roots_19 (void) {
 	{
@@ -49552,31 +49860,6 @@ static void mb_mirth_elab_ZPlusResolveDef_filterZ_roots_19 (void) {
 }
 static void mb_mirth_elab_ZPlusResolveDef_filterZ_roots_20 (void) {
 	mw_mirth_name_Namespace_ZEqualZEqual();
-}
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_roots_23 (void) {
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	{
-		VAL d2 = pop_resource();
-		mw_mirth_def_Def_qnameZ_hard();
-		push_resource(d2);
-	}
-	mw_mirth_name_QName_climbZ_upZ_dnameZAsk();
-	push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filterZ_roots_26);
-	mw_std_list_List_1_has_1();
-}
-static void mb_mirth_elab_ZPlusResolveDef_filterZ_roots_24 (void) {
-	mtw_mirth_elab_RejectedDef_RDz_NOTz_IMPORTED();
 }
 static void mb_mirth_elab_ZPlusResolveDef_filterZ_roots_26 (void) {
 	{
@@ -49647,24 +49930,20 @@ static void mb_mirth_name_QName_climbZ_upZ_nameZAsk_2 (void) {
 	}
 }
 static void mb_mirth_elab_ZPlusTypeElab_resolveZ_typeZ_conZ_nameZBang_1 (void) {
-	push_fnptr(&mb_mirth_elab_ZPlusTypeElab_resolveZ_typeZ_conZ_nameZBang_2);
-	push_fnptr(&mb_mirth_elab_ZPlusTypeElab_resolveZ_typeZ_conZ_nameZBang_3);
-	mw_mirth_elab_ZPlusResolveDef_filter_2();
+	mw_mirth_elab_ZPlusResolveDef_candidates();
+	push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotZPlusTypeElabZDotresolveZ_typeZ_conZ_nameZBangZDot14ZCommamirthZDotelabZDotZPlusTypeElabZDotresolveZ_typeZ_conZ_nameZBangZDot20ZRParen_2);
+	mw_std_list_List_1_partitionZ_either_1();
+	{
+		VAL d2 = pop_value();
+		push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotZPlusTypeElabZDotresolveZ_typeZ_conZ_nameZBangZDot14ZCommamirthZDotelabZDotZPlusTypeElabZDotresolveZ_typeZ_conZ_nameZBangZDot20ZRParenZDot0ZRParen_0);
+		mw_mirth_elab_ZPlusResolveDef_rejected_1();
+		push_value(d2);
+	}
+	mw_mirth_elab_ZPlusResolveDef_candidatesZBang();
 	mw_mirth_elab_ZPlusResolveDef_filterZ_arity();
 	mw_mirth_elab_ZPlusResolveDef_filterZ_qualifiers();
 	push_u64(0LL); // Nil
 	mw_mirth_elab_ZPlusResolveDef_filterZ_roots();
-}
-static void mb_mirth_elab_ZPlusTypeElab_resolveZ_typeZ_conZ_nameZBang_2 (void) {
-	mp_primZ_dup();
-	{
-		VAL d2 = pop_resource();
-		mw_mirth_def_Def_definesZ_aZ_typeZAsk();
-		push_resource(d2);
-	}
-}
-static void mb_mirth_elab_ZPlusTypeElab_resolveZ_typeZ_conZ_nameZBang_3 (void) {
-	mtw_mirth_elab_RejectedDef_RDz_WRONGz_SORT();
 }
 static void mb_mirth_elab_ZPlusTypeElab_elabZ_typeZ_argsZBang_3 (void) {
 	mw_mirth_elab_ZPlusTypeElab_tokenZBang();
@@ -49818,9 +50097,16 @@ static void mb_mirth_elab_elabZ_argsZBang_0 (void) {
 	mw_mirth_elab_elabZ_blockZ_atZBang();
 }
 static void mb_mirth_elab_elabZ_atomZ_resolveZ_defZBang_0 (void) {
-	push_fnptr(&mb_mirth_elab_elabZ_atomZ_resolveZ_defZBang_1);
-	push_fnptr(&mb_mirth_elab_elabZ_atomZ_resolveZ_defZBang_2);
-	mw_mirth_elab_ZPlusResolveDef_filter_2();
+	mw_mirth_elab_ZPlusResolveDef_candidates();
+	push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotelabZ_atomZ_resolveZ_defZBangZDot15ZCommamirthZDotelabZDotelabZ_atomZ_resolveZ_defZBangZDot21ZRParen_2);
+	mw_std_list_List_1_partitionZ_either_1();
+	{
+		VAL d2 = pop_value();
+		push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotelabZ_atomZ_resolveZ_defZBangZDot15ZCommamirthZDotelabZDotelabZ_atomZ_resolveZ_defZBangZDot21ZRParenZDot0ZRParen_0);
+		mw_mirth_elab_ZPlusResolveDef_rejected_1();
+		push_value(d2);
+	}
+	mw_mirth_elab_ZPlusResolveDef_candidatesZBang();
 	mw_mirth_elab_ZPlusResolveDef_filterZ_arity();
 	mw_mirth_elab_ZPlusResolveDef_filterZ_qualifiers();
 	mw_mirth_elab_ZPlusResolveDef_token();
@@ -49842,17 +50128,6 @@ static void mb_mirth_elab_elabZ_atomZ_resolveZ_defZBang_0 (void) {
 		push_u64(0LL); // Nil
 		mw_mirth_elab_ZPlusResolveDef_filterZ_roots();
 	}
-}
-static void mb_mirth_elab_elabZ_atomZ_resolveZ_defZBang_1 (void) {
-	mp_primZ_dup();
-	{
-		VAL d2 = pop_resource();
-		mw_mirth_def_Def_callableZAsk();
-		push_resource(d2);
-	}
-}
-static void mb_mirth_elab_elabZ_atomZ_resolveZ_defZBang_2 (void) {
-	mtw_mirth_elab_RejectedDef_RDz_WRONGz_SORT();
 }
 static void mb_mirth_elab_elabZ_atomZ_lambdaZBang_1 (void) {
 	{
@@ -49929,9 +50204,16 @@ static void mb_mirth_elab_elabZ_patternZ_atomZBang_0 (void) {
 	mw_mirth_match_Pattern_tokenZ_startZBang();
 }
 static void mb_mirth_elab_elabZ_patternZ_atomZBang_5 (void) {
-	push_fnptr(&mb_mirth_elab_elabZ_patternZ_atomZBang_6);
-	push_fnptr(&mb_mirth_elab_elabZ_patternZ_atomZBang_7);
-	mw_mirth_elab_ZPlusResolveDef_filter_2();
+	mw_mirth_elab_ZPlusResolveDef_candidates();
+	push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotelabZ_patternZ_atomZBangZDot31ZCommamirthZDotelabZDotelabZ_patternZ_atomZBangZDot35ZRParen_2);
+	mw_std_list_List_1_partitionZ_either_1();
+	{
+		VAL d2 = pop_value();
+		push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotelabZ_patternZ_atomZBangZDot31ZCommamirthZDotelabZDotelabZ_patternZ_atomZBangZDot35ZRParenZDot0ZRParen_0);
+		mw_mirth_elab_ZPlusResolveDef_rejected_1();
+		push_value(d2);
+	}
+	mw_mirth_elab_ZPlusResolveDef_candidatesZBang();
 	mw_mirth_elab_ZPlusResolveDef_filterZ_arity();
 	mw_mirth_elab_ZPlusResolveDef_filterZ_qualifiers();
 	LPOPR(lbl_ZPluspat);
@@ -49951,9 +50233,16 @@ static void mb_mirth_elab_elabZ_patternZ_atomZBang_5 (void) {
 			case 1LL: // Some
 				mtp_std_maybe_Maybe_1_Some();
 				mp_primZ_drop();
-				push_fnptr(&mb_mirth_elab_elabZ_patternZ_atomZBang_11);
-				push_fnptr(&mb_mirth_elab_elabZ_patternZ_atomZBang_12);
-				mw_mirth_elab_ZPlusResolveDef_filter_2();
+				mw_mirth_elab_ZPlusResolveDef_candidates();
+				push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotelabZ_patternZ_atomZBangZDot59ZCommamirthZDotelabZDotelabZ_patternZ_atomZBangZDot71ZRParen_2);
+				mw_std_list_List_1_partitionZ_either_1();
+				{
+					VAL d5 = pop_value();
+					push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotelabZ_patternZ_atomZBangZDot59ZCommamirthZDotelabZDotelabZ_patternZ_atomZBangZDot71ZRParenZDot0ZRParen_0);
+					mw_mirth_elab_ZPlusResolveDef_rejected_1();
+					push_value(d5);
+				}
+				mw_mirth_elab_ZPlusResolveDef_candidatesZBang();
 				mp_primZ_drop();
 				break;
 			case 0LL: // None
@@ -49966,53 +50255,6 @@ static void mb_mirth_elab_elabZ_patternZ_atomZBang_5 (void) {
 		}
 	} else {
 	}
-}
-static void mb_mirth_elab_elabZ_patternZ_atomZBang_6 (void) {
-	mp_primZ_dup();
-	mw_mirth_def_Def_tagZAsk();
-	switch (get_top_data_tag()) {
-		case 0LL: // None
-			(void)pop_u64();
-			push_u64(0LL); // False
-			break;
-		case 1LL: // Some
-			mtp_std_maybe_Maybe_1_Some();
-			mp_primZ_drop();
-			push_u64(1LL); // True
-			break;
-		default:
-			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
-			mp_primZ_panic();
-	}
-}
-static void mb_mirth_elab_elabZ_patternZ_atomZBang_7 (void) {
-	mtw_mirth_elab_RejectedDef_RDz_WRONGz_SORT();
-}
-static void mb_mirth_elab_elabZ_patternZ_atomZBang_11 (void) {
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	{
-		VAL d2 = pop_resource();
-		mw_mirth_def_Def_qnameZ_hard();
-		push_resource(d2);
-	}
-	mw_mirth_name_QName_namespace();
-	mp_primZ_swap();
-	push_fnptr(&mb_mirth_elab_elabZ_patternZ_atomZBang_14);
-	mw_std_list_List_1_member_1();
-}
-static void mb_mirth_elab_elabZ_patternZ_atomZBang_12 (void) {
-	mtw_mirth_elab_RejectedDef_RDz_WRONGz_CONSTRUCTOR();
 }
 static void mb_mirth_elab_elabZ_patternZ_atomZBang_14 (void) {
 	mw_mirth_name_Namespace_ZEqualZEqual();
@@ -50070,36 +50312,20 @@ static void mb_mirth_elab_elabZ_aliasZBang_0 (void) {
 static void mb_mirth_elab_elabZ_aliasZBang_1 (void) {
 	LPOP(lbl_alias);
 	mw_mirth_alias_Alias_arity();
-	push_fnptr(&mb_mirth_elab_elabZ_aliasZBang_2);
-	push_fnptr(&mb_mirth_elab_elabZ_aliasZBang_3);
-	mw_mirth_elab_ZPlusResolveDef_filter_2();
+	mw_mirth_elab_ZPlusResolveDef_candidates();
+	push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotelabZ_aliasZBangZDot32ZCommamirthZDotelabZDotelabZ_aliasZBangZDot39ZRParen_2);
+	mw_std_list_List_1_partitionZ_either_1();
+	{
+		VAL d2 = pop_value();
+		push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotelabZ_aliasZBangZDot32ZCommamirthZDotelabZDotelabZ_aliasZBangZDot39ZRParenZDot0ZRParen_0);
+		mw_mirth_elab_ZPlusResolveDef_rejected_1();
+		push_value(d2);
+	}
+	mw_mirth_elab_ZPlusResolveDef_candidatesZBang();
 	mp_primZ_drop();
 	mw_mirth_elab_ZPlusResolveDef_filterZ_qualifiers();
 	push_u64(0LL); // Nil
 	mw_mirth_elab_ZPlusResolveDef_filterZ_roots();
-}
-static void mb_mirth_elab_elabZ_aliasZBang_2 (void) {
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	{
-		VAL d2 = pop_value();
-		mp_primZ_dup();
-		push_value(d2);
-	}
-	mp_primZ_swap();
-	{
-		VAL d2 = pop_resource();
-		mw_mirth_def_Def_arity();
-		push_resource(d2);
-	}
-	mw_mirth_elab_arityZ_compatibleZAsk();
-}
-static void mb_mirth_elab_elabZ_aliasZBang_3 (void) {
-	mtw_mirth_elab_RejectedDef_RDz_WRONGz_ARITY();
 }
 static void mb_mirth_elab_elabZ_aliasZBang_6 (void) {
 	LPOP(lbl_target);
@@ -50200,17 +50426,29 @@ static void mb_mirth_elab_elabZ_fieldZBang_2 (void) {
 static void mb_mirth_elab_elabZ_fieldZBang_3 (void) {
 	mw_mirth_elab_elabZ_simpleZ_typeZ_argZBang();
 }
-static void mb_mirth_elab_elabZ_dataZBang_2 (void) {
-	mw_mirth_elab_elabZ_dataZ_tagZBang();
-}
 static void mb_mirth_elab_elabZ_embedZ_strZBang_4 (void) {
 	LPOP(lbl_contents);
 	mw_mirth_elab_abZ_strZBang();
 }
+static void mb_mirth_elab_parseZ_dataZ_tags_0 (void) {
+	mp_primZ_dup();
+	mw_mirth_token_Token_argZ_endZAsk();
+	if (pop_u64()) {
+		push_u64(0LL); // False
+	} else {
+		push_u64(1LL); // True
+	}
+}
+static void mb_mirth_elab_parseZ_dataZ_tags_1 (void) {
+	mw_mirth_elab_parseZ_dataZ_tag();
+}
+static void mb_mirth_elab_elabZ_dataZ_auxZBang_0 (void) {
+	mw_mirth_elab_elabZ_dataZ_tagZBang();
+}
 static void mb_mirth_elab_elabZ_dataZ_headerZBang_2 (void) {
 	mw_mirth_elab_elabZ_dataZ_paramsZBang();
 }
-static void mb_mirth_elab_elabZ_dataZ_tagZBang_10 (void) {
+static void mb_mirth_elab_elabZ_dataZ_tagZBang_1 (void) {
 	mp_primZ_dup();
 	mw_mirth_data_Tag_data();
 	mw_mirth_data_Data_headZAsk();
@@ -50237,7 +50475,7 @@ static void mb_mirth_elab_elabZ_dataZ_tagZBang_10 (void) {
 	LPUSH(lbl_allowZ_implicitZ_typeZ_vars);
 	push_u64(0LL); // False
 	LPUSH(lbl_allowZ_typeZ_holes);
-	mtw_mirth_elab_ZPlusTypeElab_TYPEz_ELAB();
+	mtw_mirth_elab_ZPlusTypeElab_ZPlusTypeElab();
 	mw_mirth_type_T0();
 	{
 		VAL d2 = pop_value();
@@ -50279,19 +50517,19 @@ static void mb_mirth_elab_elabZ_dataZ_tagZBang_10 (void) {
 	mw_std_prelude_pack2();
 	mw_mirth_elab_ZPlusTypeElab_rdrop();
 }
-static void mb_mirth_elab_elabZ_dataZ_tagZBang_20 (void) {
+static void mb_mirth_elab_elabZ_dataZ_tagZBang_5 (void) {
 	mp_primZ_dup();
-	mw_mirth_token_Token_sigZ_resourceZ_conZAsk();
-	if (pop_u64()) {
-		push_u64(1LL); // True
-	} else {
-		mp_primZ_dup();
-		mw_mirth_token_Token_sigZ_resourceZ_varZAsk();
-	}
 	{
 		VAL d2 = pop_value();
-		mp_primZ_drop();
+		mw_mirth_token_Token_sigZ_resourceZ_conZAsk();
 		push_value(d2);
+	}
+	mp_primZ_swap();
+	if (pop_u64()) {
+		mp_primZ_drop();
+		push_u64(1LL); // True
+	} else {
+		mw_mirth_token_Token_sigZ_resourceZ_varZAsk();
 	}
 }
 static void mb_mirth_elab_elabZ_dataZ_doneZBang_0 (void) {
@@ -54227,6 +54465,366 @@ static void mb_mirth_need_ZPlusNeeds_runZ_patternZBang_0 (void) {
 }
 static void mb_std_set_ZPlusSet_1_offsetZ_mask_0 (void) {
 	mw_std_buffer_ZPlusBuffer_expandZBang();
+}
+static void mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot105ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot123ZRParen_2 (void) {
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	{
+		VAL d2 = pop_resource();
+		mw_mirth_def_Def_qnameZ_hard();
+		push_resource(d2);
+	}
+	mw_mirth_name_QName_climbZ_upZ_dnameZAsk();
+	push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filterZ_roots_26);
+	mw_std_list_List_1_has_1();
+	if (pop_u64()) {
+		mtw_std_either_Either_2_Right();
+	} else {
+		mtw_mirth_elab_RejectedDef_RDz_NOTz_IMPORTED();
+		mtw_std_either_Either_2_Left();
+	}
+}
+static void mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot105ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot123ZRParenZDot0ZRParen_0 (void) {
+	mw_std_list_List_1_cat();
+}
+static void mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot78ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot93ZRParen_2 (void) {
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	{
+		VAL d2 = pop_resource();
+		mw_mirth_def_Def_qnameZ_hard();
+		push_resource(d2);
+	}
+	mw_mirth_name_QName_climbZ_upZ_dnameZAsk();
+	push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filterZ_roots_19);
+	mw_std_list_List_1_has_1();
+	if (pop_u64()) {
+		mtw_std_either_Either_2_Right();
+	} else {
+		{
+			VAL d3 = pop_value();
+			{
+				VAL d4 = pop_value();
+				mp_primZ_dup();
+				push_value(d4);
+			}
+			mp_primZ_swap();
+			push_value(d3);
+		}
+		mp_primZ_swap();
+		mw_std_list_List_1_emptyZAsk();
+		if (pop_u64()) {
+			mtw_mirth_elab_RejectedDef_RDz_METHODz_NOTz_AVAILABLE();
+		} else {
+			mtw_mirth_elab_RejectedDef_RDz_METHODz_WRONGz_TYPE();
+		}
+		mtw_std_either_Either_2_Left();
+	}
+}
+static void mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot78ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot93ZRParenZDot0ZRParen_0 (void) {
+	mw_std_list_List_1_cat();
+}
+static void mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot6ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot27ZRParen_2 (void) {
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	{
+		VAL d2 = pop_resource();
+		mw_mirth_def_Def_qnameZ_hard();
+		push_resource(d2);
+	}
+	mw_mirth_name_QName_namespace();
+	mp_primZ_swap();
+	push_fnptr(&mb_mirth_elab_ZPlusResolveDef_filterZ_roots_4);
+	mw_std_list_List_1_member_1();
+	if (pop_u64()) {
+		push_u64(1LL); // True
+	} else {
+		mw_mirth_elab_ZPlusResolveDef_token();
+		{
+			VAL d3 = pop_value();
+			mp_primZ_dup();
+			push_value(d3);
+		}
+		mp_primZ_swap();
+		{
+			VAL d3 = pop_resource();
+			mw_mirth_elab_defZ_isZ_importedZ_atZ_tokenZAsk();
+			push_resource(d3);
+		}
+	}
+	if (pop_u64()) {
+		mtw_std_either_Either_2_Right();
+	} else {
+		mp_primZ_dup();
+		{
+			VAL d3 = pop_resource();
+			mw_mirth_def_Def_qnameZ_hard();
+			push_resource(d3);
+		}
+		mw_mirth_name_QName_namespace();
+		switch (get_top_data_tag()) {
+			case 3LL: // NAMESPACE_TYCON
+				mtp_mirth_name_Namespace_NAMESPACEz_TYCON();
+				mp_primZ_drop();
+				mw_mirth_elab_ZPlusResolveDef_token();
+				mw_mirth_token_Token_nameZAsk();
+				switch (get_top_data_tag()) {
+					case 1LL: // Some
+						mtp_std_maybe_Maybe_1_Some();
+						break;
+					case 0LL: // None
+						(void)pop_u64();
+						STRLIT("tried to unwrap None", 20);
+						mw_std_prelude_panicZBang();
+						break;
+					default:
+						push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+						mp_primZ_panic();
+				}
+				mw_mirth_name_Name_canZ_beZ_relativeZAsk();
+				if (pop_u64()) {
+					{
+						VAL d6 = pop_value();
+						mp_primZ_dup();
+						push_value(d6);
+					}
+					mp_primZ_swap();
+					mw_std_list_List_1_emptyZAsk();
+					if (pop_u64()) {
+						mtw_mirth_elab_RejectedDef_RDz_METHODz_NOTz_AVAILABLE();
+					} else {
+						mtw_mirth_elab_RejectedDef_RDz_METHODz_WRONGz_TYPE();
+					}
+				} else {
+					mtw_mirth_elab_RejectedDef_RDz_NOTz_IMPORTED();
+				}
+				break;
+			default:
+				mp_primZ_drop();
+				mtw_mirth_elab_RejectedDef_RDz_NOTz_IMPORTED();
+				break;
+		}
+		mtw_std_either_Either_2_Left();
+	}
+}
+static void mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot6ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_rootsZDot27ZRParenZDot0ZRParen_0 (void) {
+	mw_std_list_List_1_cat();
+}
+static void mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_qualifiersZDot6ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_qualifiersZDot15ZRParen_2 (void) {
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	{
+		VAL d2 = pop_resource();
+		mw_mirth_def_Def_qnameZ_hard();
+		push_resource(d2);
+	}
+	mw_mirth_name_QName_climbZ_upZ_dnameZAsk();
+	mw_std_list_List_1_emptyZAsk();
+	if (pop_u64()) {
+		push_u64(0LL); // False
+	} else {
+		push_u64(1LL); // True
+	}
+	if (pop_u64()) {
+		mtw_std_either_Either_2_Right();
+	} else {
+		mtw_mirth_elab_RejectedDef_RDz_WRONGz_QUALIFIER();
+		mtw_std_either_Either_2_Left();
+	}
+}
+static void mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_qualifiersZDot6ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_qualifiersZDot15ZRParenZDot0ZRParen_0 (void) {
+	mw_std_list_List_1_cat();
+}
+static void mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_arityZDot4ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_arityZDot11ZRParen_2 (void) {
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	{
+		VAL d2 = pop_resource();
+		mw_mirth_def_Def_arity();
+		push_resource(d2);
+	}
+	mw_mirth_elab_arityZ_compatibleZAsk();
+	if (pop_u64()) {
+		mtw_std_either_Either_2_Right();
+	} else {
+		mtw_mirth_elab_RejectedDef_RDz_WRONGz_ARITY();
+		mtw_std_either_Either_2_Left();
+	}
+}
+static void mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZ_arityZDot4ZCommamirthZDotelabZDotZPlusResolveDefZDotfilterZ_arityZDot11ZRParenZDot0ZRParen_0 (void) {
+	mw_std_list_List_1_cat();
+}
+static void mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotZPlusTypeElabZDotresolveZ_typeZ_conZ_nameZBangZDot14ZCommamirthZDotelabZDotZPlusTypeElabZDotresolveZ_typeZ_conZ_nameZBangZDot20ZRParen_2 (void) {
+	mp_primZ_dup();
+	{
+		VAL d2 = pop_resource();
+		mw_mirth_def_Def_definesZ_aZ_typeZAsk();
+		push_resource(d2);
+	}
+	if (pop_u64()) {
+		mtw_std_either_Either_2_Right();
+	} else {
+		mtw_mirth_elab_RejectedDef_RDz_WRONGz_SORT();
+		mtw_std_either_Either_2_Left();
+	}
+}
+static void mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotZPlusTypeElabZDotresolveZ_typeZ_conZ_nameZBangZDot14ZCommamirthZDotelabZDotZPlusTypeElabZDotresolveZ_typeZ_conZ_nameZBangZDot20ZRParenZDot0ZRParen_0 (void) {
+	mw_std_list_List_1_cat();
+}
+static void mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotelabZ_patternZ_atomZBangZDot59ZCommamirthZDotelabZDotelabZ_patternZ_atomZBangZDot71ZRParen_2 (void) {
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	{
+		VAL d2 = pop_resource();
+		mw_mirth_def_Def_qnameZ_hard();
+		push_resource(d2);
+	}
+	mw_mirth_name_QName_namespace();
+	mp_primZ_swap();
+	push_fnptr(&mb_mirth_elab_elabZ_patternZ_atomZBang_14);
+	mw_std_list_List_1_member_1();
+	if (pop_u64()) {
+		mtw_std_either_Either_2_Right();
+	} else {
+		mtw_mirth_elab_RejectedDef_RDz_WRONGz_CONSTRUCTOR();
+		mtw_std_either_Either_2_Left();
+	}
+}
+static void mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotelabZ_patternZ_atomZBangZDot59ZCommamirthZDotelabZDotelabZ_patternZ_atomZBangZDot71ZRParenZDot0ZRParen_0 (void) {
+	mw_std_list_List_1_cat();
+}
+static void mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotelabZ_patternZ_atomZBangZDot31ZCommamirthZDotelabZDotelabZ_patternZ_atomZBangZDot35ZRParen_2 (void) {
+	mp_primZ_dup();
+	mw_mirth_def_Def_tagZAsk();
+	switch (get_top_data_tag()) {
+		case 0LL: // None
+			(void)pop_u64();
+			push_u64(0LL); // False
+			break;
+		case 1LL: // Some
+			mtp_std_maybe_Maybe_1_Some();
+			mp_primZ_drop();
+			push_u64(1LL); // True
+			break;
+		default:
+			push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+			mp_primZ_panic();
+	}
+	if (pop_u64()) {
+		mtw_std_either_Either_2_Right();
+	} else {
+		mtw_mirth_elab_RejectedDef_RDz_WRONGz_SORT();
+		mtw_std_either_Either_2_Left();
+	}
+}
+static void mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotelabZ_patternZ_atomZBangZDot31ZCommamirthZDotelabZDotelabZ_patternZ_atomZBangZDot35ZRParenZDot0ZRParen_0 (void) {
+	mw_std_list_List_1_cat();
+}
+static void mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotelabZ_atomZ_resolveZ_defZBangZDot15ZCommamirthZDotelabZDotelabZ_atomZ_resolveZ_defZBangZDot21ZRParen_2 (void) {
+	mp_primZ_dup();
+	{
+		VAL d2 = pop_resource();
+		mw_mirth_def_Def_callableZAsk();
+		push_resource(d2);
+	}
+	if (pop_u64()) {
+		mtw_std_either_Either_2_Right();
+	} else {
+		mtw_mirth_elab_RejectedDef_RDz_WRONGz_SORT();
+		mtw_std_either_Either_2_Left();
+	}
+}
+static void mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotelabZ_atomZ_resolveZ_defZBangZDot15ZCommamirthZDotelabZDotelabZ_atomZ_resolveZ_defZBangZDot21ZRParenZDot0ZRParen_0 (void) {
+	mw_std_list_List_1_cat();
+}
+static void mb_mirth_elab_ZPlusResolveDef_filter_2_ZLParenmirthZDotelabZDotelabZ_aliasZBangZDot32ZCommamirthZDotelabZDotelabZ_aliasZBangZDot39ZRParen_2 (void) {
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	{
+		VAL d2 = pop_value();
+		mp_primZ_dup();
+		push_value(d2);
+	}
+	mp_primZ_swap();
+	{
+		VAL d2 = pop_resource();
+		mw_mirth_def_Def_arity();
+		push_resource(d2);
+	}
+	mw_mirth_elab_arityZ_compatibleZAsk();
+	if (pop_u64()) {
+		mtw_std_either_Either_2_Right();
+	} else {
+		mtw_mirth_elab_RejectedDef_RDz_WRONGz_ARITY();
+		mtw_std_either_Either_2_Left();
+	}
+}
+static void mb_mirth_elab_ZPlusResolveDef_filter_1_ZLParenmirthZDotelabZDotZPlusResolveDefZDotfilterZDiv2ZDotZLParenmirthZDotelabZDotelabZ_aliasZBangZDot32ZCommamirthZDotelabZDotelabZ_aliasZBangZDot39ZRParenZDot0ZRParen_0 (void) {
+	mw_std_list_List_1_cat();
 }
 static void mb_std_str_ZPlusStr_splitZ_byte_1_ZLParenstdZDotstrZDotZPlusStrZDotsplitZ_byteZDot2ZRParen_11 (void) {
 	push_i64(0LL);

--- a/src/elab.mth
+++ b/src/elab.mth
@@ -37,48 +37,55 @@ import(mirth.label)
 # Type Elaboration #
 ####################
 
-data(+TypeElab, TYPE_ELAB ->
+struct +TypeElab {
     ctx:Ctx token:Token
     allow-type-holes:Bool
-    allow-implicit-type-vars:Bool)
+    allow-implicit-type-vars:Bool
+}
 
-def(+TypeElab.type-sig-start!, Token -- +TypeElab,
+def +TypeElab.type-sig-start! [ Token -- +TypeElab ] {
     >token
     Ctx0 >ctx
     False >allow-type-holes
     True >allow-implicit-type-vars
-    TYPE_ELAB)
+    +TypeElab
+}
 
-def(+TypeElab.rdrop, +TypeElab --,
-    /TYPE_ELAB
+def +TypeElab.rdrop [ +TypeElab -- ] {
+    /+TypeElab
     ctx> token> drop2
     allow-type-holes> drop
-    allow-implicit-type-vars> drop)
+    allow-implicit-type-vars> drop
+}
 
-def(+TypeElab.elab-type-sig!, +Mirth +TypeElab -- +Mirth +TypeElab ArrowType,
+def +TypeElab.elab-type-sig! [ +Mirth +TypeElab -- +Mirth +TypeElab ArrowType ] {
     token run-end? then(token "expected type signature" rdip:emit-error!)
     elab-type-sig-params!
     elab-stack-type!
     token sig-dashes? if(token:succ elab-stack-type!, dip:T0)
     token run-end? else(token "expected right paren or comma" rdip:emit-error!)
-    dip(swap for(T*)) T->)
+    dip(swap for(T*)) T->
+}
 
-def(+TypeElab.elab-type-sig-params!, +Mirth +TypeElab -- +Mirth +TypeElab List(Type),
+def +TypeElab.elab-type-sig-params! [ +Mirth +TypeElab -- +Mirth +TypeElab List(Type) ] {
     token lparen? if(
         token next
         token args map(token! elab-type-sig! TMorphism)
         dip:token!,
         L0
-    ))
+    )
+}
 
-def(+TypeElab.elab-stack-type!, +Mirth +TypeElab -- +Mirth +TypeElab StackType,
+def +TypeElab.elab-stack-type! [ +Mirth +TypeElab -- +Mirth +TypeElab StackType ] {
     token sig-stack-var? if(elab-stack-type-var!, T0)
-    elab-stack-type-parts!)
+    elab-stack-type-parts!
+}
 
-def(+TypeElab.elab-stack-type-parts!, +Mirth +TypeElab StackType -- +Mirth +TypeElab StackType,
-    while(token sig-stack-end? not, elab-stack-type-part! cons))
+def +TypeElab.elab-stack-type-parts! [ +Mirth +TypeElab StackType -- +Mirth +TypeElab StackType ] {
+    while(token sig-stack-end? not, elab-stack-type-part! cons)
+}
 
-def(+TypeElab.elab-type-arg!, +Mirth +TypeElab -- +Mirth +TypeElab Type,
+def +TypeElab.elab-type-arg! [ +Mirth +TypeElab -- +Mirth +TypeElab Type ] {
     token elab-stack-type-part!
     match(
         STPCons -> nip,
@@ -88,9 +95,10 @@ def(+TypeElab.elab-type-arg!, +Mirth +TypeElab -- +Mirth +TypeElab Type,
     )
     token arg-end? else(
         token "Unexpected token after type." rdip:emit-error!
-    ))
+    )
+}
 
-def(+TypeElab.elab-resource-arg!, +Mirth +TypeElab -- +Mirth +TypeElab Resource,
+def +TypeElab.elab-resource-arg! [ +Mirth +TypeElab -- +Mirth +TypeElab Resource ] {
     token elab-stack-type-part!
     match(
         STPCons -> drop "Expected resource, not type." rdip:emit-error! TYPE_ERROR Resource,
@@ -100,9 +108,10 @@ def(+TypeElab.elab-resource-arg!, +Mirth +TypeElab -- +Mirth +TypeElab Resource,
     )
     token arg-end? else(
         token "Unexpected token after resource." rdip:emit-error!
-    ))
+    )
+}
 
-def(+TypeElab.elab-stack-type-part!, +Mirth +TypeElab -- +Mirth +TypeElab StackTypePart,
+def +TypeElab.elab-stack-type-part! [ +Mirth +TypeElab -- +Mirth +TypeElab StackTypePart ] {
     token could-be-sig-label? if(
         elab-stack-label!,
 
@@ -129,30 +138,36 @@ def(+TypeElab.elab-stack-type-part!, +Mirth +TypeElab -- +Mirth +TypeElab StackT
 
         token "Expected type, got unknown token." rdip:emit-error!
         token:next TYPE_ERROR STPCons
-    )))))))))
+    ))))))))
+}
 
-def(+TypeElab.elab-stack-label!, +Mirth +TypeElab -- +Mirth +TypeElab StackTypePart,
+def +TypeElab.elab-stack-label! [ +Mirth +TypeElab -- +Mirth +TypeElab StackTypePart ] {
     token next dip(
         token name? unwrap Label.new!
         token:args-1 dup is-resource-label? if(
             elab-resource-arg! swap STPWithLabel,
             elab-type-arg! swap STPConsLabel
         )
-    ) token!)
+    ) token!
+}
 
-def(+TypeElab.elab-stack-type-var!, +Mirth +TypeElab -- +Mirth +TypeElab StackType,
-    TYPE_STACK elab-implicit-var! if-some(STVar, STACK_TYPE_ERROR))
+def +TypeElab.elab-stack-type-var! [ +Mirth +TypeElab -- +Mirth +TypeElab StackType ] {
+    TYPE_STACK elab-implicit-var! if-some(STVar, STACK_TYPE_ERROR)
+}
 
-def(+TypeElab.elab-type-var!, +Mirth +TypeElab -- +Mirth +TypeElab Type,
-    TYPE_TYPE elab-implicit-var! if-some(TVar, TYPE_ERROR))
+def +TypeElab.elab-type-var! [ +Mirth +TypeElab -- +Mirth +TypeElab Type ] {
+    TYPE_TYPE elab-implicit-var! if-some(TVar, TYPE_ERROR)
+}
 
-def(+TypeElab.elab-resource-var!, +Mirth +TypeElab -- +Mirth +TypeElab Resource,
-    TYPE_RESOURCE elab-implicit-var! if-some(TVar, TYPE_ERROR) Resource)
+def +TypeElab.elab-resource-var! [ +Mirth +TypeElab -- +Mirth +TypeElab Resource ] {
+    TYPE_RESOURCE elab-implicit-var! if-some(TVar, TYPE_ERROR) Resource
+}
 
-def(+TypeElab.gamma(f), (*a +Gamma -- *b +Gamma) *a +TypeElab -- *b +TypeElab,
-    token rdip(>token +Gamma f rdrop))
+def +TypeElab.gamma(f) [ (*a +Gamma -- *b +Gamma) *a +TypeElab -- *b +TypeElab ] {
+    token rdip(>token +Gamma f rdrop)
+}
 
-def(+TypeElab.elab-implicit-var!, +Mirth +TypeElab Type -- +Mirth +TypeElab Maybe(Var),
+def +TypeElab.elab-implicit-var! [ +Mirth +TypeElab Type -- +Mirth +TypeElab Maybe(Var) ] {
     token name? unwrap dup ctx lookup match(
         Some -> sip(nip type gamma:unify! drop) Some,
         None ->
@@ -163,54 +178,68 @@ def(+TypeElab.elab-implicit-var!, +Mirth +TypeElab Type -- +Mirth +TypeElab Mayb
             )
     )
     token rdip:args-0
-    token:succ)
+    token:succ
+}
 
-def(show-num-arguments, Int -- Str,
+def show-num-arguments [ Int -- Str ] {
     dup 1 == if(drop "1 argument",
-    show " arguments" cat))
+    show " arguments" cat)
+}
 
-data(+ResolveDef, RESOLVE_DEF ->
+struct +ResolveDef {
     sort: Str
     token: Token
     candidates: List(Def)
     rejected: List(RejectedDef)
     ignore-last-name: Bool
-    report-ambiguous-as-warning: Bool)
+    report-ambiguous-as-warning: Bool
+}
 
-def(+ResolveDef.filter(p),
+inline (
+    def +ResolveDef.filter(p) [
         (*a Def +ResolveDef -- *a Either(RejectedDef, Def) +ResolveDef)
-        *a +ResolveDef -- *a +ResolveDef,
-    candidates partition-either(p) dip:rejected:cat candidates!)
+        *a +ResolveDef -- *a +ResolveDef
+    ] {
+        candidates partition-either(p) dip:rejected:cat candidates!
+    }
 
-def(+ResolveDef.filter(p,q),
+    def +ResolveDef.filter(p,q) [
         (*a Def +ResolveDef -- *a Def Bool +ResolveDef,
          *a Def +ResolveDef -- *a RejectedDef +ResolveDef)
-        *a +ResolveDef -- *a +ResolveDef,
-    filter(p if(Right, q Left)))
+        *a +ResolveDef -- *a +ResolveDef
+    ] {
+        filter(p if(Right, q Left))
+    }
+)
 
-data(RejectedDef,
-    RD_WRONG_SORT -> Def,
-    RD_WRONG_ARITY -> Def,
-    RD_NOT_VISIBLE -> Def,
-    RD_NOT_IMPORTED -> Def,
-    RD_WRONG_QUALIFIER -> Def,
-    RD_WRONG_CONSTRUCTOR -> Def,
-    RD_METHOD_NOT_AVAILABLE -> Def,
-    RD_METHOD_WRONG_TYPE -> Def)
+# TODO: separate this into a reason and a def.
+data RejectedDef {
+    RD_WRONG_SORT           [ Def ]
+    RD_WRONG_ARITY          [ Def ]
+    RD_NOT_VISIBLE          [ Def ]
+    RD_NOT_IMPORTED         [ Def ]
+    RD_WRONG_QUALIFIER      [ Def ]
+    RD_WRONG_CONSTRUCTOR    [ Def ]
+    RD_METHOD_NOT_AVAILABLE [ Def ]
+    RD_METHOD_WRONG_TYPE    [ Def ]
+}
 
-def(resolve-def(f), (*a +Mirth +ResolveDef -- *b +Mirth +ResolveDef)
-        *a +Mirth
-        sort:Str
-        token:Token
-        report-ambiguous-as-warning:Bool
-        ignore-last-name:Bool
-        -- *b +Mirth Maybe(Def),
+def resolve-def(f) [
+    (*a +Mirth +ResolveDef -- *b +Mirth +ResolveDef)
+    *a +Mirth
+    sort:Str
+    token:Token
+    report-ambiguous-as-warning:Bool
+    ignore-last-name:Bool
+    --
+    *b +Mirth Maybe(Def),
+] {
     @ignore-last-name if(
         @token penultimate-name?,
         @token last-name?
     ) unwrap defs >candidates
     L0 >rejected
-    RESOLVE_DEF
+    +ResolveDef
     f
     candidates match(
         Nil -> resolve-def-unknown None,
@@ -221,16 +250,18 @@ def(resolve-def(f), (*a +Mirth +ResolveDef -- *b +Mirth +ResolveDef)
                 _ -> drop2 resolve-def-ambiguous None
             )
         )
-    ))
+    )
+}
 
-def(+ResolveDef.rdrop, +ResolveDef --,
-    /RESOLVE_DEF
+def +ResolveDef.rdrop [ +ResolveDef -- ] {
+    /+ResolveDef
     sort> token> drop2
     candidates> rejected> drop2
     report-ambiguous-as-warning> drop
-    ignore-last-name> drop)
+    ignore-last-name> drop
+}
 
-def(+ResolveDef.resolve-def-ambiguous, +Mirth +ResolveDef -- +Mirth,
+def +ResolveDef.resolve-def-ambiguous [ +Mirth +ResolveDef -- +Mirth ] {
     report-ambiguous-as-warning if(
         token Str(
             "Can't resolve " ; rdip:sort ; " due to previous errors. Candidates are:" ;
@@ -241,8 +272,9 @@ def(+ResolveDef.resolve-def-ambiguous, +Mirth +ResolveDef -- +Mirth,
             "Ambiguous " ; rdip:sort ; ". Can't decide between:" ;
             " " rdip:candidates for(swap ; rdip2(qname-hard >Str) ; ", ") drop
         ) rdip:emit-error!
-    ) rdrop)
-def(+ResolveDef.resolve-def-unknown, +Mirth +ResolveDef -- +Mirth,
+    ) rdrop
+}
+def +ResolveDef.resolve-def-unknown [ +Mirth +ResolveDef -- +Mirth ] {
     token Str(rdip:rejected match(
         Nil -> "Unknown " ; rdip:sort ; " name, possibly a misspelling." ;,
         Cons ->
@@ -287,27 +319,34 @@ def(+ResolveDef.resolve-def-unknown, +Mirth +ResolveDef -- +Mirth,
                             rdip2(qname-hard >Str) ; " is not avaliable for current stack" ; ,
                     ) ", ") drop
             )
-    )) rdip:emit-error! rdrop)
+    )) rdip:emit-error! rdrop
+}
 
-def(+ResolveDef.filter-sort(p),
-        (*a Def +ResolveDef -- *a Def Bool +ResolveDef)
-        *a +ResolveDef -- *a +ResolveDef,
-    filter(p, RD_WRONG_SORT))
-def(+ResolveDef.filter-arity, +Mirth +ResolveDef -- +Mirth +ResolveDef,
+def +ResolveDef.filter-sort(p) [
+    (*a Def +ResolveDef -- *a Def Bool +ResolveDef)
+    *a +ResolveDef -- *a +ResolveDef
+] {
+    filter(p, RD_WRONG_SORT)
+}
+
+def +ResolveDef.filter-arity [ +Mirth +ResolveDef -- +Mirth +ResolveDef ] {
     token num-args filter(
         dup2 rdip:arity arity-compatible?,
         RD_WRONG_ARITY
-    ) drop)
-def(+ResolveDef.filter-visible, +ResolveDef -- +ResolveDef,
-    filter(token over def-visible-from-token?, RD_NOT_VISIBLE))
+    ) drop
+}
+def +ResolveDef.filter-visible [ +ResolveDef -- +ResolveDef ] {
+    filter(token over def-visible-from-token?, RD_NOT_VISIBLE)
+}
 
-def(+ResolveDef.filter-qualifiers, +Mirth +ResolveDef -- +Mirth +ResolveDef,
+def +ResolveDef.filter-qualifiers [ +Mirth +ResolveDef -- +Mirth +ResolveDef ] {
     token dname? for(
         filter(dup2 rdip:qname-hard climb-up-dname? empty? not, RD_WRONG_QUALIFIER)
         drop
-    ))
+    )
+}
 
-def(+ResolveDef.filter-roots, List(Namespace) +Mirth +ResolveDef -- +Mirth +ResolveDef,
+def +ResolveDef.filter-roots [ List(Namespace) +Mirth +ResolveDef -- +Mirth +ResolveDef ] {
     token name? then(
         filter(
             dup2 rdip:qname-hard namespace swap member(==)
@@ -338,10 +377,11 @@ def(+ResolveDef.filter-roots, List(Namespace) +Mirth +ResolveDef -- +Mirth +Reso
             ), RD_NOT_IMPORTED)
         ) drop
     )
-    drop)
+    drop
+}
 
 ||| Check whether a definition can be referred to without qualification.
-def(def-is-imported-at-token?, +Mirth Token Def -- +Mirth Bool,
+def def-is-imported-at-token? [ +Mirth Token Def -- +Mirth Bool ] {
     # TODO: implement finer grained control over what is imported.
     #   https://github.com/mirth-lang/mirth/issues/243
     dup qname-hard namespace match(
@@ -350,21 +390,24 @@ def(def-is-imported-at-token?, +Mirth Token Def -- +Mirth Bool,
         NAMESPACE_MODULE -> nip module-visible-from-token?,
         NAMESPACE_TYCON -> dip:swap tycon-is-visible-at-token? if(tag? >Bool, drop False),
         NAMESPACE_WORD -> drop3 False
-    ))
+    )
+}
 
-def(tycon-is-visible-at-token?, Token Tycon -- Bool,
+def tycon-is-visible-at-token? [ Token Tycon -- Bool ] {
     TYCON_DATA -> head? if-some(.module module-visible-from-token?, drop True),
     TYCON_TABLE -> head .module module-visible-from-token?,
-    TYCON_PRIM -> drop2 True)
+    TYCON_PRIM -> drop2 True
+}
 
-def(namespace-is-imported-at-token?, +Mirth Token Namespace -- +Mirth Bool,
+def namespace-is-imported-at-token? [ +Mirth Token Namespace -- +Mirth Bool ] {
     NAMESPACE_ROOT -> drop True,
     NAMESPACE_PACKAGE -> drop2 True,
     NAMESPACE_MODULE -> module-visible-from-token?,
     NAMESPACE_TYCON -> qname-hard namespace namespace-is-imported-at-token?,
-    NAMESPACE_WORD -> drop2 False)
+    NAMESPACE_WORD -> drop2 False
+}
 
-def(QName.climb-up-name?, +Mirth Name QName -- +Mirth List(Namespace),
+def QName.climb-up-name? [ +Mirth Name QName -- +Mirth List(Namespace) ] {
     >qname >name
 
     @qname name @name == if(
@@ -385,16 +428,18 @@ def(QName.climb-up-name?, +Mirth Name QName -- +Mirth List(Namespace),
         _ -> drop
     ))
     qname> drop
-    accum>)
+    accum>
+}
 
-def(QName.climb-up-dname?, +Mirth +ResolveDef DName QName -- +Mirth +ResolveDef List(Namespace),
+def QName.climb-up-dname? [ +Mirth +ResolveDef DName QName -- +Mirth +ResolveDef List(Namespace) ] {
     dip(sip(root? >List) parts unsnoc dip(cat)
         ignore-last-name then(drop unsnoc unwrap)
     )
     rdip:climb-up-name? swap
-    reverse-for(swap bind(rdip:qname if-some(dip(dup) rdip:climb-up-name?, L0)) nip))
+    reverse-for(swap bind(rdip:qname if-some(dip(dup) rdip:climb-up-name?, L0)) nip)
+}
 
-def(+TypeElab.resolve-type-con-name!, +Mirth +TypeElab -- +Mirth +TypeElab Type,
+def +TypeElab.resolve-type-con-name! [ +Mirth +TypeElab -- +Mirth +TypeElab Type ] {
     False >report-ambiguous-as-warning
     False >ignore-last-name
     token >token "type" >sort rdip:resolve-def(
@@ -409,9 +454,10 @@ def(+TypeElab.resolve-type-con-name!, +Mirth +TypeElab -- +Mirth +TypeElab Type,
         _ ->
             drop token "compiler bug: resolve-type-con-name! doesn't understand type"
             rdip:emit-error! TYPE_ERROR,
-    ) unwrap(TYPE_ERROR))
+    ) unwrap(TYPE_ERROR)
+}
 
-def(+TypeElab.elab-type-con!, +Mirth +TypeElab -- +Mirth +TypeElab Type,
+def +TypeElab.elab-type-con! [ +Mirth +TypeElab -- +Mirth +TypeElab Type ] {
     token name? has(>Str "Mut" ==) if(
         token next dip(
             token:args-1
@@ -421,12 +467,14 @@ def(+TypeElab.elab-type-con!, +Mirth +TypeElab -- +Mirth +TypeElab Type,
 
         resolve-type-con-name! elab-type-args!
         token:next
-    ))
+    )
+}
 
-def(+TypeElab.elab-resource-con!, +Mirth +TypeElab -- +Mirth +TypeElab Resource,
-    elab-type-con! Resource)
+def +TypeElab.elab-resource-con! [ +Mirth +TypeElab -- +Mirth +TypeElab Resource ] {
+    elab-type-con! Resource
+}
 
-def(+TypeElab.elab-type-args!, +Mirth +TypeElab Type -- +Mirth +TypeElab Type,
+def +TypeElab.elab-type-args! [ +Mirth +TypeElab Type -- +Mirth +TypeElab Type ] {
     token has-args? if(
         token dip(
             token args for(
@@ -436,78 +484,89 @@ def(+TypeElab.elab-type-args!, +Mirth +TypeElab Type -- +Mirth +TypeElab Type,
         ) token!,
 
         id
-    ))
+    )
+}
 
-def(+TypeElab.elab-type-hole!, +Mirth +TypeElab -- +Mirth +TypeElab Type,
+def +TypeElab.elab-type-hole! [ +Mirth +TypeElab -- +Mirth +TypeElab Type ] {
     allow-type-holes if(
         token rdip:args-0
         token name? unwrap THole,
         token "type holes are not allowed here" rdip:emit-error!
         TYPE_ERROR
     )
-    token:next)
+    token:next
+}
 
-def(+TypeElab.elab-type-dont-care!, +Mirth +TypeElab -- +Mirth +TypeElab Type,
+def +TypeElab.elab-type-dont-care! [ +Mirth +TypeElab -- +Mirth +TypeElab Type ] {
     allow-type-holes if(
         token rdip:args-0
         TYPE_DONT_CARE,
         token "underscore is not allowed here" rdip:emit-error!
         TYPE_ERROR
     )
-    token:next)
+    token:next
+}
 
-def(+TypeElab.elab-type-quote!, +Mirth +TypeElab -- +Mirth +TypeElab Type,
+def +TypeElab.elab-type-quote! [ +Mirth +TypeElab -- +Mirth +TypeElab Type ] {
     token next dip(
         token:args-1
         token sig-has-dashes? if(
             elab-type-sig! >Type,
             elab-stack-type! >Type
         )
-    ) token!)
+    ) token!
+}
 
-def(elab-type-unify!, +Mirth Type Type Token -- +Mirth Type Token,
-    >token +Gamma unify! /+Gamma token>)
-def(elab-stack-type-unify!, +Mirth StackType StackType Token -- +Mirth StackType Token,
-    >token +Gamma unify! /+Gamma token>)
+def elab-type-unify! [ +Mirth Type Type Token -- +Mirth Type Token ] {
+    >token +Gamma unify! /+Gamma token>
+}
+def elab-stack-type-unify! [ +Mirth StackType StackType Token -- +Mirth StackType Token ] {
+    >token +Gamma unify! /+Gamma token>
+}
 
-def(elab-simple-type-arg!, +Mirth Token -- +Mirth Type,
+def elab-simple-type-arg! [ +Mirth Token -- +Mirth Type ] {
     >token
     Ctx0 >ctx
     False >allow-type-holes
     False >allow-implicit-type-vars
-    TYPE_ELAB elab-type-arg! rdrop)
+    +TypeElab elab-type-arg! rdrop
+}
 
 ####################
 # Word Elaboration #
 ####################
 
-data(+AB, MKAB -> arrow:Arrow)
-def(ab-arrow@, +AB -- +AB Arrow, arrow)
-def(ab-token@, +AB -- +AB Token, arrow token-end)
-def(ab-token!, +AB Token -- +AB, arrow:token-end!)
-def(ab-type@, +AB -- +AB StackType, arrow cod)
-def(ab-type!, +AB StackType -- +AB, arrow:cod!)
-def(ab-ctx@, +AB -- +AB Ctx, arrow ctx)
-def(ab-home@, +AB -- +AB Home, arrow home)
+struct +AB { arrow:Arrow }
+def ab-token@ [ +AB -- +AB Token ] { arrow token-end }
+def ab-token! [ +AB Token -- +AB ] { arrow:token-end! }
+def ab-type@ [ +AB -- +AB StackType ] { arrow cod }
+def ab-type! [ +AB StackType -- +AB ] { arrow:cod! }
+def ab-ctx@ [ +AB -- +AB Ctx ] { arrow ctx }
+def ab-home@ [ +AB -- +AB Home ] { arrow home }
 
-def(+AB.gamma(f), (*a +Gamma -- *b +Gamma) *a +AB -- *b +AB,
-    ab-token@ rdip(>token +Gamma f rdrop))
+def +AB.gamma(f) [ (*a +Gamma -- *b +Gamma) *a +AB -- *b +AB ] {
+    ab-token@ rdip(>token +Gamma f rdrop)
+}
 
-def(ab-build!(f), (*a +AB -- *b +AB) *a Ctx StackType Token Home -- *b Arrow,
+def ab-build!(f) [ (*a +AB -- *b +AB) *a Ctx StackType Token Home -- *b Arrow ] {
     >home
     dup >token-start >token-end
     dup >dom >cod
     >ctx L0 >atoms
-    Arrow >arrow MKAB
-    f /MKAB arrow>)
+    Arrow >arrow +AB
+    f /+AB arrow>
+}
 
 ||| Like ab-build! but takes a morphism type to build
 ||| instead of just the domain. The codomain is placed
 ||| on the stack for (in)convenience. (You can ignore it with dip.)
-def(ab-build-hom!(f), (*a StackType +Mirth +AB -- *b StackType +Mirth +AB)
-        *a Ctx ArrowType Token Home +Mirth -- *b Arrow +Mirth,
+def ab-build-hom!(f) [
+    (*a StackType +Mirth +AB -- *b StackType +Mirth +AB)
+    *a Ctx ArrowType Token Home +Mirth -- *b Arrow +Mirth
+] {
     dip2(unpack rotr)
-    ab-build!(f ab-unify-type!))
+    ab-build!(f ab-unify-type!)
+}
 
 ||| Build the arrow for a word. If the word type and context are available, use that.
 ||| Otherwise, we are in a situation where type and context were not given, so we infer them.
@@ -516,7 +575,10 @@ def(ab-build-hom!(f), (*a StackType +Mirth +AB -- *b StackType +Mirth +AB)
 ||| of metavariables). We temporarily set that as our ctx-type. Then we elaborate the word
 ||| body. After elaboration, we rigidify the type to obtain a generalized definition, by
 ||| replacing any free metavariables with universally quantified variables.
-def(ab-build-word-arrow!(f), (*a StackType +Mirth +AB -- *b StackType +Mirth +AB) *a Word +Mirth -- *b Arrow +Mirth,
+def ab-build-word-arrow!(f) [
+    (*a StackType +Mirth +AB -- *b StackType +Mirth +AB)
+    *a Word +Mirth -- *b Arrow +Mirth
+] {
     dup ~ctx-type try-force! match(
         Some ->
             unpack2 rotl sip(body) HomeWord ab-build-hom!(f),
@@ -534,9 +596,10 @@ def(ab-build-word-arrow!(f), (*a StackType +Mirth +AB -- *b StackType +Mirth +AB
             word> drop
 
             unpack arrow> cod! dom! ctx!
-    ))
+    )
+}
 
-def(guess-initial-ctx-type, +Mirth Word -- +Mirth Ctx ArrowType,
+def guess-initial-ctx-type [ +Mirth Word -- +Mirth Ctx ArrowType ] {
     >word
     Ctx0 >ctx
     MetaVar.new! STMeta >dom
@@ -566,30 +629,35 @@ def(guess-initial-ctx-type, +Mirth Word -- +Mirth Ctx ArrowType,
     ctx> dom> cod> T->
     dup2 pack2 @word WordType prop @word ~ctx-type !
     True @word ~inferring-type? !
-    word> drop)
+    word> drop
+}
 
-def(ab-build-word!(f), (*a +Mirth +AB -- *b +Mirth +AB) *a Word +Mirth -- *b Word +Mirth,
+def ab-build-word!(f) [ (*a +Mirth +AB -- *b +Mirth +AB) *a Word +Mirth -- *b Word +Mirth ] {
     sip(ab-build-word-arrow!(dip(f))) sip(WordArrow prop)
-    tuck ~arrow !)
+    tuck ~arrow !
+}
 
-def(ab-unify-type!, StackType +Mirth +AB -- +Mirth +AB,
-    dip:ab-type@ gamma:unify! ab-type!)
+def ab-unify-type! [ StackType +Mirth +AB -- +Mirth +AB ] {
+    dip:ab-type@ gamma:unify! ab-type!
+}
 
-def(ab-atom!, Atom +AB -- +AB,
+def ab-atom! [ Atom +AB -- +AB ] {
     dup token ab-token!
     # atom-dom? ab-unify-type!     # moved to ab-expand-opsig!
         # ^ a sanity check to make sure
         # atom dom matches ab-arrow cod
     dup cod ab-type!
-    arrow:atoms(swap ab-optimized-snoc!))
+    arrow:atoms(swap ab-optimized-snoc!)
+}
 
 ||| Add an atom to a list of atoms .. smartly.
-def(ab-optimized-snoc!, List(Atom) Atom -- List(Atom),
+def ab-optimized-snoc! [ List(Atom) Atom -- List(Atom) ] {
     while(dip?(atoms-has-last-block?) and(atom-accepts-args?),
         swap atoms-turn-last-block-to-arg swap)
-    List.snoc)
+    List.snoc
+}
 
-def(atom-accepts-args?, Atom -- Atom Bool,
+def atom-accepts-args? [ Atom -- Atom Bool ] {
     dup op match(
         OpWord -> dip(dup args len >Int) arity <,
         OpPrim ->
@@ -601,9 +669,10 @@ def(atom-accepts-args?, Atom -- Atom Bool,
                 _ -> drop False
             ),
         _ -> drop False
-    ))
+    )
+}
 
-def(atoms-has-last-block?, List(Atom) -- List(Atom) Bool,
+def atoms-has-last-block? [ List(Atom) -- List(Atom) Bool ] {
     dup last match(
         None -> False,
         Some ->
@@ -611,9 +680,10 @@ def(atoms-has-last-block?, List(Atom) -- List(Atom) Bool,
                 OpBlockPush -> drop True,
                 _ -> drop False
             )
-    ))
+    )
+}
 
-def(atoms-turn-last-block-to-arg, Atom List(Atom) -- Atom List(Atom),
+def atoms-turn-last-block-to-arg [ Atom List(Atom) -- Atom List(Atom) ] {
    >List+ match(
         None -> L0,
         Some ->
@@ -626,70 +696,86 @@ def(atoms-turn-last-block-to-arg, Atom List(Atom) -- Atom List(Atom),
                     swap,
                 _ -> drop List.snoc
             )
-    ))
+    )
+}
 
-def(ab-op!, Op +Mirth +AB -- +Mirth +AB,
+def ab-op! [ Op +Mirth +AB -- +Mirth +AB ] {
     ab-ctx@ >ctx
     ab-token@ >token
     ab-home@ >home
     dup >op
     rdip:elab-op-fresh-sig! dip:>subst
     ab-expand-opsig! >cod >dom
-    L0 >args Atom ab-atom!)
+    L0 >args Atom ab-atom!
+}
 
-def(ab-expand-opsig!, OpSig +Mirth +AB -- StackType StackType +Mirth +AB,
-    OPSIG_ID -> ab-type@ dup,
-    OPSIG_PUSH -> dip(ab-type@ dup) STCons,
-    OPSIG_APPLY ->
+def ab-expand-opsig! [ OpSig +Mirth +AB -- StackType StackType +Mirth +AB ] {
+    { OPSIG_ID -> ab-type@ dup }
+    { OPSIG_PUSH -> dip(ab-type@ dup) STCons }
+    { OPSIG_APPLY ->
         dip(ab-type@) unpack
-        dip(ab-token@ rdip:elab-stack-type-unify! drop))
+        dip(ab-token@ rdip:elab-stack-type-unify! drop) }
+}
 
-def(ab-int!, Int +Mirth +AB -- +Mirth +AB, OpInt ab-op!)
-def(ab-str!, Str +Mirth +AB -- +Mirth +AB, OpStr ab-op!)
-def(ab-buffer!, Buffer +Mirth +AB -- +Mirth +AB, OpBuffer ab-op!)
-def(ab-variable!, Variable +Mirth +AB -- +Mirth +AB, OpVariable ab-op!)
-def(ab-field!, Field +Mirth +AB -- +Mirth +AB, OpField ab-op!)
-def(ab-var!, Var +Mirth +AB -- +Mirth +AB, OpVar ab-op!)
-def(ab-tag!, Tag +Mirth +AB -- +Mirth +AB, OpTag ab-op!)
-def(ab-prim!, Prim +Mirth +AB -- +Mirth +AB,
+def ab-int! [ Int +Mirth +AB -- +Mirth +AB ] { OpInt ab-op! }
+def ab-str! [ Str +Mirth +AB -- +Mirth +AB ] { OpStr ab-op! }
+def ab-buffer! [ Buffer +Mirth +AB -- +Mirth +AB ] { OpBuffer ab-op! }
+def ab-variable! [ Variable +Mirth +AB -- +Mirth +AB ] { OpVariable ab-op! }
+def ab-field! [ Field +Mirth +AB -- +Mirth +AB ] { OpField ab-op! }
+def ab-var! [ Var +Mirth +AB -- +Mirth +AB ] { OpVar ab-op! }
+def ab-tag! [ Tag +Mirth +AB -- +Mirth +AB ] { OpTag ab-op! }
+def ab-prim! [ Prim +Mirth +AB -- +Mirth +AB ] {
     dup ~type mut-is-set if(
         OpPrim ab-op!,
         ab-token@ "prim does not have type" rdip:emit-fatal-error!
-    ))
-def(ab-word!, Word +Mirth +AB -- +Mirth +AB, OpWord ab-op!)
-def(ab-external!, External +Mirth +AB -- +Mirth +AB, OpExternal ab-op!)
-def(ab-coerce!, Coerce +Mirth +AB -- +Mirth +AB, OpCoerce ab-op!)
-def(ab-label-push!, Label +Mirth +AB -- +Mirth +AB, OpLabelPush ab-op!)
-def(ab-label-pop!, Label +Mirth +AB -- +Mirth +AB, OpLabelPop ab-op!)
-def(ab-label-push-r!, Label +Mirth +AB -- +Mirth +AB, OpLabelPushR ab-op!)
-def(ab-label-pop-r!, Label +Mirth +AB -- +Mirth +AB, OpLabelPopR ab-op!)
+    )
+}
+def ab-word! [ Word +Mirth +AB -- +Mirth +AB ] { OpWord ab-op! }
+def ab-external! [ External +Mirth +AB -- +Mirth +AB ] { OpExternal ab-op! }
+def ab-coerce! [ Coerce +Mirth +AB -- +Mirth +AB ] { OpCoerce ab-op! }
+def ab-label-push! [ Label +Mirth +AB -- +Mirth +AB ] { OpLabelPush ab-op! }
+def ab-label-pop! [ Label +Mirth +AB -- +Mirth +AB ] { OpLabelPop ab-op! }
+def ab-label-push-r! [ Label +Mirth +AB -- +Mirth +AB ] { OpLabelPushR ab-op! }
+def ab-label-pop-r! [ Label +Mirth +AB -- +Mirth +AB ] { OpLabelPopR ab-op! }
 
-def(ab-block-at!(f), (*a +Mirth +AB -- *b +Mirth +AB) *a Token +Mirth +AB -- *b +Mirth +AB,
+def ab-block-at!(f) [ (*a +Mirth +AB -- *b +Mirth +AB) *a Token +Mirth +AB -- *b +Mirth +AB ] {
     ab-ctx@ MetaVar.new! STMeta rotl ab-home@ rdip(ab-build!(f))
-    rdip:Block.new! OpBlockPush ab-op!)
+    rdip:Block.new! OpBlockPush ab-op!
+}
 
-def(ab-block!(f), (*a +Mirth +AB -- *b +Mirth +AB) *a +Mirth +AB -- *b +Mirth +AB,
-    ab-token@ ab-block-at!(f))
+def ab-block!(f) [ (*a +Mirth +AB -- *b +Mirth +AB) *a +Mirth +AB -- *b +Mirth +AB ] {
+    ab-token@ ab-block-at!(f)
+}
 
-def(ab-dip!(f), (*a +Mirth +AB -- *b +Mirth +AB) *a +Mirth +AB -- *b +Mirth +AB,
-    ab-block!(f) PRIM_CORE_DIP ab-prim!)
+def ab-dip!(f) [ (*a +Mirth +AB -- *b +Mirth +AB) *a +Mirth +AB -- *b +Mirth +AB ] {
+    ab-block!(f) PRIM_CORE_DIP ab-prim!
+}
 
-def(ab-rdip!(f), (*a +Mirth +AB -- *b +Mirth +AB) *a +Mirth +AB -- *b +Mirth +AB,
-    ab-block!(f) PRIM_CORE_RDIP ab-prim!)
+def ab-rdip!(f) [ (*a +Mirth +AB -- *b +Mirth +AB) *a +Mirth +AB -- *b +Mirth +AB ] {
+    ab-block!(f) PRIM_CORE_RDIP ab-prim!
+}
 
-def(ab-if!(f,g), (*a +Mirth +AB -- *b +Mirth +AB,
-                  *b +Mirth +AB -- *c +Mirth +AB)
-                  *a +Mirth +AB -- *c +Mirth +AB,
-    ab-block!(f) ab-block!(g) PRIM_CORE_IF ab-prim!)
+def ab-if!(f,g) [
+    (*a +Mirth +AB -- *b +Mirth +AB,
+     *b +Mirth +AB -- *c +Mirth +AB)
+    *a +Mirth +AB -- *c +Mirth +AB
+] {
+    ab-block!(f) ab-block!(g) PRIM_CORE_IF ab-prim!
+}
 
-def(ab-while!(f,g), (*a +Mirth +AB -- *b +Mirth +AB,
-                     *b +Mirth +AB -- *c +Mirth +AB)
-                     *a +Mirth +AB -- *c +Mirth +AB,
-    ab-block!(f) ab-block!(g) PRIM_CORE_WHILE ab-prim!)
+def ab-while!(f,g) [
+    (*a +Mirth +AB -- *b +Mirth +AB,
+     *b +Mirth +AB -- *c +Mirth +AB)
+    *a +Mirth +AB -- *c +Mirth +AB
+] {
+    ab-block!(f) ab-block!(g) PRIM_CORE_WHILE ab-prim!
+}
 
-def(ab-lambda!(f), (*a +Mirth +AB -- *b +Mirth +AB) *a List(Var) +Mirth +AB -- *b +Mirth +AB,
-    dip(ab-token@) ab-lambda-at!(f))
-def(ab-lambda-at!(f), (*a +Mirth +AB -- *b +Mirth +AB) *a Token List(Var) +Mirth +AB -- *b +Mirth +AB,
+def ab-lambda!(f) [ (*a +Mirth +AB -- *b +Mirth +AB) *a List(Var) +Mirth +AB -- *b +Mirth +AB ] {
+    dip(ab-token@) ab-lambda-at!(f)
+}
+
+def ab-lambda-at!(f) [ (*a +Mirth +AB -- *b +Mirth +AB) *a Token List(Var) +Mirth +AB -- *b +Mirth +AB ] {
     dup dip(
         dip(ab-ctx@ ab-type@) reverse-for(
             swap dip(dup dip(Ctx.new))
@@ -702,14 +788,16 @@ def(ab-lambda-at!(f), (*a +Mirth +AB -- *b +Mirth +AB) *a Token List(Var) +Mirth
     ab-ctx@ >outer-ctx
     ab-type@ >dom
     ab-token@ >token
-    Lambda OpLambda ab-op!)
+    Lambda OpLambda ab-op!
+}
 
-data(OpSig,
-    OPSIG_ID,
-    OPSIG_PUSH -> Type,
-    OPSIG_APPLY -> ArrowType)
+data OpSig {
+    OPSIG_ID
+    OPSIG_PUSH  [ Type ]
+    OPSIG_APPLY [ ArrowType ]
+}
 
-def(elab-op-fresh-sig!, +Mirth Op -- +Mirth Subst OpSig,
+def elab-op-fresh-sig! [ +Mirth Op -- +Mirth Subst OpSig ] {
     Subst.nil swap match(
         OpNone -> OPSIG_ID,
         OpInt -> VALUE_INT TValue OPSIG_PUSH,
@@ -734,70 +822,85 @@ def(elab-op-fresh-sig!, +Mirth Op -- +Mirth Subst OpSig,
         OpDataGetTag -> data-get-tag-type freshen-sig OPSIG_APPLY,
         OpDataGetLabel -> data-get-label-type freshen-sig OPSIG_APPLY,
         OpDataSetLabel -> data-set-label-type freshen-sig OPSIG_APPLY,
-    ))
+    )
+}
 
-def(data-get-tag-type, +Mirth Data -- +Mirth ArrowType,
+def data-get-tag-type [ +Mirth Data -- +Mirth ArrowType ] {
     full-type left? unwrap T1
-    TYPE_INT T1 T->)
+    TYPE_INT T1 T->
+}
 
-def(elab-coerce-sig!, Coerce -- OpSig,
+def elab-coerce-sig! [ Coerce -- OpSig ] {
     CoerceUnsafe ->
         MetaVar.new! STMeta dup
         MetaVar.new! TMeta T* swap
-        MetaVar.new! TMeta T* T-> OPSIG_APPLY)
+        MetaVar.new! TMeta T* T-> OPSIG_APPLY
+}
 
-def(elab-block-sig!, Block -- OpSig,
-    VALUE_BLOCK TValue OPSIG_PUSH)
+def elab-block-sig! [ Block -- OpSig ] {
+    VALUE_BLOCK TValue OPSIG_PUSH
+}
 
-def(elab-match-sig!, Match -- OpSig,
-    sip(dom) cod T-> OPSIG_APPLY)
+def elab-match-sig! [ Match -- OpSig ] {
+    sip(dom) cod T-> OPSIG_APPLY
+}
 
-def(elab-lambda-sig!, Lambda -- OpSig,
-    sip(dom) cod T-> OPSIG_APPLY)
+def elab-lambda-sig! [ Lambda -- OpSig ] {
+    sip(dom) cod T-> OPSIG_APPLY
+}
 
-def(elab-var-sig!, Var -- OpSig,
+def elab-var-sig! [ Var -- OpSig ] {
     dup auto-run? if(
         type morphism? unwrap semifreshen-sig OPSIG_APPLY,
         type OPSIG_PUSH
-    ))
+    )
+}
 
-def(elab-label-push-sig!, Label -- OpSig,
+def elab-label-push-sig! [ Label -- OpSig ] {
     dip(MetaVar.new! STMeta MetaVar.new! TMeta dup2)
-    STConsLabel dip(STCons) T-> OPSIG_APPLY)
+    STConsLabel dip(STCons) T-> OPSIG_APPLY
+}
 
-def(elab-label-pop-sig!, Label -- OpSig,
+def elab-label-pop-sig! [ Label -- OpSig ] {
     dip(MetaVar.new! STMeta MetaVar.new! TMeta dup2)
-    STConsLabel dip(STCons) swap T-> OPSIG_APPLY)
+    STConsLabel dip(STCons) swap T-> OPSIG_APPLY
+}
 
-def(elab-label-push-r-sig!, Label -- OpSig,
+def elab-label-push-r-sig! [ Label -- OpSig ] {
     dip(MetaVar.new! STMeta MetaVar.new! TMeta Resource dup2)
-    STWithLabel dip(STWith) T-> OPSIG_APPLY)
+    STWithLabel dip(STWith) T-> OPSIG_APPLY
+}
 
-def(elab-label-pop-r-sig!, Label -- OpSig,
+def elab-label-pop-r-sig! [ Label -- OpSig ] {
     dip(MetaVar.new! STMeta MetaVar.new! TMeta Resource dup2)
-    STWithLabel dip(STWith) swap T-> OPSIG_APPLY)
+    STWithLabel dip(STWith) swap T-> OPSIG_APPLY
+}
 
-def(elab-arrow!, +Mirth Ctx ArrowType Token Home -- +Mirth Arrow,
-    dip2(unpack) elab-arrow-hom!)
+def elab-arrow! [ +Mirth Ctx ArrowType Token Home -- +Mirth Arrow ] {
+    dip2(unpack) elab-arrow-hom!
+}
 
-def(elab-arrow-hom!, +Mirth Ctx StackType StackType Token Home -- +Mirth Arrow,
+def elab-arrow-hom! [ +Mirth Ctx StackType StackType Token Home -- +Mirth Arrow ] {
     rotl dip(
         elab-arrow-fwd!
         dup token-end >token +Gamma
         dup cod
     )
-    unify! rdrop drop)
+    unify! rdrop drop
+}
 
-def(elab-arrow-fwd!, +Mirth Ctx StackType Token Home -- +Mirth Arrow,
-    ab-build!(elab-atoms!))
+def elab-arrow-fwd! [ +Mirth Ctx StackType Token Home -- +Mirth Arrow ] {
+    ab-build!(elab-atoms!)
+}
 
-def(elab-atoms!, +Mirth +AB -- +Mirth +AB,
+def elab-atoms! [ +Mirth +AB -- +Mirth +AB ] {
     while(
         ab-token@ run-end? not,
         elab-atom! ab-token@ next ab-token!
-    ))
+    )
+}
 
-def(elab-atom!, +Mirth +AB -- +Mirth +AB,
+def elab-atom! [ +Mirth +AB -- +Mirth +AB ] {
     ab-token@ value match(
         TokenName -> elab-atom-name!,
         TokenDName -> elab-atom-dname!,
@@ -812,9 +915,10 @@ def(elab-atom!, +Mirth +AB -- +Mirth +AB,
         TokenLabelGet -> elab-label-get!,
         TokenLabelSet -> elab-label-set!,
         _ -> ab-token@ "Unexpected token in elab-atom!" rdip:emit-fatal-error!
-    ))
+    )
+}
 
-def(elab-label-get!, Label +Mirth +AB -- +Mirth +AB,
+def elab-label-get! [ Label +Mirth +AB -- +Mirth +AB ] {
     dup is-resource-label? if(
         dup ab-label-pop-r!
         ab-token@ dup rdip:args-1 ab-token! elab-atoms! ab-token!
@@ -826,18 +930,21 @@ def(elab-label-get!, Label +Mirth +AB -- +Mirth +AB,
             ab-token@ dup rdip:args-1 ab-token! elab-atoms! ab-token!
         )
         ab-label-push!
-    ))
+    )
+}
 
-def(elab-label-set!, Label +Mirth +AB -- +Mirth +AB,
+def elab-label-set! [ Label +Mirth +AB -- +Mirth +AB ] {
     ab-token@ rdip:args-0
     dup ab-label-pop!
     PRIM_CORE_DROP ab-prim!
-    ab-label-push!)
+    ab-label-push!
+}
 
-def(elab-atom-block!, +Mirth +AB -- +Mirth +AB,
-    ab-token@ rdip:args-1 elab-block-at!)
+def elab-atom-block! [ +Mirth +AB -- +Mirth +AB ] {
+    ab-token@ rdip:args-1 elab-block-at!
+}
 
-def(elab-block-at!, Token +Mirth +AB -- +Mirth +AB,
+def elab-block-at! [ Token +Mirth +AB -- +Mirth +AB ] {
     ab-ctx@ swap ab-home@ rdip:Block.new-deferred!(
         dup ctx swap
         dup dom swap
@@ -845,34 +952,41 @@ def(elab-block-at!, Token +Mirth +AB -- +Mirth +AB,
         dup token swap
         home
         elab-arrow-hom!
-    ) OpBlockPush ab-op!)
+    ) OpBlockPush ab-op!
+}
 
-def(elab-args!, +Mirth +AB -- +Mirth +AB,
-    ab-token@ args for(elab-block-at!))
+def elab-args! [ +Mirth +AB -- +Mirth +AB ] {
+    ab-token@ args for(elab-block-at!)
+}
 
-def(elab-no-args!, +Mirth +AB -- +Mirth +AB,
-    ab-token@ rdip:args-0)
+def elab-no-args! [ +Mirth +AB -- +Mirth +AB ] {
+    ab-token@ rdip:args-0
+}
 
-def(arity-compatible?, Int Int -- Bool,
-    dup -1 == dip(==) ||)
+def arity-compatible? [ Int Int -- Bool ] {
+    dup -1 == dip(==) ||
+}
 
-def(elab-atom-name!, Name +Mirth +AB -- +Mirth +AB,
+def elab-atom-name! [ Name +Mirth +AB -- +Mirth +AB ] {
     ab-ctx@ lookup match(
         Some -> elab-args! ab-var!,
         None -> elab-atom-resolve-def!
-    ))
+    )
+}
 
-def(elab-atom-dname!, DName +Mirth +AB -- +Mirth +AB,
-    drop elab-atom-resolve-def!)
+def elab-atom-dname! [ DName +Mirth +AB -- +Mirth +AB ] {
+    drop elab-atom-resolve-def!
+}
 
-def(Token.can-be-relative-name-or-dname?, Token -- Bool,
+def Token.can-be-relative-name-or-dname? [ Token -- Bool ] {
     value match(
         TokenName -> can-be-relative?,
         TokenDName -> is-relative?,
         _ -> drop False
-    ))
+    )
+}
 
-def(elab-atom-resolve-def!, +Mirth +AB -- +Mirth +AB,
+def elab-atom-resolve-def! [ +Mirth +AB -- +Mirth +AB ] {
     ab-type@ top-types-are-fine? not >report-ambiguous-as-warning
     ab-token@ >token
     "word" >sort
@@ -890,16 +1004,19 @@ def(elab-atom-resolve-def!, +Mirth +AB -- +Mirth +AB,
     ) +ab> match (
         None -> elab-atom-failed!,
         Some -> elab-atom-def!
-    ))
+    )
+}
 
-def(elab-atom-failed!, +Mirth +AB -- +Mirth +AB,
-    STACK_TYPE_ERROR ab-type!)
+def elab-atom-failed! [ +Mirth +AB -- +Mirth +AB ] {
+    STACK_TYPE_ERROR ab-type!
+}
 
-def(elab-ambiguous-name-error!, *a Token List(QName) +Mirth -- *b +Mirth,
+def elab-ambiguous-name-error! [ *a Token List(QName) +Mirth -- *b +Mirth ] {
     dip("name is ambiguous, can't decide between:")
-    for(dip(" " cat) >Str cat) emit-fatal-error!)
+    for(dip(" " cat) >Str cat) emit-fatal-error!
+}
 
-def(elab-atom-def!, Def +Mirth +AB -- +Mirth +AB,
+def elab-atom-def! [ Def +Mirth +AB -- +Mirth +AB ] {
     DefAlias -> rdip:target elab-atom-def!,
     DefBuffer -> elab-no-args! ab-buffer!,
     DefVariable -> elab-no-args! ab-variable!,
@@ -908,53 +1025,60 @@ def(elab-atom-def!, Def +Mirth +AB -- +Mirth +AB,
     DefWord -> elab-args! ab-word!,
     DefTag -> elab-args! ab-tag!,
     DefPrim -> elab-prim!,
-    _ -> rdip:qname-hard elab-atom-not-a-word!)
+    _ -> rdip:qname-hard elab-atom-not-a-word!
+}
 
-def(elab-atom-not-a-word!, QName +Mirth +AB -- +Mirth +AB,
+def elab-atom-not-a-word! [ QName +Mirth +AB -- +Mirth +AB ] {
     ab-type@ top-types-are-fine? if(
         dip(ab-token@ "Not a word: ") rdip:>Str cat rdip:emit-error!,
         drop
-    ) elab-atom-failed!)
+    ) elab-atom-failed!
+}
 
-def(elab-prim!, Prim +Mirth +AB -- +Mirth +AB,
+def elab-prim! [ Prim +Mirth +AB -- +Mirth +AB ] {
     match(
         PRIM_CORE_MATCH -> elab-atom-match!,
         PRIM_CORE_LAMBDA -> elab-atom-lambda!,
         _ -> elab-args! ab-prim!
-    ))
+    )
+}
 
-def(elab-atom-assert!, +Mirth +AB -- +Mirth +AB,
+def elab-atom-assert! [ +Mirth +AB -- +Mirth +AB ] {
     ab-token@ rdip:args-1 >token
     ab-ctx@ >ctx
     True >allow-type-holes
     False >allow-implicit-type-vars
-    TYPE_ELAB rdip':elab-stack-type! rdrop
-    dip:ab-type@ gamma:unify! drop)
+    +TypeElab rdip':elab-stack-type! rdrop
+    dip:ab-type@ gamma:unify! drop
+}
 
-def(elab-atom-match!, +Mirth +AB -- +Mirth +AB,
+def elab-atom-match! [ +Mirth +AB -- +Mirth +AB ] {
     MetaVar.new! STMeta >cod
     ab-token@ succ lcurly? if(
         ab-token@ succ succ >body
         ab-token@ succ ab-token!,
         ab-token@ rdip:args+ first >body
     )
-    elab-match-at!)
+    elab-match-at!
+}
 
 ||| Elaborate a match body within AB. Takes the output stack type,
 ||| and the token for the body of the match, from the stack. Takes
 ||| the rest from the AB environment.
-def(elab-match-at!, cod:StackType body:Token +Mirth +AB -- +Mirth +AB,
+def elab-match-at! [ cod:StackType body:Token +Mirth +AB -- +Mirth +AB ] {
     ab-match!(
         elab-match-cases!
         elab-match-exhaustive!
-    ))
+    )
+}
 
 ||| Elaborate match cases.
-def(elab-match-cases!, +Mirth +Match -- +Mirth +Match,
+def elab-match-cases! [ +Mirth +Match -- +Mirth +Match ] {
     body lcurly? if(
         elab-match-cases-curly!,
         elab-match-cases-args!
-    ))
+    )
+}
 
 def elab-match-cases-curly! [ +Mirth +Match -- +Mirth +Match ] {
     body run-tokens for(
@@ -980,10 +1104,11 @@ def(elab-match-case!, Token +Mirth +Match -- Token +Mirth +Match,
         ab-token@ dup comma? then(succ)
     ))
 
-def(elab-pattern!, List(Token) +Mirth +Pattern -- +Mirth +Pattern,
-    reverse-for(elab-pattern-atom!))
+def elab-pattern! [ List(Token) +Mirth +Pattern -- +Mirth +Pattern ] {
+    reverse-for(elab-pattern-atom!)
+}
 
-def(elab-pattern-atom!, Token +Mirth +Pattern -- +Mirth +Pattern,
+def elab-pattern-atom! [ Token +Mirth +Pattern -- +Mirth +Pattern ] {
     dup pattern:token-start!
 
     dup pat-underscore? if(
@@ -1011,23 +1136,26 @@ def(elab-pattern-atom!, Token +Mirth +Pattern -- +Mirth +Pattern,
         ),
 
         "Expected constructor name." rdip:emit-fatal-error!
-    )))
+    ))
+}
 
-def(ab-match!(f),
-        (*a +Mirth +Match -- *b +Mirth +Match)
-        *a cod:StackType body:Token +Mirth +AB -- *b +Mirth +AB,
+def ab-match!(f) [
+    (*a +Mirth +Match -- *b +Mirth +Match)
+    *a cod:StackType body:Token +Mirth +AB -- *b +Mirth +AB
+] {
     ab-ctx@ >ctx
     ab-type@ >dom
     ab-token@ >token
     ab-home@ >home
     L0 >cases
-    rdip(+Match f freeze) OpMatch ab-op!)
+    rdip(+Match f freeze) OpMatch ab-op!
+ }
 
-def(+Match.case!(mkpat,mkbod),
-        (*a +Mirth +Pattern -- *b +Mirth +Pattern,
-         *b +Mirth +AB -- *c +Mirth +AB)
-        *a Token Token +Mirth +Match -- *c +Mirth +Match,
-
+def +Match.case!(mkpat,mkbod) [
+    (*a +Mirth +Pattern -- *b +Mirth +Pattern,
+        *b +Mirth +AB -- *c +Mirth +AB)
+    *a Token Token +Mirth +Match -- *c +Mirth +Match,
+] {
     dip(
         home >home dup >token-start >token-end
         ctx dup >outer-ctx >inner-ctx
@@ -1042,15 +1170,17 @@ def(+Match.case!(mkpat,mkbod),
         >body
         pat >pattern
         CASE add-case
-    ))
+    )
+}
 
-def(elab-expand-tensor!, +Mirth StackType Token -- +Mirth StackType Type Token,
+def elab-expand-tensor! [ +Mirth StackType Token -- +Mirth StackType Type Token ] {
     >tok force-cons?! match(
         Some -> unpack2 tok>,
         None -> STACK_TYPE_ERROR TYPE_ERROR tok> dup "expected tuple type" emit-error!
-    ))
+    )
+}
 
-def(elab-lambda-param?, +Mirth Token -- +Mirth Token Maybe(Var),
+def elab-lambda-param? [ +Mirth Token -- +Mirth Token Maybe(Var) ] {
     dup pattern-var? if(
         dup args-0 sip:next
         dip(MetaVar.new! TMeta) name? unwrap Var.new! Some,
@@ -1061,42 +1191,48 @@ def(elab-lambda-param?, +Mirth Token -- +Mirth Token Maybe(Var),
         dip(MetaVar.new! STMeta MetaVar.new! STMeta T-> TMorphism)
         succ name? unwrap Var.new-auto-run! Some,
         None
-    )))
+    ))
+}
 
-def(elab-atom-lambda!, +Mirth +AB -- +Mirth +AB,
+def elab-atom-lambda! [ +Mirth +AB -- +Mirth +AB ] {
     ab-token@ rdip:args-1
     collect(rdip:elab-lambda-param?)
     dip(rdip:expect-token-arrow succ)
-    ab-lambda-at!(elab-atoms!))
+    ab-lambda-at!(elab-atoms!)
+}
 
 ||| Check that a match is exhaustive.
-def(elab-match-exhaustive!, +Mirth +Match -- +Mirth +Match,
+def elab-match-exhaustive! [ +Mirth +Match -- +Mirth +Match ] {
     freeze dup is-exhaustive? else(
         dup token "Pattern match not exhaustive." emit-error!
-    ) thaw)
+    ) thaw
+}
 
 ######################
 # Module Elaboration #
 ######################
 
 ||| Elaborate all of a module.
-def(elab-module!, Module +World +Mirth -- Module +World +Mirth,
+def elab-module! [ Module +World +Mirth -- Module +World +Mirth ] {
     dup start
     elab-module-header!
     while(dup module-end? not, elab-module-decl!)
-    drop)
+    drop
+}
 
-def(elab-module-package-name, Token +Mirth -- Package Name +Mirth,
+def elab-module-package-name [ Token +Mirth -- Package Name +Mirth ] {
     dup dname? unwrap("Expected module name. (1)" emit-fatal-error!) over args-0
     dup root? unwrap(drop "Expected module name. (2)" emit-fatal-error!)
     swap parts /L1+ unwrap(drop "Expected module name. (3)" emit-fatal-error!)
-    dip(Package.find-or-new! nip))
+    dip(Package.find-or-new! nip)
+}
 
-def(elab-module-qname, +Mirth Token -- +Mirth QName,
-    elab-module-package-name dip(NAMESPACE_PACKAGE) QNAME0)
+def elab-module-qname [ +Mirth Token -- +Mirth QName ] {
+    elab-module-package-name dip(NAMESPACE_PACKAGE) QNAME0
+}
 
 ||| Check that the `module(M)` statement exists and save the name.
-def(elab-module-header!, +World +Mirth Token -- +World +Mirth Token,
+def elab-module-header! [ +World +Mirth Token -- +World +Mirth Token ] {
     dup module-header? if(
         sip(next) args-1 dup elab-module-package-name
         over2 .module
@@ -1107,9 +1243,10 @@ def(elab-module-header!, +World +Mirth Token -- +World +Mirth Token,
         check-module-path,
 
         dup "Expected module header." emit-fatal-error!
-    ))
+    )
+}
 
-def(check-module-path, Token Module +World +Mirth -- +World +Mirth,
+def check-module-path [ Token Module +World +Mirth -- +World +Mirth ] {
     dup path split-last match(
         None ->
             swap qname rdip:to-module-path dup2 == else(
@@ -1121,10 +1258,11 @@ def(check-module-path, Token Module +World +Mirth -- +World +Mirth,
             else(over3 "expected .mth extension for mirth file" emit-warning!)
             over2 name >Str == else(over2 "expected module name to match file name" emit-fatal-error!)
             over package path! drop2
-    ))
+    )
+}
 
 ||| Elaborate a declaration. Returns the next token.
-def(elab-module-decl!, Token +World +Mirth -- Token +World +Mirth,
+def elab-module-decl! [ Token +World +Mirth -- Token +World +Mirth ] {
     dup name? unwrap("unknown declaration" emit-fatal-error!)
     defs find-some(prim?) unwrap("unknown declaration" emit-fatal-error!)
     match(
@@ -1143,11 +1281,13 @@ def(elab-module-decl!, Token +World +Mirth -- Token +World +Mirth,
         PRIM_SYNTAX_TABLE -> elab-table!,
         PRIM_SYNTAX_FIELD -> elab-field!,
         PRIM_SYNTAX_DATA -> elab-data!,
+        PRIM_SYNTAX_STRUCT -> elab-struct!,
         PRIM_SYNTAX_EMBED_STR -> elab-embed-str!,
         _ -> drop "unknown declaration" emit-fatal-error!
-    ))
+    )
+}
 
-def(load-module, Token QName +World +Mirth -- Token Module +World +Mirth,
+def load-module [ Token QName +World +Mirth -- Token Module +World +Mirth ] {
     dup def-soft? match(
         Some -> module? unwrap(drop "module name already taken" emit-fatal-error!) nip,
         None ->
@@ -1156,29 +1296,135 @@ def(load-module, Token QName +World +Mirth -- Token Module +World +Mirth,
                 # TODO: avoid elaborating here,
                 # use a single loop to dispatch top-level module elaboration.
                 #    https://github.com/mirth-lang/mirth/issues/241
-    ))
+    )
+}
 
 ||| Elaborate `import(M)` statement. Return token after import.
-def(elab-module-import!, Token +World +Mirth -- Token +World +Mirth,
+def elab-module-import! [ Token +World +Mirth -- Token +World +Mirth ] {
     sip(next)
     args-1 dup elab-module-qname
-    load-module dip(.module) add-import!)
+    load-module dip(.module) add-import!
+}
 
-||| Elaborate a data definition `data(True, ..)`
-def(elab-data!, Token +Mirth -- Token +Mirth,
-    sip(
-        Data.alloc!
-        L0 over ~tags !
-        swap args+
-        uncons dip(elab-data-header!)
-        for(elab-data-tag!)
-        elab-data-done!
-    ) next)
+def parse-data [ +Mirth Token -- +Mirth Token SyntaxData ] {
+    dup num-args 0> if(
+        succ dup lparen? else("expected left parenthesis '('" emit-fatal-error!)
+        succ parse-data-header >header
+        dup comma? then(succ)
+        parse-data-tags >tags
+        dup rparen? else("expected right parenthesis ')'" emit-fatal-error!)
+        succ,
+
+        succ parse-data-header >header
+        dup lcurly? else("expected left curly brace '{'" emit-fatal-error!)
+        succ parse-data-tags >tags
+        dup rcurly? else("expected right curly brace '}'" emit-fatal-error!)
+        succ
+    )
+    SyntaxData
+}
+
+def parse-data-header [ +Mirth Token -- +Mirth Token SyntaxDataHeader ] {
+    dup >head next
+    @head last-name? has(could-be-constructor)
+        else(@head "Expected type name." emit-fatal-error!)
+    SyntaxDataHeader
+}
+
+def parse-data-tags [ +Mirth Token -- +Mirth Token List(SyntaxDataTag) ] {
+    collect-while(dup arg-end? not, parse-data-tag)
+}
+
+||| Parse a data tag. It looks like one of these:
+|||
+|||     Tag
+|||     Tag -> Type* &ArgEnd
+|||     Tag [ Type* ]
+|||
+def parse-data-tag [ +Mirth Token -- +Mirth Token SyntaxDataTag ] {
+    dup int? dup >value? then(succ)
+    dup name? filter(could-be-constructor)
+    unwrap("Expected constructor name." emit-fatal-error!) >name
+    succ dup arrow? if(
+        succ dup Some >sig? sig-next-stack-end
+        dup arg-end? else("Expected comma." emit-fatal-error!),
+        dup lsquare? if(
+            succ dup Some >sig? sig-next-stack-end
+            dup rsquare? else("Expected right square bracket ']'" emit-fatal-error!)
+            succ,
+
+            None >sig?
+        )
+    )
+    dup comma? then(succ)
+    SyntaxDataTag
+}
+
+||| Parse a struct declaration. This looks like this:
+|||
+|||     struct(TypeCon, Type*)
+|||     struct TypeCon { Type* }
+|||
+def parse-struct [ +Mirth Token -- +Mirth Token SyntaxData ] {
+    dup num-args 0> if(
+        succ dup lparen? then("Expected left parenthesis '('" emit-fatal-error!)
+        succ parse-data-header >header
+        dup comma? then(succ)
+        parse-struct-tag L1 >tags
+        dup rparen? then("Expected right parenthesis ')'" emit-fatal-error!)
+        succ,
+
+        succ parse-data-header >header
+        dup lcurly? else("expected left curly brace '{'" emit-fatal-error!)
+        succ parse-struct-tag L1 >tags
+        dup rcurly? else("expected right curly brace '}'" emit-fatal-error!)
+        succ
+    )
+    SyntaxData
+}
+
+def parse-struct-tag
+    [  +Mirth Token header:SyntaxDataHeader
+    -- +Mirth Token header:SyntaxDataHeader SyntaxDataTag ]
+{
+    @header head last-name? filter(could-be-constructor)
+    unwrap(@header head "expected constructor name" emit-fatal-error!) >name
+    None >value?
+    dup Some >sig?
+    sig-next-stack-end
+    SyntaxDataTag
+}
+
+struct SyntaxData {
+    header: SyntaxDataHeader
+    tags: List(SyntaxDataTag)
+}
+
+struct SyntaxDataHeader {
+    head: Token
+}
+
+struct SyntaxDataTag {
+    value?: Maybe(Int)
+    name: Name
+    sig?: Maybe(Token)
+}
+
+def elab-data!   { parse-data   elab-data-aux! }
+def elab-struct! { parse-struct elab-data-aux! }
+
+def elab-data-aux! [ SyntaxData +Mirth -- +Mirth ] {
+    /SyntaxData
+    Data.alloc! L0 over ~tags !
+    header> elab-data-header!
+    tags> for(elab-data-tag!)
+    elab-data-done!
+}
 
 ||| Get the header, name, arity for a data type.
-def(elab-data-header!, Data Token +Mirth -- Data +Mirth,
-    >head >data
-    @head last-name? has(could-be-type-or-resource-con)
+def elab-data-header! [ Data SyntaxDataHeader +Mirth -- Data +Mirth ] {
+    /SyntaxDataHeader >data
+    @head last-name? has(could-be-constructor)
         else(@head "Expected type name." emit-fatal-error!)
     elab-def-head
     @head Some @data ~head? !
@@ -1188,70 +1434,60 @@ def(elab-data-header!, Data Token +Mirth -- Data +Mirth,
     @head args @data DataParams prop(elab-data-params!) @data ~params !
     @data DefData register
     head> drop
-    data>)
+    data>
+}
 
 # TODO check header args are well-formed / elaborate them properly
 #  as part of: https://github.com/mirth-lang/mirth/issues/246
-def(elab-data-params!, List(Token) +Mirth -- List(Var) +Mirth,
+def elab-data-params! [ List(Token) +Mirth -- List(Var) +Mirth ] {
     Ctx0 swap for(
         dup sig-type-var? else("expected type variable" emit-fatal-error!)
         dup name? unwrap over2 Ctx.lookup then("duplicate parameter name" emit-fatal-error!)
         name? unwrap TYPE_TYPE swap Var.new! Ctx.new
-    ) >List)
+    ) >List
+}
 
 ||| Get a tag associated with a data type.
-||| This looks like either "TAG" or "TAG -> TYPE1 .. TYPEN".
-def(elab-data-tag!, Data Token +Mirth -- Data +Mirth,
-    dup int? if-some(
-        Some >value succ,
-        None >value
-    )
-    dup2 name? unwrap(drop "Expected constructor name." emit-fatal-error!)
-    0 data-qname
-    Tag.alloc!
-    value> for(over ~value !)
-    None over ~untag !
-    tuck ~qname !
-    dup DefTag register
-    { +Mirth Data Token Tag }
-    dip(over) dup2 ~data !
-    tuck dip(add-tag!)
-    { +Mirth Data Token Tag }
-    swap succ
-    dup pat-arrow? if(
-        succ Some over ~sig? !,
-    dup run-end? if(
-        drop None over ~sig? !,
-        "Expected arrow, comma, or right paren." emit-fatal-error!
-    ))
-    { +Mirth Data Tag }
-    dup dup TagType prop(
+def elab-data-tag! [ Data SyntaxDataTag +Mirth -- Data +Mirth ] {
+    >syn >dat
+    Tag.alloc! >tag
+
+    @dat @syn name 0 data-qname @tag ~qname !
+    @syn sig? @tag ~sig? !
+    @syn value? for(@tag ~value !)
+    @dat @tag ~data !
+    @tag @dat add-tag!
+    @tag DefTag register
+
+    @tag @tag TagType prop(
         dup .data head? unwrap >token
         dup .data params >Ctx >ctx
         True >allow-implicit-type-vars
         False >allow-type-holes
-        TYPE_ELAB
+        +TypeElab
         T0 over .data rdip:full-type T*+
         swap sig? match(
             None -> T0,
             Some -> token! T0 elab-stack-type-parts!
         )
         swap T-> dip:ctx pack2 rdrop
-    ) over ~ctx-type !
-    sip(num-type-inputs-from-sig) sip(~num-type-inputs !)
-    sip(num-resource-inputs-from-sig) sip(~num-resource-inputs !)
-    sip(label-inputs-from-sig) sip(~label-inputs !)
+    ) @tag ~ctx-type !
+    @tag num-type-inputs-from-sig @tag ~num-type-inputs !
+    @tag num-resource-inputs-from-sig @tag ~num-resource-inputs !
+    @tag label-inputs-from-sig @tag ~label-inputs !
 
-    dup outputs-resource? not
-    over num-resource-inputs 0> && then(
-        dup sig? unwrap run-tokens find(
-            dup sig-resource-con? or(dup sig-resource-var?) nip
+    @tag outputs-resource? not
+    @tag num-resource-inputs 0> && then(
+        @tag sig? unwrap run-tokens find(
+            or(sig-resource-con?, sig-resource-var?)
         ) unwrap "Value type cannot contain resource." emit-error!
     )
 
-    drop)
+    tag> syn> drop2
+    dat>
+}
 
-def(data-word-new!, +Mirth Data Str Int -- +Mirth Word,
+def data-word-new! [ +Mirth Data Str Int -- +Mirth Word ] {
     dup >arity
     over >Name >name
     dip2(dup head? unwrap dup >body >head)
@@ -1259,9 +1495,10 @@ def(data-word-new!, +Mirth Data Str Int -- +Mirth Word,
     None >sig
     Word.new!
 
-    qname> over WordQName prop over ~qname !)
+    qname> over WordQName prop over ~qname !
+}
 
-def(elab-data-done!, +Mirth Data -- +Mirth,
+def elab-data-done! [ +Mirth Data -- +Mirth ] {
     \(dat ->
         dat is-value-type? then(
             dat "tag" 0 data-word-new! \(tag ->
@@ -1319,25 +1556,29 @@ def(elab-data-done!, +Mirth Data -- +Mirth,
                 None
             )))
         ) dat ~ctype? !
-    ))
+    )
+}
 
 ||| Return the tag's output type or resource in context.
-def(Tag.output-type, +Mirth Tag -- +Mirth Type/Resource,
+def Tag.output-type [ +Mirth Tag -- +Mirth Type/Resource ] {
     dup type cod expand match(
         STCons -> Left dip(drop2),
         STWith -> Right dip(drop2),
         _ -> drop dip("Unexpected output type for constructor ") qname >Str cat panic!
-    ))
+    )
+}
 
 ||| Return the tag's output type or resource in context, except for a missing field.
-def(Tag.output-type-except-field, +Mirth Label Tag -- +Mirth Type/Resource,
-    dup output-type map(except-field, except-field))
+def Tag.output-type-except-field [ +Mirth Label Tag -- +Mirth Type/Resource ] {
+    dup output-type map(except-field, except-field)
+}
 
 ||| Return the input type for a tag along a given label.
-def(Tag.project-input-label, +Mirth Label Tag -- +Mirth Maybe(Type/Resource),
-    type dom label-top?)
+def Tag.project-input-label [ +Mirth Label Tag -- +Mirth Maybe(Type/Resource) ] {
+    type dom label-top?
+}
 
-def(data-get-label-type, +Mirth Tag Label -- +Mirth ArrowType,
+def data-get-label-type [ +Mirth Tag Label -- +Mirth ArrowType ] {
     \(tag lbl ->
         lbl tag project-input-label unwrap match(
             Left ->
@@ -1349,9 +1590,10 @@ def(data-get-label-type, +Mirth Tag Label -- +Mirth ArrowType,
                 T0 rotl T+ lbl tag output-type-except-field T*+
                 T->
         )
-    ))
+    )
+}
 
-def(data-set-label-type, +Mirth Tag Label -- +Mirth ArrowType,
+def data-set-label-type [ +Mirth Tag Label -- +Mirth ArrowType ] {
     \(tag lbl ->
         lbl tag project-input-label unwrap match(
             Left ->
@@ -1362,9 +1604,10 @@ def(data-set-label-type, +Mirth Tag Label -- +Mirth ArrowType,
                 T0 swap T+ lbl tag output-type-except-field T*+
                 T0 tag output-type T*+ T->
         )
-    ))
+    )
+}
 
-def(create-projectors!, +Mirth Tag -- +Mirth,
+def create-projectors! [ +Mirth Tag -- +Mirth ] {
     dup .data over .untag unwrap \(tag dat untag ->
     tag label-inputs reverse-for(\(lbl -> dat lbl name 0 data-qname undefined-soft? then(
         dat lbl >Str 0 data-word-new!
@@ -1423,16 +1666,18 @@ def(create-projectors!, +Mirth Tag -- +Mirth,
                 )
             )) lbl_lens ~arrow !
         )
-    )))))
+    ))))
+}
 
-def(expect-token-arrow, +Mirth Token -- +Mirth Token,
-    dup pat-arrow? else("Expected arrow." emit-fatal-error!))
+def expect-token-arrow [ +Mirth Token -- +Mirth Token ] {
+    dup arrow? else("Expected arrow." emit-fatal-error!)
+}
 
 ||| Parse an alias declaration.
 ||| Either `alias(head, target)` or `alias head target`.
 ||| Both `head` and `target` are names (or dnames), with `head` taking
 ||| an optional argument list (for the arity), and `target` taking no arguments.
-def(parse-alias, +Mirth Token -- +Mirth Token head:Token target:Token,
+def parse-alias [ +Mirth Token -- +Mirth Token head:Token target:Token ] {
     dup succ lparen? >Bool >has-paren
     @has-paren if(
         sip(next) args-2 >target >head,
@@ -1445,10 +1690,11 @@ def(parse-alias, +Mirth Token -- +Mirth Token head:Token target:Token,
         @head next arg-end? else(@head "expected comma after alias name" emit-fatal-error!)
         @target succ arg-end? else(@head "expected end of arguments after alias target" emit-fatal-error!)
     )
-    has-paren> drop)
+    has-paren> drop
+}
 
 ||| Elaborate an alias declaration.
-def(elab-alias!, +Mirth Token -- +Mirth Token,
+def elab-alias! [ +Mirth Token -- +Mirth Token ] {
     parse-alias elab-def-head Alias.new!
     dup AliasQName >label Prop over ~qname !
 
@@ -1477,21 +1723,24 @@ def(elab-alias!, +Mirth Token -- +Mirth Token,
             _ -> id
         )
         target> drop
-    ) swap ~target !)
+    ) swap ~target !
+}
 
 ||| Elaborate a missing word definition `def-missing(w,t,b...)`
-def(elab-def-missing!, +Mirth Token -- +Mirth Token,
+def elab-def-missing! [ +Mirth Token -- +Mirth Token ] {
     dup args len 3 >Nat < then("def-missing expects at least three arguments" emit-fatal-error!)
-    dup succ succ elab-def-qname defined-hard? if(next, elab-def!))
+    dup succ succ elab-def-qname defined-hard? if(next, elab-def!)
+}
 
-def(elab-inline!, Token +World +Mirth -- Token +World +Mirth,
+def elab-inline! [ Token +World +Mirth -- Token +World +Mirth ] {
     sip:next args-1
     dip:prefer-inline-defs
     True prefer-inline-defs!
     while(dup arg-end? not, elab-module-decl!)
-    drop prefer-inline-defs!)
+    drop prefer-inline-defs!
+}
 
-||| Parse a word definition! It will look like one of these:
+||| Parse a word definition. It looks like one of these:
 |||
 |||     def(word, sig, body...)
 |||     def word [ sig ] { body... }
@@ -1527,8 +1776,8 @@ def parse-def [ +Mirth Token -- +Mirth Token
         else("expected match case" emit-fatal-error!) >body
 }
 
-||| Elaborate a word definition `def(w, t, b...)`.
-def(elab-def!, +Mirth Token -- +Mirth Token,
+||| Elaborate a word definition.
+def elab-def! [ +Mirth Token -- +Mirth Token ] {
     parse-def elab-def-head Word.new! >word
     @word WordQName >label Prop @word ~qname !
 
@@ -1555,19 +1804,23 @@ def(elab-def!, +Mirth Token -- +Mirth Token,
             )
         ) tuck check-inline-recursion-arrow!
     ) @word ~arrow !
-    word> drop)
+    word> drop
+}
 
-def(check-inline-recursion-arrow!, +Mirth Word Arrow -- +Mirth,
-    atoms for(dip:dup check-inline-recursion-atom!) drop)
-def(check-inline-recursion-atom!, +Mirth Word Atom -- +Mirth,
+def check-inline-recursion-arrow! [ +Mirth Word Arrow -- +Mirth ] {
+    atoms for(dip:dup check-inline-recursion-atom!) drop
+}
+def check-inline-recursion-atom! [ +Mirth Word Atom -- +Mirth ] {
     over prefer-inline? if(
         dup2 op check-inline-recursion-op!
         args for(dip:dup check-inline-recursion-arg!) drop,
         drop2
-    ))
-def(check-inline-recursion-arg!, +Mirth Word Arg -- +Mirth,
-    ArgBlock -> arrow check-inline-recursion-arrow!)
-def(check-inline-recursion-op!, +Mirth Word Op -- +Mirth,
+    )
+}
+def check-inline-recursion-arg! [ +Mirth Word Arg -- +Mirth ] {
+    ArgBlock -> arrow check-inline-recursion-arrow!
+}
+def check-inline-recursion-op! [ +Mirth Word Op -- +Mirth ] {
     OpBlockRun -> arrow check-inline-recursion-arrow!,
     OpWord ->
         dup2 == if(
@@ -1582,16 +1835,18 @@ def(check-inline-recursion-op!, +Mirth Word Op -- +Mirth,
         ),
     OpMatch -> cases for(dip:dup body check-inline-recursion-arrow!) drop,
     OpLambda -> body check-inline-recursion-arrow!,
-    _ -> drop2)
-def(check-inline-recursion-failed!, +Mirth Word -- +Mirth,
+    _ -> drop2
+}
+def check-inline-recursion-failed! [ +Mirth Word -- +Mirth ] {
     dup prefer-inline? if(
         False over ~prefer-inline? !
         head "recursive word cannot be inlined" emit-warning!,
         drop
-    ))
+    )
+}
 
 ||| Elaborate a word's parameters from its type and declaration.
-def(elab-def-params!, +Mirth Word -- +Mirth List(Var),
+def elab-def-params! [ +Mirth Word -- +Mirth List(Var) ] {
     L0 over type
     rotl head dip(unpack) nip
     args reverse-for(
@@ -1602,21 +1857,24 @@ def(elab-def-params!, +Mirth Word -- +Mirth List(Var),
             "need function type for param" emit-fatal-error!)
         name? unwrap Var.new-auto-run!
         rotr dip(cons)
-    ) drop)
+    ) drop
+}
 
 ||| Elaborate the body of a `def`. Takes the codomain from the stack,
 ||| and the rest from the AB environment.
-def(elab-def-body!, StackType +Mirth +AB -- StackType +Mirth +AB,
+def elab-def-body! [ StackType +Mirth +AB -- StackType +Mirth +AB ] {
     ab-token@ run-arrow? or(ab-token@ lcurly? some?) if(
         dup >cod ab-token@ >body elab-match-at!,
         elab-atoms!
-    ))
+    )
+}
 
-data(ExternalDeclPart,
-    EDPCode -> token:Token code:Str,
-    EDPDef  -> head:Token symbol:Maybe(Token) sig:Token)
+data ExternalDeclPart {
+    EDPCode [ token:Token code:Str ]
+    EDPDef  [ head:Token symbol:Maybe(Token) sig:Token ]
+}
 
-def(parse-external-decl, +Mirth Token -- +Mirth Token List(ExternalDeclPart),
+def parse-external-decl [ +Mirth Token -- +Mirth Token List(ExternalDeclPart) ] {
     sip(next)
     succ dup lparen-or-lcolon? else(
         pred Str(
@@ -1630,9 +1888,10 @@ def(parse-external-decl, +Mirth Token -- +Mirth Token List(ExternalDeclPart),
         while(dup args-end? not,
             rdip(parse-external-decl-part) ;)
         drop
-    ))
+    )
+}
 
-def(parse-external-decl-part, +Mirth Token -- +Mirth Token ExternalDeclPart,
+def parse-external-decl-part [ +Mirth Token -- +Mirth Token ExternalDeclPart ] {
     dup str? if-some(
         >code dup >token
         succ
@@ -1641,7 +1900,7 @@ def(parse-external-decl-part, +Mirth Token -- +Mirth Token ExternalDeclPart,
         dup >head
         dup name-or-dname? else("expected external word name" emit-fatal-error!)
         succ
-        dup pat-arrow? if(
+        dup arrow? if(
             succ dup name? else("expected external symbol name" emit-fatal-error!)
             dup Some >symbol
             succ,
@@ -1660,23 +1919,26 @@ def(parse-external-decl-part, +Mirth Token -- +Mirth Token ExternalDeclPart,
         )
         EDPDef
     )
-    dip(dup comma? then(succ)))
+    dip(dup comma? then(succ))
+}
 
 ||| Elaborate an external declaration.
-def(elab-external!, +Mirth Token -- +Mirth Token,
+def elab-external! [ +Mirth Token -- +Mirth Token ] {
     dup >token
     parse-external-decl
     map(elab-external-block-part!) >parts
     ExternalBlock.alloc! >extblock
     token> @extblock ~token !
     parts> @extblock ~parts !
-    extblock> drop)
+    extblock> drop
+}
 
-def(elab-external-block-part!, +Mirth ExternalDeclPart -- +Mirth ExternalBlockPart,
-    EDPCode -> token> drop code> EBPCode,
-    EDPDef -> elab-external-def! EBPDef)
+def elab-external-block-part! [ +Mirth ExternalDeclPart -- +Mirth ExternalBlockPart ] {
+    { EDPCode -> token> drop code> EBPCode }
+    { EDPDef -> elab-external-def! EBPDef }
+}
 
-def(elab-external-def!, +Mirth head:Token symbol:Maybe(Token) sig:Token -- +Mirth External,
+def elab-external-def! [ +Mirth head:Token symbol:Maybe(Token) sig:Token -- +Mirth External ] {
     elab-def-head
 
     symbol> if-some(name? unwrap, @name) >Str >symbol
@@ -1696,9 +1958,10 @@ def(elab-external-def!, +Mirth head:Token symbol:Maybe(Token) sig:Token -- +Mirt
         elab-def-external-ctype
     ) @external ~ctype !
     @external DefExternal register
-    external>)
+    external>
+}
 
-def(elab-def-external-ctype, +Mirth External -- +Mirth CTypeArrow,
+def elab-def-external-ctype [ +Mirth External -- +Mirth CTypeArrow ] {
     dup head with-error-token(
         type ctype
         dup cod parts
@@ -1713,44 +1976,49 @@ def(elab-def-external-ctype, +Mirth External -- +Mirth CTypeArrow,
         swap difference(==) for(
             Str("Output label "; name >Str ; " not present in input";) error!
         )
-    ))
+    )
+}
 
 ||| Elaborate a type definition `def-type(t1, t2)`.
-def(elab-def-type!, +Mirth Token -- +Mirth Token,
+def elab-def-type! [ +Mirth Token -- +Mirth Token ] {
     sip(next) args-2 >target >head
     @head args-0
     @head sig-type-con? else("expected type constructor" emit-fatal-error!)
     elab-def-head @head:Some
     arity> drop
     TypeDef.new!
-    target> over TypeDefTarget prop(elab-simple-type-arg!) swap ~target !)
+    target> over TypeDefTarget prop(elab-simple-type-arg!) swap ~target !
+}
 
 ||| Elaborate a buffer definition `buffer(B, size)`.
-def(elab-buffer!, +Mirth Token -- +Mirth Token,
+def elab-buffer! [ +Mirth Token -- +Mirth Token ] {
     sip(next) args-2
     swap dup elab-def-qname-undefined
     rotl dup int? unwrap("expected buffer size" emit-fatal-error!) nip
-   >Size Buffer.new! drop)
+    >Size Buffer.new! drop
+}
 
 ||| Elaborate a var declaration `var(v, type)`.
-def(elab-variable!, +Mirth Token -- +Mirth Token,
+def elab-variable! [ +Mirth Token -- +Mirth Token ] {
     sip(next) args-2
     swap dup elab-def-qname-undefined Variable.new!
     tuck VariableType prop(elab-simple-type-arg!)
-    over ~type ! drop)
+    over ~type ! drop
+}
 
 ||| Elaborate a table definition `table(True)`.
-def(elab-table!, +Mirth Token -- +Mirth Token,
+def elab-table! [ +Mirth Token -- +Mirth Token ] {
     sip(next) args-1 >head
     @head sig-type-con? else(@head "expected type name" emit-fatal-error!)
     @head args-0
     @head succ arg-end? else(@head succ "expected end of argument after table name" emit-fatal-error!)
     elab-def-head
     arity> drop
-    table-new! drop)
+    table-new! drop
+}
 
 ||| Create entry point based on word name.
-def(elab-entry-point, QName +Mirth -- Arrow +Mirth,
+def elab-entry-point [ QName +Mirth -- Arrow +Mirth ] {
     dup def-hard? bind(word?) unwrap(
         dup dip(
             namespace module? unwrap start
@@ -1761,11 +2029,12 @@ def(elab-entry-point, QName +Mirth -- Arrow +Mirth,
     dup dip(Ctx0 T0 RESOURCE_WORLD T+ T0 RESOURCE_WORLD T+ T->)
     head dup HomeMain ab-build-hom!(
         dip(ab-word!)
-    ))
+    )
+}
 
 ||| Embed a file as a string, embed-str(name, "path").
 ||| The path is relative to compiler's cwd, not source root.
-def(elab-embed-str!, Token +World +Mirth -- Token +World +Mirth,
+def elab-embed-str! [ Token +World +Mirth -- Token +World +Mirth ] {
     sip:next args-2 swap
     >head elab-def-head
     @arity 0= else(@head "expected no arguments" emit-fatal-error!)
@@ -1776,29 +2045,33 @@ def(elab-embed-str!, Token +World +Mirth -- Token +World +Mirth,
     dup WordQName >label Prop over ~qname !
 
     Ctx0 T0 TYPE_STR T1 T-> over2 WordType prop2 over ~ctx-type !
-    ab-build-word!(contents> ab-str!) drop)
+    ab-build-word!(contents> ab-str!) drop
+}
 
 ||| Ensure that everything so far has been typechecked.
-def(typecheck-everything!, +Mirth -- +Mirth,
+def typecheck-everything! [ +Mirth -- +Mirth ] {
     Name.for(defs for(dup qname-hard drop typecheck!))
     Block.for(typecheck!)
-    External.for(ctype drop))
+    External.for(ctype drop)
+}
 
 #########
 # TABLE #
 #########
 
-def(TABLE_MAX_COUNT, Nat, 0x80000 >Nat)
+def TABLE_MAX_COUNT { 0x80000 >Nat }
 
-def(table-qname, Table Str Int -- QName,
-    >arity >Name >name TYCON_TABLE NAMESPACE_TYCON >namespace MKQNAME)
+def table-qname [ Table Str Int -- QName ] {
+    >arity >Name >name TYCON_TABLE NAMESPACE_TYCON >namespace MKQNAME
+}
 
-def(table-word-new!, +Mirth Table Str Int -- +Mirth Word,
+def table-word-new! [ +Mirth Table Str Int -- +Mirth Word ] {
     over2 head dup >head >body None >sig
     dup >arity over >Name >name table-qname >qname Word.new!
-    qname> over WordQName prop over ~qname !)
+    qname> over WordQName prop over ~qname !
+}
 
-def(table-new!, +Mirth head:Token name:Name state:PropState(QName) -- +Mirth Table,
+def table-new! [ +Mirth head:Token name:Name state:PropState(QName) -- +Mirth Table ] {
     Table.alloc! >tbl
     @tbl TableQName >label Prop @tbl ~qname !
     head> @tbl ~head !
@@ -1973,13 +2246,14 @@ def(table-new!, +Mirth head:Token name:Name state:PropState(QName) -- +Mirth Tab
         CoerceUnsafe ab-coerce!
     ) drop
 
-    tbl>)
+    tbl>
+}
 
 #########
 # FIELD #
 #########
 
-def(resolve-def-namespace, +Mirth Token -- +Mirth Maybe(Namespace),
+def resolve-def-namespace [ +Mirth Token -- +Mirth Maybe(Namespace) ] {
     >token
     "namespace" >sort
     True >ignore-last-name
@@ -1989,61 +2263,71 @@ def(resolve-def-namespace, +Mirth Token -- +Mirth Maybe(Namespace),
         filter-qualifiers
         L0 filter-roots
     )
-    bind(as-namespace?))
+    bind(as-namespace?)
+}
 
-def(elab-qname-from-nonrelative-dname, +Mirth Token DName Int -- +Mirth QName,
+def elab-qname-from-nonrelative-dname [ +Mirth Token DName Int -- +Mirth QName ] {
     >arity
     dup root? else(drop "relative name not allowed" emit-fatal-error!)
     last-name >name
     dup resolve-def-namespace unwrap(panic-diagnostics!) >namespace
-    drop MKQNAME)
+    drop MKQNAME
+}
 
-def(module-visible-from-token?, Token Module -- Bool,
-    swap .module visible)
+def module-visible-from-token? [ Token Module -- Bool ] {
+    swap .module visible
+}
 
-def(def-visible-from-token?, Token Def -- Bool,
+def def-visible-from-token? [ Token Def -- Bool ] {
     defining-module? match(
         None -> drop True,
         Some -> module-visible-from-token?
-    ))
+    )
+}
 
 ||| Elaborate the qname for a word definition.
 ||| Generally speaking this is going to use the module namespace.
-def(elab-def-qname, +Mirth Token -- +Mirth QName,
+def elab-def-qname [ +Mirth Token -- +Mirth QName ] {
     dup name-or-dname? unwrap("expected name" emit-fatal-error!)
     match(
         Left -> >name dup .module NAMESPACE_MODULE >namespace num-args >arity MKQNAME,
         Right -> over num-args elab-qname-from-nonrelative-dname
-    ))
+    )
+}
 
 ||| Same as `elab-def-qname` but raises an error if the qname is already defined.
-def(elab-def-qname-undefined, +Mirth Token -- +Mirth QName,
+def elab-def-qname-undefined [ +Mirth Token -- +Mirth QName ] {
     dup elab-def-qname
     dup defined-soft? then(drop "name already defined" emit-fatal-error!)
-    nip)
+    nip
+}
 
 ||| Elaborate the head, i.e. the name-giving token, of a definition.
 ||| We defer the full resolution of the qualified name, but otherwise
 ||| we collect arity and (simple) name data from the head token.
-def(elab-def-head,
-        +Mirth head:Token --
-        +Mirth head:Token name:Name arity:Int state:PropState(QName),
+def elab-def-head [
+    +Mirth head:Token --
+    +Mirth head:Token name:Name arity:Int state:PropState(QName)
+] {
     @head name-or-dname?
         unwrap(@head "expected name" emit-fatal-error!)
         either(id, parts last) >name
     @head num-args >arity
-    @head [elab-def-qname-undefined] PSDelay >state)
+    @head [elab-def-qname-undefined] PSDelay >state
+}
 
 ||| Parse a field definition, `field(f, T1, T2)`
-def(parse-field,
-        +Mirth Token -- +Mirth Token
-        head:Token index-type:Token value-type:Token,
+def parse-field [
+    +Mirth Token -- +Mirth Token
+    head:Token index-type:Token value-type:Token
+] {
     sip(next) args-3 >value-type >index-type >head
     @head name-or-dname? else(@head "expected field name" emit-fatal-error!)
-    @head args-0)
+    @head args-0
+}
 
 ||| Elaborate a field definition `field(f, T1, T2)`.
-def(elab-field!, +Mirth Token -- +Mirth Token,
+def elab-field! [ +Mirth Token -- +Mirth Token ] {
     parse-field elab-def-head
     Field.alloc! >fld
     name> @fld ~name !
@@ -2052,4 +2336,5 @@ def(elab-field!, +Mirth Token -- +Mirth Token,
     @fld FieldQName >label Prop @fld ~qname !
     index-type> @fld FieldIndexType prop(elab-simple-type-arg!) @fld ~index-type !
     value-type> @fld FieldValueType prop(elab-simple-type-arg!) @fld ~value-type !
-    fld> DefField register)
+    fld> DefField register
+}

--- a/src/name.mth
+++ b/src/name.mth
@@ -98,7 +98,14 @@ def(Name.is-underscore, Name -- Bool, dup head B'_' == swap tail-head BNUL == &&
 def(Name.could-be-stack-var, Name -- Bool, dup head B'*' == swap tail-head is-lower &&)
 def(Name.could-be-resource-var, Name -- Bool, dup head B'+' == swap tail-head is-lower &&)
 def(Name.could-be-resource-con, Name -- Bool, dup head B'+' == swap tail-head is-upper &&)
-def(Name.could-be-type-or-resource-con, Name -- Bool, dup could-be-type-con or(dup could-be-resource-con) nip)
+
+def Name.could-be-constructor [ Name -- Bool ] {
+    dup head match(
+        B'+' -> tail-head is-upper,
+        _ -> nip is-upper,
+    )
+}
+
 def(Name.mangle-compute!, Name -- Str,
     Str(>Str bytes-for(zencode ;)))
 

--- a/src/prim.mth
+++ b/src/prim.mth
@@ -107,6 +107,7 @@ data(Prim,
     PRIM_SYNTAX_TABLE,
     PRIM_SYNTAX_FIELD,
     PRIM_SYNTAX_DATA,
+    PRIM_SYNTAX_STRUCT,
     PRIM_SYNTAX_DASHES,
     PRIM_SYNTAX_ARROW)
 field(Prim.~name, Prim, Name)
@@ -154,6 +155,7 @@ def(init-prims!, +Mirth -- +Mirth,
     PRIM_SYNTAX_FIELD "field" -1 def-prim!
     PRIM_SYNTAX_EMBED_STR "embed-str" -1 def-prim!
     PRIM_SYNTAX_DATA "data" -1 def-prim!
+    PRIM_SYNTAX_STRUCT "struct" -1 def-prim!
     PRIM_SYNTAX_VARIABLE "var" -1 def-prim!
     PRIM_SYNTAX_ARROW "->" -1 def-prim!
     PRIM_SYNTAX_DASHES "--" -1 def-prim!

--- a/src/token.mth
+++ b/src/token.mth
@@ -109,7 +109,7 @@ def(TokenValue.sig-stack-var?, TokenValue -- Bool, name? has(could-be-stack-var)
 def(TokenValue.sig-resource-var?, TokenValue -- Bool, name? has(could-be-resource-var))
 def(TokenValue.sig-resource-con?, TokenValue -- Bool, last-name? has(could-be-resource-con))
 def(TokenValue.sig-dashes?, TokenValue -- Bool, name? has(PRIM_SYNTAX_DASHES name ==))
-def(TokenValue.pat-arrow?, TokenValue -- Bool, name? has(PRIM_SYNTAX_ARROW name ==))
+def(TokenValue.arrow?, TokenValue -- Bool, name? has(PRIM_SYNTAX_ARROW name ==))
 def(TokenValue.pat-underscore?, TokenValue -- Bool, name? has(is-underscore))
 def(TokenValue.module-header?, TokenValue -- Bool, name? has(>Str "module" ==))
 
@@ -160,7 +160,7 @@ def(Token.sig-stack-var?, Token -- Bool, value sig-stack-var?)
 def(Token.sig-resource-var?, Token -- Bool, value sig-resource-var?)
 def(Token.sig-resource-con?, Token -- Bool, value sig-resource-con?)
 def(Token.sig-dashes?, Token -- Bool, value sig-dashes?)
-def(Token.pat-arrow?, Token -- Bool, value pat-arrow?)
+def(Token.arrow?, Token -- Bool, value arrow?)
 def(Token.pat-underscore?, Token -- Bool, value pat-underscore?)
 def(Token.module-header?, Token -- Bool, value module-header?)
 def(Token.can-take-args?, Token -- Bool, value can-take-args?)
@@ -316,7 +316,7 @@ def(Token.run-length, Token -- Nat,
     dip(0 >Nat) while(dup run-end? not, next dip(1+)) drop)
 
 def(Token.run-arrow?, Token -- Maybe(Token),
-    run-tokens find(pat-arrow?))
+    run-tokens find(arrow?))
 
 ###################
 # Type Signatures #
@@ -352,4 +352,4 @@ def(Token.sig-skip-dashes, Token -- Token,
     dup sig-has-dashes? then(sig-next-stack-end next))
 
 def(Token.pat-tokens, Token -- List(Token),
-    run-tokens take-while(pat-arrow? not))
+    run-tokens take-while(arrow? not))

--- a/test/data-syntax.mth
+++ b/test/data-syntax.mth
@@ -14,10 +14,15 @@ data(TJ, J1, J2 -> Int,)
 data(TK)
 data(TL,)
 
-data(Foo, Foo [ Int ])
-data(Bar, Bar1, Bar2 [ Str x:Str ])
+data(Foo, Foo1 Foo2 [ Int ])
+data Bar { Bar1 Bar2 [ Str x:Str ] }
+struct Baz { something:Int something-else:Str }
 
-def(main, --,
-    10 Foo drop
+def main {
+    Foo1 drop
+    10 Foo2 drop
     "hi" "bye" >x Bar2 drop
-    Bar1 drop)
+    Bar1 drop
+    10 >something "here" >something-else
+    Baz drop
+}

--- a/test/data-syntax.mth
+++ b/test/data-syntax.mth
@@ -14,4 +14,10 @@ data(TJ, J1, J2 -> Int,)
 data(TK)
 data(TL,)
 
-def(main, --, id)
+data(Foo, Foo [ Int ])
+data(Bar, Bar1, Bar2 [ Str x:Str ])
+
+def(main, --,
+    10 Foo drop
+    "hi" "bye" >x Bar2 drop
+    Bar1 drop)


### PR DESCRIPTION
This PR adds syntactic sugar for `data` declarations. Now we can write them as follows:
```
data Maybe(t) {
    None
    Some [ t ]
}
```
Constructors can still be written in the old style, with arrows and commas:
```
data Maybe(t) {
    None,
    Some -> t,
}
```

In addition, I added a `struct` declaration, which is syntactic sugar for a single-constructor `data` declaration:
```
struct Person {
    name: Str
    age: Int
}
```
is equivalent to:
```
data Person {
    Person [
        name: Str
        age: Int
    ]
}
```
The rationale behind the new data syntax is to make it look visually distinct from the new `def` syntax, so that it's easier to not confuse them, which was a problem with the old style.