### PR TITLE
Make package search paths part of the +Mirth resource and add a CLI argument to add to it

### DIFF
--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -7032,6 +7032,7 @@ static void mb_mirth_main_compilerZ_parseZ_args_13 (void);
 static void mb_mirth_main_compilerZ_parseZ_args_16 (void);
 static void mb_mirth_main_compilerZ_parseZ_args_18 (void);
 static void mb_mirth_main_compilerZ_parseZ_args_21 (void);
+static void mb_mirth_main_compilerZ_parseZ_args_24 (void);
 static void mb_mirth_specializzer_SPKey_ZEqualZEqual_1 (void);
 static void mb_std_maybe_Maybe_1_ZEqualZEqual_1_0 (void);
 static void mb_std_maybe_Maybe_1_ZEqualZEqual_1_1 (void);
@@ -46162,9 +46163,7 @@ static void mw_mirth_main_Arguments_default (void) {
 	LPUSH(lbl_entryZ_point);
 	push_u64(0LL); // Nil
 	LPUSH(lbl_packages);
-	STRLIT("lib", 3);
 	push_u64(0LL); // Nil
-	mtw_std_list_List_1_Cons();
 	LPUSH(lbl_packageZ_searchZ_paths);
 	mtw_mirth_main_Arguments_Arguments();
 }
@@ -46552,6 +46551,21 @@ static void mw_mirth_main_compilerZ_parseZ_args (void) {
 					push_value(mkstr("unexpected fallthrough in match\n", 32)); 
 					mp_primZ_panic();
 			}
+			mw_argZ_parser_types_ZPlusArgumentParser_1_state();
+			mw_argZ_parser_state_State_1_arguments();
+			mw_mirth_main_Arguments_packageZ_searchZ_paths();
+			mw_std_list_List_1_emptyZAsk();
+			if (pop_u64()) {
+				{
+					VAL d5 = pop_value();
+					push_fnptr(&mb_mirth_main_compilerZ_parseZ_args_24);
+					mw_std_list_LIST_1();
+					mp_primZ_swap();
+					mw_mirth_main_Arguments_packageZ_searchZ_pathsZBang();
+					push_value(d5);
+				}
+			} else {
+			}
 			mp_primZ_drop();
 			break;
 		default:
@@ -46924,6 +46938,10 @@ static void mb_mirth_main_compilerZ_parseZ_args_18 (void) {
 }
 static void mb_mirth_main_compilerZ_parseZ_args_21 (void) {
 	mw_argZ_parser_state_State_1_errorZBang();
+}
+static void mb_mirth_main_compilerZ_parseZ_args_24 (void) {
+	STRLIT("lib", 3);
+	mw_std_list_ZPlusList_1_pushZBang();
 }
 static void mb_mirth_specializzer_SPKey_ZEqualZEqual_1 (void) {
 	mw_mirth_arrow_Arg_ZEqualZEqual();

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -1304,6 +1304,7 @@ static VAL lbl_inputZ_file = MKNIL_C;
 static VAL lbl_outputZ_file = MKNIL_C;
 static VAL lbl_entryZ_point = MKNIL_C;
 static VAL lbl_packages = MKNIL_C;
+static VAL lbl_packageZ_searchZ_paths = MKNIL_C;
 static VAL lbl_outputZ_path = MKNIL_C;
 static VAL lbl_name = MKNIL_C;
 static VAL lbl_flagZ_type = MKNIL_C;
@@ -3941,17 +3942,18 @@ static void mtw_mirth_mirth_Builtin_Builtin (void) {
 	push_value(MKTUP(tup, 62));
 }
 static void mtw_mirth_mirth_ZPlusMirth_ZPlusMirth (void) {
-	TUP* tup = tup_new(8);
-	tup->size = 8;
+	TUP* tup = tup_new(9);
+	tup->size = 9;
 	tup->cells[0] = MKU64(0LL);
-	tup->cells[7] = lpop(&lbl_ZPluspropstack);
-	tup->cells[6] = lpop(&lbl_ZPlusdiagnostics);
+	tup->cells[8] = lpop(&lbl_ZPluspropstack);
+	tup->cells[7] = lpop(&lbl_ZPlusdiagnostics);
+	tup->cells[6] = lpop(&lbl_packageZ_searchZ_paths);
 	tup->cells[5] = lpop(&lbl_errorZ_token);
 	tup->cells[4] = lpop(&lbl_builtin);
 	tup->cells[3] = lpop(&lbl_preferZ_inlineZ_defs);
 	tup->cells[2] = lpop(&lbl_numZ_warnings);
 	tup->cells[1] = lpop(&lbl_numZ_errors);
-	push_resource(MKTUP(tup, 8));
+	push_resource(MKTUP(tup, 9));
 }
 static void mtp_mirth_mirth_ZPlusMirth_ZPlusMirth (void) {
 	VAL val = pop_resource();
@@ -3962,8 +3964,9 @@ static void mtp_mirth_mirth_ZPlusMirth_ZPlusMirth (void) {
 	lpush(&lbl_preferZ_inlineZ_defs, tup->cells[3]);
 	lpush(&lbl_builtin, tup->cells[4]);
 	lpush(&lbl_errorZ_token, tup->cells[5]);
-	lpush(&lbl_ZPlusdiagnostics, tup->cells[6]);
-	lpush(&lbl_ZPluspropstack, tup->cells[7]);
+	lpush(&lbl_packageZ_searchZ_paths, tup->cells[6]);
+	lpush(&lbl_ZPlusdiagnostics, tup->cells[7]);
+	lpush(&lbl_ZPluspropstack, tup->cells[8]);
 	if (tup->refs > 1) {
 		incref(tup->cells[1]);
 		incref(tup->cells[2]);
@@ -3972,6 +3975,7 @@ static void mtp_mirth_mirth_ZPlusMirth_ZPlusMirth (void) {
 		incref(tup->cells[5]);
 		incref(tup->cells[6]);
 		incref(tup->cells[7]);
+		incref(tup->cells[8]);
 		decref(val);
 	} else {
 		free(tup);
@@ -5180,15 +5184,16 @@ static void mtp_mirth_c99_ZPlusC99_ZPlusC99 (void) {
 	}
 }
 static void mtw_mirth_main_Arguments_Arguments (void) {
-	TUP* tup = tup_new(6);
-	tup->size = 6;
+	TUP* tup = tup_new(7);
+	tup->size = 7;
 	tup->cells[0] = MKU64(0LL);
-	tup->cells[5] = lpop(&lbl_emitZ_debugZ_info);
+	tup->cells[6] = lpop(&lbl_emitZ_debugZ_info);
+	tup->cells[5] = lpop(&lbl_packageZ_searchZ_paths);
 	tup->cells[4] = lpop(&lbl_packages);
 	tup->cells[3] = lpop(&lbl_entryZ_point);
 	tup->cells[2] = lpop(&lbl_outputZ_file);
 	tup->cells[1] = lpop(&lbl_inputZ_file);
-	push_value(MKTUP(tup, 6));
+	push_value(MKTUP(tup, 7));
 }
 static void mtp_mirth_main_Arguments_Arguments (void) {
 	VAL val = pop_value();
@@ -5198,13 +5203,15 @@ static void mtp_mirth_main_Arguments_Arguments (void) {
 	lpush(&lbl_outputZ_file, tup->cells[2]);
 	lpush(&lbl_entryZ_point, tup->cells[3]);
 	lpush(&lbl_packages, tup->cells[4]);
-	lpush(&lbl_emitZ_debugZ_info, tup->cells[5]);
+	lpush(&lbl_packageZ_searchZ_paths, tup->cells[5]);
+	lpush(&lbl_emitZ_debugZ_info, tup->cells[6]);
 	if (tup->refs > 1) {
 		incref(tup->cells[1]);
 		incref(tup->cells[2]);
 		incref(tup->cells[3]);
 		incref(tup->cells[4]);
 		incref(tup->cells[5]);
+		incref(tup->cells[6]);
 		decref(val);
 	} else {
 		free(tup);
@@ -5289,10 +5296,6 @@ static void mbuf_mirth_name_HASHz_BUF (void) {
 static void mbuf_mirth_package_Package_NUM (void) {
 	static uint8_t b[8] = {0};
 	push_ptr(&b);
-}
-static void mvar_mirth_package_PACKAGEz_SEARCHz_PATH (void) {
-	static VAL v = {0};
-	push_ptr(&v);
 }
 size_t strlen (const char *);
 static void mext_std_ctypes_CStr_numZ_bytes (void) {
@@ -6328,6 +6331,9 @@ static void mw_mirth_mirth_ZPlusMirth_ZDivZPlusMirth (void);
 static void mw_mirth_mirth_ZPlusMirth_ZPlusdiagnostics (void);
 static void mw_mirth_mirth_ZPlusMirth_ZPlusdiagnosticsZBang (void);
 static void mw_mirth_mirth_ZPlusMirth_ZPlusdiagnostics_1 (void);
+static void mw_mirth_mirth_ZPlusMirth_packageZ_searchZ_paths (void);
+static void mw_mirth_mirth_ZPlusMirth_packageZ_searchZ_pathsZBang (void);
+static void mw_mirth_mirth_ZPlusMirth_packageZ_searchZ_paths_1 (void);
 static void mw_mirth_mirth_ZPlusMirth_errorZ_token (void);
 static void mw_mirth_mirth_ZPlusMirth_errorZ_tokenZBang (void);
 static void mw_mirth_mirth_ZPlusMirth_builtin (void);
@@ -6973,6 +6979,9 @@ static void mw_mirth_c99_c99Z_fieldZ_defZBang (void);
 static void mw_mirth_c99_c99Z_mainZBang (void);
 static void mw_mirth_main_Arguments_ZDivArguments (void);
 static void mw_mirth_main_Arguments_emitZ_debugZ_infoZBang (void);
+static void mw_mirth_main_Arguments_packageZ_searchZ_paths (void);
+static void mw_mirth_main_Arguments_packageZ_searchZ_pathsZBang (void);
+static void mw_mirth_main_Arguments_packageZ_searchZ_paths_1 (void);
 static void mw_mirth_main_Arguments_packages (void);
 static void mw_mirth_main_Arguments_packagesZBang (void);
 static void mw_mirth_main_Arguments_packages_1 (void);
@@ -6996,11 +7005,12 @@ static void mb_mirth_main_main_3 (void);
 static void mb_std_prim_Str_showZThen_0 (void);
 static void mb_mirth_specializzer_SPKey_ZToStr_0 (void);
 static void mb_mirth_specializzer_SPKey_ZToStr_2 (void);
-static void mb_mirth_main_compileZBang_1 (void);
+static void mb_mirth_main_compileZBang_0 (void);
 static void mb_mirth_main_compileZBang_2 (void);
-static void mb_mirth_main_compileZBang_4 (void);
-static void mb_mirth_main_compileZBang_10 (void);
-static void mb_mirth_main_compileZBang_12 (void);
+static void mb_mirth_main_compileZBang_3 (void);
+static void mb_mirth_main_compileZBang_5 (void);
+static void mb_mirth_main_compileZBang_11 (void);
+static void mb_mirth_main_compileZBang_13 (void);
 static void mb_std_list_List_1_for_2_2 (void);
 static void mb_std_prim_Str_ZToName_2 (void);
 static void mb_mirth_elab_typecheckZ_everythingZBang_0 (void);
@@ -7015,12 +7025,13 @@ static void mb_mirth_main_compilerZ_parseZ_args_1 (void);
 static void mb_mirth_main_compilerZ_parseZ_args_2 (void);
 static void mb_mirth_main_compilerZ_parseZ_args_3 (void);
 static void mb_mirth_main_compilerZ_parseZ_args_5 (void);
-static void mb_mirth_main_compilerZ_parseZ_args_6 (void);
-static void mb_mirth_main_compilerZ_parseZ_args_9 (void);
+static void mb_mirth_main_compilerZ_parseZ_args_7 (void);
+static void mb_mirth_main_compilerZ_parseZ_args_8 (void);
 static void mb_mirth_main_compilerZ_parseZ_args_11 (void);
-static void mb_mirth_main_compilerZ_parseZ_args_14 (void);
+static void mb_mirth_main_compilerZ_parseZ_args_13 (void);
 static void mb_mirth_main_compilerZ_parseZ_args_16 (void);
-static void mb_mirth_main_compilerZ_parseZ_args_19 (void);
+static void mb_mirth_main_compilerZ_parseZ_args_18 (void);
+static void mb_mirth_main_compilerZ_parseZ_args_21 (void);
 static void mb_mirth_specializzer_SPKey_ZEqualZEqual_1 (void);
 static void mb_std_maybe_Maybe_1_ZEqualZEqual_1_0 (void);
 static void mb_std_maybe_Maybe_1_ZEqualZEqual_1_1 (void);
@@ -7127,7 +7138,6 @@ static void mb_argZ_parser_parse_argvZ_toZ_str_1 (void);
 static void mb_mirth_arrow_Block_qname_0 (void);
 static void mb_mirth_package_Package_pathZ_orZ_search_0 (void);
 static void mb_mirth_package_Package_pathZ_orZ_search_1 (void);
-static void mb_mirth_package_Package_pathZ_orZ_search_2 (void);
 static void mb_mirth_package_Package_pathZBang_2 (void);
 static void mb_mirth_label_Label_newZBang_0 (void);
 static void mb_mirth_def_Def_register_2 (void);
@@ -7300,7 +7310,7 @@ static void mb_mirth_elab_elabZ_patternZ_atomZBang_5 (void);
 static void mb_mirth_elab_elabZ_patternZ_atomZBang_14 (void);
 static void mb_mirth_elab_elabZ_patternZ_atomZBang_16 (void);
 static void mb_mirth_elab_elabZ_moduleZ_declZBang_1 (void);
-static void mb_mirth_elab_checkZ_moduleZ_path_2 (void);
+static void mb_mirth_elab_checkZ_moduleZ_path_1 (void);
 static void mb_mirth_elab_elabZ_aliasZBang_0 (void);
 static void mb_mirth_elab_elabZ_aliasZBang_1 (void);
 static void mb_mirth_elab_elabZ_aliasZBang_6 (void);
@@ -27799,8 +27809,8 @@ static void mw_mirth_mirth_ZPlusMirth_ZDivZPlusMirth (void) {
 static void mw_mirth_mirth_ZPlusMirth_ZPlusdiagnostics (void) {
 	VAL v = pop_resource();
 	ASSERT1(IS_TUP(v), v);
-	ASSERT1(VTUPLEN(v) == 8, v);
-	VAL* p = &VTUP(v)->cells[6];
+	ASSERT1(VTUPLEN(v) == 9, v);
+	VAL* p = &VTUP(v)->cells[7];
 	VAL u = *p;
 	ASSERT1(VREFS(v) == 1, v);
 	*p = (VAL){0};
@@ -27811,9 +27821,9 @@ static void mw_mirth_mirth_ZPlusMirth_ZPlusdiagnosticsZBang (void) {
 	VAL v = pop_resource();
 	VAL u = pop_resource();
 	ASSERT1(IS_TUP(v), v);
-	ASSERT1(VTUPLEN(v) == 8, v);
+	ASSERT1(VTUPLEN(v) == 9, v);
 	ASSERT1(VREFS(v) == 1, v);
-	VAL* p = &VTUP(v)->cells[6];
+	VAL* p = &VTUP(v)->cells[7];
 	ASSERT1(p->tag == 0, v);
 	*p = u;
 	push_resource(v);
@@ -27832,10 +27842,42 @@ static void mw_mirth_mirth_ZPlusMirth_ZPlusdiagnostics_1 (void) {
 		decref(var_f);
 	}
 }
+static void mw_mirth_mirth_ZPlusMirth_packageZ_searchZ_paths (void) {
+	VAL v = pop_resource();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 9, v);
+	VAL* p = &VTUP(v)->cells[6];
+	VAL u = *p;
+	incref(u);
+	push_resource(v);
+	push_value(u);
+}
+static void mw_mirth_mirth_ZPlusMirth_packageZ_searchZ_pathsZBang (void) {
+	VAL v = top_resource();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 9, v);
+	VAL* p = &VTUP(v)->cells[6];
+	VAL t = *p; *p = u; decref(t);
+}
+static void mw_mirth_mirth_ZPlusMirth_packageZ_searchZ_paths_1 (void) {
+	{
+		VAL var_f = pop_value();
+		mw_mirth_mirth_ZPlusMirth_packageZ_searchZ_paths();
+		{
+			VAL d3 = pop_resource();
+			incref(var_f);
+			run_value(var_f);
+			push_resource(d3);
+		}
+		mw_mirth_mirth_ZPlusMirth_packageZ_searchZ_pathsZBang();
+		decref(var_f);
+	}
+}
 static void mw_mirth_mirth_ZPlusMirth_errorZ_token (void) {
 	VAL v = pop_resource();
 	ASSERT1(IS_TUP(v), v);
-	ASSERT1(VTUPLEN(v) == 8, v);
+	ASSERT1(VTUPLEN(v) == 9, v);
 	VAL* p = &VTUP(v)->cells[5];
 	VAL u = *p;
 	incref(u);
@@ -27846,14 +27888,14 @@ static void mw_mirth_mirth_ZPlusMirth_errorZ_tokenZBang (void) {
 	VAL v = top_resource();
 	VAL u = pop_value();
 	ASSERT1(IS_TUP(v), v);
-	ASSERT1(VTUPLEN(v) == 8, v);
+	ASSERT1(VTUPLEN(v) == 9, v);
 	VAL* p = &VTUP(v)->cells[5];
 	VAL t = *p; *p = u; decref(t);
 }
 static void mw_mirth_mirth_ZPlusMirth_builtin (void) {
 	VAL v = pop_resource();
 	ASSERT1(IS_TUP(v), v);
-	ASSERT1(VTUPLEN(v) == 8, v);
+	ASSERT1(VTUPLEN(v) == 9, v);
 	VAL* p = &VTUP(v)->cells[4];
 	VAL u = *p;
 	incref(u);
@@ -27863,7 +27905,7 @@ static void mw_mirth_mirth_ZPlusMirth_builtin (void) {
 static void mw_mirth_mirth_ZPlusMirth_preferZ_inlineZ_defs (void) {
 	VAL v = pop_resource();
 	ASSERT1(IS_TUP(v), v);
-	ASSERT1(VTUPLEN(v) == 8, v);
+	ASSERT1(VTUPLEN(v) == 9, v);
 	VAL* p = &VTUP(v)->cells[3];
 	VAL u = *p;
 	incref(u);
@@ -27874,14 +27916,14 @@ static void mw_mirth_mirth_ZPlusMirth_preferZ_inlineZ_defsZBang (void) {
 	VAL v = top_resource();
 	VAL u = pop_value();
 	ASSERT1(IS_TUP(v), v);
-	ASSERT1(VTUPLEN(v) == 8, v);
+	ASSERT1(VTUPLEN(v) == 9, v);
 	VAL* p = &VTUP(v)->cells[3];
 	VAL t = *p; *p = u; decref(t);
 }
 static void mw_mirth_mirth_ZPlusMirth_numZ_warnings (void) {
 	VAL v = pop_resource();
 	ASSERT1(IS_TUP(v), v);
-	ASSERT1(VTUPLEN(v) == 8, v);
+	ASSERT1(VTUPLEN(v) == 9, v);
 	VAL* p = &VTUP(v)->cells[2];
 	VAL u = *p;
 	incref(u);
@@ -27892,7 +27934,7 @@ static void mw_mirth_mirth_ZPlusMirth_numZ_warningsZBang (void) {
 	VAL v = top_resource();
 	VAL u = pop_value();
 	ASSERT1(IS_TUP(v), v);
-	ASSERT1(VTUPLEN(v) == 8, v);
+	ASSERT1(VTUPLEN(v) == 9, v);
 	VAL* p = &VTUP(v)->cells[2];
 	VAL t = *p; *p = u; decref(t);
 }
@@ -27913,7 +27955,7 @@ static void mw_mirth_mirth_ZPlusMirth_numZ_warnings_1 (void) {
 static void mw_mirth_mirth_ZPlusMirth_numZ_errors (void) {
 	VAL v = pop_resource();
 	ASSERT1(IS_TUP(v), v);
-	ASSERT1(VTUPLEN(v) == 8, v);
+	ASSERT1(VTUPLEN(v) == 9, v);
 	VAL* p = &VTUP(v)->cells[1];
 	VAL u = *p;
 	incref(u);
@@ -27924,7 +27966,7 @@ static void mw_mirth_mirth_ZPlusMirth_numZ_errorsZBang (void) {
 	VAL v = top_resource();
 	VAL u = pop_value();
 	ASSERT1(IS_TUP(v), v);
-	ASSERT1(VTUPLEN(v) == 8, v);
+	ASSERT1(VTUPLEN(v) == 9, v);
 	VAL* p = &VTUP(v)->cells[1];
 	VAL t = *p; *p = u; decref(t);
 }
@@ -27954,6 +27996,8 @@ static void mw_mirth_mirth_ZPlusMirth_initZBang (void) {
 	mw_mirth_mirth_Builtin_allocZBang();
 	LPUSH(lbl_builtin);
 	push_u64(0LL); // Nil
+	LPUSH(lbl_packageZ_searchZ_paths);
+	push_u64(0LL); // Nil
 	mw_std_list_List_1_thaw();
 	LPUSHR(lbl_ZPlusdiagnostics);
 	push_u64(0LL); // Nil
@@ -27978,6 +28022,8 @@ static void mw_mirth_mirth_ZPlusMirth_rdrop (void) {
 	LPOP(lbl_builtin);
 	mp_primZ_drop();
 	LPOP(lbl_errorZ_token);
+	mp_primZ_drop();
+	LPOP(lbl_packageZ_searchZ_paths);
 	mp_primZ_drop();
 	LPOPR(lbl_ZPlusdiagnostics);
 	mw_std_list_ZPlusList_1_freezze();
@@ -30927,12 +30973,10 @@ static void mw_mirth_package_Package_pathZ_orZ_search (void) {
 			break;
 		case 0LL: // None
 			(void)pop_u64();
-			mvar_mirth_package_PACKAGEz_SEARCHz_PATH();
+			mw_mirth_mirth_ZPlusMirth_packageZ_searchZ_paths();
 			push_fnptr(&mb_mirth_package_Package_pathZ_orZ_search_0);
-			mw_std_prelude_memoizze_1();
-			push_fnptr(&mb_mirth_package_Package_pathZ_orZ_search_1);
 			mw_std_list_List_1_map_1();
-			push_fnptr(&mb_mirth_package_Package_pathZ_orZ_search_2);
+			push_fnptr(&mb_mirth_package_Package_pathZ_orZ_search_1);
 			mw_std_list_List_1_find_1();
 			mp_primZ_dup();
 			{
@@ -36765,11 +36809,7 @@ static void mw_mirth_elab_checkZ_moduleZ_path (void) {
 			(void)pop_u64();
 			mp_primZ_swap();
 			mw_mirth_module_Module_qname();
-			{
-				VAL d4 = pop_resource();
-				mw_mirth_name_QName_toZ_moduleZ_path();
-				push_resource(d4);
-			}
+			mw_mirth_name_QName_toZ_moduleZ_path();
 			{
 				VAL d4 = pop_value();
 				mp_primZ_dup();
@@ -36847,7 +36887,7 @@ static void mw_mirth_elab_checkZ_moduleZ_path (void) {
 			break;
 		case 1LL: // Some
 			mtp_std_maybe_Maybe_1_Some();
-			push_fnptr(&mb_mirth_elab_checkZ_moduleZ_path_2);
+			push_fnptr(&mb_mirth_elab_checkZ_moduleZ_path_1);
 			mw_std_prim_Str_splitZ_lastZ_byte_1();
 			STRLIT("mth", 3);
 			mtw_std_maybe_Maybe_1_Some();
@@ -37180,11 +37220,7 @@ static void mw_mirth_elab_loadZ_module (void) {
 			break;
 		case 0LL: // None
 			(void)pop_u64();
-			{
-				VAL d4 = pop_resource();
-				mw_mirth_name_QName_toZ_moduleZ_path();
-				push_resource(d4);
-			}
+			mw_mirth_name_QName_toZ_moduleZ_path();
 			mw_mirth_lexer_runZ_lexerZBang();
 			mw_mirth_elab_elabZ_moduleZBang();
 			break;
@@ -45855,28 +45891,77 @@ static void mw_mirth_main_Arguments_emitZ_debugZ_infoZBang (void) {
 	VAL v = pop_value();
 	VAL u = pop_value();
 	ASSERT1(IS_TUP(v), v);
-	ASSERT1(VTUPLEN(v) == 6, v);
+	ASSERT1(VTUPLEN(v) == 7, v);
+	if (VTUP(v)->refs == 1) {
+		VAL* p = &VTUP(v)->cells[6];
+		VAL t = *p; *p = u; decref(t);
+		push_value(v);
+	} else {
+		TUP *tup = tup_new(7);
+		tup->size = 7;
+		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
+		tup->cells[1] = VTUP(v)->cells[1]; incref(tup->cells[1]);
+		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
+		tup->cells[3] = VTUP(v)->cells[3]; incref(tup->cells[3]);
+		tup->cells[4] = VTUP(v)->cells[4]; incref(tup->cells[4]);
+		tup->cells[5] = VTUP(v)->cells[5]; incref(tup->cells[5]);
+		tup->cells[6] = u;
+		decref(v);
+		push_value(MKTUP(tup,7));
+	}
+}
+static void mw_mirth_main_Arguments_packageZ_searchZ_paths (void) {
+	VAL v = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 7, v);
+	VAL* p = &VTUP(v)->cells[5];
+	VAL u = *p;
+	incref(u);
+	decref(v);
+	push_value(u);
+}
+static void mw_mirth_main_Arguments_packageZ_searchZ_pathsZBang (void) {
+	VAL v = pop_value();
+	VAL u = pop_value();
+	ASSERT1(IS_TUP(v), v);
+	ASSERT1(VTUPLEN(v) == 7, v);
 	if (VTUP(v)->refs == 1) {
 		VAL* p = &VTUP(v)->cells[5];
 		VAL t = *p; *p = u; decref(t);
 		push_value(v);
 	} else {
-		TUP *tup = tup_new(6);
-		tup->size = 6;
+		TUP *tup = tup_new(7);
+		tup->size = 7;
 		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
 		tup->cells[1] = VTUP(v)->cells[1]; incref(tup->cells[1]);
 		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
 		tup->cells[3] = VTUP(v)->cells[3]; incref(tup->cells[3]);
 		tup->cells[4] = VTUP(v)->cells[4]; incref(tup->cells[4]);
 		tup->cells[5] = u;
+		tup->cells[6] = VTUP(v)->cells[6]; incref(tup->cells[6]);
 		decref(v);
-		push_value(MKTUP(tup,6));
+		push_value(MKTUP(tup,7));
+	}
+}
+static void mw_mirth_main_Arguments_packageZ_searchZ_paths_1 (void) {
+	{
+		VAL var_f = pop_value();
+		mp_primZ_dup();
+		{
+			VAL d3 = pop_value();
+			mw_mirth_main_Arguments_packageZ_searchZ_paths();
+			incref(var_f);
+			run_value(var_f);
+			push_value(d3);
+		}
+		mw_mirth_main_Arguments_packageZ_searchZ_pathsZBang();
+		decref(var_f);
 	}
 }
 static void mw_mirth_main_Arguments_packages (void) {
 	VAL v = pop_value();
 	ASSERT1(IS_TUP(v), v);
-	ASSERT1(VTUPLEN(v) == 6, v);
+	ASSERT1(VTUPLEN(v) == 7, v);
 	VAL* p = &VTUP(v)->cells[4];
 	VAL u = *p;
 	incref(u);
@@ -45887,22 +45972,23 @@ static void mw_mirth_main_Arguments_packagesZBang (void) {
 	VAL v = pop_value();
 	VAL u = pop_value();
 	ASSERT1(IS_TUP(v), v);
-	ASSERT1(VTUPLEN(v) == 6, v);
+	ASSERT1(VTUPLEN(v) == 7, v);
 	if (VTUP(v)->refs == 1) {
 		VAL* p = &VTUP(v)->cells[4];
 		VAL t = *p; *p = u; decref(t);
 		push_value(v);
 	} else {
-		TUP *tup = tup_new(6);
-		tup->size = 6;
+		TUP *tup = tup_new(7);
+		tup->size = 7;
 		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
 		tup->cells[1] = VTUP(v)->cells[1]; incref(tup->cells[1]);
 		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
 		tup->cells[3] = VTUP(v)->cells[3]; incref(tup->cells[3]);
 		tup->cells[4] = u;
 		tup->cells[5] = VTUP(v)->cells[5]; incref(tup->cells[5]);
+		tup->cells[6] = VTUP(v)->cells[6]; incref(tup->cells[6]);
 		decref(v);
-		push_value(MKTUP(tup,6));
+		push_value(MKTUP(tup,7));
 	}
 }
 static void mw_mirth_main_Arguments_packages_1 (void) {
@@ -45923,7 +46009,7 @@ static void mw_mirth_main_Arguments_packages_1 (void) {
 static void mw_mirth_main_Arguments_entryZ_point (void) {
 	VAL v = pop_value();
 	ASSERT1(IS_TUP(v), v);
-	ASSERT1(VTUPLEN(v) == 6, v);
+	ASSERT1(VTUPLEN(v) == 7, v);
 	VAL* p = &VTUP(v)->cells[3];
 	VAL u = *p;
 	incref(u);
@@ -45934,22 +46020,23 @@ static void mw_mirth_main_Arguments_entryZ_pointZBang (void) {
 	VAL v = pop_value();
 	VAL u = pop_value();
 	ASSERT1(IS_TUP(v), v);
-	ASSERT1(VTUPLEN(v) == 6, v);
+	ASSERT1(VTUPLEN(v) == 7, v);
 	if (VTUP(v)->refs == 1) {
 		VAL* p = &VTUP(v)->cells[3];
 		VAL t = *p; *p = u; decref(t);
 		push_value(v);
 	} else {
-		TUP *tup = tup_new(6);
-		tup->size = 6;
+		TUP *tup = tup_new(7);
+		tup->size = 7;
 		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
 		tup->cells[1] = VTUP(v)->cells[1]; incref(tup->cells[1]);
 		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
 		tup->cells[3] = u;
 		tup->cells[4] = VTUP(v)->cells[4]; incref(tup->cells[4]);
 		tup->cells[5] = VTUP(v)->cells[5]; incref(tup->cells[5]);
+		tup->cells[6] = VTUP(v)->cells[6]; incref(tup->cells[6]);
 		decref(v);
-		push_value(MKTUP(tup,6));
+		push_value(MKTUP(tup,7));
 	}
 }
 static void mw_mirth_main_Arguments_entryZ_point_1 (void) {
@@ -45970,7 +46057,7 @@ static void mw_mirth_main_Arguments_entryZ_point_1 (void) {
 static void mw_mirth_main_Arguments_outputZ_file (void) {
 	VAL v = pop_value();
 	ASSERT1(IS_TUP(v), v);
-	ASSERT1(VTUPLEN(v) == 6, v);
+	ASSERT1(VTUPLEN(v) == 7, v);
 	VAL* p = &VTUP(v)->cells[2];
 	VAL u = *p;
 	incref(u);
@@ -45981,22 +46068,23 @@ static void mw_mirth_main_Arguments_outputZ_fileZBang (void) {
 	VAL v = pop_value();
 	VAL u = pop_value();
 	ASSERT1(IS_TUP(v), v);
-	ASSERT1(VTUPLEN(v) == 6, v);
+	ASSERT1(VTUPLEN(v) == 7, v);
 	if (VTUP(v)->refs == 1) {
 		VAL* p = &VTUP(v)->cells[2];
 		VAL t = *p; *p = u; decref(t);
 		push_value(v);
 	} else {
-		TUP *tup = tup_new(6);
-		tup->size = 6;
+		TUP *tup = tup_new(7);
+		tup->size = 7;
 		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
 		tup->cells[1] = VTUP(v)->cells[1]; incref(tup->cells[1]);
 		tup->cells[2] = u;
 		tup->cells[3] = VTUP(v)->cells[3]; incref(tup->cells[3]);
 		tup->cells[4] = VTUP(v)->cells[4]; incref(tup->cells[4]);
 		tup->cells[5] = VTUP(v)->cells[5]; incref(tup->cells[5]);
+		tup->cells[6] = VTUP(v)->cells[6]; incref(tup->cells[6]);
 		decref(v);
-		push_value(MKTUP(tup,6));
+		push_value(MKTUP(tup,7));
 	}
 }
 static void mw_mirth_main_Arguments_outputZ_file_1 (void) {
@@ -46017,7 +46105,7 @@ static void mw_mirth_main_Arguments_outputZ_file_1 (void) {
 static void mw_mirth_main_Arguments_inputZ_file (void) {
 	VAL v = pop_value();
 	ASSERT1(IS_TUP(v), v);
-	ASSERT1(VTUPLEN(v) == 6, v);
+	ASSERT1(VTUPLEN(v) == 7, v);
 	VAL* p = &VTUP(v)->cells[1];
 	VAL u = *p;
 	incref(u);
@@ -46028,22 +46116,23 @@ static void mw_mirth_main_Arguments_inputZ_fileZBang (void) {
 	VAL v = pop_value();
 	VAL u = pop_value();
 	ASSERT1(IS_TUP(v), v);
-	ASSERT1(VTUPLEN(v) == 6, v);
+	ASSERT1(VTUPLEN(v) == 7, v);
 	if (VTUP(v)->refs == 1) {
 		VAL* p = &VTUP(v)->cells[1];
 		VAL t = *p; *p = u; decref(t);
 		push_value(v);
 	} else {
-		TUP *tup = tup_new(6);
-		tup->size = 6;
+		TUP *tup = tup_new(7);
+		tup->size = 7;
 		tup->cells[0] = VTUP(v)->cells[0]; incref(tup->cells[0]);
 		tup->cells[1] = u;
 		tup->cells[2] = VTUP(v)->cells[2]; incref(tup->cells[2]);
 		tup->cells[3] = VTUP(v)->cells[3]; incref(tup->cells[3]);
 		tup->cells[4] = VTUP(v)->cells[4]; incref(tup->cells[4]);
 		tup->cells[5] = VTUP(v)->cells[5]; incref(tup->cells[5]);
+		tup->cells[6] = VTUP(v)->cells[6]; incref(tup->cells[6]);
 		decref(v);
-		push_value(MKTUP(tup,6));
+		push_value(MKTUP(tup,7));
 	}
 }
 static void mw_mirth_main_Arguments_inputZ_file_1 (void) {
@@ -46073,13 +46162,20 @@ static void mw_mirth_main_Arguments_default (void) {
 	LPUSH(lbl_entryZ_point);
 	push_u64(0LL); // Nil
 	LPUSH(lbl_packages);
+	STRLIT("lib", 3);
+	push_u64(0LL); // Nil
+	mtw_std_list_List_1_Cons();
+	LPUSH(lbl_packageZ_searchZ_paths);
 	mtw_mirth_main_Arguments_Arguments();
 }
 static void mw_mirth_main_compileZBang (void) {
 	mw_mirth_main_Arguments_ZDivArguments();
+	LPOP(lbl_packageZ_searchZ_paths);
+	push_fnptr(&mb_mirth_main_compileZBang_0);
+	mw_mirth_mirth_ZPlusMirth_packageZ_searchZ_paths_1();
 	{
 		VAL d2 = pop_resource();
-		push_fnptr(&mb_mirth_main_compileZBang_1);
+		push_fnptr(&mb_mirth_main_compileZBang_2);
 		mw_std_str_Str_1();
 		STRLIT("\n", 1);
 		mp_primZ_strZ_cat();
@@ -46087,13 +46183,13 @@ static void mw_mirth_main_compileZBang (void) {
 		push_resource(d2);
 	}
 	LPOP(lbl_packages);
-	push_fnptr(&mb_mirth_main_compileZBang_2);
+	push_fnptr(&mb_mirth_main_compileZBang_3);
 	mw_std_list_List_1_for_1();
 	LPOP(lbl_inputZ_file);
 	mw_mirth_lexer_runZ_lexerZBang();
 	{
 		VAL d2 = pop_resource();
-		push_fnptr(&mb_mirth_main_compileZBang_4);
+		push_fnptr(&mb_mirth_main_compileZBang_5);
 		mw_std_str_Str_1();
 		STRLIT("\n", 1);
 		mp_primZ_strZ_cat();
@@ -46139,7 +46235,7 @@ static void mw_mirth_main_compileZBang (void) {
 		mw_mirth_mirth_ZPlusMirth_numZ_errors();
 		{
 			VAL d3 = pop_resource();
-			push_fnptr(&mb_mirth_main_compileZBang_10);
+			push_fnptr(&mb_mirth_main_compileZBang_11);
 			mw_std_str_Str_1();
 			STRLIT("\n", 1);
 			mp_primZ_strZ_cat();
@@ -46151,7 +46247,7 @@ static void mw_mirth_main_compileZBang (void) {
 	} else {
 		{
 			VAL d3 = pop_resource();
-			push_fnptr(&mb_mirth_main_compileZBang_12);
+			push_fnptr(&mb_mirth_main_compileZBang_13);
 			mw_std_str_Str_1();
 			STRLIT("\n", 1);
 			mp_primZ_strZ_cat();
@@ -46290,13 +46386,35 @@ static void mw_mirth_main_compilerZ_parseZ_args (void) {
 					push_fnptr(&mb_mirth_main_compilerZ_parseZ_args_5);
 					mw_mirth_main_Arguments_packages_1();
 					break;
+				case 80LL: // B'P'
+					(void)pop_u64();
+					{
+						VAL d6 = pop_value();
+						switch (get_top_data_tag()) {
+							case 1LL: // Some
+								mtp_std_maybe_Maybe_1_Some();
+								break;
+							case 0LL: // None
+								(void)pop_u64();
+								STRLIT("tried to unwrap None", 20);
+								mw_std_prelude_panicZBang();
+								break;
+							default:
+								push_value(mkstr("unexpected fallthrough in match\n", 32)); 
+								mp_primZ_panic();
+						}
+						push_value(d6);
+					}
+					push_fnptr(&mb_mirth_main_compilerZ_parseZ_args_7);
+					mw_mirth_main_Arguments_packageZ_searchZ_paths_1();
+					break;
 				default:
 					mp_primZ_drop();
 					mp_primZ_swap();
 					mp_primZ_drop();
 					push_u64(4LL); // UnknownArg
 					mtw_std_maybe_Maybe_1_Some();
-					push_fnptr(&mb_mirth_main_compilerZ_parseZ_args_6);
+					push_fnptr(&mb_mirth_main_compilerZ_parseZ_args_8);
 					mw_argZ_parser_types_ZPlusArgumentParser_1_state_1();
 					break;
 			}
@@ -46309,7 +46427,7 @@ static void mw_mirth_main_compilerZ_parseZ_args (void) {
 			push_i64(0LL);
 			mp_primZ_intZ_eq();
 			if (pop_u64()) {
-				push_fnptr(&mb_mirth_main_compilerZ_parseZ_args_9);
+				push_fnptr(&mb_mirth_main_compilerZ_parseZ_args_11);
 				mw_mirth_main_Arguments_inputZ_file_1();
 			} else {
 				{
@@ -46319,7 +46437,7 @@ static void mw_mirth_main_compilerZ_parseZ_args (void) {
 				}
 				push_u64(2LL); // TooManyArgs
 				mtw_std_maybe_Maybe_1_Some();
-				push_fnptr(&mb_mirth_main_compilerZ_parseZ_args_11);
+				push_fnptr(&mb_mirth_main_compilerZ_parseZ_args_13);
 				mw_argZ_parser_types_ZPlusArgumentParser_1_state_1();
 			}
 			break;
@@ -46382,7 +46500,7 @@ static void mw_mirth_main_compilerZ_parseZ_args (void) {
 				mp_primZ_drop();
 				push_u64(4LL); // UnknownArg
 				mtw_std_maybe_Maybe_1_Some();
-				push_fnptr(&mb_mirth_main_compilerZ_parseZ_args_14);
+				push_fnptr(&mb_mirth_main_compilerZ_parseZ_args_16);
 				mw_argZ_parser_types_ZPlusArgumentParser_1_state_1();
 			}
 			break;
@@ -46395,7 +46513,7 @@ static void mw_mirth_main_compilerZ_parseZ_args (void) {
 			if (pop_u64()) {
 				push_u64(3LL); // TooFewArgs
 				mtw_std_maybe_Maybe_1_Some();
-				push_fnptr(&mb_mirth_main_compilerZ_parseZ_args_16);
+				push_fnptr(&mb_mirth_main_compilerZ_parseZ_args_18);
 				mw_argZ_parser_types_ZPlusArgumentParser_1_state_1();
 			} else {
 			}
@@ -46419,7 +46537,7 @@ static void mw_mirth_main_compilerZ_parseZ_args (void) {
 							STRLIT("output-file", 11);
 							mtw_argZ_parser_types_ArgumentParsingError_MissingArg();
 							mtw_std_maybe_Maybe_1_Some();
-							push_fnptr(&mb_mirth_main_compilerZ_parseZ_args_19);
+							push_fnptr(&mb_mirth_main_compilerZ_parseZ_args_21);
 							mw_argZ_parser_types_ZPlusArgumentParser_1_state_1();
 							break;
 						case 0LL: // None
@@ -46552,6 +46670,22 @@ static void mb_mirth_main_main_0 (void) {
 	LPUSH(lbl_group);
 	mtw_argZ_parser_types_ArgpOption_ArgpOption();
 	mw_std_list_ZPlusList_1_pushZBang();
+	STRLIT("package-search-path", 19);
+	mtw_std_maybe_Maybe_1_Some();
+	LPUSH(lbl_name);
+	push_u64(80LL); // B'P'
+	mtw_argZ_parser_types_ArgpOptionType_Short();
+	LPUSH(lbl_flagZ_type);
+	STRLIT("SEARCH_PATH*", 12);
+	mtw_std_maybe_Maybe_1_Some();
+	LPUSH(lbl_argZ_doc);
+	STRLIT("Package search paths", 20);
+	mtw_std_maybe_Maybe_1_Some();
+	LPUSH(lbl_doc);
+	push_u64(0LL); // None
+	LPUSH(lbl_group);
+	mtw_argZ_parser_types_ArgpOption_ArgpOption();
+	mw_std_list_ZPlusList_1_pushZBang();
 	STRLIT("debug", 5);
 	mtw_std_maybe_Maybe_1_Some();
 	LPUSH(lbl_name);
@@ -46607,7 +46741,10 @@ static void mb_mirth_specializzer_SPKey_ZToStr_2 (void) {
 	mw_std_str_ZPlusStr_pushZ_strZBang();
 	STRLIT(",", 1);
 }
-static void mb_mirth_main_compileZBang_1 (void) {
+static void mb_mirth_main_compileZBang_0 (void) {
+	mp_primZ_drop();
+}
+static void mb_mirth_main_compileZBang_2 (void) {
 	STRLIT("Compiling ", 10);
 	mw_std_str_ZPlusStr_pushZ_strZBang();
 	LPOP(lbl_inputZ_file);
@@ -46615,18 +46752,18 @@ static void mb_mirth_main_compileZBang_1 (void) {
 	LPUSH(lbl_inputZ_file);
 	mw_std_path_Path_pathZThen();
 }
-static void mb_mirth_main_compileZBang_2 (void) {
+static void mb_mirth_main_compileZBang_3 (void) {
 	mw_std_prelude_unpack2();
 	mp_primZ_swap();
 	mw_std_prim_Str_ZToName();
 	mw_mirth_package_Package_newZ_orZ_pathZBang();
 	mp_primZ_drop();
 }
-static void mb_mirth_main_compileZBang_4 (void) {
+static void mb_mirth_main_compileZBang_5 (void) {
 	STRLIT("Building.", 9);
 	mw_std_str_ZPlusStr_pushZ_strZBang();
 }
-static void mb_mirth_main_compileZBang_10 (void) {
+static void mb_mirth_main_compileZBang_11 (void) {
 	push_u64(31LL); // FGRed
 	mw_std_terminal_Sgr_emitZThen();
 	mp_primZ_intZ_toZ_str();
@@ -46636,7 +46773,7 @@ static void mb_mirth_main_compileZBang_10 (void) {
 	push_u64(0LL); // Reset
 	mw_std_terminal_Sgr_emitZThen();
 }
-static void mb_mirth_main_compileZBang_12 (void) {
+static void mb_mirth_main_compileZBang_13 (void) {
 	push_u64(32LL); // FGGreen
 	mw_std_terminal_Sgr_emitZThen();
 	STRLIT("No errors.", 10);
@@ -46754,10 +46891,13 @@ static void mb_mirth_main_compilerZ_parseZ_args_3 (void) {
 static void mb_mirth_main_compilerZ_parseZ_args_5 (void) {
 	mtw_std_list_List_1_Cons();
 }
-static void mb_mirth_main_compilerZ_parseZ_args_6 (void) {
+static void mb_mirth_main_compilerZ_parseZ_args_7 (void) {
+	mtw_std_list_List_1_Cons();
+}
+static void mb_mirth_main_compilerZ_parseZ_args_8 (void) {
 	mw_argZ_parser_state_State_1_errorZBang();
 }
-static void mb_mirth_main_compilerZ_parseZ_args_9 (void) {
+static void mb_mirth_main_compilerZ_parseZ_args_11 (void) {
 	mp_primZ_drop();
 	switch (get_top_data_tag()) {
 		case 1LL: // Some
@@ -46773,16 +46913,16 @@ static void mb_mirth_main_compilerZ_parseZ_args_9 (void) {
 			mp_primZ_panic();
 	}
 }
-static void mb_mirth_main_compilerZ_parseZ_args_11 (void) {
-	mw_argZ_parser_state_State_1_errorZBang();
-}
-static void mb_mirth_main_compilerZ_parseZ_args_14 (void) {
+static void mb_mirth_main_compilerZ_parseZ_args_13 (void) {
 	mw_argZ_parser_state_State_1_errorZBang();
 }
 static void mb_mirth_main_compilerZ_parseZ_args_16 (void) {
 	mw_argZ_parser_state_State_1_errorZBang();
 }
-static void mb_mirth_main_compilerZ_parseZ_args_19 (void) {
+static void mb_mirth_main_compilerZ_parseZ_args_18 (void) {
+	mw_argZ_parser_state_State_1_errorZBang();
+}
+static void mb_mirth_main_compilerZ_parseZ_args_21 (void) {
 	mw_argZ_parser_state_State_1_errorZBang();
 }
 static void mb_mirth_specializzer_SPKey_ZEqualZEqual_1 (void) {
@@ -48336,11 +48476,6 @@ static void mb_mirth_arrow_Block_qname_0 (void) {
 	}
 }
 static void mb_mirth_package_Package_pathZ_orZ_search_0 (void) {
-	STRLIT("lib", 3);
-	push_u64(0LL); // Nil
-	mtw_std_list_List_1_Cons();
-}
-static void mb_mirth_package_Package_pathZ_orZ_search_1 (void) {
 	{
 		VAL d2 = pop_value();
 		mp_primZ_dup();
@@ -48351,8 +48486,12 @@ static void mb_mirth_package_Package_pathZ_orZ_search_1 (void) {
 	mw_mirth_name_Name_ZToStr();
 	mw_std_path_Path_join();
 }
-static void mb_mirth_package_Package_pathZ_orZ_search_2 (void) {
-	mw_std_prim_ZPlusWorld_isZ_directoryZAsk();
+static void mb_mirth_package_Package_pathZ_orZ_search_1 (void) {
+	{
+		VAL d2 = pop_resource();
+		mw_std_prim_ZPlusWorld_isZ_directoryZAsk();
+		push_resource(d2);
+	}
 }
 static void mb_mirth_package_Package_pathZBang_2 (void) {
 	STRLIT("Tried to set different path for the same package.", 49);
@@ -50253,7 +50392,7 @@ static void mb_mirth_elab_elabZ_patternZ_atomZBang_16 (void) {
 static void mb_mirth_elab_elabZ_moduleZ_declZBang_1 (void) {
 	mw_mirth_def_Def_primZAsk();
 }
-static void mb_mirth_elab_checkZ_moduleZ_path_2 (void) {
+static void mb_mirth_elab_checkZ_moduleZ_path_1 (void) {
 	push_u64(46LL); // BDOT
 	mw_std_byte_Byte_ZEqualZEqual();
 }

--- a/src/elab.mth
+++ b/src/elab.mth
@@ -1247,7 +1247,7 @@ def elab-module-header! [ +World +Mirth Token -- +World +Mirth Token ] {
 def check-module-path [ Token Module +World +Mirth -- +World +Mirth ] {
     dup path split-last match(
         None ->
-            swap qname rdip:to-module-path dup2 == else(
+            swap qname to-module-path dup2 == else(
                 "expected module name to match path\n" swap >Str cat "\n" cat swap >Str cat emit-fatal-error!
             ) drop3,
 
@@ -1289,7 +1289,7 @@ def load-module [ Token QName +World +Mirth -- Token Module +World +Mirth ] {
     dup def-soft? match(
         Some -> module? unwrap(drop "module name already taken" emit-fatal-error!) nip,
         None ->
-            rdip:to-module-path run-lexer!
+            to-module-path run-lexer!
             elab-module!
                 # TODO: avoid elaborating here,
                 # use a single loop to dispatch top-level module elaboration.

--- a/src/main.mth
+++ b/src/main.mth
@@ -38,6 +38,7 @@ data(Arguments, Arguments ->
     output-file: Maybe(Path)
     entry-point: Maybe(Str)
     packages: List([Str Path])
+    package-search-paths: List(Path)
     emit-debug-info: Bool)
 
 ||| Create a default initialized arguments table
@@ -48,6 +49,7 @@ def(Arguments.default, -- Arguments,
     None >output-file
     "main" Some >entry-point
     L0 >packages
+    "lib" Path L1 >package-search-paths
     Arguments)
 
 ||| Pretty print the contents of the arguments struct
@@ -59,6 +61,7 @@ def(Arguments.show;, Arguments +Str -- +Str,
     ", entry-point: " ; entry-point> show;:show;
     ", emit-debug-info: " ; emit-debug-info> show;
     ", packages: " ; packages> show;:pack2-show;(show;,show;)
+    ", package-search-path: " ; package-search-paths> show;:show;
     " }" ;)
 
 ########
@@ -67,6 +70,7 @@ def(Arguments.show;, Arguments +Str -- +Str,
 
 def(compile!, Arguments +World +Mirth -- +World +Mirth,
     /Arguments
+    package-search-paths> package-search-paths:drop
     rdip:trace("Compiling "; @input-file path;)
     packages> for(
         unpack2 swap >Name Package.new-or-path! drop
@@ -113,6 +117,7 @@ def(compiler-parse-args, +ArgumentParser(Arguments) Arguments Maybe(Str) ArgpOpt
         B'e' -> entry-point(drop unwrap Some),
         B'c' -> entry-point(drop drop None),
         B'p' -> dip(unwrap parse-package-def) packages(cons),
+	B'P' -> dip(unwrap >Path) package-search-paths(cons),
         _ -> drop swap drop UnknownArg Some state:error!
     ),
     Positional -> swap state positional-index 0= if(
@@ -167,6 +172,13 @@ def(main, +World -- +World,
         "Package locations" Some >doc
         None >group
         ArgpOption ;
+
+	"package-search-path" Some >name
+	B'P' Short >flag-type
+	"SEARCH_PATH*" Some >arg-doc
+	"Package search paths" Some >doc
+	None >group
+	ArgpOption ;
 
         "debug" Some >name
         "debug" LongOnly >flag-type

--- a/src/main.mth
+++ b/src/main.mth
@@ -137,8 +137,9 @@ def(compiler-parse-args, +ArgumentParser(Arguments) Arguments Maybe(Str) ArgpOpt
                 "output-file" MissingArg Some state:error!
             )
         )
+
 	state arguments package-search-paths empty? then(
-	  "lib" >Path L1 state:arguments:package-search-paths!
+	  dip(LIST("lib" >Path ;) swap package-search-paths!)
 	)
         drop,
     _ -> drop drop UnknownArg Some state error! state!)
@@ -199,8 +200,6 @@ def(main, +World -- +World,
         Right -> ,
         Left -> rdip:trace(unpack2 ; emit;) 1 posix-exit!
     )
-
-    dup rdip:print(show;)
 
     compile!
     rdrop)

--- a/src/main.mth
+++ b/src/main.mth
@@ -49,7 +49,7 @@ def(Arguments.default, -- Arguments,
     None >output-file
     "main" Some >entry-point
     L0 >packages
-    "lib" Path L1 >package-search-paths
+    L0 >package-search-paths
     Arguments)
 
 ||| Pretty print the contents of the arguments struct
@@ -137,6 +137,9 @@ def(compiler-parse-args, +ArgumentParser(Arguments) Arguments Maybe(Str) ArgpOpt
                 "output-file" MissingArg Some state:error!
             )
         )
+	state arguments package-search-paths empty? then(
+	  "lib" >Path L1 state:arguments:package-search-paths!
+	)
         drop,
     _ -> drop drop UnknownArg Some state error! state!)
 
@@ -196,6 +199,8 @@ def(main, +World -- +World,
         Right -> ,
         Left -> rdip:trace(unpack2 ; emit;) 1 posix-exit!
     )
+
+    dup rdip:print(show;)
 
     compile!
     rdrop)

--- a/src/mirth.mth
+++ b/src/mirth.mth
@@ -8,6 +8,7 @@ import(std.str)
 import(std.terminal)
 import(std.maybe)
 import(std.output)
+import(std.path)
 
 import(mirth.mirth)
 import(mirth.location)
@@ -25,7 +26,7 @@ import(mirth.type)
 import(mirth.typedef)
 import(mirth.prim)
 
-data(Builtin, Builtin ->
+struct Builtin {
     std: Package
     prim: Module
     bool: Data  true: Tag   false: Tag
@@ -59,7 +60,7 @@ data(Builtin, Builtin ->
     crestrict:  Data  mk-crestrict:  Tag
     cvolatile:  Data  mk-cvolatile:  Tag
     cvoid:      Data  mk-cvoid:      Tag
-)
+}
 
 def(Builtin.alloc!, -- Builtin,
     Package.alloc! >std
@@ -98,20 +99,23 @@ def(Builtin.alloc!, -- Builtin,
 
     Builtin)
 
-data(+Mirth, +Mirth ->
+struct +Mirth {
     num-errors: Nat
     num-warnings: Nat
     prefer-inline-defs: Bool
     builtin: Builtin
     error-token: Maybe(Token)
+    package-search-paths: List(Path)
     +diagnostics: +List(Diagnostic)
-    +propstack: +List(PropLabel))
+    +propstack: +List(PropLabel)
+}
 
 def(+Mirth.init!, -- +Mirth,
     0 >Nat >num-errors
     0 >Nat >num-warnings
     False >prefer-inline-defs
     Builtin.alloc! >builtin
+    L0 >package-search-paths
     L0 thaw >+diagnostics
     L0 thaw >+propstack
     None >error-token
@@ -128,13 +132,15 @@ def(+Mirth.rdrop, +Mirth --,
     prefer-inline-defs> drop
     builtin> drop
     error-token> drop
+    package-search-paths> drop
     +diagnostics> freeze drop
     +propstack> freeze drop)
 
-data(Diagnostic, Diagnostic ->
+struct Diagnostic {
     severity: Severity
     location: Location
-    message: Str)
+    message: Str
+}
 
 data(Severity, Error, Warning, Info)
 def(Severity.>Str, Severity -- Str,

--- a/src/name.mth
+++ b/src/name.mth
@@ -239,7 +239,7 @@ def(QName.>Str, +Mirth QName -- +Mirth Str, MKQNAME ->
     name> >Str cat
     arity> dup 0= if(drop, dip:"/" show cat cat))
 
-def(QName.to-module-path, QName +World -- Path +World,
+def(QName.to-module-path, QName +World +Mirth -- Path +World +Mirth,
     dup namespace match(
         NAMESPACE_PACKAGE ->
             path-or-search unwrap("No path defined for package" panic!)

--- a/src/package.mth
+++ b/src/package.mth
@@ -18,21 +18,19 @@ def(Package.name, Package -- Name, ~name @)
 def(Package.qname, Package -- QName, NAMESPACE_ROOT swap name QNAME0)
 def(Package.path, Package -- Maybe(Path), ~path @)
 
-var(PACKAGE_SEARCH_PATH, List(Path))
-
 def(Package.std, +Mirth -- +Mirth Package, builtin std)
 def(init-packages!, +Mirth -- +Mirth,
     builtin std
     "std" >Name over ~name !
     None swap ~path !)
 
-def(Package.path-or-search, +World Package -- +World Maybe(Path),
+def(Package.path-or-search, +World +Mirth Package -- +World +Mirth Maybe(Path),
     dup path match(
         Some -> nip Some,
         None ->
-            PACKAGE_SEARCH_PATH memoize("lib" Path L1)
+            package-search-paths
             map(over name >Str >Path join)
-            find(is-directory?)
+            find(rdip:is-directory?)
             tuck swap ~path !
     ))
 


### PR DESCRIPTION
Replaces the existing PACKAGE_SEARCH_PATH variable with a field in the +Mirth resource and adds the `-P` command line flag to add items to it, without any package search path flags it defaults to `lib`. This also replaces the couple `data` definitions related to +Mirth with the struct syntax sugar, but that's easy to undo separately from the rest of the changes if not wanted.