### PR TITLE
Add default parameters for higher-order words.

### DIFF
--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -1097,6 +1097,8 @@ static STACK lbl_txs = {0};
 static STACK lbl_tys = {0};
 static STACK lbl_qname = {0};
 static STACK lbl_type = {0};
+static STACK lbl_cod = {0};
+static STACK lbl_dom = {0};
 static STACK lbl_data = {0};
 static STACK lbl_field = {0};
 static STACK lbl_labels = {0};
@@ -1104,8 +1106,6 @@ static STACK lbl_withses = {0};
 static STACK lbl_conses = {0};
 static STACK lbl_parts = {0};
 static STACK lbl_baseZAsk = {0};
-static STACK lbl_dom = {0};
-static STACK lbl_cod = {0};
 static STACK lbl_ctype = {0};
 static STACK lbl_tags = {0};
 static STACK lbl_params = {0};
@@ -2655,21 +2655,21 @@ static VAL mtp_mirth_type_StackType_STWithLabel (VAL in_StackType_1, VAL *out_Re
 	*out_Resource_3 = v6;
 	return v5;
 }
-static VAL mtw_mirth_type_ArrowType_ARROWz_TYPE (VAL in_StackType_1, VAL in_StackType_2) {
+static VAL mtw_mirth_type_ArrowType_ArrowType (VAL in_StackType_1, VAL in_StackType_2) {
 	TUP* v4 = tup_new(3);
 	v4->size = 3;
-	v4->cells[0] = MKI64(0LL /* ARROW_TYPE */);
+	v4->cells[0] = MKI64(0LL /* ArrowType */);
 	v4->cells[2] = in_StackType_2;
 	v4->cells[1] = in_StackType_1;
 	VAL v5 = MKTUP(v4, 3);
 	return v5;
 }
-static VAL mtp_mirth_type_ArrowType_ARROWz_TYPE (VAL in_ArrowType_1, VAL *out_StackType_3) {
+static void mtp_mirth_type_ArrowType_ArrowType (VAL in_ArrowType_1, VAL *out_StackType_2, VAL *out_StackType_3) {
 	VAL v4 = VTUP(in_ArrowType_1)->cells[1];
 	VAL v5 = VTUP(in_ArrowType_1)->cells[2];
 	tup_decref_outer(VTUP(in_ArrowType_1),3);
 	*out_StackType_3 = v5;
-	return v4;
+	*out_StackType_2 = v4;
 }
 static VAL mtw_mirth_type_Subst_SUBSTz_CON (VAL in_Subst_1, VAL in_Type_2, uint64_t in_Var_3) {
 	TUP* v5 = tup_new(4);
@@ -5123,11 +5123,8 @@ static VAL mw_mirth_type_StackType_freshenZ_aux (VAL in_StackType_1, VAL in_Subs
 static VAL mw_mirth_type_StackType_rigidifyZBang (VAL in_ZPlusMirth_1, VAL in_Ctx_2, VAL in_StackType_3, VAL *out_ZPlusMirth_4, VAL *out_StackType_6);
 static VAL mw_mirth_type_StackType_linearZ_baseZ_metaZAsk (VAL in_StackType_1);
 static VAL mw_mirth_type_StackType_linearZ_baseZ_varZAsk (VAL in_StackType_1);
-static VAL mw_mirth_type_ArrowType_ZToType (VAL in_ArrowType_1);
 static VAL mw_mirth_type_ArrowType_invert (VAL in_ArrowType_1);
 static VAL mw_mirth_type_ArrowType_unpack (VAL in_ArrowType_1, VAL *out_StackType_3);
-static VAL mw_mirth_type_ArrowType_dom (VAL in_ArrowType_1);
-static VAL mw_mirth_type_ArrowType_cod (VAL in_ArrowType_1);
 static VAL mw_mirth_type_ArrowType_unifyZBang (VAL in_ZPlusMirth_1, uint64_t in_ZPlusGamma_2, VAL in_ArrowType_3, VAL in_ArrowType_4, VAL *out_ZPlusMirth_5, uint64_t *out_ZPlusGamma_6);
 static VAL mw_mirth_type_ArrowType_unifyZ_errorZBang (VAL in_ZPlusMirth_1, uint64_t in_ZPlusGamma_2, VAL in_ArrowType_3, VAL *out_ZPlusMirth_4, uint64_t *out_ZPlusGamma_5);
 static int64_t mw_mirth_type_ArrowType_hasZ_metaZAsk (uint64_t in_MetaVar_1, VAL in_ArrowType_2);
@@ -12932,7 +12929,9 @@ static VAL mw_mirth_data_Tag_inputs (VAL in_ZPlusMirth_1, uint64_t in_Tag_2, VAL
 	} else {
 		VAL v11;
 		VAL v12 = mw_mirth_data_Tag_type(in_ZPlusMirth_1, in_Tag_2, &v11);
-		VAL v13 = mw_mirth_type_ArrowType_dom(v12);
+		VAL v13 = VTUP(v12)->cells[1];
+		incref(v13);
+		decref(v12);
 		VAL v14;
 		VAL v15 = mw_mirth_type_StackType_splitZ_parts(v13, &v14);
 		decref(v15);
@@ -15218,7 +15217,7 @@ static VAL mw_mirth_type_TZMulZPlus (VAL in_StackType_1, VAL in_Either_2) {
 	return branch_StackType_4;
 }
 static VAL mw_mirth_type_TZ_ZTo (VAL in_StackType_1, VAL in_StackType_2) {
-	VAL v4 = mtw_mirth_type_ArrowType_ARROWz_TYPE(in_StackType_1, in_StackType_2);
+	VAL v4 = mtw_mirth_type_ArrowType_ArrowType(in_StackType_1, in_StackType_2);
 	return v4;
 }
 static VAL mw_mirth_type_TT (VAL in_List_1) {
@@ -16282,7 +16281,7 @@ static VAL mw_mirth_type_Value_unifyZBang (VAL in_ZPlusMirth_1, uint64_t in_ZPlu
 						VAL v73;
 						uint64_t v74;
 						VAL v75 = mw_mirth_arrow_blockZ_unifyZ_typeZBang(v70, in_ZPlusGamma_2, v59, v72, &v73, &v74);
-						VAL v76 = mw_mirth_type_ArrowType_ZToType(v75);
+						VAL v76 = mtw_mirth_type_Type_TMorphism(v75);
 						branch_Type_67 = v76;
 						branch_ZPlusGamma_66 = v74;
 						branch_ZPlusMirth_65 = v73;
@@ -16531,7 +16530,7 @@ static VAL mw_mirth_type_Type_unifyZ_blockZBang (VAL in_ZPlusMirth_1, uint64_t i
 		case 3LL: { // TMeta
 			uint64_t v19 = mtp_mirth_type_Type_TMeta(v8);
 			VAL v20 = mw_mirth_arrow_Block_type(in_Block_3);
-			VAL v21 = mw_mirth_type_ArrowType_ZToType(v20);
+			VAL v21 = mtw_mirth_type_Type_TMorphism(v20);
 			VAL v22;
 			uint64_t v23;
 			VAL v24 = mw_mirth_type_MetaVar_unifyZBang(in_ZPlusMirth_1, in_ZPlusGamma_2, v21, v19, &v22, &v23);
@@ -16539,7 +16538,7 @@ static VAL mw_mirth_type_Type_unifyZ_blockZBang (VAL in_ZPlusMirth_1, uint64_t i
 			VAL v25;
 			VAL v26 = mw_mirth_arrow_Block_arrow(v22, in_Block_3, &v25);
 			VAL v27 = mw_mirth_arrow_Arrow_type(v26);
-			VAL v28 = mw_mirth_type_ArrowType_ZToType(v27);
+			VAL v28 = mtw_mirth_type_Type_TMorphism(v27);
 			branch_Type_11 = v28;
 			branch_ZPlusGamma_10 = v23;
 			branch_ZPlusMirth_9 = v25;
@@ -16549,14 +16548,14 @@ static VAL mw_mirth_type_Type_unifyZ_blockZBang (VAL in_ZPlusMirth_1, uint64_t i
 			VAL v30;
 			uint64_t v31;
 			VAL v32 = mw_mirth_arrow_blockZ_unifyZ_typeZBang(in_ZPlusMirth_1, in_ZPlusGamma_2, in_Block_3, v29, &v30, &v31);
-			VAL v33 = mw_mirth_type_ArrowType_ZToType(v32);
+			VAL v33 = mtw_mirth_type_Type_TMorphism(v32);
 			branch_Type_11 = v33;
 			branch_ZPlusGamma_10 = v31;
 			branch_ZPlusMirth_9 = v30;
 		} break;
 		default: {
 			VAL v34 = mw_mirth_arrow_Block_type(in_Block_3);
-			VAL v35 = mw_mirth_type_ArrowType_ZToType(v34);
+			VAL v35 = mtw_mirth_type_Type_TMorphism(v34);
 			VAL v36;
 			uint64_t v37;
 			VAL v38 = mw_mirth_type_Type_unifyZBang(in_ZPlusMirth_1, in_ZPlusGamma_2, v35, v8, &v36, &v37);
@@ -17042,7 +17041,7 @@ static VAL mw_mirth_type_Value_type (VAL in_Value_1) {
 		case 3LL: { // VALUE_BLOCK
 			uint64_t v13 = mtp_mirth_type_Value_VALUEz_BLOCK(in_Value_1);
 			VAL v14 = mw_mirth_arrow_Block_type(v13);
-			VAL v15 = mw_mirth_type_ArrowType_ZToType(v14);
+			VAL v15 = mtw_mirth_type_Type_TMorphism(v14);
 			branch_Type_3 = v15;
 		} break;
 		default: {
@@ -17421,7 +17420,7 @@ static VAL mw_mirth_type_Value_rigidifyZBang (VAL in_ZPlusMirth_1, VAL in_Ctx_2,
 			VAL v23;
 			VAL v24;
 			VAL v25 = mw_mirth_type_ArrowType_rigidifyZBang(v20, in_Ctx_2, v22, &v23, &v24);
-			VAL v26 = mw_mirth_type_ArrowType_ZToType(v24);
+			VAL v26 = mtw_mirth_type_Type_TMorphism(v24);
 			branch_Type_9 = v26;
 			branch_Ctx_8 = v25;
 			branch_ZPlusMirth_7 = v23;
@@ -20623,67 +20622,67 @@ static VAL mw_mirth_type_StackType_linearZ_baseZ_varZAsk (VAL in_StackType_1) {
 	}
 	return branch_Maybe_3;
 }
-static VAL mw_mirth_type_ArrowType_ZToType (VAL in_ArrowType_1) {
-	VAL v3 = mtw_mirth_type_Type_TMorphism(in_ArrowType_1);
-	return v3;
-}
 static VAL mw_mirth_type_ArrowType_invert (VAL in_ArrowType_1) {
 	VAL v3;
-	VAL v4 = mtp_mirth_type_ArrowType_ARROWz_TYPE(in_ArrowType_1, &v3);
-	VAL v5 = mtw_mirth_type_ArrowType_ARROWz_TYPE(v3, v4);
+	VAL v4;
+	mtp_mirth_type_ArrowType_ArrowType(in_ArrowType_1, &v3, &v4);
+	VAL v5 = mtw_mirth_type_ArrowType_ArrowType(v4, v3);
 	return v5;
 }
 static VAL mw_mirth_type_ArrowType_unpack (VAL in_ArrowType_1, VAL *out_StackType_3) {
-	VAL v4;
-	VAL v5 = mtp_mirth_type_ArrowType_ARROWz_TYPE(in_ArrowType_1, &v4);
-	*out_StackType_3 = v4;
-	return v5;
-}
-static VAL mw_mirth_type_ArrowType_dom (VAL in_ArrowType_1) {
-	VAL v3;
-	VAL v4 = mw_mirth_type_ArrowType_unpack(in_ArrowType_1, &v3);
-	decref(v3);
+	incref(in_ArrowType_1);
+	VAL v4 = VTUP(in_ArrowType_1)->cells[1];
+	incref(v4);
+	decref(in_ArrowType_1);
+	VAL v5 = VTUP(in_ArrowType_1)->cells[2];
+	incref(v5);
+	decref(in_ArrowType_1);
+	*out_StackType_3 = v5;
 	return v4;
-}
-static VAL mw_mirth_type_ArrowType_cod (VAL in_ArrowType_1) {
-	VAL v3;
-	VAL v4 = mw_mirth_type_ArrowType_unpack(in_ArrowType_1, &v3);
-	decref(v4);
-	return v3;
 }
 static VAL mw_mirth_type_ArrowType_unifyZBang (VAL in_ZPlusMirth_1, uint64_t in_ZPlusGamma_2, VAL in_ArrowType_3, VAL in_ArrowType_4, VAL *out_ZPlusMirth_5, uint64_t *out_ZPlusGamma_6) {
 	VAL v8;
-	VAL v9 = mw_mirth_type_ArrowType_unpack(in_ArrowType_3, &v8);
+	VAL v9;
+	mtp_mirth_type_ArrowType_ArrowType(in_ArrowType_3, &v8, &v9);
 	VAL v10;
-	VAL v11 = mw_mirth_type_ArrowType_unpack(in_ArrowType_4, &v10);
+	VAL v11;
+	mtp_mirth_type_ArrowType_ArrowType(in_ArrowType_4, &v10, &v11);
 	VAL v12;
 	uint64_t v13;
-	VAL v14 = mw_mirth_type_StackType_unifyZBang(in_ZPlusMirth_1, in_ZPlusGamma_2, v9, v11, &v12, &v13);
+	VAL v14 = mw_mirth_type_StackType_unifyZBang(in_ZPlusMirth_1, in_ZPlusGamma_2, v10, v8, &v12, &v13);
 	VAL v15;
 	uint64_t v16;
-	VAL v17 = mw_mirth_type_StackType_unifyZBang(v12, v13, v8, v10, &v15, &v16);
-	VAL v18 = mtw_mirth_type_ArrowType_ARROWz_TYPE(v14, v17);
+	VAL v17 = mw_mirth_type_StackType_unifyZBang(v12, v13, v11, v9, &v15, &v16);
+	VAL v18 = mtw_mirth_type_ArrowType_ArrowType(v14, v17);
 	*out_ZPlusGamma_6 = v16;
 	*out_ZPlusMirth_5 = v15;
 	return v18;
 }
 static VAL mw_mirth_type_ArrowType_unifyZ_errorZBang (VAL in_ZPlusMirth_1, uint64_t in_ZPlusGamma_2, VAL in_ArrowType_3, VAL *out_ZPlusMirth_4, uint64_t *out_ZPlusGamma_5) {
-	VAL v7;
-	VAL v8 = mw_mirth_type_ArrowType_unpack(in_ArrowType_3, &v7);
-	VAL v9;
-	uint64_t v10;
-	VAL v11 = mw_mirth_type_StackType_unifyZ_errorZBang(in_ZPlusMirth_1, in_ZPlusGamma_2, v8, &v9, &v10);
-	VAL v12;
-	uint64_t v13;
-	VAL v14 = mw_mirth_type_StackType_unifyZ_errorZBang(v9, v10, v7, &v12, &v13);
-	VAL v15 = mtw_mirth_type_ArrowType_ARROWz_TYPE(v11, v14);
-	*out_ZPlusGamma_5 = v13;
-	*out_ZPlusMirth_4 = v12;
-	return v15;
+	incref(in_ArrowType_3);
+	VAL v7 = VTUP(in_ArrowType_3)->cells[1];
+	incref(v7);
+	decref(in_ArrowType_3);
+	VAL v8;
+	uint64_t v9;
+	VAL v10 = mw_mirth_type_StackType_unifyZ_errorZBang(in_ZPlusMirth_1, in_ZPlusGamma_2, v7, &v8, &v9);
+	VAL v11 = tup_replace(in_ArrowType_3, 1, v10);
+	incref(v11);
+	VAL v12 = VTUP(v11)->cells[2];
+	incref(v12);
+	decref(v11);
+	VAL v13;
+	uint64_t v14;
+	VAL v15 = mw_mirth_type_StackType_unifyZ_errorZBang(v8, v9, v12, &v13, &v14);
+	VAL v16 = tup_replace(v11, 2, v15);
+	*out_ZPlusGamma_5 = v14;
+	*out_ZPlusMirth_4 = v13;
+	return v16;
 }
 static int64_t mw_mirth_type_ArrowType_hasZ_metaZAsk (uint64_t in_MetaVar_1, VAL in_ArrowType_2) {
 	VAL v4;
-	VAL v5 = mw_mirth_type_ArrowType_unpack(in_ArrowType_2, &v4);
+	VAL v5;
+	mtp_mirth_type_ArrowType_ArrowType(in_ArrowType_2, &v4, &v5);
 	int64_t v6 = mw_mirth_type_StackType_hasZ_metaZAsk(in_MetaVar_1, v4);
 	int64_t branch_Bool_7;
 	if (((bool)v6)) {
@@ -20698,7 +20697,8 @@ static int64_t mw_mirth_type_ArrowType_hasZ_metaZAsk (uint64_t in_MetaVar_1, VAL
 }
 static int64_t mw_mirth_type_ArrowType_hasZ_varZAsk (uint64_t in_Var_1, VAL in_ArrowType_2) {
 	VAL v4;
-	VAL v5 = mw_mirth_type_ArrowType_unpack(in_ArrowType_2, &v4);
+	VAL v5;
+	mtp_mirth_type_ArrowType_ArrowType(in_ArrowType_2, &v4, &v5);
 	int64_t v6 = mw_mirth_type_StackType_hasZ_varZAsk(in_Var_1, v4);
 	int64_t branch_Bool_7;
 	if (((bool)v6)) {
@@ -20713,15 +20713,16 @@ static int64_t mw_mirth_type_ArrowType_hasZ_varZAsk (uint64_t in_Var_1, VAL in_A
 }
 static void mw_mirth_type_ArrowType_sigZThen (VAL in_ZPlusStr_1, VAL in_ArrowType_2, VAL *out_ZPlusStr_3) {
 	VAL v4;
-	VAL v5 = mw_mirth_type_ArrowType_unpack(in_ArrowType_2, &v4);
+	VAL v5;
+	mtp_mirth_type_ArrowType_ArrowType(in_ArrowType_2, &v4, &v5);
 	VAL v6;
-	mw_mirth_type_StackType_domZThen(in_ZPlusStr_1, v5, &v6);
+	mw_mirth_type_StackType_domZThen(in_ZPlusStr_1, v4, &v6);
 	STR* v7;
 	STRLIT(v7, "--", 2);
 	VAL v8;
 	mw_std_str_ZPlusStr_pushZ_strZBang(MKSTR(v7), v6, &v8);
 	VAL v9;
-	mw_mirth_type_StackType_codZThen(v8, v4, &v9);
+	mw_mirth_type_StackType_codZThen(v8, v5, &v9);
 	*out_ZPlusStr_3 = v9;
 }
 static VAL mw_mirth_type_ArrowType_semifreshenZ_sig (VAL in_ArrowType_1) {
@@ -20737,34 +20738,40 @@ static VAL mw_mirth_type_ArrowType_semifreshenZ_sig (VAL in_ArrowType_1) {
 	return branch_ArrowType_4;
 }
 static VAL mw_mirth_type_ArrowType_semifreshenZ_aux (VAL in_ArrowType_1) {
-	uint64_t v3 = mw_mirth_type_MetaVar_newZBang();
-	VAL v4 = mtw_mirth_type_StackType_STMeta(v3);
-	VAL v5;
-	VAL v6 = mw_mirth_type_ArrowType_unpack(in_ArrowType_1, &v5);
+	VAL v3;
+	VAL v4;
+	mtp_mirth_type_ArrowType_ArrowType(in_ArrowType_1, &v3, &v4);
+	uint64_t v5 = mw_mirth_type_MetaVar_newZBang();
+	VAL v6 = mtw_mirth_type_StackType_STMeta(v5);
 	VAL v7;
-	VAL v8 = mw_mirth_type_StackType_semifreshen(v4, v6, &v7);
+	VAL v8 = mw_mirth_type_StackType_semifreshen(v6, v4, &v7);
 	VAL v9;
-	VAL v10 = mw_mirth_type_StackType_semifreshen(v8, v5, &v9);
-	VAL v11 = mtw_mirth_type_ArrowType_ARROWz_TYPE(v7, v9);
+	VAL v10 = mw_mirth_type_StackType_semifreshen(v8, v3, &v9);
+	VAL v11 = mtw_mirth_type_ArrowType_ArrowType(v9, v7);
 	decref(v10);
 	return v11;
 }
 static int64_t mw_mirth_type_ArrowType_needsZ_freshZ_stackZ_restZAsk (VAL in_ArrowType_1) {
 	VAL v3;
-	VAL v4 = mw_mirth_type_ArrowType_unpack(in_ArrowType_1, &v3);
+	VAL v4;
+	mtp_mirth_type_ArrowType_ArrowType(in_ArrowType_1, &v3, &v4);
 	VAL v5 = mw_mirth_type_StackType_base(v3);
 	int64_t v6 = mw_mirth_type_StackType_unitZAsk(v5);
-	int64_t branch_Bool_7;
+	VAL branch_StackType_7;
+	int64_t branch_Bool_8;
 	if (((bool)v6)) {
-		VAL v8 = mw_mirth_type_StackType_base(v4);
-		int64_t v9 = mw_mirth_type_StackType_unitZAsk(v8);
-		branch_Bool_7 = v9;
+		incref(v4);
+		VAL v9 = mw_mirth_type_StackType_base(v4);
+		int64_t v10 = mw_mirth_type_StackType_unitZAsk(v9);
+		branch_Bool_8 = v10;
+		branch_StackType_7 = v4;
 	} else {
-		decref(v4);
-		int64_t v10 = 0LL /* False */;
-		branch_Bool_7 = v10;
+		int64_t v11 = 0LL /* False */;
+		branch_Bool_8 = v11;
+		branch_StackType_7 = v4;
 	}
-	return branch_Bool_7;
+	decref(branch_StackType_7);
+	return branch_Bool_8;
 }
 static VAL mw_mirth_type_ArrowType_freshenZ_sig (VAL in_Subst_1, VAL in_ArrowType_2, VAL *out_ArrowType_4) {
 	incref(in_ArrowType_2);
@@ -20786,42 +20793,45 @@ static VAL mw_mirth_type_ArrowType_freshenZ_sig (VAL in_Subst_1, VAL in_ArrowTyp
 	return branch_Subst_6;
 }
 static VAL mw_mirth_type_ArrowType_freshenZ_sigZ_aux (VAL in_Subst_1, VAL in_ArrowType_2, VAL *out_ArrowType_4) {
-	uint64_t v5 = mw_mirth_type_MetaVar_newZBang();
-	VAL v6 = mtw_mirth_type_StackType_STMeta(v5);
-	VAL v7;
-	VAL v8 = mw_mirth_type_ArrowType_unpack(in_ArrowType_2, &v7);
+	VAL v5;
+	VAL v6;
+	mtp_mirth_type_ArrowType_ArrowType(in_ArrowType_2, &v5, &v6);
+	uint64_t v7 = mw_mirth_type_MetaVar_newZBang();
+	VAL v8 = mtw_mirth_type_StackType_STMeta(v7);
 	VAL v9;
 	VAL v10;
-	VAL v11 = mw_mirth_type_StackType_freshenZ_aux(v6, in_Subst_1, v8, &v9, &v10);
+	VAL v11 = mw_mirth_type_StackType_freshenZ_aux(v8, in_Subst_1, v5, &v9, &v10);
 	VAL v12;
 	VAL v13;
-	VAL v14 = mw_mirth_type_StackType_freshenZ_aux(v11, v9, v7, &v12, &v13);
-	VAL v15 = mtw_mirth_type_ArrowType_ARROWz_TYPE(v10, v13);
+	VAL v14 = mw_mirth_type_StackType_freshenZ_aux(v11, v9, v6, &v12, &v13);
+	VAL v15 = mtw_mirth_type_ArrowType_ArrowType(v10, v13);
 	decref(v14);
 	*out_ArrowType_4 = v15;
 	return v12;
 }
 static VAL mw_mirth_type_ArrowType_freshen (VAL in_Subst_1, VAL in_ArrowType_2, VAL *out_ArrowType_4) {
 	VAL v5;
-	VAL v6 = mw_mirth_type_ArrowType_unpack(in_ArrowType_2, &v5);
+	VAL v6;
+	mtp_mirth_type_ArrowType_ArrowType(in_ArrowType_2, &v5, &v6);
 	VAL v7;
-	VAL v8 = mw_mirth_type_StackType_freshen(in_Subst_1, v6, &v7);
+	VAL v8 = mw_mirth_type_StackType_freshen(in_Subst_1, v5, &v7);
 	VAL v9;
-	VAL v10 = mw_mirth_type_StackType_freshen(v8, v5, &v9);
-	VAL v11 = mtw_mirth_type_ArrowType_ARROWz_TYPE(v7, v9);
+	VAL v10 = mw_mirth_type_StackType_freshen(v8, v6, &v9);
+	VAL v11 = mtw_mirth_type_ArrowType_ArrowType(v7, v9);
 	*out_ArrowType_4 = v11;
 	return v10;
 }
 static VAL mw_mirth_type_ArrowType_rigidifyZBang (VAL in_ZPlusMirth_1, VAL in_Ctx_2, VAL in_ArrowType_3, VAL *out_ZPlusMirth_4, VAL *out_ArrowType_6) {
 	VAL v7;
-	VAL v8 = mw_mirth_type_ArrowType_unpack(in_ArrowType_3, &v7);
+	VAL v8;
+	mtp_mirth_type_ArrowType_ArrowType(in_ArrowType_3, &v7, &v8);
 	VAL v9;
 	VAL v10;
-	VAL v11 = mw_mirth_type_StackType_rigidifyZBang(in_ZPlusMirth_1, in_Ctx_2, v8, &v9, &v10);
+	VAL v11 = mw_mirth_type_StackType_rigidifyZBang(in_ZPlusMirth_1, in_Ctx_2, v7, &v9, &v10);
 	VAL v12;
 	VAL v13;
-	VAL v14 = mw_mirth_type_StackType_rigidifyZBang(v9, v11, v7, &v12, &v13);
-	VAL v15 = mtw_mirth_type_ArrowType_ARROWz_TYPE(v10, v13);
+	VAL v14 = mw_mirth_type_StackType_rigidifyZBang(v9, v11, v8, &v12, &v13);
+	VAL v15 = mtw_mirth_type_ArrowType_ArrowType(v10, v13);
 	*out_ArrowType_6 = v15;
 	*out_ZPlusMirth_4 = v12;
 	return v14;
@@ -35477,7 +35487,7 @@ static VAL mw_mirth_elab_ZPlusTypeElab_elabZ_typeZ_quoteZBang (VAL in_ZPlusMirth
 		VAL v16;
 		VAL v17;
 		VAL v18 = mw_mirth_elab_ZPlusTypeElab_elabZ_typeZ_sigZBang(v9, in_ZPlusTypeElab_2, &v16, &v17);
-		VAL v19 = mw_mirth_type_ArrowType_ZToType(v18);
+		VAL v19 = mtw_mirth_type_Type_TMorphism(v18);
 		branch_Type_15 = v19;
 		branch_ZPlusTypeElab_14 = v17;
 		branch_ZPlusMirth_13 = v16;
@@ -35747,7 +35757,7 @@ static VAL mw_mirth_elab_guessZ_initialZ_ctxZ_type (VAL in_ZPlusMirth_1, uint64_
 		uint64_t v54 = mw_mirth_type_MetaVar_newZBang();
 		VAL v55 = mtw_mirth_type_StackType_STMeta(v54);
 		VAL v56 = mw_mirth_type_TZ_ZTo(v53, v55);
-		VAL v57 = mw_mirth_type_ArrowType_ZToType(v56);
+		VAL v57 = mtw_mirth_type_Type_TMorphism(v56);
 		VAL v58 = mw_mirth_type_TZMul(v50, v57);
 		int64_t v59 = 1LL;
 		int64_t v60 = i64_sub(v51, v59);
@@ -40144,7 +40154,9 @@ static VAL mw_mirth_data_Tag_outputZ_type (VAL in_ZPlusMirth_1, uint64_t in_Tag_
 	} else {
 		VAL v11;
 		VAL v12 = mw_mirth_data_Tag_type(in_ZPlusMirth_1, in_Tag_2, &v11);
-		VAL v13 = mw_mirth_type_ArrowType_cod(v12);
+		VAL v13 = VTUP(v12)->cells[2];
+		incref(v13);
+		decref(v12);
 		VAL v14 = mw_mirth_type_StackType_expand(v13);
 		uint64_t branch_Tag_15;
 		VAL branch_ZPlusMirth_16;
@@ -40253,7 +40265,9 @@ static VAL mw_mirth_data_Tag_outputZ_typeZ_exceptZ_field (VAL in_ZPlusMirth_1, u
 static VAL mw_mirth_data_Tag_projectZ_inputZ_label (VAL in_ZPlusMirth_1, uint64_t in_Label_2, uint64_t in_Tag_3, VAL *out_ZPlusMirth_4) {
 	VAL v6;
 	VAL v7 = mw_mirth_data_Tag_type(in_ZPlusMirth_1, in_Tag_3, &v6);
-	VAL v8 = mw_mirth_type_ArrowType_dom(v7);
+	VAL v8 = VTUP(v7)->cells[1];
+	incref(v8);
+	decref(v7);
 	VAL v9 = mw_mirth_type_StackType_labelZ_topZAsk(in_Label_2, v8);
 	*out_ZPlusMirth_4 = v6;
 	return v9;
@@ -52712,13 +52726,17 @@ static VAL mw_mirth_c99_ZPlusC99_cnameZ_typeZ_toZ_c99Z_api (VAL in_Str_1, VAL in
 	int64_t v7 = value_i64(VTUP(in_ZPlusC99_3)->cells[3]);
 	VTUP(in_ZPlusC99_3)->cells[3] = MKI64(v6);
 	incref(in_ArrowType_2);
-	VAL v8 = mw_mirth_type_ArrowType_dom(in_ArrowType_2);
+	VAL v8 = VTUP(in_ArrowType_2)->cells[1];
+	incref(v8);
+	decref(in_ArrowType_2);
 	int64_t v9 = 0LL /* In */;
 	int64_t v10;
 	VAL v11;
 	VAL v12 = mw_mirth_c99_ZPlusC99_stackZ_typeZ_toZ_c99Z_apiZ_params(v8, v9, in_ZPlusC99_3, &v10, &v11);
 	incref(in_ArrowType_2);
-	VAL v13 = mw_mirth_type_ArrowType_cod(in_ArrowType_2);
+	VAL v13 = VTUP(in_ArrowType_2)->cells[2];
+	incref(v13);
+	decref(in_ArrowType_2);
 	int64_t v14 = 1LL /* Out */;
 	int64_t v15;
 	VAL v16;
@@ -52786,7 +52804,9 @@ static VAL mw_mirth_c99_ZPlusC99_cnameZ_typeZ_toZ_c99Z_api (VAL in_Str_1, VAL in
 	VTUP(v16)->cells[3] = MKI64(v7);
 	bool v47 = (((bool)v15) || ((bool)v10));
 	incref(in_ArrowType_2);
-	VAL v48 = mw_mirth_type_ArrowType_cod(in_ArrowType_2);
+	VAL v48 = VTUP(in_ArrowType_2)->cells[2];
+	incref(v48);
+	decref(in_ArrowType_2);
 	VAL v49 = mw_mirth_type_StackType_linearZ_baseZ_varZAsk(v48);
 	VAL branch_ArrowType_50;
 	int64_t branch_Bool_51;
@@ -52794,7 +52814,9 @@ static VAL mw_mirth_c99_ZPlusC99_cnameZ_typeZ_toZ_c99Z_api (VAL in_Str_1, VAL in
 		case 1LL: { // Some
 			VAL v52 = mtp_std_maybe_Maybe_1_Some(v49);
 			incref(in_ArrowType_2);
-			VAL v53 = mw_mirth_type_ArrowType_dom(in_ArrowType_2);
+			VAL v53 = VTUP(in_ArrowType_2)->cells[1];
+			incref(v53);
+			decref(in_ArrowType_2);
 			VAL v54 = mw_mirth_type_StackType_linearZ_baseZ_varZAsk(v53);
 			int64_t branch_Bool_55;
 			switch (get_data_tag(v54)) {
@@ -63392,7 +63414,9 @@ static void mw_mirth_c99_c99Z_blockZ_defZBang (uint64_t in_Block_1, VAL in_ZPlus
 	incref(v15);
 	VAL v22;
 	VAL v23 = mw_mirth_c99_ZPlusC99Branch_ZPlusmirth_1_sp3(v15, v20, &v22);
-	VAL v24 = mw_mirth_type_ArrowType_dom(v23);
+	VAL v24 = VTUP(v23)->cells[1];
+	incref(v24);
+	decref(v23);
 	VAL v25;
 	mw_mirth_c99_exposeZ_stackZ_typeZBang(v24, v22, &v25);
 	VAL v26;
@@ -67248,7 +67272,9 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp5_2 (void) {
 	uint64_t v1 = value_u64(pop_value());
 	VAL v2;
 	VAL v3 = mw_mirth_word_Word_type(v1, r0, &v2);
-	VAL v4 = mw_mirth_type_ArrowType_dom(v3);
+	VAL v4 = VTUP(v3)->cells[1];
+	incref(v4);
+	decref(v3);
 	VAL v5 = mw_mirth_type_StackType_topZ_typeZAsk(v4);
 	VAL branch_ZPlusMirth_6;
 	VAL branch_z_x1_7;
@@ -67705,7 +67731,9 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp12_7 (void) {
 	incref(v2);
 	VAL v14;
 	VAL v15 = mw_mirth_data_Tag_type(v4, value_u64(v2), &v14);
-	VAL v16 = mw_mirth_type_ArrowType_dom(v15);
+	VAL v16 = VTUP(v15)->cells[1];
+	incref(v16);
+	decref(v15);
 	incref(v2);
 	uint64_t v17 = mw_mirth_data_Tag_data(value_u64(v2));
 	VAL v18 = mw_mirth_data_Data_headZAsk(v17);

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -1104,6 +1104,7 @@ static STACK lbl_field = {0};
 static STACK lbl_labels = {0};
 static STACK lbl_withses = {0};
 static STACK lbl_conses = {0};
+static STACK lbl_arrowtype = {0};
 static STACK lbl_parts = {0};
 static STACK lbl_baseZAsk = {0};
 static STACK lbl_ctype = {0};
@@ -1867,10 +1868,10 @@ static void mtp_mirth_match_ZPlusMatch_ZPlusMatch (VAL in_ZPlusMatch_1, VAL *out
 	*out_Token_3 = value_u64(v10);
 	*out_Home_2 = v9;
 }
-static VAL mtw_mirth_match_Case_CASE (VAL in_Pattern_1, VAL in_Arrow_2) {
+static VAL mtw_mirth_match_Case_Case (VAL in_Pattern_1, VAL in_Arrow_2) {
 	TUP* v4 = tup_new(3);
 	v4->size = 3;
-	v4->cells[0] = MKI64(0LL /* CASE */);
+	v4->cells[0] = MKI64(0LL /* Case */);
 	v4->cells[2] = in_Arrow_2;
 	v4->cells[1] = in_Pattern_1;
 	VAL v5 = MKTUP(v4, 3);
@@ -5124,7 +5125,6 @@ static VAL mw_mirth_type_StackType_rigidifyZBang (VAL in_ZPlusMirth_1, VAL in_Ct
 static VAL mw_mirth_type_StackType_linearZ_baseZ_metaZAsk (VAL in_StackType_1);
 static VAL mw_mirth_type_StackType_linearZ_baseZ_varZAsk (VAL in_StackType_1);
 static VAL mw_mirth_type_ArrowType_invert (VAL in_ArrowType_1);
-static VAL mw_mirth_type_ArrowType_unpack (VAL in_ArrowType_1, VAL *out_StackType_3);
 static VAL mw_mirth_type_ArrowType_unifyZBang (VAL in_ZPlusMirth_1, uint64_t in_ZPlusGamma_2, VAL in_ArrowType_3, VAL in_ArrowType_4, VAL *out_ZPlusMirth_5, uint64_t *out_ZPlusGamma_6);
 static VAL mw_mirth_type_ArrowType_unifyZ_errorZBang (VAL in_ZPlusMirth_1, uint64_t in_ZPlusGamma_2, VAL in_ArrowType_3, VAL *out_ZPlusMirth_4, uint64_t *out_ZPlusGamma_5);
 static int64_t mw_mirth_type_ArrowType_hasZ_metaZAsk (uint64_t in_MetaVar_1, VAL in_ArrowType_2);
@@ -6036,7 +6036,7 @@ static VAL mw_std_maybe_Maybe_1_filter_1_sp13 (VAL in_Maybe_1);
 static VAL mw_mirth_mirth_PropLabel_prop_1_sp15 (uint64_t in_Token_1, VAL in_PropLabel_2);
 static VAL mw_std_list_List_1_filterZ_some_1_sp4 (VAL in_List_1);
 static VAL mw_mirth_elab_abZ_buildZBang_1_sp32 (VAL in_ZPlusMirth_1, VAL in_Ctx_2, VAL in_StackType_3, uint64_t in_Token_4, VAL in_Home_5, VAL *out_ZPlusMirth_6);
-static void mw_std_maybe_Maybe_1_for_1_sp19 (VAL in_ZPlusList_1, VAL in_Maybe_2, VAL *out_ZPlusList_3);
+static void mw_std_maybe_Maybe_1_for_1_sp21 (VAL in_ZPlusList_1, VAL in_Maybe_2, VAL *out_ZPlusList_3);
 static VAL mw_std_maybe_Maybe_1_map_1_sp14 (VAL in_Str_1, VAL in_Maybe_2, VAL *out_Maybe_4);
 static void mb_mirth_main_main_1 (void);
 static void mb_mirth_elab_elabZ_defZ_head_3 (void);
@@ -13804,7 +13804,8 @@ static void mw_mirth_match_ZPlusPattern_tagZBang (VAL in_ZPlusMirth_1, VAL in_ZP
 	VAL v13;
 	VAL v14 = mw_mirth_type_ArrowType_freshenZ_sig(v10, v12, &v13);
 	VAL v15;
-	VAL v16 = mw_mirth_type_ArrowType_unpack(v13, &v15);
+	VAL v16;
+	mtp_mirth_type_ArrowType_ArrowType(v13, &v15, &v16);
 	incref(in_ZPlusPattern_2);
 	VAL v17 = VTUP(in_ZPlusPattern_2)->cells[7];
 	incref(v17);
@@ -13814,13 +13815,13 @@ static void mw_mirth_match_ZPlusPattern_tagZBang (VAL in_ZPlusMirth_1, VAL in_ZP
 	decref(in_ZPlusPattern_2);
 	VAL v19;
 	uint64_t v20;
-	VAL v21 = mw_mirth_type_StackType_unifyZBang(v11, v18, v17, v15, &v19, &v20);
+	VAL v21 = mw_mirth_type_StackType_unifyZBang(v11, v18, v17, v16, &v19, &v20);
 	mw_mirth_type_ZPlusGamma_rdrop(v20);
-	incref(v16);
+	incref(v15);
 	incref(in_ZPlusPattern_2);
-	VAL v22 = tup_replace(in_ZPlusPattern_2, 7, v16);
+	VAL v22 = tup_replace(in_ZPlusPattern_2, 7, v15);
 	decref(in_ZPlusPattern_2);
-	VAL v23 = mtw_mirth_match_PatternAtom_PATATOM(v8, v9, v7, v16, v21, v14, v6);
+	VAL v23 = mtw_mirth_match_PatternAtom_PATATOM(v8, v9, v7, v15, v21, v14, v6);
 	incref(v22);
 	incref(v22);
 	VAL v24 = VTUP(v22)->cells[9];
@@ -18306,10 +18307,10 @@ static VAL mw_mirth_type_StackType_topZ_namespaces (VAL in_StackType_1) {
 	incref(in_StackType_1);
 	VAL v5 = mw_mirth_type_StackType_topZ_tyconZAsk(in_StackType_1);
 	VAL v6;
-	mw_std_maybe_Maybe_1_for_1_sp19(v4, v5, &v6);
+	mw_std_maybe_Maybe_1_for_1_sp21(v4, v5, &v6);
 	VAL v7 = mw_mirth_type_StackType_topZ_resourceZ_tyconZAsk(in_StackType_1);
 	VAL v8;
-	mw_std_maybe_Maybe_1_for_1_sp19(v6, v7, &v8);
+	mw_std_maybe_Maybe_1_for_1_sp21(v6, v7, &v8);
 	VAL v9 = mw_std_list_List_1_reverse(v8);
 	return v9;
 }
@@ -20629,17 +20630,6 @@ static VAL mw_mirth_type_ArrowType_invert (VAL in_ArrowType_1) {
 	VAL v5 = mtw_mirth_type_ArrowType_ArrowType(v4, v3);
 	return v5;
 }
-static VAL mw_mirth_type_ArrowType_unpack (VAL in_ArrowType_1, VAL *out_StackType_3) {
-	incref(in_ArrowType_1);
-	VAL v4 = VTUP(in_ArrowType_1)->cells[1];
-	incref(v4);
-	decref(in_ArrowType_1);
-	VAL v5 = VTUP(in_ArrowType_1)->cells[2];
-	incref(v5);
-	decref(in_ArrowType_1);
-	*out_StackType_3 = v5;
-	return v4;
-}
 static VAL mw_mirth_type_ArrowType_unifyZBang (VAL in_ZPlusMirth_1, uint64_t in_ZPlusGamma_2, VAL in_ArrowType_3, VAL in_ArrowType_4, VAL *out_ZPlusMirth_5, uint64_t *out_ZPlusGamma_6) {
 	VAL v8;
 	VAL v9;
@@ -20838,48 +20828,60 @@ static VAL mw_mirth_type_ArrowType_rigidifyZBang (VAL in_ZPlusMirth_1, VAL in_Ct
 }
 static VAL mw_mirth_type_ArrowType_rigidifyZ_sigZBang (VAL in_ZPlusMirth_1, VAL in_Ctx_2, VAL in_ArrowType_3, VAL *out_ZPlusMirth_4, VAL *out_ArrowType_6) {
 	incref(in_ArrowType_3);
-	VAL v7;
-	VAL v8 = mw_mirth_type_ArrowType_unpack(in_ArrowType_3, &v7);
-	VAL v9 = mw_mirth_type_StackType_linearZ_baseZ_metaZAsk(v7);
-	switch (get_data_tag(v9)) {
+	VAL v7 = VTUP(in_ArrowType_3)->cells[1];
+	incref(v7);
+	decref(in_ArrowType_3);
+	VAL v8 = mw_mirth_type_StackType_linearZ_baseZ_metaZAsk(v7);
+	VAL branch_ArrowType_9;
+	switch (get_data_tag(v8)) {
 		case 1LL: { // Some
-			VAL v10 = mtp_std_maybe_Maybe_1_Some(v9);
-			VAL v11 = mw_mirth_type_StackType_linearZ_baseZ_metaZAsk(v8);
-			switch (get_data_tag(v11)) {
+			VAL v10 = mtp_std_maybe_Maybe_1_Some(v8);
+			incref(in_ArrowType_3);
+			VAL v11 = VTUP(in_ArrowType_3)->cells[2];
+			incref(v11);
+			decref(in_ArrowType_3);
+			VAL v12 = mw_mirth_type_StackType_linearZ_baseZ_metaZAsk(v11);
+			uint64_t branch_MetaVar_13;
+			switch (get_data_tag(v12)) {
 				case 1LL: { // Some
-					VAL v12 = mtp_std_maybe_Maybe_1_Some(v11);
+					VAL v14 = mtp_std_maybe_Maybe_1_Some(v12);
 					incref(v10);
-					int64_t v13 = mw_mirth_type_MetaVar_ZEqualZEqual(value_u64(v12), value_u64(v10));
-					if (((bool)v13)) {
-						VAL v14 = mw_mirth_type_TYPEz_UNIT();
-						VAL v15 = mtw_std_maybe_Maybe_1_Some(v14);
-						void* v16 = field_mut(&mfld_mirth_type_MetaVar_ZTildetypeZAsk, value_u64(v10));
-						mut_set(v15, v16);
+					int64_t v15 = mw_mirth_type_MetaVar_ZEqualZEqual(value_u64(v14), value_u64(v10));
+					uint64_t branch_MetaVar_16;
+					if (((bool)v15)) {
+						VAL v17 = mw_mirth_type_TYPEz_UNIT();
+						VAL v18 = mtw_std_maybe_Maybe_1_Some(v17);
+						incref(v10);
+						void* v19 = field_mut(&mfld_mirth_type_MetaVar_ZTildetypeZAsk, value_u64(v10));
+						mut_set(v18, v19);
+						branch_MetaVar_16 = value_u64(v10);
 					} else {
-						decref(v10);
+						branch_MetaVar_16 = value_u64(v10);
 					}
+					branch_MetaVar_13 = branch_MetaVar_16;
 				} break;
 				case 0LL: { // None
-					decref(v10);
+					branch_MetaVar_13 = value_u64(v10);
 				} break;
 				default: {
 					do_panic(str_make("unexpected fallthrough in match\n", 32));
 				}
 			}
+			branch_ArrowType_9 = in_ArrowType_3;
 		} break;
 		case 0LL: { // None
-			decref(v8);
+			branch_ArrowType_9 = in_ArrowType_3;
 		} break;
 		default: {
 			do_panic(str_make("unexpected fallthrough in match\n", 32));
 		}
 	}
-	VAL v17;
-	VAL v18;
-	VAL v19 = mw_mirth_type_ArrowType_rigidifyZBang(in_ZPlusMirth_1, in_Ctx_2, in_ArrowType_3, &v17, &v18);
-	*out_ArrowType_6 = v18;
-	*out_ZPlusMirth_4 = v17;
-	return v19;
+	VAL v20;
+	VAL v21;
+	VAL v22 = mw_mirth_type_ArrowType_rigidifyZBang(in_ZPlusMirth_1, in_Ctx_2, branch_ArrowType_9, &v20, &v21);
+	*out_ArrowType_6 = v21;
+	*out_ZPlusMirth_4 = v20;
+	return v22;
 }
 static VAL mw_mirth_type_Subst_nil (void) {
 	VAL v2 = MKI64(0LL /* SUBST_NIL */);
@@ -21881,11 +21883,12 @@ static VAL mw_mirth_type_StackType_ctype (VAL in_StackType_1, VAL in_ZPlusMirth_
 }
 static VAL mw_mirth_type_ArrowType_ctype (VAL in_ArrowType_1, VAL in_ZPlusMirth_2, VAL *out_ZPlusMirth_4) {
 	VAL v5;
-	VAL v6 = mw_mirth_type_ArrowType_unpack(in_ArrowType_1, &v5);
+	VAL v6;
+	mtp_mirth_type_ArrowType_ArrowType(in_ArrowType_1, &v5, &v6);
 	VAL v7;
-	VAL v8 = mw_mirth_type_StackType_ctype(v6, in_ZPlusMirth_2, &v7);
+	VAL v8 = mw_mirth_type_StackType_ctype(v5, in_ZPlusMirth_2, &v7);
 	VAL v9;
-	VAL v10 = mw_mirth_type_StackType_ctype(v5, v7, &v9);
+	VAL v10 = mw_mirth_type_StackType_ctype(v6, v7, &v9);
 	VAL v11 = mtw_mirth_type_CTypeArrow_CTypeArrow(v8, v10);
 	*out_ZPlusMirth_4 = v9;
 	return v11;
@@ -35643,9 +35646,10 @@ static VAL mw_mirth_elab_finalizzeZ_wordZ_arrow (VAL in_ZPlusMirth_1, VAL in_Arr
 		void* v21 = field_mut(&mfld_mirth_word_Word_ZTildeinferringZ_typeZAsk, in_Word_3);
 		mut_set(MKI64(v20), v21);
 		VAL v22;
-		VAL v23 = mw_mirth_type_ArrowType_unpack(v13, &v22);
-		VAL v24 = tup_replace(in_Arrow_2, 6, v22);
-		VAL v25 = tup_replace(v24, 5, v23);
+		VAL v23;
+		mtp_mirth_type_ArrowType_ArrowType(v13, &v22, &v23);
+		VAL v24 = tup_replace(in_Arrow_2, 6, v23);
+		VAL v25 = tup_replace(v24, 5, v22);
 		VAL v26 = tup_replace(v25, 4, v14);
 		branch_Arrow_9 = v26;
 		branch_Word_8 = in_Word_3;
@@ -36100,17 +36104,18 @@ static VAL mw_mirth_elab_abZ_expandZ_opsigZBang (VAL in_OpSig_1, VAL in_ZPlusMir
 		case 2LL: { // OPSIG_APPLY
 			VAL v18 = mtp_mirth_elab_OpSig_OPSIGz_APPLY(in_OpSig_1);
 			VAL v19;
-			VAL v20 = mw_mirth_elab_abZ_typeZAt(in_ZPlusAB_3, &v19);
+			VAL v20;
+			mtp_mirth_type_ArrowType_ArrowType(v18, &v19, &v20);
 			VAL v21;
-			VAL v22 = mw_mirth_type_ArrowType_unpack(v18, &v21);
+			VAL v22 = mw_mirth_elab_abZ_typeZAt(in_ZPlusAB_3, &v21);
 			VAL v23;
-			uint64_t v24 = mw_mirth_elab_abZ_tokenZAt(v19, &v23);
+			uint64_t v24 = mw_mirth_elab_abZ_tokenZAt(v21, &v23);
 			VAL v25;
 			uint64_t v26;
-			VAL v27 = mw_mirth_elab_elabZ_stackZ_typeZ_unifyZBang(in_ZPlusMirth_2, v20, v22, v24, &v25, &v26);
+			VAL v27 = mw_mirth_elab_elabZ_stackZ_typeZ_unifyZBang(in_ZPlusMirth_2, v22, v19, v24, &v25, &v26);
 			branch_ZPlusAB_11 = v23;
 			branch_ZPlusMirth_10 = v25;
-			branch_StackType_9 = v21;
+			branch_StackType_9 = v20;
 			branch_StackType_8 = v27;
 		} break;
 		default: {
@@ -37808,10 +37813,11 @@ static uint64_t mw_mirth_elab_elabZ_matchZ_caseZBang (uint64_t in_Token_1, VAL i
 	VAL v49 = VTUP(branch_z_x1_28)->cells[1];
 	incref(v49);
 	VAL v50;
-	VAL v51 = mw_mirth_type_ArrowType_unpack(v48, &v50);
-	incref(v51);
+	VAL v51;
+	mtp_mirth_type_ArrowType_ArrowType(v48, &v50, &v51);
+	incref(v50);
 	VAL v52 = MKI64(0LL /* Nil */);
-	VAL v53 = mtw_mirth_arrow_Arrow_Arrow(v49, v34, v34, v45, v51, v51, v52);
+	VAL v53 = mtw_mirth_arrow_Arrow_Arrow(v49, v34, v34, v45, v50, v50, v52);
 	VAL v54;
 	VAL v55;
 	mw_mirth_elab_elabZ_atomsZBang(v42, v53, &v54, &v55);
@@ -37827,8 +37833,8 @@ static uint64_t mw_mirth_elab_elabZ_matchZ_caseZBang (uint64_t in_Token_1, VAL i
 	}
 	VAL v61;
 	VAL v62;
-	mw_mirth_elab_abZ_unifyZ_typeZBang(v50, v54, v56, &v61, &v62);
-	VAL v63 = mtw_mirth_match_Case_CASE(v44, v62);
+	mw_mirth_elab_abZ_unifyZ_typeZBang(v51, v54, v56, &v61, &v62);
+	VAL v63 = mtw_mirth_match_Case_Case(v44, v62);
 	VAL v64;
 	VAL v65;
 	mw_mirth_match_ZPlusMatch_addZ_case(v61, branch_z_x1_28, v63, &v64, &v65);
@@ -40005,17 +40011,18 @@ static void mw_mirth_elab_elabZ_dataZ_doneZBang (VAL in_ZPlusMirth_1, uint64_t i
 		uint64_t v24;
 		VAL v25 = mw_mirth_elab_initialZ_ctxZ_typeZ_bodyZ_home(v17, v10, &v20, &v21, &v22, &v23, &v24);
 		VAL v26;
-		VAL v27 = mw_mirth_type_ArrowType_unpack(v21, &v26);
-		incref(v27);
+		VAL v27;
+		mtp_mirth_type_ArrowType_ArrowType(v21, &v26, &v27);
+		incref(v26);
 		VAL v28 = MKI64(0LL /* Nil */);
-		VAL v29 = mtw_mirth_arrow_Arrow_Arrow(v23, v22, v22, v25, v27, v27, v28);
+		VAL v29 = mtw_mirth_arrow_Arrow_Arrow(v23, v22, v22, v25, v26, v26, v28);
 		VAL v30 = mtw_mirth_arrow_Op_OpDataGetEnumValue(in_Data_2);
 		VAL v31;
 		VAL v32;
 		mw_mirth_elab_abZ_opZBang(v30, v20, v29, &v31, &v32);
 		VAL v33;
 		VAL v34;
-		mw_mirth_elab_abZ_unifyZ_typeZBang(v26, v31, v32, &v33, &v34);
+		mw_mirth_elab_abZ_unifyZ_typeZBang(v27, v31, v32, &v33, &v34);
 		VAL v35;
 		VAL v36 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v33, v34, v24, &v35);
 		VAL v37 = mtw_mirth_mirth_PropLabel_WordArrow(v10);
@@ -40056,17 +40063,18 @@ static void mw_mirth_elab_elabZ_dataZ_doneZBang (VAL in_ZPlusMirth_1, uint64_t i
 		uint64_t v61;
 		VAL v62 = mw_mirth_elab_initialZ_ctxZ_typeZ_bodyZ_home(v54, v47, &v57, &v58, &v59, &v60, &v61);
 		VAL v63;
-		VAL v64 = mw_mirth_type_ArrowType_unpack(v58, &v63);
-		incref(v64);
+		VAL v64;
+		mtp_mirth_type_ArrowType_ArrowType(v58, &v63, &v64);
+		incref(v63);
 		VAL v65 = MKI64(0LL /* Nil */);
-		VAL v66 = mtw_mirth_arrow_Arrow_Arrow(v60, v59, v59, v62, v64, v64, v65);
+		VAL v66 = mtw_mirth_arrow_Arrow_Arrow(v60, v59, v59, v62, v63, v63, v65);
 		VAL v67 = mtw_mirth_arrow_Op_OpDataFromEnumValue(branch_Data_5);
 		VAL v68;
 		VAL v69;
 		mw_mirth_elab_abZ_opZBang(v67, v57, v66, &v68, &v69);
 		VAL v70;
 		VAL v71;
-		mw_mirth_elab_abZ_unifyZ_typeZBang(v63, v68, v69, &v70, &v71);
+		mw_mirth_elab_abZ_unifyZ_typeZBang(v64, v68, v69, &v70, &v71);
 		VAL v72;
 		VAL v73 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v70, v71, v61, &v72);
 		VAL v74 = mtw_mirth_mirth_PropLabel_WordArrow(v47);
@@ -41280,13 +41288,14 @@ static VAL mw_mirth_elab_elabZ_defZ_paramsZBang (VAL in_ZPlusMirth_1, uint64_t i
 	VAL v7 = mw_mirth_word_Word_type(in_Word_2, in_ZPlusMirth_1, &v6);
 	uint64_t v8 = mw_mirth_word_Word_head(in_Word_2);
 	VAL v9;
-	VAL v10 = mw_mirth_type_ArrowType_unpack(v7, &v9);
-	decref(v9);
+	VAL v10;
+	mtp_mirth_type_ArrowType_ArrowType(v7, &v9, &v10);
+	decref(v10);
 	VAL v11 = mw_mirth_token_Token_args(v8);
 	VAL v12 = mw_std_list_List_1_reverse(v11);
 	int64_t v13 = 1LL /* True */;
 	VAL v14 = v5;
-	VAL v15 = v10;
+	VAL v15 = v9;
 	VAL v16 = v6;
 	VAL v17 = v12;
 	int64_t v18 = v13;
@@ -42429,16 +42438,17 @@ static uint64_t mw_mirth_elab_elabZ_embedZ_strZBang (uint64_t in_Token_1, VAL in
 	uint64_t v55;
 	VAL v56 = mw_mirth_elab_initialZ_ctxZ_typeZ_bodyZ_home(v48, v38, &v51, &v52, &v53, &v54, &v55);
 	VAL v57;
-	VAL v58 = mw_mirth_type_ArrowType_unpack(v52, &v57);
-	incref(v58);
+	VAL v58;
+	mtp_mirth_type_ArrowType_ArrowType(v52, &v57, &v58);
+	incref(v57);
 	VAL v59 = MKI64(0LL /* Nil */);
-	VAL v60 = mtw_mirth_arrow_Arrow_Arrow(v54, v53, v53, v56, v58, v58, v59);
+	VAL v60 = mtw_mirth_arrow_Arrow_Arrow(v54, v53, v53, v56, v57, v57, v59);
 	VAL v61;
 	VAL v62;
 	mw_mirth_elab_abZ_strZBang(v36, v51, v60, &v61, &v62);
 	VAL v63;
 	VAL v64;
-	mw_mirth_elab_abZ_unifyZ_typeZBang(v57, v61, v62, &v63, &v64);
+	mw_mirth_elab_abZ_unifyZ_typeZBang(v58, v61, v62, &v63, &v64);
 	VAL v65;
 	VAL v66 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v63, v64, v55, &v65);
 	VAL v67 = mtw_mirth_mirth_PropLabel_WordArrow(v38);
@@ -42617,10 +42627,11 @@ static uint64_t mw_mirth_elab_tableZ_newZBang (VAL in_ZPlusMirth_1, uint64_t in_
 	uint64_t v32;
 	VAL v33 = mw_mirth_elab_initialZ_ctxZ_typeZ_bodyZ_home(v25, v18, &v28, &v29, &v30, &v31, &v32);
 	VAL v34;
-	VAL v35 = mw_mirth_type_ArrowType_unpack(v29, &v34);
-	incref(v35);
+	VAL v35;
+	mtp_mirth_type_ArrowType_ArrowType(v29, &v34, &v35);
+	incref(v34);
 	VAL v36 = MKI64(0LL /* Nil */);
-	VAL v37 = mtw_mirth_arrow_Arrow_Arrow(v31, v30, v30, v33, v35, v35, v36);
+	VAL v37 = mtw_mirth_arrow_Arrow_Arrow(v31, v30, v30, v33, v34, v34, v36);
 	uint64_t v38 = mw_mirth_table_Table_head(v7);
 	VAL v39;
 	mw_mirth_elab_abZ_tokenZBang(v37, v38, &v39);
@@ -42634,7 +42645,7 @@ static uint64_t mw_mirth_elab_tableZ_newZBang (VAL in_ZPlusMirth_1, uint64_t in_
 	mw_mirth_elab_abZ_opZBang(v43, v41, v42, &v44, &v45);
 	VAL v46;
 	VAL v47;
-	mw_mirth_elab_abZ_unifyZ_typeZBang(v34, v44, v45, &v46, &v47);
+	mw_mirth_elab_abZ_unifyZ_typeZBang(v35, v44, v45, &v46, &v47);
 	VAL v48;
 	VAL v49 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v46, v47, v32, &v48);
 	VAL v50 = mtw_mirth_mirth_PropLabel_WordArrow(v18);
@@ -42675,10 +42686,11 @@ static uint64_t mw_mirth_elab_tableZ_newZBang (VAL in_ZPlusMirth_1, uint64_t in_
 	uint64_t v80;
 	VAL v81 = mw_mirth_elab_initialZ_ctxZ_typeZ_bodyZ_home(v73, v65, &v76, &v77, &v78, &v79, &v80);
 	VAL v82;
-	VAL v83 = mw_mirth_type_ArrowType_unpack(v77, &v82);
-	incref(v83);
+	VAL v83;
+	mtp_mirth_type_ArrowType_ArrowType(v77, &v82, &v83);
+	incref(v82);
 	VAL v84 = MKI64(0LL /* Nil */);
-	VAL v85 = mtw_mirth_arrow_Arrow_Arrow(v79, v78, v78, v81, v83, v83, v84);
+	VAL v85 = mtw_mirth_arrow_Arrow_Arrow(v79, v78, v78, v81, v82, v82, v84);
 	uint64_t v86 = mw_mirth_table_Table_head(v7);
 	VAL v87;
 	mw_mirth_elab_abZ_tokenZBang(v85, v86, &v87);
@@ -42688,7 +42700,7 @@ static uint64_t mw_mirth_elab_tableZ_newZBang (VAL in_ZPlusMirth_1, uint64_t in_
 	mw_mirth_elab_abZ_opZBang(v88, v76, v87, &v89, &v90);
 	VAL v91;
 	VAL v92;
-	mw_mirth_elab_abZ_unifyZ_typeZBang(v82, v89, v90, &v91, &v92);
+	mw_mirth_elab_abZ_unifyZ_typeZBang(v83, v89, v90, &v91, &v92);
 	VAL v93;
 	VAL v94 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v91, v92, v80, &v93);
 	VAL v95 = mtw_mirth_mirth_PropLabel_WordArrow(v65);
@@ -42719,10 +42731,11 @@ static uint64_t mw_mirth_elab_tableZ_newZBang (VAL in_ZPlusMirth_1, uint64_t in_
 	uint64_t v117;
 	VAL v118 = mw_mirth_elab_initialZ_ctxZ_typeZ_bodyZ_home(v110, v102, &v113, &v114, &v115, &v116, &v117);
 	VAL v119;
-	VAL v120 = mw_mirth_type_ArrowType_unpack(v114, &v119);
-	incref(v120);
+	VAL v120;
+	mtp_mirth_type_ArrowType_ArrowType(v114, &v119, &v120);
+	incref(v119);
 	VAL v121 = MKI64(0LL /* Nil */);
-	VAL v122 = mtw_mirth_arrow_Arrow_Arrow(v116, v115, v115, v118, v120, v120, v121);
+	VAL v122 = mtw_mirth_arrow_Arrow_Arrow(v116, v115, v115, v118, v119, v119, v121);
 	uint64_t v123 = mw_mirth_table_Table_head(v7);
 	VAL v124;
 	mw_mirth_elab_abZ_tokenZBang(v122, v123, &v124);
@@ -42732,7 +42745,7 @@ static uint64_t mw_mirth_elab_tableZ_newZBang (VAL in_ZPlusMirth_1, uint64_t in_
 	mw_mirth_elab_abZ_opZBang(v125, v113, v124, &v126, &v127);
 	VAL v128;
 	VAL v129;
-	mw_mirth_elab_abZ_unifyZ_typeZBang(v119, v126, v127, &v128, &v129);
+	mw_mirth_elab_abZ_unifyZ_typeZBang(v120, v126, v127, &v128, &v129);
 	VAL v130;
 	VAL v131 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v128, v129, v117, &v130);
 	VAL v132 = mtw_mirth_mirth_PropLabel_WordArrow(v102);
@@ -42762,10 +42775,11 @@ static uint64_t mw_mirth_elab_tableZ_newZBang (VAL in_ZPlusMirth_1, uint64_t in_
 	uint64_t v152;
 	VAL v153 = mw_mirth_elab_initialZ_ctxZ_typeZ_bodyZ_home(v145, v139, &v148, &v149, &v150, &v151, &v152);
 	VAL v154;
-	VAL v155 = mw_mirth_type_ArrowType_unpack(v149, &v154);
-	incref(v155);
+	VAL v155;
+	mtp_mirth_type_ArrowType_ArrowType(v149, &v154, &v155);
+	incref(v154);
 	VAL v156 = MKI64(0LL /* Nil */);
-	VAL v157 = mtw_mirth_arrow_Arrow_Arrow(v151, v150, v150, v153, v155, v155, v156);
+	VAL v157 = mtw_mirth_arrow_Arrow_Arrow(v151, v150, v150, v153, v154, v154, v156);
 	uint64_t v158 = mw_mirth_table_Table_head(v7);
 	VAL v159;
 	mw_mirth_elab_abZ_tokenZBang(v157, v158, &v159);
@@ -42787,7 +42801,7 @@ static uint64_t mw_mirth_elab_tableZ_newZBang (VAL in_ZPlusMirth_1, uint64_t in_
 	mw_mirth_elab_abZ_opZBang(v169, v167, v168, &v170, &v171);
 	VAL v172;
 	VAL v173;
-	mw_mirth_elab_abZ_unifyZ_typeZBang(v154, v170, v171, &v172, &v173);
+	mw_mirth_elab_abZ_unifyZ_typeZBang(v155, v170, v171, &v172, &v173);
 	VAL v174;
 	VAL v175 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v172, v173, v152, &v174);
 	VAL v176 = mtw_mirth_mirth_PropLabel_WordArrow(v139);
@@ -42817,10 +42831,11 @@ static uint64_t mw_mirth_elab_tableZ_newZBang (VAL in_ZPlusMirth_1, uint64_t in_
 	uint64_t v196;
 	VAL v197 = mw_mirth_elab_initialZ_ctxZ_typeZ_bodyZ_home(v189, v183, &v192, &v193, &v194, &v195, &v196);
 	VAL v198;
-	VAL v199 = mw_mirth_type_ArrowType_unpack(v193, &v198);
-	incref(v199);
+	VAL v199;
+	mtp_mirth_type_ArrowType_ArrowType(v193, &v198, &v199);
+	incref(v198);
 	VAL v200 = MKI64(0LL /* Nil */);
-	VAL v201 = mtw_mirth_arrow_Arrow_Arrow(v195, v194, v194, v197, v199, v199, v200);
+	VAL v201 = mtw_mirth_arrow_Arrow_Arrow(v195, v194, v194, v197, v198, v198, v200);
 	uint64_t v202 = mw_mirth_table_Table_head(v7);
 	VAL v203;
 	mw_mirth_elab_abZ_tokenZBang(v201, v202, &v203);
@@ -42892,7 +42907,7 @@ static uint64_t mw_mirth_elab_tableZ_newZBang (VAL in_ZPlusMirth_1, uint64_t in_
 	mw_mirth_elab_abZ_opZBang(v255, v253, v254, &v256, &v257);
 	VAL v258;
 	VAL v259;
-	mw_mirth_elab_abZ_unifyZ_typeZBang(v198, v256, v257, &v258, &v259);
+	mw_mirth_elab_abZ_unifyZ_typeZBang(v199, v256, v257, &v258, &v259);
 	VAL v260;
 	VAL v261 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v258, v259, v196, &v260);
 	VAL v262 = mtw_mirth_mirth_PropLabel_WordArrow(v183);
@@ -42945,10 +42960,11 @@ static uint64_t mw_mirth_elab_tableZ_newZBang (VAL in_ZPlusMirth_1, uint64_t in_
 	uint64_t v302;
 	VAL v303 = mw_mirth_elab_initialZ_ctxZ_typeZ_bodyZ_home(v295, v269, &v298, &v299, &v300, &v301, &v302);
 	VAL v304;
-	VAL v305 = mw_mirth_type_ArrowType_unpack(v299, &v304);
-	incref(v305);
+	VAL v305;
+	mtp_mirth_type_ArrowType_ArrowType(v299, &v304, &v305);
+	incref(v304);
 	VAL v306 = MKI64(0LL /* Nil */);
-	VAL v307 = mtw_mirth_arrow_Arrow_Arrow(v301, v300, v300, v303, v305, v305, v306);
+	VAL v307 = mtw_mirth_arrow_Arrow_Arrow(v301, v300, v300, v303, v304, v304, v306);
 	uint64_t v308 = mw_mirth_table_Table_head(v7);
 	VAL v309;
 	mw_mirth_elab_abZ_tokenZBang(v307, v308, &v309);
@@ -43089,7 +43105,7 @@ static uint64_t mw_mirth_elab_tableZ_newZBang (VAL in_ZPlusMirth_1, uint64_t in_
 	mw_mirth_elab_abZ_opZBang(v419, v410, v416, &v420, &v421);
 	VAL v422;
 	VAL v423;
-	mw_mirth_elab_abZ_unifyZ_typeZBang(v304, v420, v421, &v422, &v423);
+	mw_mirth_elab_abZ_unifyZ_typeZBang(v305, v420, v421, &v422, &v423);
 	VAL v424;
 	VAL v425 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v422, v423, v302, &v424);
 	VAL v426 = mtw_mirth_mirth_PropLabel_WordArrow(v269);
@@ -43119,10 +43135,11 @@ static uint64_t mw_mirth_elab_tableZ_newZBang (VAL in_ZPlusMirth_1, uint64_t in_
 	uint64_t v447;
 	VAL v448 = mw_mirth_elab_initialZ_ctxZ_typeZ_bodyZ_home(v440, v433, &v443, &v444, &v445, &v446, &v447);
 	VAL v449;
-	VAL v450 = mw_mirth_type_ArrowType_unpack(v444, &v449);
-	incref(v450);
+	VAL v450;
+	mtp_mirth_type_ArrowType_ArrowType(v444, &v449, &v450);
+	incref(v449);
 	VAL v451 = MKI64(0LL /* Nil */);
-	VAL v452 = mtw_mirth_arrow_Arrow_Arrow(v446, v445, v445, v448, v450, v450, v451);
+	VAL v452 = mtw_mirth_arrow_Arrow_Arrow(v446, v445, v445, v448, v449, v449, v451);
 	uint64_t v453 = mw_mirth_table_Table_head(v7);
 	VAL v454;
 	mw_mirth_elab_abZ_tokenZBang(v452, v453, &v454);
@@ -43168,7 +43185,7 @@ static uint64_t mw_mirth_elab_tableZ_newZBang (VAL in_ZPlusMirth_1, uint64_t in_
 	mw_mirth_elab_abZ_opZBang(v482, v480, v481, &v483, &v484);
 	VAL v485;
 	VAL v486;
-	mw_mirth_elab_abZ_unifyZ_typeZBang(v449, v483, v484, &v485, &v486);
+	mw_mirth_elab_abZ_unifyZ_typeZBang(v450, v483, v484, &v485, &v486);
 	VAL v487;
 	VAL v488 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v485, v486, v447, &v487);
 	VAL v489 = mtw_mirth_mirth_PropLabel_WordArrow(v433);
@@ -46044,10 +46061,11 @@ static void mw_mirth_specializzer_ZPlusSPSynth_synthZ_matchZBang (VAL in_ZPlusMi
 				VAL v90 = VTUP(v37)->cells[1];
 				incref(v90);
 				VAL v91;
-				VAL v92 = mw_mirth_type_ArrowType_unpack(v89, &v91);
-				incref(v92);
+				VAL v92;
+				mtp_mirth_type_ArrowType_ArrowType(v89, &v91, &v92);
+				incref(v91);
 				VAL v93 = MKI64(0LL /* Nil */);
-				VAL v94 = mtw_mirth_arrow_Arrow_Arrow(v90, v52, v52, v86, v92, v92, v93);
+				VAL v94 = mtw_mirth_arrow_Arrow_Arrow(v90, v52, v52, v86, v91, v91, v93);
 				VAL v95;
 				mtw_mirth_specializzer_ZPlusSPSynth_ZPlusSPSYNTH(v33, v34, v35, v94, &v95);
 				VAL v96 = VTUP(v48)->cells[2];
@@ -46063,8 +46081,8 @@ static void mw_mirth_specializzer_ZPlusSPSynth_synthZ_matchZBang (VAL in_ZPlusMi
 				mtp_mirth_specializzer_ZPlusSPSynth_ZPlusSPSYNTH(v98, &v99, &v100, &v101, &v102);
 				VAL v103;
 				VAL v104;
-				mw_mirth_elab_abZ_unifyZ_typeZBang(v91, v97, v102, &v103, &v104);
-				VAL v105 = mtw_mirth_match_Case_CASE(v85, v104);
+				mw_mirth_elab_abZ_unifyZ_typeZBang(v92, v97, v102, &v103, &v104);
+				VAL v105 = mtw_mirth_match_Case_Case(v85, v104);
 				VAL v106;
 				VAL v107;
 				mw_mirth_match_ZPlusMatch_addZ_case(v103, v37, v105, &v106, &v107);
@@ -53717,11 +53735,12 @@ static void mw_mirth_c99_c99Z_codipZ_arrowZBang (VAL in_Arrow_1, VAL in_ZPlusC99
 	VAL v4;
 	VAL v5 = mw_mirth_c99_ZPlusC99Branch_ZPlusmirth_1_sp3(in_Arrow_1, in_ZPlusC99Branch_2, &v4);
 	VAL v6;
-	VAL v7 = mw_mirth_type_ArrowType_unpack(v5, &v6);
+	VAL v7;
+	mtp_mirth_type_ArrowType_ArrowType(v5, &v6, &v7);
 	VAL v8;
-	VAL v9 = mw_mirth_type_StackType_splitZ_parts(v6, &v8);
+	VAL v9 = mw_mirth_type_StackType_splitZ_parts(v7, &v8);
 	VAL v10;
-	VAL v11 = mw_mirth_type_StackType_splitZ_parts(v7, &v10);
+	VAL v11 = mw_mirth_type_StackType_splitZ_parts(v6, &v10);
 	int64_t v12 = mw_mirth_type_StackTypeBase_unitZAsk(v9);
 	int64_t v13 = mw_mirth_type_StackTypeBase_unitZAsk(v11);
 	bool v14 = (((bool)v12) && ((bool)v13));
@@ -66333,16 +66352,17 @@ static void mw_std_list_List_1_for_1_sp46 (VAL in_ZPlusList_1, VAL in_List_2, VA
 }
 static VAL mw_mirth_elab_abZ_buildZ_homZBang_1_sp1 (uint64_t in_Word_1, VAL in_ZPlusMirth_2, VAL in_Ctx_3, VAL in_ArrowType_4, uint64_t in_Token_5, VAL in_Home_6, VAL *out_ZPlusMirth_7) {
 	VAL v9;
-	VAL v10 = mw_mirth_type_ArrowType_unpack(in_ArrowType_4, &v9);
-	incref(v10);
+	VAL v10;
+	mtp_mirth_type_ArrowType_ArrowType(in_ArrowType_4, &v9, &v10);
+	incref(v9);
 	VAL v11 = MKI64(0LL /* Nil */);
-	VAL v12 = mtw_mirth_arrow_Arrow_Arrow(in_Home_6, in_Token_5, in_Token_5, in_Ctx_3, v10, v10, v11);
+	VAL v12 = mtw_mirth_arrow_Arrow_Arrow(in_Home_6, in_Token_5, in_Token_5, in_Ctx_3, v9, v9, v11);
 	VAL v13;
 	VAL v14;
 	mw_mirth_elab_abZ_wordZBang(in_Word_1, in_ZPlusMirth_2, v12, &v13, &v14);
 	VAL v15;
 	VAL v16;
-	mw_mirth_elab_abZ_unifyZ_typeZBang(v9, v13, v14, &v15, &v16);
+	mw_mirth_elab_abZ_unifyZ_typeZBang(v10, v13, v14, &v15, &v16);
 	*out_ZPlusMirth_7 = v15;
 	return v16;
 }
@@ -67048,7 +67068,7 @@ static VAL mw_mirth_elab_abZ_buildZBang_1_sp32 (VAL in_ZPlusMirth_1, VAL in_Ctx_
 	*out_ZPlusMirth_6 = v10;
 	return v11;
 }
-static void mw_std_maybe_Maybe_1_for_1_sp19 (VAL in_ZPlusList_1, VAL in_Maybe_2, VAL *out_ZPlusList_3) {
+static void mw_std_maybe_Maybe_1_for_1_sp21 (VAL in_ZPlusList_1, VAL in_Maybe_2, VAL *out_ZPlusList_3) {
 	VAL branch_ZPlusList_4;
 	switch (get_data_tag(in_Maybe_2)) {
 		case 1LL: { // Some
@@ -67138,16 +67158,17 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp2_2 (void) {
 	uint64_t v9;
 	VAL v10 = mw_mirth_elab_initialZ_ctxZ_typeZ_bodyZ_home(r1, value_u64(v4), &v5, &v6, &v7, &v8, &v9);
 	VAL v11;
-	VAL v12 = mw_mirth_type_ArrowType_unpack(v6, &v11);
-	incref(v12);
+	VAL v12;
+	mtp_mirth_type_ArrowType_ArrowType(v6, &v11, &v12);
+	incref(v11);
 	VAL v13 = MKI64(0LL /* Nil */);
-	VAL v14 = mtw_mirth_arrow_Arrow_Arrow(v8, v7, v7, v10, v12, v12, v13);
+	VAL v14 = mtw_mirth_arrow_Arrow_Arrow(v8, v7, v7, v10, v11, v11, v13);
 	VAL v15;
 	VAL v16;
 	mw_mirth_specializzer_synthZ_specializzedZ_wordZBang(v5, v14, v2, value_u64(v3), &v15, &v16);
 	VAL v17;
 	VAL v18;
-	mw_mirth_elab_abZ_unifyZ_typeZBang(v11, v15, v16, &v17, &v18);
+	mw_mirth_elab_abZ_unifyZ_typeZBang(v12, v15, v16, &v17, &v18);
 	VAL v19;
 	VAL v20 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v17, v18, v9, &v19);
 	push_resource(v19);
@@ -67260,12 +67281,10 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp4_0 (void) {
 	VAL v2;
 	VAL v3;
 	VAL v4 = mw_mirth_data_Tag_ctxZ_type(r1, v0, &v2, &v3);
-	VAL v5;
-	VAL v6 = mw_mirth_type_ArrowType_unpack(v3, &v5);
-	VAL v7 = mw_mirth_type_TZ_ZTo(v5, v6);
-	TUP* v8 = tup_pack2(v4, v7);
+	VAL v5 = mw_mirth_type_ArrowType_invert(v3);
+	TUP* v6 = tup_pack2(v4, v5);
 	push_resource(v2);
-	push_value(MKTUP(v8, 2));
+	push_value(MKTUP(v6, 2));
 }
 static void mb_mirth_mirth_PropLabel_prop_1_sp5_2 (void) {
 	VAL r0 = pop_resource();
@@ -67336,10 +67355,11 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp6_9 (void) {
 	uint64_t v10;
 	VAL v11 = mw_mirth_elab_initialZ_ctxZ_typeZ_bodyZ_home(r1, value_u64(v5), &v6, &v7, &v8, &v9, &v10);
 	VAL v12;
-	VAL v13 = mw_mirth_type_ArrowType_unpack(v7, &v12);
-	incref(v13);
+	VAL v13;
+	mtp_mirth_type_ArrowType_ArrowType(v7, &v12, &v13);
+	incref(v12);
 	VAL v14 = MKI64(0LL /* Nil */);
-	VAL v15 = mtw_mirth_arrow_Arrow_Arrow(v9, v8, v8, v11, v13, v13, v14);
+	VAL v15 = mtw_mirth_arrow_Arrow_Arrow(v9, v8, v8, v11, v12, v12, v14);
 	VAL v16;
 	VAL v17 = mw_mirth_word_Word_params(value_u64(v5), v6, &v16);
 	incref(v17);
@@ -67466,7 +67486,7 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp6_9 (void) {
 	mw_mirth_elab_abZ_opZBang(v101, branch_ZPlusMirth_41, v98, &v102, &v103);
 	VAL v104;
 	VAL v105;
-	mw_mirth_elab_abZ_unifyZ_typeZBang(v12, v102, v103, &v104, &v105);
+	mw_mirth_elab_abZ_unifyZ_typeZBang(v13, v102, v103, &v104, &v105);
 	VAL v106;
 	VAL v107 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v104, v105, v10, &v106);
 	push_resource(v106);
@@ -67555,10 +67575,11 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp8_5 (void) {
 	uint64_t v9;
 	VAL v10 = mw_mirth_elab_initialZ_ctxZ_typeZ_bodyZ_home(r1, value_u64(v4), &v5, &v6, &v7, &v8, &v9);
 	VAL v11;
-	VAL v12 = mw_mirth_type_ArrowType_unpack(v6, &v11);
-	incref(v12);
+	VAL v12;
+	mtp_mirth_type_ArrowType_ArrowType(v6, &v11, &v12);
+	incref(v11);
 	VAL v13 = MKI64(0LL /* Nil */);
-	VAL v14 = mtw_mirth_arrow_Arrow_Arrow(v8, v7, v7, v10, v12, v12, v13);
+	VAL v14 = mtw_mirth_arrow_Arrow_Arrow(v8, v7, v7, v10, v11, v11, v13);
 	VAL v15;
 	VAL v16 = mw_mirth_data_Tag_projectZ_tagZ_field(v5, value_u64(v3), value_u64(v2), &v15);
 	VAL branch_ZPlusMirth_17;
@@ -67586,7 +67607,7 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp8_5 (void) {
 	mw_mirth_elab_abZ_opZBang(v24, branch_ZPlusMirth_17, branch_z_x1_18, &v25, &v26);
 	VAL v27;
 	VAL v28;
-	mw_mirth_elab_abZ_unifyZ_typeZBang(v11, v25, v26, &v27, &v28);
+	mw_mirth_elab_abZ_unifyZ_typeZBang(v12, v25, v26, &v27, &v28);
 	VAL v29;
 	VAL v30 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v27, v28, v9, &v29);
 	push_resource(v29);
@@ -67640,10 +67661,11 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp10_5 (void) {
 	uint64_t v9;
 	VAL v10 = mw_mirth_elab_initialZ_ctxZ_typeZ_bodyZ_home(r1, value_u64(v4), &v5, &v6, &v7, &v8, &v9);
 	VAL v11;
-	VAL v12 = mw_mirth_type_ArrowType_unpack(v6, &v11);
-	incref(v12);
+	VAL v12;
+	mtp_mirth_type_ArrowType_ArrowType(v6, &v11, &v12);
+	incref(v11);
 	VAL v13 = MKI64(0LL /* Nil */);
-	VAL v14 = mtw_mirth_arrow_Arrow_Arrow(v8, v7, v7, v10, v12, v12, v13);
+	VAL v14 = mtw_mirth_arrow_Arrow_Arrow(v8, v7, v7, v10, v11, v11, v13);
 	VAL v15;
 	VAL v16 = mw_mirth_data_Tag_projectZ_tagZ_field(v5, value_u64(v3), value_u64(v2), &v15);
 	VAL branch_ZPlusMirth_17;
@@ -67671,7 +67693,7 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp10_5 (void) {
 	mw_mirth_elab_abZ_opZBang(v24, branch_ZPlusMirth_17, branch_z_x1_18, &v25, &v26);
 	VAL v27;
 	VAL v28;
-	mw_mirth_elab_abZ_unifyZ_typeZBang(v11, v25, v26, &v27, &v28);
+	mw_mirth_elab_abZ_unifyZ_typeZBang(v12, v25, v26, &v27, &v28);
 	VAL v29;
 	VAL v30 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v27, v28, v9, &v29);
 	push_resource(v29);
@@ -67724,10 +67746,11 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp12_7 (void) {
 	uint64_t v8;
 	VAL v9 = mw_mirth_elab_initialZ_ctxZ_typeZ_bodyZ_home(r1, value_u64(v3), &v4, &v5, &v6, &v7, &v8);
 	VAL v10;
-	VAL v11 = mw_mirth_type_ArrowType_unpack(v5, &v10);
-	incref(v11);
+	VAL v11;
+	mtp_mirth_type_ArrowType_ArrowType(v5, &v10, &v11);
+	incref(v10);
 	VAL v12 = MKI64(0LL /* Nil */);
-	VAL v13 = mtw_mirth_arrow_Arrow_Arrow(v7, v6, v6, v9, v11, v11, v12);
+	VAL v13 = mtw_mirth_arrow_Arrow_Arrow(v7, v6, v6, v9, v10, v10, v12);
 	incref(v2);
 	VAL v14;
 	VAL v15 = mw_mirth_data_Tag_type(v4, value_u64(v2), &v14);
@@ -67800,15 +67823,16 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp12_7 (void) {
 	VAL v50 = VTUP(v35)->cells[1];
 	incref(v50);
 	VAL v51;
-	VAL v52 = mw_mirth_type_ArrowType_unpack(v49, &v51);
+	VAL v52;
+	mtp_mirth_type_ArrowType_ArrowType(v49, &v51, &v52);
 	incref(branch_z_x2_21);
-	incref(v52);
+	incref(v51);
 	VAL v53 = MKI64(0LL /* Nil */);
-	VAL v54 = mtw_mirth_arrow_Arrow_Arrow(v50, value_u64(branch_z_x2_21), value_u64(branch_z_x2_21), v46, v52, v52, v53);
+	VAL v54 = mtw_mirth_arrow_Arrow_Arrow(v50, value_u64(branch_z_x2_21), value_u64(branch_z_x2_21), v46, v51, v51, v53);
 	VAL v55;
 	VAL v56;
-	mw_mirth_elab_abZ_unifyZ_typeZBang(v51, v43, v54, &v55, &v56);
-	VAL v57 = mtw_mirth_match_Case_CASE(v45, v56);
+	mw_mirth_elab_abZ_unifyZ_typeZBang(v52, v43, v54, &v55, &v56);
+	VAL v57 = mtw_mirth_match_Case_Case(v45, v56);
 	VAL v58;
 	VAL v59;
 	mw_mirth_match_ZPlusMatch_addZ_case(v55, v35, v57, &v58, &v59);
@@ -67819,7 +67843,7 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp12_7 (void) {
 	mw_mirth_elab_abZ_opZBang(v61, v58, v32, &v62, &v63);
 	VAL v64;
 	VAL v65;
-	mw_mirth_elab_abZ_unifyZ_typeZBang(v10, v62, v63, &v64, &v65);
+	mw_mirth_elab_abZ_unifyZ_typeZBang(v11, v62, v63, &v64, &v65);
 	VAL v66;
 	VAL v67 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v64, v65, v8, &v66);
 	decref(v2);
@@ -67979,10 +68003,11 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp20_5 (void) {
 	uint64_t v6;
 	VAL v7 = mw_mirth_elab_initialZ_ctxZ_typeZ_bodyZ_home(r1, v0, &v2, &v3, &v4, &v5, &v6);
 	VAL v8;
-	VAL v9 = mw_mirth_type_ArrowType_unpack(v3, &v8);
-	incref(v9);
+	VAL v9;
+	mtp_mirth_type_ArrowType_ArrowType(v3, &v8, &v9);
+	incref(v8);
 	VAL v10 = MKI64(0LL /* Nil */);
-	VAL v11 = mtw_mirth_arrow_Arrow_Arrow(v5, v4, v4, v7, v9, v9, v10);
+	VAL v11 = mtw_mirth_arrow_Arrow_Arrow(v5, v4, v4, v7, v8, v8, v10);
 	VAL v12;
 	VAL v13 = mw_mirth_word_Word_params(v0, v2, &v12);
 	incref(v13);
@@ -67994,7 +68019,7 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp20_5 (void) {
 		decref(v13);
 		VAL v18;
 		VAL v19;
-		VAL v20 = mw_mirth_elab_elabZ_defZ_bodyZBang(v8, v12, v11, &v18, &v19);
+		VAL v20 = mw_mirth_elab_elabZ_defZ_bodyZBang(v9, v12, v11, &v18, &v19);
 		branch_ZPlusAB_17 = v19;
 		branch_ZPlusMirth_16 = v18;
 		branch_StackType_15 = v20;
@@ -68017,7 +68042,7 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp20_5 (void) {
 		VAL v34 = mtw_mirth_arrow_Arrow_Arrow(v32, v22, v22, v30, v29, v29, v33);
 		VAL v35;
 		VAL v36;
-		VAL v37 = mw_mirth_elab_elabZ_defZ_bodyZBang(v8, v27, v34, &v35, &v36);
+		VAL v37 = mw_mirth_elab_elabZ_defZ_bodyZBang(v9, v27, v34, &v35, &v36);
 		VAL v38;
 		VAL v39 = mw_mirth_elab_abZ_ctxZAt(v31, &v38);
 		VAL v40;

--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -1120,6 +1120,8 @@ static STACK lbl_input = {0};
 static STACK lbl_typeZDivresource = {0};
 static STACK lbl_body = {0};
 static STACK lbl_sigZAsk = {0};
+static STACK lbl_var = {0};
+static STACK lbl_default = {0};
 static STACK lbl_pattern = {0};
 static STACK lbl_ctx = {0};
 static STACK lbl_subst = {0};
@@ -1264,7 +1266,6 @@ static STACK lbl_arg2 = {0};
 static STACK lbl_argZ_type = {0};
 static STACK lbl_ZPlusfnptr = {0};
 static STACK lbl_ZPlustup = {0};
-static STACK lbl_var = {0};
 static STACK lbl_ZPlusclosure = {0};
 static STACK lbl_ZPlusindex = {0};
 static STACK lbl_stack = {0};
@@ -1722,6 +1723,15 @@ static VAL mtp_argZ_parser_types_ArgumentParsingError_MissingArg (VAL in_Argumen
 	VAL v3 = VTUP(in_ArgumentParsingError_1)->cells[1];
 	tup_decref_outer(VTUP(in_ArgumentParsingError_1),2);
 	return v3;
+}
+static VAL mtw_mirth_word_Param_Param (uint64_t in_Var_1, VAL in_Maybe_2) {
+	TUP* v4 = tup_new(3);
+	v4->size = 3;
+	v4->cells[0] = MKI64(0LL /* Param */);
+	v4->cells[2] = in_Maybe_2;
+	v4->cells[1] = MKU64(in_Var_1);
+	VAL v5 = MKTUP(v4, 3);
+	return v5;
 }
 static VAL mtw_mirth_tycon_Tycon_TYCONz_DATA (uint64_t in_Data_1) {
 	TUP* v3 = tup_new(2);
@@ -4696,6 +4706,8 @@ static VAL mw_std_list_List_1_first (VAL in_List_1);
 static VAL mw_std_list_List_1_last (VAL in_List_1);
 static VAL mw_std_list_ListZPlus_1_first (VAL in_ListZPlus_1);
 static VAL mw_std_list_ListZPlus_1_last (VAL in_ListZPlus_1);
+static VAL mw_std_list_List_1_tail (VAL in_List_1);
+static VAL mw_std_list_List_1_dropZ_slice (int64_t in_Nat_1, VAL in_List_2);
 static VAL mw_std_list_List_1_reverse (VAL in_List_1);
 static VAL mw_std_list_ListZPlus_1_reverse (VAL in_ListZPlus_1);
 static VAL mw_std_prim_Int_range (int64_t in_Int_1, int64_t in_Int_2);
@@ -5586,6 +5598,7 @@ static void mw_mirth_elab_elabZ_labelZ_setZBang (uint64_t in_Label_1, VAL in_ZPl
 static void mw_mirth_elab_elabZ_atomZ_blockZBang (VAL in_ZPlusMirth_1, VAL in_ZPlusAB_2, VAL *out_ZPlusMirth_3, VAL *out_ZPlusAB_4);
 static void mw_mirth_elab_elabZ_blockZ_atZBang (uint64_t in_Token_1, VAL in_ZPlusMirth_2, VAL in_ZPlusAB_3, VAL *out_ZPlusMirth_4, VAL *out_ZPlusAB_5);
 static void mw_mirth_elab_elabZ_argsZBang (VAL in_ZPlusMirth_1, VAL in_ZPlusAB_2, VAL *out_ZPlusMirth_3, VAL *out_ZPlusAB_4);
+static uint64_t mw_mirth_elab_elabZ_wordZ_argsZBang (uint64_t in_Word_1, VAL in_ZPlusMirth_2, VAL in_ZPlusAB_3, VAL *out_ZPlusMirth_5, VAL *out_ZPlusAB_6);
 static void mw_mirth_elab_elabZ_noZ_argsZBang (VAL in_ZPlusMirth_1, VAL in_ZPlusAB_2, VAL *out_ZPlusMirth_3, VAL *out_ZPlusAB_4);
 static int64_t mw_mirth_elab_arityZ_compatibleZAsk (int64_t in_Int_1, int64_t in_Int_2);
 static void mw_mirth_elab_elabZ_atomZ_nameZBang (uint64_t in_Name_1, VAL in_ZPlusMirth_2, VAL in_ZPlusAB_3, VAL *out_ZPlusMirth_4, VAL *out_ZPlusAB_5);
@@ -5671,6 +5684,7 @@ static uint64_t mw_mirth_elab_tableZ_newZBang (VAL in_ZPlusMirth_1, uint64_t in_
 static VAL mw_mirth_elab_resolveZ_defZ_namespace (VAL in_ZPlusMirth_1, uint64_t in_Token_2, VAL in_Either_3, VAL *out_ZPlusMirth_4);
 static VAL mw_mirth_elab_elabZ_qnameZ_fromZ_nonrelativeZ_dname (VAL in_ZPlusMirth_1, uint64_t in_Token_2, VAL in_DName_3, int64_t in_Int_4, VAL *out_ZPlusMirth_5);
 static int64_t mw_mirth_elab_moduleZ_visibleZ_fromZ_tokenZAsk (uint64_t in_Token_1, uint64_t in_Module_2);
+static int64_t mw_mirth_token_Token_isZ_defaultZ_paramZAsk (uint64_t in_Token_1);
 static VAL mw_mirth_elab_elabZ_defZ_qname (VAL in_ZPlusMirth_1, uint64_t in_Token_2, VAL *out_ZPlusMirth_3);
 static VAL mw_mirth_elab_elabZ_defZ_qnameZ_undefined (VAL in_ZPlusMirth_1, uint64_t in_Token_2, VAL *out_ZPlusMirth_3);
 static void mw_mirth_elab_elabZ_defZ_head (VAL in_ZPlusMirth_1, uint64_t in_Token_2, VAL *out_ZPlusMirth_3, uint64_t *out_Token_4, uint64_t *out_Name_5, int64_t *out_Nat_6, VAL *out_PropState_7);
@@ -5990,9 +6004,9 @@ static void mw_mirth_c99_C99ReprType_vZ_macro_1_sp4 (uint64_t in_Label_1, VAL in
 static VAL mw_std_maybe_Maybe_1_map_1_sp3 (VAL in_Resource_1, VAL in_Maybe_2, VAL *out_Maybe_4);
 static VAL mw_std_maybe_Maybe_1_map_1_sp4 (VAL in_Type_1, VAL in_Maybe_2, VAL *out_Maybe_4);
 static VAL mw_std_list_List_1_filter_1_sp1 (VAL in_List_1);
-static VAL mw_std_list_List_1_unions_1_sp1 (VAL in_List_1);
-static VAL mw_std_list_List_1_union_1_sp1 (VAL in_List_1, VAL in_List_2);
-static VAL mw_std_list_List_1_difference_1_sp1 (VAL in_List_1, VAL in_List_2);
+static VAL mw_std_list_List_1_unions_sp1 (VAL in_List_1);
+static VAL mw_std_list_List_1_union_sp1 (VAL in_List_1, VAL in_List_2);
+static VAL mw_std_list_List_1_difference_sp1 (VAL in_List_1, VAL in_List_2);
 static void mw_mirth_c99_ZPlusC99BranchSplit_c99Z_line_1_sp2 (VAL in_ZPlusC99BranchSplit_1, VAL *out_ZPlusC99BranchSplit_2);
 static void mw_std_list_List_1_for_1_sp16 (VAL in_ZPlusC99Branch_1, VAL in_List_2, VAL *out_ZPlusC99Branch_3);
 static void mw_mirth_c99_ZPlusC99_c99Z_lineZ_if_1_sp23 (int64_t in_Bool_1, VAL in_ZPlusC99_2, VAL *out_ZPlusC99_3);
@@ -6025,12 +6039,13 @@ static VAL mw_std_maybe_Maybe_1_filter_1_sp5 (VAL in_Resource_1, VAL in_Maybe_2,
 static VAL mw_std_maybe_Maybe_1_map_1_sp10 (VAL in_Maybe_1);
 static VAL mw_std_list_List_1_reverseZ_for_1_sp8 (VAL in_ZPlusMirth_1, VAL in_ZPlusAB_2, VAL in_Ctx_3, VAL in_StackType_4, VAL in_List_5, VAL *out_ZPlusMirth_6, VAL *out_ZPlusAB_7, VAL *out_StackType_9);
 static VAL mw_std_maybe_Maybe_1_bind_1_sp5 (VAL in_Maybe_1);
-static int64_t mw_std_list_List_1_ZEqualZEqual_1_sp1 (VAL in_ZPlusMirth_1, VAL in_List_2, VAL in_List_3, VAL *out_ZPlusMirth_4);
+static int64_t mw_std_list_List_1_ZEqualZEqual_sp1 (VAL in_ZPlusMirth_1, VAL in_List_2, VAL in_List_3, VAL *out_ZPlusMirth_4);
 static void mw_std_list_List_1_for_1_sp60 (VAL in_ZPlusSPCheck_1, VAL in_List_2, VAL *out_ZPlusSPCheck_3);
 static VAL mw_std_maybe_Maybe_1_bind_1_sp7 (VAL in_ZPlusMirth_1, VAL in_Maybe_2, VAL *out_ZPlusMirth_3);
 static VAL mw_std_list_List_1_for_1_sp63 (VAL in_ZPlusMirth_1, VAL in_z_x1_2, VAL in_ZPlusStr_3, VAL in_Str_4, VAL in_List_5, VAL *out_ZPlusMirth_6, VAL *out_z_x1_7, VAL *out_ZPlusStr_8);
-static int64_t mw_std_list_List_1_member_1_sp4 (VAL in_Namespace_1, VAL in_List_2);
-static VAL mw_std_list_List_1_for_1_sp80 (VAL in_StackType_1, VAL in_List_2);
+static int64_t mw_std_list_List_1_member_sp4 (VAL in_Namespace_1, VAL in_List_2);
+static VAL mw_std_list_List_1_map_1_sp7 (VAL in_List_1);
+static VAL mw_std_list_List_1_for_1_sp81 (VAL in_StackType_1, VAL in_List_2);
 static int64_t mw_std_maybe_Maybe_1_has_1_sp7 (VAL in_Maybe_1);
 static VAL mw_std_maybe_Maybe_1_filter_1_sp13 (VAL in_Maybe_1);
 static VAL mw_mirth_mirth_PropLabel_prop_1_sp15 (uint64_t in_Token_1, VAL in_PropLabel_2);
@@ -6045,7 +6060,7 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp2_2 (void);
 static void mb_mirth_mirth_PropLabel_prop_1_sp3_6 (void);
 static void mb_mirth_mirth_PropLabel_prop_1_sp4_0 (void);
 static void mb_mirth_mirth_PropLabel_prop_1_sp5_2 (void);
-static void mb_mirth_mirth_PropLabel_prop_1_sp6_9 (void);
+static void mb_mirth_mirth_PropLabel_prop_1_sp6_10 (void);
 static void mb_mirth_mirth_PropLabel_prop_1_sp7_1 (void);
 static void mb_mirth_mirth_PropLabel_prop_1_sp8_5 (void);
 static void mb_mirth_mirth_PropLabel_prop_1_sp9_3 (void);
@@ -6059,7 +6074,7 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp16_1 (void);
 static void mb_mirth_mirth_PropLabel_prop_1_sp17_0 (void);
 static void mb_mirth_mirth_PropLabel_prop_1_sp18_1 (void);
 static void mb_mirth_mirth_PropLabel_prop_1_sp19_0 (void);
-static void mb_mirth_mirth_PropLabel_prop_1_sp20_5 (void);
+static void mb_mirth_mirth_PropLabel_prop_1_sp20_6 (void);
 static void mb_mirth_mirth_PropLabel_prop_1_sp21_0 (void);
 static void mb_mirth_mirth_PropLabel_prop_1_sp22_6 (void);
 int main (int argc, char** argv) {
@@ -7477,6 +7492,54 @@ static VAL mw_std_list_ListZPlus_1_last (VAL in_ListZPlus_1) {
 		v6 = branch_z_x1_13;
 	}
 	decref(v7);
+	return v6;
+}
+static VAL mw_std_list_List_1_tail (VAL in_List_1) {
+	VAL branch_List_3;
+	switch (get_data_tag(in_List_1)) {
+		case 0LL: { // Nil
+			VAL v4 = MKI64(0LL /* Nil */);
+			branch_List_3 = v4;
+		} break;
+		case 1LL: { // Cons
+			VAL v5;
+			VAL v6 = mtp_std_list_List_1_Cons(in_List_1, &v5);
+			decref(v6);
+			branch_List_3 = v5;
+		} break;
+		default: {
+			do_panic(str_make("unexpected fallthrough in match\n", 32));
+		}
+	}
+	return branch_List_3;
+}
+static VAL mw_std_list_List_1_dropZ_slice (int64_t in_Nat_1, VAL in_List_2) {
+	int64_t v4 = 0LL;
+	bool v5 = (in_Nat_1 > v4);
+	VAL v6 = in_List_2;
+	int64_t v7 = in_Nat_1;
+	bool v8 = v5;
+	while (v8) {
+		VAL v9 = v6;
+		int64_t v10 = v7;
+		VAL v11 = mw_std_list_List_1_tail(v9);
+		int64_t v12 = 1LL;
+		int64_t v13 = i64_sub(v10, v12);
+		int64_t v14 = 0LL;
+		bool v15 = (v13 < v14);
+		int64_t branch_Nat_16;
+		if (v15) {
+			int64_t v17 = 0LL;
+			branch_Nat_16 = v17;
+		} else {
+			branch_Nat_16 = v13;
+		}
+		int64_t v18 = 0LL;
+		bool v19 = (branch_Nat_16 > v18);
+		v8 = v19;
+		v7 = branch_Nat_16;
+		v6 = v11;
+	}
 	return v6;
 }
 static VAL mw_std_list_List_1_reverse (VAL in_List_1) {
@@ -10754,10 +10817,21 @@ static int64_t mw_mirth_word_Word_arity (uint64_t in_Word_1) {
 }
 static VAL mw_mirth_word_Word_params (uint64_t in_Word_1, VAL in_ZPlusMirth_2, VAL *out_ZPlusMirth_4) {
 	void* v5 = field_mut(&mfld_mirth_word_Word_ZTildeparams, in_Word_1);
-	VAL v6;
-	VAL v7 = mw_mirth_mirth_Prop_1_forceZBang(v5, in_ZPlusMirth_2, &v6);
-	*out_ZPlusMirth_4 = v6;
-	return v7;
+	bool v6 = mut_is_set(v5);
+	VAL branch_List_7;
+	VAL branch_ZPlusMirth_8;
+	if (v6) {
+		VAL v9;
+		VAL v10 = mw_mirth_mirth_Prop_1_forceZBang(v5, in_ZPlusMirth_2, &v9);
+		branch_ZPlusMirth_8 = v9;
+		branch_List_7 = v10;
+	} else {
+		VAL v11 = MKI64(0LL /* Nil */);
+		branch_ZPlusMirth_8 = in_ZPlusMirth_2;
+		branch_List_7 = v11;
+	}
+	*out_ZPlusMirth_4 = branch_ZPlusMirth_8;
+	return branch_List_7;
 }
 static VAL mw_mirth_word_Word_arrow (uint64_t in_Word_1, VAL in_ZPlusMirth_2, VAL *out_ZPlusMirth_4) {
 	void* v5 = field_mut(&mfld_mirth_word_Word_ZTildearrow, in_Word_1);
@@ -14446,7 +14520,7 @@ static VAL mw_mirth_arrow_Arrow_freeZ_vars (VAL in_ZPlusMirth_1, VAL in_Arrow_2,
 	}
 	decref(v11);
 	VAL v30 = mw_std_list_List_1_reverse(v10);
-	VAL v31 = mw_std_list_List_1_unions_1_sp1(v30);
+	VAL v31 = mw_std_list_List_1_unions_sp1(v30);
 	*out_ZPlusMirth_3 = v9;
 	return v31;
 }
@@ -14505,13 +14579,13 @@ static VAL mw_mirth_arrow_Atom_freeZ_vars (VAL in_ZPlusMirth_1, VAL in_Atom_2, V
 	}
 	decref(v11);
 	VAL v30 = mw_std_list_List_1_reverse(v10);
-	VAL v31 = mw_std_list_List_1_unions_1_sp1(v30);
+	VAL v31 = mw_std_list_List_1_unions_sp1(v30);
 	VAL v32 = VTUP(in_Atom_2)->cells[4];
 	incref(v32);
 	decref(in_Atom_2);
 	VAL v33;
 	VAL v34 = mw_mirth_arrow_Op_freeZ_vars(v9, v32, &v33);
-	VAL v35 = mw_std_list_List_1_union_1_sp1(v31, v34);
+	VAL v35 = mw_std_list_List_1_union_sp1(v31, v34);
 	*out_ZPlusMirth_3 = v33;
 	return v35;
 }
@@ -14749,7 +14823,7 @@ static VAL mw_mirth_match_Match_freeZ_vars (VAL in_ZPlusMirth_1, VAL in_Match_2,
 	}
 	decref(v11);
 	VAL v30 = mw_std_list_List_1_reverse(v10);
-	VAL v31 = mw_std_list_List_1_unions_1_sp1(v30);
+	VAL v31 = mw_std_list_List_1_unions_sp1(v30);
 	*out_ZPlusMirth_3 = v9;
 	return v31;
 }
@@ -14772,7 +14846,7 @@ static VAL mw_mirth_arrow_Lambda_freeZ_vars (VAL in_ZPlusMirth_1, VAL in_Lambda_
 	VAL v8 = VTUP(in_Lambda_2)->cells[4];
 	incref(v8);
 	decref(in_Lambda_2);
-	VAL v9 = mw_std_list_List_1_difference_1_sp1(v7, v8);
+	VAL v9 = mw_std_list_List_1_difference_sp1(v7, v8);
 	*out_ZPlusMirth_3 = v6;
 	return v9;
 }
@@ -15223,7 +15297,7 @@ static VAL mw_mirth_type_TZ_ZTo (VAL in_StackType_1, VAL in_StackType_2) {
 }
 static VAL mw_mirth_type_TT (VAL in_List_1) {
 	VAL v3 = mw_mirth_type_T0();
-	VAL v4 = mw_std_list_List_1_for_1_sp80(v3, in_List_1);
+	VAL v4 = mw_std_list_List_1_for_1_sp81(v3, in_List_1);
 	return v4;
 }
 static VAL mw_mirth_type_T0 (void) {
@@ -32062,7 +32136,7 @@ static VAL mw_mirth_elab_ZPlusTypeElab_elabZ_typeZ_sigZBang (VAL in_ZPlusMirth_1
 		branch_ZPlusTypeElab_35 = branch_ZPlusTypeElab_24;
 		branch_ZPlusMirth_34 = v38;
 	}
-	VAL v39 = mw_std_list_List_1_for_1_sp80(branch_StackType_22, branch_List_21);
+	VAL v39 = mw_std_list_List_1_for_1_sp81(branch_StackType_22, branch_List_21);
 	VAL v40 = mw_mirth_type_TZ_ZTo(v39, branch_StackType_25);
 	*out_ZPlusTypeElab_4 = branch_ZPlusTypeElab_35;
 	*out_ZPlusMirth_3 = branch_ZPlusMirth_34;
@@ -33484,117 +33558,132 @@ static void mw_mirth_elab_ZPlusResolveDef_filterZ_arity (VAL in_ZPlusMirth_1, VA
 	VAL v8 = MKI64(0LL /* Nil */);
 	VAL v9 = MKI64(0LL /* Nil */);
 	int64_t v10 = 1LL /* True */;
-	VAL v11 = in_ZPlusResolveDef_2;
-	int64_t v12 = v6;
-	VAL v13 = v8;
-	VAL v14 = v9;
-	VAL v15 = v7;
-	int64_t v16 = v10;
+	VAL v11 = in_ZPlusMirth_1;
+	VAL v12 = in_ZPlusResolveDef_2;
+	int64_t v13 = v6;
+	VAL v14 = v8;
+	VAL v15 = v9;
+	VAL v16 = v7;
 	int64_t v17 = v10;
-	while (((bool)v17)) {
-		VAL v18 = v11;
-		int64_t v19 = v12;
-		VAL v20 = v13;
-		VAL v21 = v14;
-		VAL v22 = v15;
-		int64_t v23 = v16;
-		int64_t branch_Nat_24;
-		VAL branch_z_x1_25;
-		VAL branch_List_26;
-		VAL branch_List_27;
-		VAL branch_List_28;
-		int64_t branch_Bool_29;
-		switch (get_data_tag(v22)) {
+	int64_t v18 = v10;
+	while (((bool)v18)) {
+		VAL v19 = v11;
+		VAL v20 = v12;
+		int64_t v21 = v13;
+		VAL v22 = v14;
+		VAL v23 = v15;
+		VAL v24 = v16;
+		int64_t v25 = v17;
+		int64_t branch_Nat_26;
+		VAL branch_ZPlusMirth_27;
+		VAL branch_z_x1_28;
+		VAL branch_List_29;
+		VAL branch_List_30;
+		VAL branch_List_31;
+		int64_t branch_Bool_32;
+		switch (get_data_tag(v24)) {
 			case 1LL: { // Cons
-				VAL v30;
-				VAL v31 = mtp_std_list_List_1_Cons(v22, &v30);
-				incref(v31);
-				int64_t v32 = mw_mirth_def_Def_arity(v31);
-				int64_t v33 = mw_mirth_elab_arityZ_compatibleZAsk(v19, v32);
-				int64_t branch_Nat_34;
-				VAL branch_z_x1_35;
-				VAL branch_Either_36;
-				if (((bool)v33)) {
-					VAL v37 = mtw_std_either_Either_2_Right(v31);
-					branch_Either_36 = v37;
-					branch_z_x1_35 = v18;
-					branch_Nat_34 = v19;
-				} else {
-					VAL v38 = mtw_mirth_elab_RejectedDef_RDz_WRONGz_ARITY(v31);
-					VAL v39 = mtw_std_either_Either_2_Left(v38);
-					branch_Either_36 = v39;
-					branch_z_x1_35 = v18;
-					branch_Nat_34 = v19;
-				}
-				int64_t branch_Nat_40;
+				VAL v33;
+				VAL v34 = mtp_std_list_List_1_Cons(v24, &v33);
+				incref(v34);
+				VAL v35;
+				VAL v36 = mw_mirth_def_Def_qnameZ_hard(v19, v34, &v35);
+				int64_t v37 = value_i64(VTUP(v36)->cells[3]);
+				decref(v36);
+				int64_t v38 = mw_mirth_elab_arityZ_compatibleZAsk(v21, v37);
+				int64_t branch_Nat_39;
+				VAL branch_ZPlusMirth_40;
 				VAL branch_z_x1_41;
-				VAL branch_List_42;
-				VAL branch_List_43;
-				switch (get_data_tag(branch_Either_36)) {
+				VAL branch_Either_42;
+				if (((bool)v38)) {
+					VAL v43 = mtw_std_either_Either_2_Right(v34);
+					branch_Either_42 = v43;
+					branch_z_x1_41 = v20;
+					branch_ZPlusMirth_40 = v35;
+					branch_Nat_39 = v21;
+				} else {
+					VAL v44 = mtw_mirth_elab_RejectedDef_RDz_WRONGz_ARITY(v34);
+					VAL v45 = mtw_std_either_Either_2_Left(v44);
+					branch_Either_42 = v45;
+					branch_z_x1_41 = v20;
+					branch_ZPlusMirth_40 = v35;
+					branch_Nat_39 = v21;
+				}
+				int64_t branch_Nat_46;
+				VAL branch_ZPlusMirth_47;
+				VAL branch_z_x1_48;
+				VAL branch_List_49;
+				VAL branch_List_50;
+				switch (get_data_tag(branch_Either_42)) {
 					case 0LL: { // Left
-						VAL v44 = mtp_std_either_Either_2_Left(branch_Either_36);
-						VAL v45 = mtw_std_list_List_1_Cons(v44, v20);
-						branch_List_43 = v21;
-						branch_List_42 = v45;
-						branch_z_x1_41 = branch_z_x1_35;
-						branch_Nat_40 = branch_Nat_34;
+						VAL v51 = mtp_std_either_Either_2_Left(branch_Either_42);
+						VAL v52 = mtw_std_list_List_1_Cons(v51, v22);
+						branch_List_50 = v23;
+						branch_List_49 = v52;
+						branch_z_x1_48 = branch_z_x1_41;
+						branch_ZPlusMirth_47 = branch_ZPlusMirth_40;
+						branch_Nat_46 = branch_Nat_39;
 					} break;
 					case 1LL: { // Right
-						VAL v46 = mtp_std_either_Either_2_Right(branch_Either_36);
-						VAL v47 = mtw_std_list_List_1_Cons(v46, v21);
-						branch_List_43 = v47;
-						branch_List_42 = v20;
-						branch_z_x1_41 = branch_z_x1_35;
-						branch_Nat_40 = branch_Nat_34;
+						VAL v53 = mtp_std_either_Either_2_Right(branch_Either_42);
+						VAL v54 = mtw_std_list_List_1_Cons(v53, v23);
+						branch_List_50 = v54;
+						branch_List_49 = v22;
+						branch_z_x1_48 = branch_z_x1_41;
+						branch_ZPlusMirth_47 = branch_ZPlusMirth_40;
+						branch_Nat_46 = branch_Nat_39;
 					} break;
 					default: {
 						do_panic(str_make("unexpected fallthrough in match\n", 32));
 					}
 				}
-				int64_t v48 = 1LL /* True */;
-				branch_Bool_29 = v48;
-				branch_List_28 = v30;
-				branch_List_27 = branch_List_43;
-				branch_List_26 = branch_List_42;
-				branch_z_x1_25 = branch_z_x1_41;
-				branch_Nat_24 = branch_Nat_40;
+				int64_t v55 = 1LL /* True */;
+				branch_Bool_32 = v55;
+				branch_List_31 = v33;
+				branch_List_30 = branch_List_50;
+				branch_List_29 = branch_List_49;
+				branch_z_x1_28 = branch_z_x1_48;
+				branch_ZPlusMirth_27 = branch_ZPlusMirth_47;
+				branch_Nat_26 = branch_Nat_46;
 			} break;
 			case 0LL: { // Nil
-				VAL v49 = MKI64(0LL /* Nil */);
-				int64_t v50 = 0LL /* False */;
-				branch_Bool_29 = v50;
-				branch_List_28 = v49;
-				branch_List_27 = v21;
-				branch_List_26 = v20;
-				branch_z_x1_25 = v18;
-				branch_Nat_24 = v19;
+				VAL v56 = MKI64(0LL /* Nil */);
+				int64_t v57 = 0LL /* False */;
+				branch_Bool_32 = v57;
+				branch_List_31 = v56;
+				branch_List_30 = v23;
+				branch_List_29 = v22;
+				branch_z_x1_28 = v20;
+				branch_ZPlusMirth_27 = v19;
+				branch_Nat_26 = v21;
 			} break;
 			default: {
 				do_panic(str_make("unexpected fallthrough in match\n", 32));
 			}
 		}
-		v17 = branch_Bool_29;
-		v16 = branch_Bool_29;
-		v15 = branch_List_28;
-		v14 = branch_List_27;
-		v13 = branch_List_26;
-		v12 = branch_Nat_24;
-		v11 = branch_z_x1_25;
+		v18 = branch_Bool_32;
+		v17 = branch_Bool_32;
+		v16 = branch_List_31;
+		v15 = branch_List_30;
+		v14 = branch_List_29;
+		v13 = branch_Nat_26;
+		v12 = branch_z_x1_28;
+		v11 = branch_ZPlusMirth_27;
 	}
-	decref(v15);
-	VAL v51 = mw_std_list_List_1_reverse(v13);
-	VAL v52 = mw_std_list_List_1_reverse(v14);
-	VAL v53 = VTUP(v11)->cells[5];
-	incref(v53);
-	VAL v54 = mw_std_list_List_1_cat(v51, v53);
-	VAL v55 = VTUP(v11)->cells[5];
-	decref(v55);
-	VTUP(v11)->cells[5] = v54;
-	VAL v56 = VTUP(v11)->cells[4];
-	decref(v56);
-	VTUP(v11)->cells[4] = v52;
-	*out_ZPlusResolveDef_4 = v11;
-	*out_ZPlusMirth_3 = in_ZPlusMirth_1;
+	decref(v16);
+	VAL v58 = mw_std_list_List_1_reverse(v14);
+	VAL v59 = mw_std_list_List_1_reverse(v15);
+	VAL v60 = VTUP(v12)->cells[5];
+	incref(v60);
+	VAL v61 = mw_std_list_List_1_cat(v58, v60);
+	VAL v62 = VTUP(v12)->cells[5];
+	decref(v62);
+	VTUP(v12)->cells[5] = v61;
+	VAL v63 = VTUP(v12)->cells[4];
+	decref(v63);
+	VTUP(v12)->cells[4] = v59;
+	*out_ZPlusResolveDef_4 = v12;
+	*out_ZPlusMirth_3 = v11;
 }
 static void mw_mirth_elab_ZPlusResolveDef_filterZ_qualifiers (VAL in_ZPlusMirth_1, VAL in_ZPlusResolveDef_2, VAL *out_ZPlusMirth_3, VAL *out_ZPlusResolveDef_4) {
 	uint64_t v5 = value_u64(VTUP(in_ZPlusResolveDef_2)->cells[2]);
@@ -33802,7 +33891,7 @@ static void mw_mirth_elab_ZPlusResolveDef_filterZ_roots (VAL in_List_1, VAL in_Z
 						VAL v44 = VTUP(v43)->cells[1];
 						incref(v44);
 						decref(v43);
-						int64_t v45 = mw_std_list_List_1_member_1_sp4(v44, v27);
+						int64_t v45 = mw_std_list_List_1_member_sp4(v44, v27);
 						VAL branch_ZPlusMirth_46;
 						VAL branch_Def_47;
 						VAL branch_ZPlusResolveDef_48;
@@ -34093,7 +34182,7 @@ static void mw_mirth_elab_ZPlusResolveDef_filterZ_roots (VAL in_List_1, VAL in_Z
 										VAL v175 = mtp_std_maybe_Maybe_1_Some(v168);
 										incref(v175);
 										incref(v161);
-										int64_t v176 = mw_std_list_List_1_member_1_sp4(v175, v161);
+										int64_t v176 = mw_std_list_List_1_member_sp4(v175, v161);
 										VAL branch_List_177;
 										VAL branch_z_x1_178;
 										VAL branch_z_x2_179;
@@ -37068,6 +37157,106 @@ static void mw_mirth_elab_elabZ_argsZBang (VAL in_ZPlusMirth_1, VAL in_ZPlusAB_2
 	*out_ZPlusAB_4 = v10;
 	*out_ZPlusMirth_3 = v9;
 }
+static uint64_t mw_mirth_elab_elabZ_wordZ_argsZBang (uint64_t in_Word_1, VAL in_ZPlusMirth_2, VAL in_ZPlusAB_3, VAL *out_ZPlusMirth_5, VAL *out_ZPlusAB_6) {
+	VAL v7;
+	VAL v8;
+	mw_mirth_elab_elabZ_argsZBang(in_ZPlusMirth_2, in_ZPlusAB_3, &v7, &v8);
+	VAL v9;
+	uint64_t v10 = mw_mirth_elab_abZ_tokenZAt(v8, &v9);
+	int64_t v11 = mw_mirth_token_Token_numZ_args(v10);
+	int64_t v12 = mw_mirth_word_Word_arity(in_Word_1);
+	bool v13 = (v11 < v12);
+	uint64_t branch_Word_14;
+	VAL branch_ZPlusMirth_15;
+	VAL branch_ZPlusAB_16;
+	if (v13) {
+		VAL v17;
+		uint64_t v18 = mw_mirth_elab_abZ_tokenZAt(v9, &v17);
+		int64_t v19 = mw_mirth_token_Token_numZ_args(v18);
+		VAL v20;
+		VAL v21 = mw_mirth_word_Word_params(in_Word_1, v7, &v20);
+		VAL v22 = mw_std_list_List_1_dropZ_slice(v19, v21);
+		int64_t v23 = 1LL /* True */;
+		VAL v24 = v20;
+		VAL v25 = v17;
+		VAL v26 = v22;
+		int64_t v27 = v23;
+		int64_t v28 = v23;
+		while (((bool)v28)) {
+			VAL v29 = v24;
+			VAL v30 = v25;
+			VAL v31 = v26;
+			int64_t v32 = v27;
+			VAL branch_ZPlusMirth_33;
+			VAL branch_ZPlusAB_34;
+			VAL branch_List_35;
+			int64_t branch_Bool_36;
+			switch (get_data_tag(v31)) {
+				case 1LL: { // Cons
+					VAL v37;
+					VAL v38 = mtp_std_list_List_1_Cons(v31, &v37);
+					VAL v39 = VTUP(v38)->cells[2];
+					incref(v39);
+					decref(v38);
+					VAL branch_ZPlusMirth_40;
+					VAL branch_ZPlusAB_41;
+					switch (get_data_tag(v39)) {
+						case 1LL: { // Some
+							VAL v42 = mtp_std_maybe_Maybe_1_Some(v39);
+							VAL v43;
+							VAL v44;
+							mw_mirth_elab_elabZ_blockZ_atZBang(value_u64(v42), v29, v30, &v43, &v44);
+							branch_ZPlusAB_41 = v44;
+							branch_ZPlusMirth_40 = v43;
+						} break;
+						case 0LL: { // None
+							VAL v45;
+							uint64_t v46 = mw_mirth_elab_abZ_tokenZAt(v30, &v45);
+							STR* v47;
+							STRLIT(v47, "word parameter is missing, has no default implementation", 56);
+							mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang(v46, MKSTR(v47), v29);
+						} break;
+						default: {
+							do_panic(str_make("unexpected fallthrough in match\n", 32));
+						}
+					}
+					int64_t v49 = 1LL /* True */;
+					branch_Bool_36 = v49;
+					branch_List_35 = v37;
+					branch_ZPlusAB_34 = branch_ZPlusAB_41;
+					branch_ZPlusMirth_33 = branch_ZPlusMirth_40;
+				} break;
+				case 0LL: { // Nil
+					VAL v50 = MKI64(0LL /* Nil */);
+					int64_t v51 = 0LL /* False */;
+					branch_Bool_36 = v51;
+					branch_List_35 = v50;
+					branch_ZPlusAB_34 = v30;
+					branch_ZPlusMirth_33 = v29;
+				} break;
+				default: {
+					do_panic(str_make("unexpected fallthrough in match\n", 32));
+				}
+			}
+			v28 = branch_Bool_36;
+			v27 = branch_Bool_36;
+			v26 = branch_List_35;
+			v25 = branch_ZPlusAB_34;
+			v24 = branch_ZPlusMirth_33;
+		}
+		decref(v26);
+		branch_ZPlusAB_16 = v25;
+		branch_ZPlusMirth_15 = v24;
+		branch_Word_14 = in_Word_1;
+	} else {
+		branch_ZPlusAB_16 = v9;
+		branch_ZPlusMirth_15 = v7;
+		branch_Word_14 = in_Word_1;
+	}
+	*out_ZPlusAB_6 = branch_ZPlusAB_16;
+	*out_ZPlusMirth_5 = branch_ZPlusMirth_15;
+	return branch_Word_14;
+}
 static void mw_mirth_elab_elabZ_noZ_argsZBang (VAL in_ZPlusMirth_1, VAL in_ZPlusAB_2, VAL *out_ZPlusMirth_3, VAL *out_ZPlusAB_4) {
 	VAL v5;
 	uint64_t v6 = mw_mirth_elab_abZ_tokenZAt(in_ZPlusAB_2, &v5);
@@ -37414,40 +37603,40 @@ static void mw_mirth_elab_elabZ_atomZ_defZBang (VAL in_Def_1, VAL in_ZPlusMirth_
 			uint64_t v33 = mtp_mirth_def_Def_DefWord(in_Def_1);
 			VAL v34;
 			VAL v35;
-			mw_mirth_elab_elabZ_argsZBang(in_ZPlusMirth_2, in_ZPlusAB_3, &v34, &v35);
-			VAL v36;
+			uint64_t v36 = mw_mirth_elab_elabZ_wordZ_argsZBang(v33, in_ZPlusMirth_2, in_ZPlusAB_3, &v34, &v35);
 			VAL v37;
-			mw_mirth_elab_abZ_wordZBang(v33, v34, v35, &v36, &v37);
-			branch_ZPlusAB_7 = v37;
-			branch_ZPlusMirth_6 = v36;
+			VAL v38;
+			mw_mirth_elab_abZ_wordZBang(v36, v34, v35, &v37, &v38);
+			branch_ZPlusAB_7 = v38;
+			branch_ZPlusMirth_6 = v37;
 		} break;
 		case 6LL: { // DefTag
-			uint64_t v38 = mtp_mirth_def_Def_DefTag(in_Def_1);
-			VAL v39;
+			uint64_t v39 = mtp_mirth_def_Def_DefTag(in_Def_1);
 			VAL v40;
-			mw_mirth_elab_elabZ_argsZBang(in_ZPlusMirth_2, in_ZPlusAB_3, &v39, &v40);
 			VAL v41;
+			mw_mirth_elab_elabZ_argsZBang(in_ZPlusMirth_2, in_ZPlusAB_3, &v40, &v41);
 			VAL v42;
-			mw_mirth_elab_abZ_tagZBang(v38, v39, v40, &v41, &v42);
-			branch_ZPlusAB_7 = v42;
-			branch_ZPlusMirth_6 = v41;
+			VAL v43;
+			mw_mirth_elab_abZ_tagZBang(v39, v40, v41, &v42, &v43);
+			branch_ZPlusAB_7 = v43;
+			branch_ZPlusMirth_6 = v42;
 		} break;
 		case 7LL: { // DefPrim
-			int64_t v43 = mtp_mirth_def_Def_DefPrim(in_Def_1);
-			VAL v44;
+			int64_t v44 = mtp_mirth_def_Def_DefPrim(in_Def_1);
 			VAL v45;
-			mw_mirth_elab_elabZ_primZBang(v43, in_ZPlusMirth_2, in_ZPlusAB_3, &v44, &v45);
-			branch_ZPlusAB_7 = v45;
-			branch_ZPlusMirth_6 = v44;
+			VAL v46;
+			mw_mirth_elab_elabZ_primZBang(v44, in_ZPlusMirth_2, in_ZPlusAB_3, &v45, &v46);
+			branch_ZPlusAB_7 = v46;
+			branch_ZPlusMirth_6 = v45;
 		} break;
 		default: {
-			VAL v46;
-			VAL v47 = mw_mirth_def_Def_qnameZ_hard(in_ZPlusMirth_2, in_Def_1, &v46);
-			VAL v48;
+			VAL v47;
+			VAL v48 = mw_mirth_def_Def_qnameZ_hard(in_ZPlusMirth_2, in_Def_1, &v47);
 			VAL v49;
-			mw_mirth_elab_elabZ_atomZ_notZ_aZ_wordZBang(v47, v46, in_ZPlusAB_3, &v48, &v49);
-			branch_ZPlusAB_7 = v49;
-			branch_ZPlusMirth_6 = v48;
+			VAL v50;
+			mw_mirth_elab_elabZ_atomZ_notZ_aZ_wordZBang(v48, v47, in_ZPlusAB_3, &v49, &v50);
+			branch_ZPlusAB_7 = v50;
+			branch_ZPlusMirth_6 = v49;
 		} break;
 	}
 	*out_ZPlusAB_5 = branch_ZPlusAB_7;
@@ -38087,7 +38276,7 @@ static void mw_mirth_elab_elabZ_patternZ_atomZBang (uint64_t in_Token_1, VAL in_
 									VAL v113 = VTUP(v112)->cells[1];
 									incref(v113);
 									decref(v112);
-									int64_t v114 = mw_std_list_List_1_member_1_sp4(v113, v97);
+									int64_t v114 = mw_std_list_List_1_member_sp4(v113, v97);
 									VAL branch_List_115;
 									VAL branch_ZPlusMirth_116;
 									VAL branch_z_x1_117;
@@ -40522,7 +40711,7 @@ static void mw_mirth_elab_createZ_projectorsZBang (VAL in_ZPlusMirth_1, uint64_t
 					mut_set(v82, v83);
 					VAL v84 = mtw_mirth_mirth_PropLabel_WordArrow(v48);
 					TUP* v85 = tup_pack4(MKU64(v16), MKU64(v38), MKU64(v44), MKU64(v48));
-					FNPTR v86 = &mb_mirth_mirth_PropLabel_prop_1_sp6_9;
+					FNPTR v86 = &mb_mirth_mirth_PropLabel_prop_1_sp6_10;
 					VAL v87 = mtw_mirth_mirth_PropState_1_PSDelay(MKTUP(v85, 4), MKFNPTR(v86));
 					VAL v88 = mtw_mirth_mirth_Prop_1_Prop(v84, v87);
 					void* v89 = field_mut(&mfld_mirth_word_Word_ZTildearrow, v48);
@@ -41008,7 +41197,7 @@ static uint64_t mw_mirth_elab_elabZ_defZBang (VAL in_ZPlusMirth_1, uint64_t in_T
 	void* v32 = field_mut(&mfld_mirth_word_Word_ZTildeparams, v17);
 	mut_set(v31, v32);
 	VAL v33 = mtw_mirth_mirth_PropLabel_WordArrow(v17);
-	FNPTR v34 = &mb_mirth_mirth_PropLabel_prop_1_sp20_5;
+	FNPTR v34 = &mb_mirth_mirth_PropLabel_prop_1_sp20_6;
 	VAL v35 = mtw_mirth_mirth_PropState_1_PSDelay(MKU64(v17), MKFNPTR(v34));
 	VAL v36 = mtw_mirth_mirth_Prop_1_Prop(v33, v35);
 	void* v37 = field_mut(&mfld_mirth_word_Word_ZTildearrow, v17);
@@ -41343,55 +41532,91 @@ static VAL mw_mirth_elab_elabZ_defZ_paramsZBang (VAL in_ZPlusMirth_1, uint64_t i
 				VAL branch_ZPlusMirth_45;
 				uint64_t branch_Name_46;
 				uint64_t branch_Token_47;
+				VAL branch_Maybe_48;
 				if (((bool)v42)) {
+					VAL v49 = MKI64(0LL /* None */);
+					branch_Maybe_48 = v49;
 					branch_Token_47 = branch_Token_33;
 					branch_Name_46 = value_u64(branch_z_x1_35);
 					branch_ZPlusMirth_45 = branch_ZPlusMirth_34;
 					branch_StackType_44 = v21;
 					branch_List_43 = v20;
 				} else {
-					STR* v48;
-					STRLIT(v48, "expected right paren or comma", 29);
-					mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang(v41, MKSTR(v48), branch_ZPlusMirth_34);
+					VAL v50 = mw_mirth_token_Token_lcurlyZAsk(v41);
+					int64_t v51 = get_data_tag(v50);
+					decref(v50);
+					int64_t v52 = 1LL;
+					bool v53 = (v51 == v52);
+					VAL branch_ZPlusMirth_54;
+					VAL branch_Maybe_55;
+					if (v53) {
+						uint64_t v56 = mw_mirth_token_Token_succ(v41);
+						VAL v57 = mtw_std_maybe_Maybe_1_Some(MKU64(v56));
+						uint64_t v58 = mw_mirth_token_Token_next(v41);
+						int64_t v59 = mw_mirth_token_Token_runZ_endZAsk(v58);
+						VAL branch_ZPlusMirth_60;
+						VAL branch_Maybe_61;
+						if (((bool)v59)) {
+							branch_Maybe_61 = v57;
+							branch_ZPlusMirth_60 = branch_ZPlusMirth_34;
+						} else {
+							STR* v62;
+							STRLIT(v62, "expected right paren or comma", 29);
+							mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang(v58, MKSTR(v62), branch_ZPlusMirth_34);
+						}
+						branch_Maybe_55 = branch_Maybe_61;
+						branch_ZPlusMirth_54 = branch_ZPlusMirth_60;
+					} else {
+						STR* v64;
+						STRLIT(v64, "expected right paren, left curly, or comma", 42);
+						mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang(v41, MKSTR(v64), branch_ZPlusMirth_34);
+					}
+					branch_Maybe_48 = branch_Maybe_55;
+					branch_Token_47 = branch_Token_33;
+					branch_Name_46 = value_u64(branch_z_x1_35);
+					branch_ZPlusMirth_45 = branch_ZPlusMirth_54;
+					branch_StackType_44 = v21;
+					branch_List_43 = v20;
 				}
-				VAL v50;
-				VAL v51;
-				uint64_t v52;
-				VAL v53 = mw_mirth_elab_elabZ_expandZ_tensorZBang(branch_ZPlusMirth_45, branch_StackType_44, branch_Token_47, &v50, &v51, &v52);
-				VAL v54 = mw_mirth_type_Type_morphismZAsk(v51);
-				uint64_t branch_Token_55;
-				VAL branch_ZPlusMirth_56;
-				VAL branch_z_x1_57;
-				switch (get_data_tag(v54)) {
+				VAL v67;
+				VAL v68;
+				uint64_t v69;
+				VAL v70 = mw_mirth_elab_elabZ_expandZ_tensorZBang(branch_ZPlusMirth_45, branch_StackType_44, branch_Token_47, &v67, &v68, &v69);
+				VAL v71 = mw_mirth_type_Type_morphismZAsk(v68);
+				uint64_t branch_Token_72;
+				VAL branch_ZPlusMirth_73;
+				VAL branch_z_x1_74;
+				switch (get_data_tag(v71)) {
 					case 1LL: { // Some
-						VAL v58 = mtp_std_maybe_Maybe_1_Some(v54);
-						branch_z_x1_57 = v58;
-						branch_ZPlusMirth_56 = v50;
-						branch_Token_55 = v52;
+						VAL v75 = mtp_std_maybe_Maybe_1_Some(v71);
+						branch_z_x1_74 = v75;
+						branch_ZPlusMirth_73 = v67;
+						branch_Token_72 = v69;
 					} break;
 					case 0LL: { // None
-						STR* v59;
-						STRLIT(v59, "need function type for param", 28);
-						mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang(v52, MKSTR(v59), v50);
+						STR* v76;
+						STRLIT(v76, "need function type for param", 28);
+						mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang(v69, MKSTR(v76), v67);
 					} break;
 					default: {
 						do_panic(str_make("unexpected fallthrough in match\n", 32));
 					}
 				}
-				uint64_t v63 = mw_mirth_var_Var_newZ_autoZ_runZBang(branch_z_x1_57, branch_Name_46);
-				VAL v64 = mtw_std_list_List_1_Cons(MKU64(v63), branch_List_43);
-				int64_t v65 = 1LL /* True */;
-				branch_Bool_29 = v65;
+				uint64_t v80 = mw_mirth_var_Var_newZ_autoZ_runZBang(branch_z_x1_74, branch_Name_46);
+				VAL v81 = mtw_mirth_word_Param_Param(v80, branch_Maybe_48);
+				VAL v82 = mtw_std_list_List_1_Cons(v81, branch_List_43);
+				int64_t v83 = 1LL /* True */;
+				branch_Bool_29 = v83;
 				branch_List_28 = v30;
-				branch_StackType_27 = v53;
-				branch_List_26 = v64;
-				branch_ZPlusMirth_25 = branch_ZPlusMirth_56;
+				branch_StackType_27 = v70;
+				branch_List_26 = v82;
+				branch_ZPlusMirth_25 = branch_ZPlusMirth_73;
 			} break;
 			case 0LL: { // Nil
-				VAL v66 = MKI64(0LL /* Nil */);
-				int64_t v67 = 0LL /* False */;
-				branch_Bool_29 = v67;
-				branch_List_28 = v66;
+				VAL v84 = MKI64(0LL /* Nil */);
+				int64_t v85 = 0LL /* False */;
+				branch_Bool_29 = v85;
+				branch_List_28 = v84;
 				branch_StackType_27 = v21;
 				branch_List_26 = v20;
 				branch_ZPlusMirth_25 = v22;
@@ -42945,255 +43170,257 @@ static uint64_t mw_mirth_elab_tableZ_newZBang (VAL in_ZPlusMirth_1, uint64_t in_
 	VAL v290 = mw_mirth_mirth_PropLabel_prop2(v282, v287, v288, v268, &v289);
 	void* v291 = field_mut(&mfld_mirth_word_Word_ZTildectxZ_type, v269);
 	mut_set(v290, v291);
-	VAL v292 = MKI64(0LL /* Nil */);
-	VAL v293 = mtw_std_list_List_1_Cons(MKU64(v281), v292);
-	VAL v294 = mtw_mirth_mirth_PropLabel_WordParams(v269);
-	VAL v295;
-	VAL v296 = mw_mirth_mirth_PropLabel_prop(v293, v294, v289, &v295);
-	void* v297 = field_mut(&mfld_mirth_word_Word_ZTildeparams, v269);
-	mut_set(v296, v297);
+	VAL v292 = MKI64(0LL /* None */);
+	VAL v293 = mtw_mirth_word_Param_Param(v281, v292);
+	VAL v294 = MKI64(0LL /* Nil */);
+	VAL v295 = mtw_std_list_List_1_Cons(v293, v294);
+	VAL v296 = mtw_mirth_mirth_PropLabel_WordParams(v269);
+	VAL v297;
+	VAL v298 = mw_mirth_mirth_PropLabel_prop(v295, v296, v289, &v297);
+	void* v299 = field_mut(&mfld_mirth_word_Word_ZTildeparams, v269);
+	mut_set(v298, v299);
 	mw_mirth_word_Word_makeZ_inlineZBang(v269);
-	VAL v298;
-	VAL v299;
-	uint64_t v300;
+	VAL v300;
 	VAL v301;
 	uint64_t v302;
-	VAL v303 = mw_mirth_elab_initialZ_ctxZ_typeZ_bodyZ_home(v295, v269, &v298, &v299, &v300, &v301, &v302);
-	VAL v304;
-	VAL v305;
-	mtp_mirth_type_ArrowType_ArrowType(v299, &v304, &v305);
-	incref(v304);
-	VAL v306 = MKI64(0LL /* Nil */);
-	VAL v307 = mtw_mirth_arrow_Arrow_Arrow(v301, v300, v300, v303, v304, v304, v306);
-	uint64_t v308 = mw_mirth_table_Table_head(v7);
-	VAL v309;
-	mw_mirth_elab_abZ_tokenZBang(v307, v308, &v309);
-	VAL v310 = MKI64(0LL /* Nil */);
-	VAL v311 = mtw_std_list_List_1_Cons(MKU64(v281), v310);
-	VAL v312;
-	uint64_t v313 = mw_mirth_elab_abZ_tokenZAt(v309, &v312);
-	incref(v311);
+	VAL v303;
+	uint64_t v304;
+	VAL v305 = mw_mirth_elab_initialZ_ctxZ_typeZ_bodyZ_home(v297, v269, &v300, &v301, &v302, &v303, &v304);
+	VAL v306;
+	VAL v307;
+	mtp_mirth_type_ArrowType_ArrowType(v301, &v306, &v307);
+	incref(v306);
+	VAL v308 = MKI64(0LL /* Nil */);
+	VAL v309 = mtw_mirth_arrow_Arrow_Arrow(v303, v302, v302, v305, v306, v306, v308);
+	uint64_t v310 = mw_mirth_table_Table_head(v7);
+	VAL v311;
+	mw_mirth_elab_abZ_tokenZBang(v309, v310, &v311);
+	VAL v312 = MKI64(0LL /* Nil */);
+	VAL v313 = mtw_std_list_List_1_Cons(MKU64(v281), v312);
 	VAL v314;
-	VAL v315 = mw_mirth_elab_abZ_ctxZAt(v312, &v314);
+	uint64_t v315 = mw_mirth_elab_abZ_tokenZAt(v311, &v314);
+	incref(v313);
 	VAL v316;
-	VAL v317 = mw_mirth_elab_abZ_typeZAt(v314, &v316);
+	VAL v317 = mw_mirth_elab_abZ_ctxZAt(v314, &v316);
 	VAL v318;
-	VAL v319;
+	VAL v319 = mw_mirth_elab_abZ_typeZAt(v316, &v318);
 	VAL v320;
-	VAL v321 = mw_std_list_List_1_reverseZ_for_1_sp8(v298, v316, v315, v317, v311, &v318, &v319, &v320);
+	VAL v321;
 	VAL v322;
-	VAL v323 = mw_mirth_elab_abZ_homeZAt(v319, &v322);
-	incref(v320);
-	VAL v324 = MKI64(0LL /* Nil */);
-	VAL v325 = mtw_mirth_arrow_Arrow_Arrow(v323, v313, v313, v321, v320, v320, v324);
-	int64_t v326 = 1LL;
-	VAL v327;
-	VAL v328;
-	mw_mirth_elab_abZ_intZBang(v326, v318, v325, &v327, &v328);
+	VAL v323 = mw_std_list_List_1_reverseZ_for_1_sp8(v300, v318, v317, v319, v313, &v320, &v321, &v322);
+	VAL v324;
+	VAL v325 = mw_mirth_elab_abZ_homeZAt(v321, &v324);
+	incref(v322);
+	VAL v326 = MKI64(0LL /* Nil */);
+	VAL v327 = mtw_mirth_arrow_Arrow_Arrow(v325, v315, v315, v323, v322, v322, v326);
+	int64_t v328 = 1LL;
 	VAL v329;
-	uint64_t v330 = mw_mirth_elab_abZ_tokenZAt(v328, &v329);
+	VAL v330;
+	mw_mirth_elab_abZ_intZBang(v328, v320, v327, &v329, &v330);
 	VAL v331;
-	VAL v332 = mw_mirth_elab_abZ_ctxZAt(v329, &v331);
-	uint64_t v333 = mw_mirth_type_MetaVar_newZBang();
-	VAL v334 = mtw_mirth_type_StackType_STMeta(v333);
-	VAL v335;
-	VAL v336 = mw_mirth_elab_abZ_homeZAt(v331, &v335);
-	incref(v334);
-	VAL v337 = MKI64(0LL /* Nil */);
-	VAL v338 = mtw_mirth_arrow_Arrow_Arrow(v336, v330, v330, v332, v334, v334, v337);
-	int64_t v339 = 1LL /* PRIM_CORE_DUP */;
-	VAL v340;
-	VAL v341;
-	mw_mirth_elab_abZ_primZBang(v339, v327, v338, &v340, &v341);
-	uint64_t v342 = mw_mirth_table_Table_numZ_buffer(v7);
+	uint64_t v332 = mw_mirth_elab_abZ_tokenZAt(v330, &v331);
+	VAL v333;
+	VAL v334 = mw_mirth_elab_abZ_ctxZAt(v331, &v333);
+	uint64_t v335 = mw_mirth_type_MetaVar_newZBang();
+	VAL v336 = mtw_mirth_type_StackType_STMeta(v335);
+	VAL v337;
+	VAL v338 = mw_mirth_elab_abZ_homeZAt(v333, &v337);
+	incref(v336);
+	VAL v339 = MKI64(0LL /* Nil */);
+	VAL v340 = mtw_mirth_arrow_Arrow_Arrow(v338, v332, v332, v334, v336, v336, v339);
+	int64_t v341 = 1LL /* PRIM_CORE_DUP */;
+	VAL v342;
 	VAL v343;
-	VAL v344;
-	mw_mirth_elab_abZ_bufferZBang(v342, v340, v341, &v343, &v344);
-	int64_t v345 = 48LL /* PRIM_I64_GET */;
+	mw_mirth_elab_abZ_primZBang(v341, v329, v340, &v342, &v343);
+	uint64_t v344 = mw_mirth_table_Table_numZ_buffer(v7);
+	VAL v345;
 	VAL v346;
-	VAL v347;
-	mw_mirth_elab_abZ_primZBang(v345, v343, v344, &v346, &v347);
-	int64_t v348 = 50LL /* PRIM_I64_TO_INT */;
+	mw_mirth_elab_abZ_bufferZBang(v344, v342, v343, &v345, &v346);
+	int64_t v347 = 48LL /* PRIM_I64_GET */;
+	VAL v348;
 	VAL v349;
-	VAL v350;
-	mw_mirth_elab_abZ_primZBang(v348, v346, v347, &v349, &v350);
-	int64_t v351 = 16LL /* PRIM_INT_LE */;
+	mw_mirth_elab_abZ_primZBang(v347, v345, v346, &v348, &v349);
+	int64_t v350 = 50LL /* PRIM_I64_TO_INT */;
+	VAL v351;
 	VAL v352;
-	VAL v353;
-	mw_mirth_elab_abZ_primZBang(v351, v349, v350, &v352, &v353);
+	mw_mirth_elab_abZ_primZBang(v350, v348, v349, &v351, &v352);
+	int64_t v353 = 16LL /* PRIM_INT_LE */;
 	VAL v354;
-	uint64_t v355 = mw_mirth_arrow_Block_newZBang(v352, v353, &v354);
-	VAL v356 = mtw_mirth_arrow_Op_OpBlockPush(v355);
-	VAL v357;
-	VAL v358;
-	mw_mirth_elab_abZ_opZBang(v356, v354, v335, &v357, &v358);
+	VAL v355;
+	mw_mirth_elab_abZ_primZBang(v353, v351, v352, &v354, &v355);
+	VAL v356;
+	uint64_t v357 = mw_mirth_arrow_Block_newZBang(v354, v355, &v356);
+	VAL v358 = mtw_mirth_arrow_Op_OpBlockPush(v357);
 	VAL v359;
-	uint64_t v360 = mw_mirth_elab_abZ_tokenZAt(v358, &v359);
+	VAL v360;
+	mw_mirth_elab_abZ_opZBang(v358, v356, v337, &v359, &v360);
 	VAL v361;
-	VAL v362 = mw_mirth_elab_abZ_ctxZAt(v359, &v361);
-	uint64_t v363 = mw_mirth_type_MetaVar_newZBang();
-	VAL v364 = mtw_mirth_type_StackType_STMeta(v363);
-	VAL v365;
-	VAL v366 = mw_mirth_elab_abZ_homeZAt(v361, &v365);
-	incref(v364);
-	VAL v367 = MKI64(0LL /* Nil */);
-	VAL v368 = mtw_mirth_arrow_Arrow_Arrow(v366, v360, v360, v362, v364, v364, v367);
-	int64_t v369 = 1LL /* PRIM_CORE_DUP */;
-	VAL v370;
-	VAL v371;
-	mw_mirth_elab_abZ_primZBang(v369, v357, v368, &v370, &v371);
+	uint64_t v362 = mw_mirth_elab_abZ_tokenZAt(v360, &v361);
+	VAL v363;
+	VAL v364 = mw_mirth_elab_abZ_ctxZAt(v361, &v363);
+	uint64_t v365 = mw_mirth_type_MetaVar_newZBang();
+	VAL v366 = mtw_mirth_type_StackType_STMeta(v365);
+	VAL v367;
+	VAL v368 = mw_mirth_elab_abZ_homeZAt(v363, &v367);
+	incref(v366);
+	VAL v369 = MKI64(0LL /* Nil */);
+	VAL v370 = mtw_mirth_arrow_Arrow_Arrow(v368, v362, v362, v364, v366, v366, v369);
+	int64_t v371 = 1LL /* PRIM_CORE_DUP */;
 	VAL v372;
-	uint64_t v373 = mw_mirth_elab_abZ_tokenZAt(v371, &v372);
+	VAL v373;
+	mw_mirth_elab_abZ_primZBang(v371, v359, v370, &v372, &v373);
 	VAL v374;
-	VAL v375 = mw_mirth_elab_abZ_ctxZAt(v372, &v374);
-	uint64_t v376 = mw_mirth_type_MetaVar_newZBang();
-	VAL v377 = mtw_mirth_type_StackType_STMeta(v376);
-	VAL v378;
-	VAL v379 = mw_mirth_elab_abZ_homeZAt(v374, &v378);
-	incref(v377);
-	VAL v380 = MKI64(0LL /* Nil */);
-	VAL v381 = mtw_mirth_arrow_Arrow_Arrow(v379, v373, v373, v375, v377, v377, v380);
-	VAL v382 = mtw_mirth_arrow_Op_OpTableFromIndex(v7);
-	VAL v383;
-	VAL v384;
-	mw_mirth_elab_abZ_opZBang(v382, v370, v381, &v383, &v384);
+	uint64_t v375 = mw_mirth_elab_abZ_tokenZAt(v373, &v374);
+	VAL v376;
+	VAL v377 = mw_mirth_elab_abZ_ctxZAt(v374, &v376);
+	uint64_t v378 = mw_mirth_type_MetaVar_newZBang();
+	VAL v379 = mtw_mirth_type_StackType_STMeta(v378);
+	VAL v380;
+	VAL v381 = mw_mirth_elab_abZ_homeZAt(v376, &v380);
+	incref(v379);
+	VAL v382 = MKI64(0LL /* Nil */);
+	VAL v383 = mtw_mirth_arrow_Arrow_Arrow(v381, v375, v375, v377, v379, v379, v382);
+	VAL v384 = mtw_mirth_arrow_Op_OpTableFromIndex(v7);
 	VAL v385;
 	VAL v386;
-	mw_mirth_elab_abZ_varZBang(v281, v383, v384, &v385, &v386);
+	mw_mirth_elab_abZ_opZBang(v384, v372, v383, &v385, &v386);
 	VAL v387;
-	uint64_t v388 = mw_mirth_arrow_Block_newZBang(v385, v386, &v387);
-	VAL v389 = mtw_mirth_arrow_Op_OpBlockPush(v388);
-	VAL v390;
-	VAL v391;
-	mw_mirth_elab_abZ_opZBang(v389, v387, v378, &v390, &v391);
-	int64_t v392 = 5LL /* PRIM_CORE_DIP */;
+	VAL v388;
+	mw_mirth_elab_abZ_varZBang(v281, v385, v386, &v387, &v388);
+	VAL v389;
+	uint64_t v390 = mw_mirth_arrow_Block_newZBang(v387, v388, &v389);
+	VAL v391 = mtw_mirth_arrow_Op_OpBlockPush(v390);
+	VAL v392;
 	VAL v393;
-	VAL v394;
-	mw_mirth_elab_abZ_primZBang(v392, v390, v391, &v393, &v394);
-	int64_t v395 = 1LL;
+	mw_mirth_elab_abZ_opZBang(v391, v389, v380, &v392, &v393);
+	int64_t v394 = 5LL /* PRIM_CORE_DIP */;
+	VAL v395;
 	VAL v396;
-	VAL v397;
-	mw_mirth_elab_abZ_intZBang(v395, v393, v394, &v396, &v397);
-	int64_t v398 = 20LL /* PRIM_INT_ADD */;
+	mw_mirth_elab_abZ_primZBang(v394, v392, v393, &v395, &v396);
+	int64_t v397 = 1LL;
+	VAL v398;
 	VAL v399;
-	VAL v400;
-	mw_mirth_elab_abZ_primZBang(v398, v396, v397, &v399, &v400);
+	mw_mirth_elab_abZ_intZBang(v397, v395, v396, &v398, &v399);
+	int64_t v400 = 20LL /* PRIM_INT_ADD */;
 	VAL v401;
-	uint64_t v402 = mw_mirth_arrow_Block_newZBang(v399, v400, &v401);
-	VAL v403 = mtw_mirth_arrow_Op_OpBlockPush(v402);
-	VAL v404;
-	VAL v405;
-	mw_mirth_elab_abZ_opZBang(v403, v401, v365, &v404, &v405);
-	int64_t v406 = 8LL /* PRIM_CORE_WHILE */;
+	VAL v402;
+	mw_mirth_elab_abZ_primZBang(v400, v398, v399, &v401, &v402);
+	VAL v403;
+	uint64_t v404 = mw_mirth_arrow_Block_newZBang(v401, v402, &v403);
+	VAL v405 = mtw_mirth_arrow_Op_OpBlockPush(v404);
+	VAL v406;
 	VAL v407;
-	VAL v408;
-	mw_mirth_elab_abZ_primZBang(v406, v404, v405, &v407, &v408);
-	int64_t v409 = 2LL /* PRIM_CORE_DROP */;
+	mw_mirth_elab_abZ_opZBang(v405, v403, v367, &v406, &v407);
+	int64_t v408 = 8LL /* PRIM_CORE_WHILE */;
+	VAL v409;
 	VAL v410;
-	VAL v411;
-	mw_mirth_elab_abZ_primZBang(v409, v407, v408, &v410, &v411);
+	mw_mirth_elab_abZ_primZBang(v408, v406, v407, &v409, &v410);
+	int64_t v411 = 2LL /* PRIM_CORE_DROP */;
 	VAL v412;
-	VAL v413 = mw_mirth_elab_abZ_ctxZAt(v322, &v412);
+	VAL v413;
+	mw_mirth_elab_abZ_primZBang(v411, v409, v410, &v412, &v413);
 	VAL v414;
-	VAL v415 = mw_mirth_elab_abZ_typeZAt(v412, &v414);
+	VAL v415 = mw_mirth_elab_abZ_ctxZAt(v324, &v414);
 	VAL v416;
-	uint64_t v417 = mw_mirth_elab_abZ_tokenZAt(v414, &v416);
-	VAL v418 = mtw_mirth_arrow_Lambda_Lambda(v417, v413, v415, v311, v411);
-	VAL v419 = mtw_mirth_arrow_Op_OpLambda(v418);
-	VAL v420;
-	VAL v421;
-	mw_mirth_elab_abZ_opZBang(v419, v410, v416, &v420, &v421);
+	VAL v417 = mw_mirth_elab_abZ_typeZAt(v414, &v416);
+	VAL v418;
+	uint64_t v419 = mw_mirth_elab_abZ_tokenZAt(v416, &v418);
+	VAL v420 = mtw_mirth_arrow_Lambda_Lambda(v419, v415, v417, v313, v413);
+	VAL v421 = mtw_mirth_arrow_Op_OpLambda(v420);
 	VAL v422;
 	VAL v423;
-	mw_mirth_elab_abZ_unifyZ_typeZBang(v305, v420, v421, &v422, &v423);
+	mw_mirth_elab_abZ_opZBang(v421, v412, v418, &v422, &v423);
 	VAL v424;
-	VAL v425 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v422, v423, v302, &v424);
-	VAL v426 = mtw_mirth_mirth_PropLabel_WordArrow(v269);
-	VAL v427;
-	VAL v428 = mw_mirth_mirth_PropLabel_prop(v425, v426, v424, &v427);
-	void* v429 = field_mut(&mfld_mirth_word_Word_ZTildearrow, v269);
-	mut_set(v428, v429);
-	STR* v430;
-	STRLIT(v430, "alloc!", 6);
-	int64_t v431 = 0LL;
-	VAL v432;
-	uint64_t v433 = mw_mirth_elab_tableZ_wordZ_newZBang(v427, v7, MKSTR(v430), v431, &v432);
-	VAL v434 = MKI64(0LL /* Nil */);
-	VAL v435 = mw_mirth_type_T0();
-	VAL v436 = mtw_mirth_type_Type_TTable(v7);
-	VAL v437 = mw_mirth_type_T1(v436);
-	VAL v438 = mw_mirth_type_TZ_ZTo(v435, v437);
-	VAL v439 = mtw_mirth_mirth_PropLabel_WordType(v433);
-	VAL v440;
-	VAL v441 = mw_mirth_mirth_PropLabel_prop2(v434, v438, v439, v432, &v440);
-	void* v442 = field_mut(&mfld_mirth_word_Word_ZTildectxZ_type, v433);
-	mut_set(v441, v442);
-	VAL v443;
-	VAL v444;
-	uint64_t v445;
+	VAL v425;
+	mw_mirth_elab_abZ_unifyZ_typeZBang(v307, v422, v423, &v424, &v425);
+	VAL v426;
+	VAL v427 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v424, v425, v304, &v426);
+	VAL v428 = mtw_mirth_mirth_PropLabel_WordArrow(v269);
+	VAL v429;
+	VAL v430 = mw_mirth_mirth_PropLabel_prop(v427, v428, v426, &v429);
+	void* v431 = field_mut(&mfld_mirth_word_Word_ZTildearrow, v269);
+	mut_set(v430, v431);
+	STR* v432;
+	STRLIT(v432, "alloc!", 6);
+	int64_t v433 = 0LL;
+	VAL v434;
+	uint64_t v435 = mw_mirth_elab_tableZ_wordZ_newZBang(v429, v7, MKSTR(v432), v433, &v434);
+	VAL v436 = MKI64(0LL /* Nil */);
+	VAL v437 = mw_mirth_type_T0();
+	VAL v438 = mtw_mirth_type_Type_TTable(v7);
+	VAL v439 = mw_mirth_type_T1(v438);
+	VAL v440 = mw_mirth_type_TZ_ZTo(v437, v439);
+	VAL v441 = mtw_mirth_mirth_PropLabel_WordType(v435);
+	VAL v442;
+	VAL v443 = mw_mirth_mirth_PropLabel_prop2(v436, v440, v441, v434, &v442);
+	void* v444 = field_mut(&mfld_mirth_word_Word_ZTildectxZ_type, v435);
+	mut_set(v443, v444);
+	VAL v445;
 	VAL v446;
 	uint64_t v447;
-	VAL v448 = mw_mirth_elab_initialZ_ctxZ_typeZ_bodyZ_home(v440, v433, &v443, &v444, &v445, &v446, &v447);
-	VAL v449;
-	VAL v450;
-	mtp_mirth_type_ArrowType_ArrowType(v444, &v449, &v450);
-	incref(v449);
-	VAL v451 = MKI64(0LL /* Nil */);
-	VAL v452 = mtw_mirth_arrow_Arrow_Arrow(v446, v445, v445, v448, v449, v449, v451);
-	uint64_t v453 = mw_mirth_table_Table_head(v7);
-	VAL v454;
-	mw_mirth_elab_abZ_tokenZBang(v452, v453, &v454);
-	uint64_t v455 = mw_mirth_table_Table_numZ_buffer(v7);
+	VAL v448;
+	uint64_t v449;
+	VAL v450 = mw_mirth_elab_initialZ_ctxZ_typeZ_bodyZ_home(v442, v435, &v445, &v446, &v447, &v448, &v449);
+	VAL v451;
+	VAL v452;
+	mtp_mirth_type_ArrowType_ArrowType(v446, &v451, &v452);
+	incref(v451);
+	VAL v453 = MKI64(0LL /* Nil */);
+	VAL v454 = mtw_mirth_arrow_Arrow_Arrow(v448, v447, v447, v450, v451, v451, v453);
+	uint64_t v455 = mw_mirth_table_Table_head(v7);
 	VAL v456;
-	VAL v457;
-	mw_mirth_elab_abZ_bufferZBang(v455, v443, v454, &v456, &v457);
-	int64_t v458 = 48LL /* PRIM_I64_GET */;
+	mw_mirth_elab_abZ_tokenZBang(v454, v455, &v456);
+	uint64_t v457 = mw_mirth_table_Table_numZ_buffer(v7);
+	VAL v458;
 	VAL v459;
-	VAL v460;
-	mw_mirth_elab_abZ_primZBang(v458, v456, v457, &v459, &v460);
-	int64_t v461 = 50LL /* PRIM_I64_TO_INT */;
+	mw_mirth_elab_abZ_bufferZBang(v457, v445, v456, &v458, &v459);
+	int64_t v460 = 48LL /* PRIM_I64_GET */;
+	VAL v461;
 	VAL v462;
-	VAL v463;
-	mw_mirth_elab_abZ_primZBang(v461, v459, v460, &v462, &v463);
-	int64_t v464 = 1LL;
+	mw_mirth_elab_abZ_primZBang(v460, v458, v459, &v461, &v462);
+	int64_t v463 = 50LL /* PRIM_I64_TO_INT */;
+	VAL v464;
 	VAL v465;
-	VAL v466;
-	mw_mirth_elab_abZ_intZBang(v464, v462, v463, &v465, &v466);
-	int64_t v467 = 20LL /* PRIM_INT_ADD */;
+	mw_mirth_elab_abZ_primZBang(v463, v461, v462, &v464, &v465);
+	int64_t v466 = 1LL;
+	VAL v467;
 	VAL v468;
-	VAL v469;
-	mw_mirth_elab_abZ_primZBang(v467, v465, v466, &v468, &v469);
-	int64_t v470 = 1LL /* PRIM_CORE_DUP */;
+	mw_mirth_elab_abZ_intZBang(v466, v464, v465, &v467, &v468);
+	int64_t v469 = 20LL /* PRIM_INT_ADD */;
+	VAL v470;
 	VAL v471;
-	VAL v472;
-	mw_mirth_elab_abZ_primZBang(v470, v468, v469, &v471, &v472);
-	int64_t v473 = 31LL /* PRIM_INT_TO_I64 */;
+	mw_mirth_elab_abZ_primZBang(v469, v467, v468, &v470, &v471);
+	int64_t v472 = 1LL /* PRIM_CORE_DUP */;
+	VAL v473;
 	VAL v474;
-	VAL v475;
-	mw_mirth_elab_abZ_primZBang(v473, v471, v472, &v474, &v475);
-	uint64_t v476 = mw_mirth_table_Table_numZ_buffer(v7);
+	mw_mirth_elab_abZ_primZBang(v472, v470, v471, &v473, &v474);
+	int64_t v475 = 31LL /* PRIM_INT_TO_I64 */;
+	VAL v476;
 	VAL v477;
-	VAL v478;
-	mw_mirth_elab_abZ_bufferZBang(v476, v474, v475, &v477, &v478);
-	int64_t v479 = 49LL /* PRIM_I64_SET */;
+	mw_mirth_elab_abZ_primZBang(v475, v473, v474, &v476, &v477);
+	uint64_t v478 = mw_mirth_table_Table_numZ_buffer(v7);
+	VAL v479;
 	VAL v480;
-	VAL v481;
-	mw_mirth_elab_abZ_primZBang(v479, v477, v478, &v480, &v481);
-	VAL v482 = mtw_mirth_arrow_Op_OpTableFromIndex(v7);
+	mw_mirth_elab_abZ_bufferZBang(v478, v476, v477, &v479, &v480);
+	int64_t v481 = 49LL /* PRIM_I64_SET */;
+	VAL v482;
 	VAL v483;
-	VAL v484;
-	mw_mirth_elab_abZ_opZBang(v482, v480, v481, &v483, &v484);
+	mw_mirth_elab_abZ_primZBang(v481, v479, v480, &v482, &v483);
+	VAL v484 = mtw_mirth_arrow_Op_OpTableFromIndex(v7);
 	VAL v485;
 	VAL v486;
-	mw_mirth_elab_abZ_unifyZ_typeZBang(v450, v483, v484, &v485, &v486);
+	mw_mirth_elab_abZ_opZBang(v484, v482, v483, &v485, &v486);
 	VAL v487;
-	VAL v488 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v485, v486, v447, &v487);
-	VAL v489 = mtw_mirth_mirth_PropLabel_WordArrow(v433);
-	VAL v490;
-	VAL v491 = mw_mirth_mirth_PropLabel_prop(v488, v489, v487, &v490);
-	void* v492 = field_mut(&mfld_mirth_word_Word_ZTildearrow, v433);
-	mut_set(v491, v492);
-	*out_ZPlusMirth_5 = v490;
+	VAL v488;
+	mw_mirth_elab_abZ_unifyZ_typeZBang(v452, v485, v486, &v487, &v488);
+	VAL v489;
+	VAL v490 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v487, v488, v449, &v489);
+	VAL v491 = mtw_mirth_mirth_PropLabel_WordArrow(v435);
+	VAL v492;
+	VAL v493 = mw_mirth_mirth_PropLabel_prop(v490, v491, v489, &v492);
+	void* v494 = field_mut(&mfld_mirth_word_Word_ZTildearrow, v435);
+	mut_set(v493, v494);
+	*out_ZPlusMirth_5 = v492;
 	return v7;
 }
 static VAL mw_mirth_elab_resolveZ_defZ_namespace (VAL in_ZPlusMirth_1, uint64_t in_Token_2, VAL in_Either_3, VAL *out_ZPlusMirth_4) {
@@ -43385,53 +43612,161 @@ static int64_t mw_mirth_elab_moduleZ_visibleZ_fromZ_tokenZAsk (uint64_t in_Token
 	int64_t v5 = mw_mirth_module_Module_visible(in_Module_2, v4);
 	return v5;
 }
+static int64_t mw_mirth_token_Token_isZ_defaultZ_paramZAsk (uint64_t in_Token_1) {
+	VAL v3 = mw_mirth_token_Token_nameZAsk(in_Token_1);
+	int64_t v4 = get_data_tag(v3);
+	decref(v3);
+	int64_t v5 = 1LL;
+	bool v6 = (v4 == v5);
+	uint64_t branch_Token_7;
+	int64_t branch_Bool_8;
+	if (v6) {
+		uint64_t v9 = mw_mirth_token_Token_succ(in_Token_1);
+		VAL v10 = mw_mirth_token_Token_lcurlyZAsk(v9);
+		int64_t v11 = get_data_tag(v10);
+		decref(v10);
+		int64_t v12 = 1LL;
+		bool v13 = (v11 == v12);
+		branch_Bool_8 = ((int64_t)v13);
+		branch_Token_7 = in_Token_1;
+	} else {
+		int64_t v14 = 0LL /* False */;
+		branch_Bool_8 = v14;
+		branch_Token_7 = in_Token_1;
+	}
+	return branch_Bool_8;
+}
 static VAL mw_mirth_elab_elabZ_defZ_qname (VAL in_ZPlusMirth_1, uint64_t in_Token_2, VAL *out_ZPlusMirth_3) {
-	VAL v5 = mw_mirth_token_Token_nameZDivdnameZAsk(in_Token_2);
-	uint64_t branch_Token_6;
-	VAL branch_ZPlusMirth_7;
-	VAL branch_z_x1_8;
-	switch (get_data_tag(v5)) {
+	VAL v5 = mw_mirth_token_Token_args(in_Token_2);
+	incref(v5);
+	VAL v6 = MKI64(0LL /* None */);
+	int64_t v7 = 1LL /* True */;
+	VAL v8 = v6;
+	VAL v9 = v5;
+	int64_t v10 = v7;
+	int64_t v11 = v7;
+	while (((bool)v11)) {
+		VAL v12 = v8;
+		VAL v13 = v9;
+		int64_t v14 = v10;
+		VAL v15;
+		VAL v16 = mw_std_list_List_1_uncons(v13, &v15);
+		VAL branch_Maybe_17;
+		VAL branch_List_18;
+		int64_t branch_Bool_19;
+		switch (get_data_tag(v16)) {
+			case 1LL: { // Some
+				VAL v20 = mtp_std_maybe_Maybe_1_Some(v16);
+				incref(v20);
+				int64_t v21 = mw_mirth_token_Token_isZ_defaultZ_paramZAsk(value_u64(v20));
+				VAL branch_Maybe_22;
+				if (((bool)v21)) {
+					VAL v23 = mtw_std_maybe_Maybe_1_Some(v20);
+					branch_Maybe_22 = v23;
+				} else {
+					decref(v20);
+					VAL v24 = MKI64(0LL /* None */);
+					branch_Maybe_22 = v24;
+				}
+				VAL branch_Maybe_25;
+				VAL branch_List_26;
+				switch (get_data_tag(branch_Maybe_22)) {
+					case 0LL: { // None
+						branch_List_26 = v15;
+						branch_Maybe_25 = v12;
+					} break;
+					default: {
+						decref(v15);
+						decref(v12);
+						VAL v27 = MKI64(0LL /* Nil */);
+						branch_List_26 = v27;
+						branch_Maybe_25 = branch_Maybe_22;
+					} break;
+				}
+				int64_t v28 = 1LL /* True */;
+				branch_Bool_19 = v28;
+				branch_List_18 = branch_List_26;
+				branch_Maybe_17 = branch_Maybe_25;
+			} break;
+			case 0LL: { // None
+				int64_t v29 = 0LL /* False */;
+				branch_Bool_19 = v29;
+				branch_List_18 = v15;
+				branch_Maybe_17 = v12;
+			} break;
+			default: {
+				do_panic(str_make("unexpected fallthrough in match\n", 32));
+			}
+		}
+		v11 = branch_Bool_19;
+		v10 = branch_Bool_19;
+		v9 = branch_List_18;
+		v8 = branch_Maybe_17;
+	}
+	decref(v9);
+	int64_t v30 = get_data_tag(v8);
+	decref(v8);
+	int64_t v31 = 1LL;
+	bool v32 = (v30 == v31);
+	VAL branch_ZPlusMirth_33;
+	uint64_t branch_Token_34;
+	VAL branch__35;
+	if (v32) {
+		decref(v5);
+		int64_t v36 = -1LL;
+		branch__35 = MKI64(v36);
+		branch_Token_34 = in_Token_2;
+		branch_ZPlusMirth_33 = in_ZPlusMirth_1;
+	} else {
+		int64_t v37 = mw_std_list_List_1_len(v5);
+		branch__35 = MKI64(v37);
+		branch_Token_34 = in_Token_2;
+		branch_ZPlusMirth_33 = in_ZPlusMirth_1;
+	}
+	VAL v38 = mw_mirth_token_Token_nameZDivdnameZAsk(branch_Token_34);
+	uint64_t branch_Token_39;
+	VAL branch_ZPlusMirth_40;
+	VAL branch_z_x1_41;
+	switch (get_data_tag(v38)) {
 		case 1LL: { // Some
-			VAL v9 = mtp_std_maybe_Maybe_1_Some(v5);
-			branch_z_x1_8 = v9;
-			branch_ZPlusMirth_7 = in_ZPlusMirth_1;
-			branch_Token_6 = in_Token_2;
+			VAL v42 = mtp_std_maybe_Maybe_1_Some(v38);
+			branch_z_x1_41 = v42;
+			branch_ZPlusMirth_40 = branch_ZPlusMirth_33;
+			branch_Token_39 = branch_Token_34;
 		} break;
 		case 0LL: { // None
-			STR* v10;
-			STRLIT(v10, "expected name", 13);
-			mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang(in_Token_2, MKSTR(v10), in_ZPlusMirth_1);
+			STR* v43;
+			STRLIT(v43, "expected name", 13);
+			mw_mirth_mirth_ZPlusMirth_emitZ_fatalZ_errorZBang(branch_Token_34, MKSTR(v43), branch_ZPlusMirth_33);
 		} break;
 		default: {
 			do_panic(str_make("unexpected fallthrough in match\n", 32));
 		}
 	}
-	VAL branch_ZPlusMirth_14;
-	VAL branch_QName_15;
-	switch (get_data_tag(branch_z_x1_8)) {
+	VAL branch_ZPlusMirth_47;
+	VAL branch_QName_48;
+	switch (get_data_tag(branch_z_x1_41)) {
 		case 0LL: { // Left
-			VAL v16 = mtp_std_either_Either_2_Left(branch_z_x1_8);
-			uint64_t v17 = mw_mirth_token_Token_module(branch_Token_6);
-			VAL v18 = mtw_mirth_name_Namespace_NAMESPACEz_MODULE(v17);
-			int64_t v19 = mw_mirth_token_Token_numZ_args(branch_Token_6);
-			VAL v20 = mtw_mirth_name_QName_MKQNAME(v18, value_u64(v16), v19);
-			branch_QName_15 = v20;
-			branch_ZPlusMirth_14 = branch_ZPlusMirth_7;
+			VAL v49 = mtp_std_either_Either_2_Left(branch_z_x1_41);
+			uint64_t v50 = mw_mirth_token_Token_module(branch_Token_39);
+			VAL v51 = mtw_mirth_name_Namespace_NAMESPACEz_MODULE(v50);
+			VAL v52 = mtw_mirth_name_QName_MKQNAME(v51, value_u64(v49), value_i64(branch__35));
+			branch_QName_48 = v52;
+			branch_ZPlusMirth_47 = branch_ZPlusMirth_40;
 		} break;
 		case 1LL: { // Right
-			VAL v21 = mtp_std_either_Either_2_Right(branch_z_x1_8);
-			int64_t v22 = mw_mirth_token_Token_numZ_args(branch_Token_6);
-			VAL v23;
-			VAL v24 = mw_mirth_elab_elabZ_qnameZ_fromZ_nonrelativeZ_dname(branch_ZPlusMirth_7, branch_Token_6, v21, v22, &v23);
-			branch_QName_15 = v24;
-			branch_ZPlusMirth_14 = v23;
+			VAL v53 = mtp_std_either_Either_2_Right(branch_z_x1_41);
+			VAL v54;
+			VAL v55 = mw_mirth_elab_elabZ_qnameZ_fromZ_nonrelativeZ_dname(branch_ZPlusMirth_40, branch_Token_39, v53, value_i64(branch__35), &v54);
+			branch_QName_48 = v55;
+			branch_ZPlusMirth_47 = v54;
 		} break;
 		default: {
 			do_panic(str_make("unexpected fallthrough in match\n", 32));
 		}
 	}
-	*out_ZPlusMirth_3 = branch_ZPlusMirth_14;
-	return branch_QName_15;
+	*out_ZPlusMirth_3 = branch_ZPlusMirth_47;
+	return branch_QName_48;
 }
 static VAL mw_mirth_elab_elabZ_defZ_qnameZ_undefined (VAL in_ZPlusMirth_1, uint64_t in_Token_2, VAL *out_ZPlusMirth_3) {
 	VAL v5;
@@ -44620,7 +44955,7 @@ static int64_t mw_mirth_arrow_Atom_similar (VAL in_ZPlusMirth_1, VAL in_Atom_2, 
 		incref(v15);
 		decref(in_Atom_3);
 		VAL v16;
-		int64_t v17 = mw_std_list_List_1_ZEqualZEqual_1_sp1(v8, v14, v15, &v16);
+		int64_t v17 = mw_std_list_List_1_ZEqualZEqual_sp1(v8, v14, v15, &v16);
 		branch_Bool_13 = v17;
 		branch_Atom_12 = in_Atom_3;
 		branch_Atom_11 = in_Atom_2;
@@ -45183,7 +45518,7 @@ static int64_t mw_mirth_specializzer_SPKey_similar (VAL in_ZPlusMirth_1, VAL in_
 	mtp_std_list_ListZPlus_1_ListZPlus(in_SPKey_3, &v9, &v10);
 	VAL v11 = mtw_std_list_List_1_Cons(v9, v10);
 	VAL v12;
-	int64_t v13 = mw_std_list_List_1_ZEqualZEqual_1_sp1(in_ZPlusMirth_1, v8, v11, &v12);
+	int64_t v13 = mw_std_list_List_1_ZEqualZEqual_sp1(in_ZPlusMirth_1, v8, v11, &v12);
 	*out_ZPlusMirth_4 = v12;
 	return v13;
 }
@@ -65215,7 +65550,7 @@ static VAL mw_std_list_List_1_filter_1_sp1 (VAL in_List_1) {
 	VAL v24 = mw_std_list_List_1_reverse(v6);
 	return v24;
 }
-static VAL mw_std_list_List_1_unions_1_sp1 (VAL in_List_1) {
+static VAL mw_std_list_List_1_unions_sp1 (VAL in_List_1) {
 	VAL v3 = mw_std_list_List_1_ZToListZPlus(in_List_1);
 	VAL branch_Maybe_4;
 	switch (get_data_tag(v3)) {
@@ -65239,7 +65574,7 @@ static VAL mw_std_list_List_1_unions_1_sp1 (VAL in_List_1) {
 					case 1LL: { // Cons
 						VAL v19;
 						VAL v20 = mtp_std_list_List_1_Cons(v14, &v19);
-						VAL v21 = mw_std_list_List_1_union_1_sp1(v13, v20);
+						VAL v21 = mw_std_list_List_1_union_sp1(v13, v20);
 						int64_t v22 = 1LL /* True */;
 						branch_Bool_18 = v22;
 						branch_List_17 = v19;
@@ -65289,13 +65624,13 @@ static VAL mw_std_list_List_1_unions_1_sp1 (VAL in_List_1) {
 	}
 	return branch_List_27;
 }
-static VAL mw_std_list_List_1_union_1_sp1 (VAL in_List_1, VAL in_List_2) {
+static VAL mw_std_list_List_1_union_sp1 (VAL in_List_1, VAL in_List_2) {
 	incref(in_List_1);
-	VAL v4 = mw_std_list_List_1_difference_1_sp1(in_List_2, in_List_1);
+	VAL v4 = mw_std_list_List_1_difference_sp1(in_List_2, in_List_1);
 	VAL v5 = mw_std_list_List_1_cat(in_List_1, v4);
 	return v5;
 }
-static VAL mw_std_list_List_1_difference_1_sp1 (VAL in_List_1, VAL in_List_2) {
+static VAL mw_std_list_List_1_difference_sp1 (VAL in_List_1, VAL in_List_2) {
 	VAL v4 = MKI64(0LL /* Nil */);
 	VAL v5 = mw_std_list_List_1_reverse(v4);
 	int64_t v6 = 1LL /* True */;
@@ -66566,7 +66901,7 @@ static VAL mw_std_maybe_Maybe_1_bind_1_sp5 (VAL in_Maybe_1) {
 	}
 	return branch_Maybe_3;
 }
-static int64_t mw_std_list_List_1_ZEqualZEqual_1_sp1 (VAL in_ZPlusMirth_1, VAL in_List_2, VAL in_List_3, VAL *out_ZPlusMirth_4) {
+static int64_t mw_std_list_List_1_ZEqualZEqual_sp1 (VAL in_ZPlusMirth_1, VAL in_List_2, VAL in_List_3, VAL *out_ZPlusMirth_4) {
 	int64_t v6 = 1LL /* True */;
 	VAL v7;
 	VAL v8 = mw_std_list_List_1_uncons(in_List_2, &v7);
@@ -66831,7 +67166,7 @@ static VAL mw_std_list_List_1_for_1_sp63 (VAL in_ZPlusMirth_1, VAL in_z_x1_2, VA
 	*out_ZPlusMirth_6 = v11;
 	return v14;
 }
-static int64_t mw_std_list_List_1_member_1_sp4 (VAL in_Namespace_1, VAL in_List_2) {
+static int64_t mw_std_list_List_1_member_sp4 (VAL in_Namespace_1, VAL in_List_2) {
 	VAL v4 = MKI64(0LL /* None */);
 	int64_t v5 = 1LL /* True */;
 	VAL v6 = in_Namespace_1;
@@ -66917,7 +67252,54 @@ static int64_t mw_std_list_List_1_member_1_sp4 (VAL in_Namespace_1, VAL in_List_
 	bool v35 = (v33 == v34);
 	return ((int64_t)v35);
 }
-static VAL mw_std_list_List_1_for_1_sp80 (VAL in_StackType_1, VAL in_List_2) {
+static VAL mw_std_list_List_1_map_1_sp7 (VAL in_List_1) {
+	VAL v3 = MKI64(0LL /* Nil */);
+	VAL v4 = mw_std_list_List_1_reverse(v3);
+	int64_t v5 = 1LL /* True */;
+	VAL v6 = v4;
+	VAL v7 = in_List_1;
+	int64_t v8 = v5;
+	int64_t v9 = v5;
+	while (((bool)v9)) {
+		VAL v10 = v6;
+		VAL v11 = v7;
+		int64_t v12 = v8;
+		VAL branch_ZPlusList_13;
+		VAL branch_List_14;
+		int64_t branch_Bool_15;
+		switch (get_data_tag(v11)) {
+			case 1LL: { // Cons
+				VAL v16;
+				VAL v17 = mtp_std_list_List_1_Cons(v11, &v16);
+				uint64_t v18 = value_u64(VTUP(v17)->cells[1]);
+				decref(v17);
+				VAL v19 = mtw_std_list_List_1_Cons(MKU64(v18), v10);
+				int64_t v20 = 1LL /* True */;
+				branch_Bool_15 = v20;
+				branch_List_14 = v16;
+				branch_ZPlusList_13 = v19;
+			} break;
+			case 0LL: { // Nil
+				VAL v21 = MKI64(0LL /* Nil */);
+				int64_t v22 = 0LL /* False */;
+				branch_Bool_15 = v22;
+				branch_List_14 = v21;
+				branch_ZPlusList_13 = v10;
+			} break;
+			default: {
+				do_panic(str_make("unexpected fallthrough in match\n", 32));
+			}
+		}
+		v9 = branch_Bool_15;
+		v8 = branch_Bool_15;
+		v7 = branch_List_14;
+		v6 = branch_ZPlusList_13;
+	}
+	decref(v7);
+	VAL v23 = mw_std_list_List_1_reverse(v6);
+	return v23;
+}
+static VAL mw_std_list_List_1_for_1_sp81 (VAL in_StackType_1, VAL in_List_2) {
 	int64_t v4 = 1LL /* True */;
 	VAL v5 = in_StackType_1;
 	VAL v6 = in_List_2;
@@ -67334,12 +67716,14 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp5_2 (void) {
 	STRLIT(v19, "f", 1);
 	uint64_t v20 = mw_std_prim_Str_ZToName(MKSTR(v19));
 	uint64_t v21 = mw_mirth_var_Var_newZ_autoZ_runZBang(branch_z_x1_14, v20);
-	VAL v22 = MKI64(0LL /* Nil */);
-	VAL v23 = mtw_std_list_List_1_Cons(MKU64(v21), v22);
+	VAL v22 = MKI64(0LL /* None */);
+	VAL v23 = mtw_mirth_word_Param_Param(v21, v22);
+	VAL v24 = MKI64(0LL /* Nil */);
+	VAL v25 = mtw_std_list_List_1_Cons(v23, v24);
 	push_resource(branch_ZPlusMirth_13);
-	push_value(v23);
+	push_value(v25);
 }
-static void mb_mirth_mirth_PropLabel_prop_1_sp6_9 (void) {
+static void mb_mirth_mirth_PropLabel_prop_1_sp6_10 (void) {
 	TUP* v0 = value_tup(pop_value(), 4);
 	VAL r1 = pop_resource();
 	VAL v2 = v0->cells[0];
@@ -67362,135 +67746,136 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp6_9 (void) {
 	VAL v15 = mtw_mirth_arrow_Arrow_Arrow(v9, v8, v8, v11, v12, v12, v14);
 	VAL v16;
 	VAL v17 = mw_mirth_word_Word_params(value_u64(v5), v6, &v16);
-	incref(v17);
-	VAL v18;
-	uint64_t v19 = mw_mirth_elab_abZ_tokenZAt(v15, &v18);
-	incref(v17);
-	VAL v20;
-	VAL v21 = mw_mirth_elab_abZ_ctxZAt(v18, &v20);
-	VAL v22;
-	VAL v23 = mw_mirth_elab_abZ_typeZAt(v20, &v22);
-	VAL v24;
+	VAL v18 = mw_std_list_List_1_map_1_sp7(v17);
+	incref(v18);
+	VAL v19;
+	uint64_t v20 = mw_mirth_elab_abZ_tokenZAt(v15, &v19);
+	incref(v18);
+	VAL v21;
+	VAL v22 = mw_mirth_elab_abZ_ctxZAt(v19, &v21);
+	VAL v23;
+	VAL v24 = mw_mirth_elab_abZ_typeZAt(v21, &v23);
 	VAL v25;
 	VAL v26;
-	VAL v27 = mw_std_list_List_1_reverseZ_for_1_sp8(v16, v22, v21, v23, v17, &v24, &v25, &v26);
-	VAL v28;
-	VAL v29 = mw_mirth_elab_abZ_homeZAt(v25, &v28);
-	incref(v26);
-	VAL v30 = MKI64(0LL /* Nil */);
-	VAL v31 = mtw_mirth_arrow_Arrow_Arrow(v29, v19, v19, v27, v26, v26, v30);
-	VAL v32 = mw_std_list_List_1_ZDivL1(v17);
-	VAL branch_ZPlusMirth_33;
-	VAL branch_z_x1_34;
-	VAL branch_z_x2_35;
-	switch (get_data_tag(v32)) {
+	VAL v27;
+	VAL v28 = mw_std_list_List_1_reverseZ_for_1_sp8(v16, v23, v22, v24, v18, &v25, &v26, &v27);
+	VAL v29;
+	VAL v30 = mw_mirth_elab_abZ_homeZAt(v26, &v29);
+	incref(v27);
+	VAL v31 = MKI64(0LL /* Nil */);
+	VAL v32 = mtw_mirth_arrow_Arrow_Arrow(v30, v20, v20, v28, v27, v27, v31);
+	VAL v33 = mw_std_list_List_1_ZDivL1(v18);
+	VAL branch_ZPlusMirth_34;
+	VAL branch_z_x1_35;
+	VAL branch_z_x2_36;
+	switch (get_data_tag(v33)) {
 		case 1LL: { // Some
-			VAL v36 = mtp_std_maybe_Maybe_1_Some(v32);
-			branch_z_x2_35 = v36;
-			branch_z_x1_34 = v31;
-			branch_ZPlusMirth_33 = v24;
+			VAL v37 = mtp_std_maybe_Maybe_1_Some(v33);
+			branch_z_x2_36 = v37;
+			branch_z_x1_35 = v32;
+			branch_ZPlusMirth_34 = v25;
 		} break;
 		case 0LL: { // None
-			STR* v37;
-			STRLIT(v37, "Expected one parameter.", 23);
-			mw_mirth_mirth_ZPlusMirth_fatalZ_errorZBang(MKSTR(v37), v24);
+			STR* v38;
+			STRLIT(v38, "Expected one parameter.", 23);
+			mw_mirth_mirth_ZPlusMirth_fatalZ_errorZBang(MKSTR(v38), v25);
 		} break;
 		default: {
 			do_panic(str_make("unexpected fallthrough in match\n", 32));
 		}
 	}
-	int64_t v40 = mw_mirth_data_Data_isZ_resourceZAsk(value_u64(v2));
-	VAL branch_ZPlusMirth_41;
-	VAL branch_ZPlusAB_42;
-	if (((bool)v40)) {
-		VAL v43;
+	int64_t v41 = mw_mirth_data_Data_isZ_resourceZAsk(value_u64(v2));
+	VAL branch_ZPlusMirth_42;
+	VAL branch_ZPlusAB_43;
+	if (((bool)v41)) {
 		VAL v44;
-		mw_mirth_elab_abZ_wordZBang(value_u64(v3), branch_ZPlusMirth_33, branch_z_x1_34, &v43, &v44);
 		VAL v45;
-		uint64_t v46 = mw_mirth_elab_abZ_tokenZAt(v44, &v45);
-		VAL v47;
-		VAL v48 = mw_mirth_elab_abZ_ctxZAt(v45, &v47);
-		uint64_t v49 = mw_mirth_type_MetaVar_newZBang();
-		VAL v50 = mtw_mirth_type_StackType_STMeta(v49);
-		VAL v51;
-		VAL v52 = mw_mirth_elab_abZ_homeZAt(v47, &v51);
-		incref(v50);
-		VAL v53 = MKI64(0LL /* Nil */);
-		VAL v54 = mtw_mirth_arrow_Arrow_Arrow(v52, v46, v46, v48, v50, v50, v53);
-		VAL v55;
+		mw_mirth_elab_abZ_wordZBang(value_u64(v3), branch_ZPlusMirth_34, branch_z_x1_35, &v44, &v45);
+		VAL v46;
+		uint64_t v47 = mw_mirth_elab_abZ_tokenZAt(v45, &v46);
+		VAL v48;
+		VAL v49 = mw_mirth_elab_abZ_ctxZAt(v46, &v48);
+		uint64_t v50 = mw_mirth_type_MetaVar_newZBang();
+		VAL v51 = mtw_mirth_type_StackType_STMeta(v50);
+		VAL v52;
+		VAL v53 = mw_mirth_elab_abZ_homeZAt(v48, &v52);
+		incref(v51);
+		VAL v54 = MKI64(0LL /* Nil */);
+		VAL v55 = mtw_mirth_arrow_Arrow_Arrow(v53, v47, v47, v49, v51, v51, v54);
 		VAL v56;
-		mw_mirth_elab_abZ_varZBang(value_u64(branch_z_x2_35), v43, v54, &v55, &v56);
 		VAL v57;
-		uint64_t v58 = mw_mirth_arrow_Block_newZBang(v55, v56, &v57);
-		VAL v59 = mtw_mirth_arrow_Op_OpBlockPush(v58);
-		VAL v60;
+		mw_mirth_elab_abZ_varZBang(value_u64(branch_z_x2_36), v44, v55, &v56, &v57);
+		VAL v58;
+		uint64_t v59 = mw_mirth_arrow_Block_newZBang(v56, v57, &v58);
+		VAL v60 = mtw_mirth_arrow_Op_OpBlockPush(v59);
 		VAL v61;
-		mw_mirth_elab_abZ_opZBang(v59, v57, v51, &v60, &v61);
-		int64_t v62 = 6LL /* PRIM_CORE_RDIP */;
-		VAL v63;
+		VAL v62;
+		mw_mirth_elab_abZ_opZBang(v60, v58, v52, &v61, &v62);
+		int64_t v63 = 6LL /* PRIM_CORE_RDIP */;
 		VAL v64;
-		mw_mirth_elab_abZ_primZBang(v62, v60, v61, &v63, &v64);
 		VAL v65;
+		mw_mirth_elab_abZ_primZBang(v63, v61, v62, &v64, &v65);
 		VAL v66;
-		mw_mirth_elab_abZ_wordZBang(value_u64(v4), v63, v64, &v65, &v66);
-		branch_ZPlusAB_42 = v66;
-		branch_ZPlusMirth_41 = v65;
+		VAL v67;
+		mw_mirth_elab_abZ_wordZBang(value_u64(v4), v64, v65, &v66, &v67);
+		branch_ZPlusAB_43 = v67;
+		branch_ZPlusMirth_42 = v66;
 	} else {
-		int64_t v67 = 1LL /* PRIM_CORE_DUP */;
-		VAL v68;
+		int64_t v68 = 1LL /* PRIM_CORE_DUP */;
 		VAL v69;
-		mw_mirth_elab_abZ_primZBang(v67, branch_ZPlusMirth_33, branch_z_x1_34, &v68, &v69);
 		VAL v70;
-		uint64_t v71 = mw_mirth_elab_abZ_tokenZAt(v69, &v70);
-		VAL v72;
-		VAL v73 = mw_mirth_elab_abZ_ctxZAt(v70, &v72);
-		uint64_t v74 = mw_mirth_type_MetaVar_newZBang();
-		VAL v75 = mtw_mirth_type_StackType_STMeta(v74);
-		VAL v76;
-		VAL v77 = mw_mirth_elab_abZ_homeZAt(v72, &v76);
-		incref(v75);
-		VAL v78 = MKI64(0LL /* Nil */);
-		VAL v79 = mtw_mirth_arrow_Arrow_Arrow(v77, v71, v71, v73, v75, v75, v78);
-		VAL v80;
+		mw_mirth_elab_abZ_primZBang(v68, branch_ZPlusMirth_34, branch_z_x1_35, &v69, &v70);
+		VAL v71;
+		uint64_t v72 = mw_mirth_elab_abZ_tokenZAt(v70, &v71);
+		VAL v73;
+		VAL v74 = mw_mirth_elab_abZ_ctxZAt(v71, &v73);
+		uint64_t v75 = mw_mirth_type_MetaVar_newZBang();
+		VAL v76 = mtw_mirth_type_StackType_STMeta(v75);
+		VAL v77;
+		VAL v78 = mw_mirth_elab_abZ_homeZAt(v73, &v77);
+		incref(v76);
+		VAL v79 = MKI64(0LL /* Nil */);
+		VAL v80 = mtw_mirth_arrow_Arrow_Arrow(v78, v72, v72, v74, v76, v76, v79);
 		VAL v81;
-		mw_mirth_elab_abZ_wordZBang(value_u64(v3), v68, v79, &v80, &v81);
 		VAL v82;
+		mw_mirth_elab_abZ_wordZBang(value_u64(v3), v69, v80, &v81, &v82);
 		VAL v83;
-		mw_mirth_elab_abZ_varZBang(value_u64(branch_z_x2_35), v80, v81, &v82, &v83);
 		VAL v84;
-		uint64_t v85 = mw_mirth_arrow_Block_newZBang(v82, v83, &v84);
-		VAL v86 = mtw_mirth_arrow_Op_OpBlockPush(v85);
-		VAL v87;
+		mw_mirth_elab_abZ_varZBang(value_u64(branch_z_x2_36), v81, v82, &v83, &v84);
+		VAL v85;
+		uint64_t v86 = mw_mirth_arrow_Block_newZBang(v83, v84, &v85);
+		VAL v87 = mtw_mirth_arrow_Op_OpBlockPush(v86);
 		VAL v88;
-		mw_mirth_elab_abZ_opZBang(v86, v84, v76, &v87, &v88);
-		int64_t v89 = 5LL /* PRIM_CORE_DIP */;
-		VAL v90;
+		VAL v89;
+		mw_mirth_elab_abZ_opZBang(v87, v85, v77, &v88, &v89);
+		int64_t v90 = 5LL /* PRIM_CORE_DIP */;
 		VAL v91;
-		mw_mirth_elab_abZ_primZBang(v89, v87, v88, &v90, &v91);
 		VAL v92;
+		mw_mirth_elab_abZ_primZBang(v90, v88, v89, &v91, &v92);
 		VAL v93;
-		mw_mirth_elab_abZ_wordZBang(value_u64(v4), v90, v91, &v92, &v93);
-		branch_ZPlusAB_42 = v93;
-		branch_ZPlusMirth_41 = v92;
+		VAL v94;
+		mw_mirth_elab_abZ_wordZBang(value_u64(v4), v91, v92, &v93, &v94);
+		branch_ZPlusAB_43 = v94;
+		branch_ZPlusMirth_42 = v93;
 	}
-	VAL v94;
-	VAL v95 = mw_mirth_elab_abZ_ctxZAt(v28, &v94);
-	VAL v96;
-	VAL v97 = mw_mirth_elab_abZ_typeZAt(v94, &v96);
-	VAL v98;
-	uint64_t v99 = mw_mirth_elab_abZ_tokenZAt(v96, &v98);
-	VAL v100 = mtw_mirth_arrow_Lambda_Lambda(v99, v95, v97, v17, branch_ZPlusAB_42);
-	VAL v101 = mtw_mirth_arrow_Op_OpLambda(v100);
-	VAL v102;
+	VAL v95;
+	VAL v96 = mw_mirth_elab_abZ_ctxZAt(v29, &v95);
+	VAL v97;
+	VAL v98 = mw_mirth_elab_abZ_typeZAt(v95, &v97);
+	VAL v99;
+	uint64_t v100 = mw_mirth_elab_abZ_tokenZAt(v97, &v99);
+	VAL v101 = mtw_mirth_arrow_Lambda_Lambda(v100, v96, v98, v18, branch_ZPlusAB_43);
+	VAL v102 = mtw_mirth_arrow_Op_OpLambda(v101);
 	VAL v103;
-	mw_mirth_elab_abZ_opZBang(v101, branch_ZPlusMirth_41, v98, &v102, &v103);
 	VAL v104;
+	mw_mirth_elab_abZ_opZBang(v102, branch_ZPlusMirth_42, v99, &v103, &v104);
 	VAL v105;
-	mw_mirth_elab_abZ_unifyZ_typeZBang(v13, v102, v103, &v104, &v105);
 	VAL v106;
-	VAL v107 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v104, v105, v10, &v106);
-	push_resource(v106);
-	push_value(v107);
+	mw_mirth_elab_abZ_unifyZ_typeZBang(v13, v103, v104, &v105, &v106);
+	VAL v107;
+	VAL v108 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v105, v106, v10, &v107);
+	push_resource(v107);
+	push_value(v108);
 }
 static void mb_mirth_mirth_PropLabel_prop_1_sp7_1 (void) {
 	TUP* v0 = value_tup(pop_value(), 2);
@@ -67993,7 +68378,7 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp19_0 (void) {
 	push_resource(v2);
 	push_value(v3);
 }
-static void mb_mirth_mirth_PropLabel_prop_1_sp20_5 (void) {
+static void mb_mirth_mirth_PropLabel_prop_1_sp20_6 (void) {
 	uint64_t v0 = value_u64(pop_value());
 	VAL r1 = pop_resource();
 	VAL v2;
@@ -68024,50 +68409,51 @@ static void mb_mirth_mirth_PropLabel_prop_1_sp20_5 (void) {
 		branch_ZPlusMirth_16 = v18;
 		branch_StackType_15 = v20;
 	} else {
-		VAL v21;
-		uint64_t v22 = mw_mirth_elab_abZ_tokenZAt(v11, &v21);
-		incref(v13);
-		VAL v23;
-		VAL v24 = mw_mirth_elab_abZ_ctxZAt(v21, &v23);
-		VAL v25;
-		VAL v26 = mw_mirth_elab_abZ_typeZAt(v23, &v25);
-		VAL v27;
+		VAL v21 = mw_std_list_List_1_map_1_sp7(v13);
+		VAL v22;
+		uint64_t v23 = mw_mirth_elab_abZ_tokenZAt(v11, &v22);
+		incref(v21);
+		VAL v24;
+		VAL v25 = mw_mirth_elab_abZ_ctxZAt(v22, &v24);
+		VAL v26;
+		VAL v27 = mw_mirth_elab_abZ_typeZAt(v24, &v26);
 		VAL v28;
 		VAL v29;
-		VAL v30 = mw_std_list_List_1_reverseZ_for_1_sp8(v12, v25, v24, v26, v13, &v27, &v28, &v29);
-		VAL v31;
-		VAL v32 = mw_mirth_elab_abZ_homeZAt(v28, &v31);
-		incref(v29);
-		VAL v33 = MKI64(0LL /* Nil */);
-		VAL v34 = mtw_mirth_arrow_Arrow_Arrow(v32, v22, v22, v30, v29, v29, v33);
-		VAL v35;
+		VAL v30;
+		VAL v31 = mw_std_list_List_1_reverseZ_for_1_sp8(v12, v26, v25, v27, v21, &v28, &v29, &v30);
+		VAL v32;
+		VAL v33 = mw_mirth_elab_abZ_homeZAt(v29, &v32);
+		incref(v30);
+		VAL v34 = MKI64(0LL /* Nil */);
+		VAL v35 = mtw_mirth_arrow_Arrow_Arrow(v33, v23, v23, v31, v30, v30, v34);
 		VAL v36;
-		VAL v37 = mw_mirth_elab_elabZ_defZ_bodyZBang(v9, v27, v34, &v35, &v36);
-		VAL v38;
-		VAL v39 = mw_mirth_elab_abZ_ctxZAt(v31, &v38);
-		VAL v40;
-		VAL v41 = mw_mirth_elab_abZ_typeZAt(v38, &v40);
-		VAL v42;
-		uint64_t v43 = mw_mirth_elab_abZ_tokenZAt(v40, &v42);
-		VAL v44 = mtw_mirth_arrow_Lambda_Lambda(v43, v39, v41, v13, v36);
-		VAL v45 = mtw_mirth_arrow_Op_OpLambda(v44);
-		VAL v46;
+		VAL v37;
+		VAL v38 = mw_mirth_elab_elabZ_defZ_bodyZBang(v9, v28, v35, &v36, &v37);
+		VAL v39;
+		VAL v40 = mw_mirth_elab_abZ_ctxZAt(v32, &v39);
+		VAL v41;
+		VAL v42 = mw_mirth_elab_abZ_typeZAt(v39, &v41);
+		VAL v43;
+		uint64_t v44 = mw_mirth_elab_abZ_tokenZAt(v41, &v43);
+		VAL v45 = mtw_mirth_arrow_Lambda_Lambda(v44, v40, v42, v21, v37);
+		VAL v46 = mtw_mirth_arrow_Op_OpLambda(v45);
 		VAL v47;
-		mw_mirth_elab_abZ_opZBang(v45, v35, v42, &v46, &v47);
-		branch_ZPlusAB_17 = v47;
-		branch_ZPlusMirth_16 = v46;
-		branch_StackType_15 = v37;
+		VAL v48;
+		mw_mirth_elab_abZ_opZBang(v46, v36, v43, &v47, &v48);
+		branch_ZPlusAB_17 = v48;
+		branch_ZPlusMirth_16 = v47;
+		branch_StackType_15 = v38;
 	}
-	VAL v48;
 	VAL v49;
-	mw_mirth_elab_abZ_unifyZ_typeZBang(branch_StackType_15, branch_ZPlusMirth_16, branch_ZPlusAB_17, &v48, &v49);
 	VAL v50;
-	VAL v51 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v48, v49, v6, &v50);
-	incref(v51);
-	VAL v52;
-	mw_mirth_elab_checkZ_inlineZ_recursionZ_arrowZBang(v50, v0, v51, &v52);
-	push_value(v51);
-	push_resource(v52);
+	mw_mirth_elab_abZ_unifyZ_typeZBang(branch_StackType_15, branch_ZPlusMirth_16, branch_ZPlusAB_17, &v49, &v50);
+	VAL v51;
+	VAL v52 = mw_mirth_elab_finalizzeZ_wordZ_arrow(v49, v50, v6, &v51);
+	incref(v52);
+	VAL v53;
+	mw_mirth_elab_checkZ_inlineZ_recursionZ_arrowZBang(v51, v0, v52, &v53);
+	push_value(v52);
+	push_resource(v53);
 }
 static void mb_mirth_mirth_PropLabel_prop_1_sp21_0 (void) {
 	uint64_t v0 = value_u64(pop_value());

--- a/examples/snake.mth
+++ b/examples/snake.mth
@@ -254,7 +254,7 @@ def +SnakeLogic.tick! [ +SnakeLogic -- +SnakeLogic Bool ] {
     )
 }
 
-def +SnakeLogic.in-snake { snake member(==) }
+def +SnakeLogic.in-snake { snake member }
 def +SnakeLogic.randomize-mouse! [ +World +SnakeLogic -- +World +SnakeLogic ] {
     rdip:Position.Random!
     while(dup in-snake, drop rdip:Position.Random!)

--- a/lib/std/list.mth
+++ b/lib/std/list.mth
@@ -106,6 +106,17 @@ def List.last  [ List(t) -- Maybe(t) ] { >List+ map(last) }
 def List+.first [ List+(t) -- t ] { head }
 def List+.last  [ List+(t) -- t ] { uncons for(nip) }
 
+def List.head [ List(x) -- Maybe(x) ] {
+    { Nil -> None }
+    { Cons -> drop Some }
+}
+def List.tail [ List(x) -- List(x) ] {
+    { Nil -> Nil }
+    { Cons -> nip }
+}
+
+def List.drop-slice [ Nat List(x) -- List(x) ] { swap repeat(tail) }
+
 ||| Reverse the list.
 def List.reverse [ List(a) -- List(a) ] {
     Nil swap for(swap Cons)
@@ -173,6 +184,28 @@ def List.fold(g) [ (*c a a -- *c a) *c List(a) -- *c Maybe(a) ] {
 
 ||| Reduce a list via binary operation.
 def List+.fold(g) [ (*c a a -- *c a) *c List+(a) -- *c a ] {
+    uncons for(g)
+}
+
+||| Sum together a list of numbers.
+def List.sum(z {0}, g {+}) [ (*c -- *c a, *c a a -- *c a) *c List(a) -- *c a] {
+    { Nil -> z }
+    { Cons -> for(g) }
+}
+
+||| Sum together a list of numbers.
+def List+.sum(g {+}) [ (*c a a -- *c a) *c List+(a) -- *c a ] {
+    uncons for(g)
+}
+
+||| Multiply together a list of numbers.
+def List.product(z {1}, g {*}) [ (*c -- *c a, *c a a -- *c a) *c List(a) -- *c a] {
+    { Nil -> z }
+    { Cons -> for(g) }
+}
+
+||| Multiply together a list of numbers.
+def List+.product(g {*}) [ (*c a a -- *c a) *c List+(a) -- *c a ] {
     uncons for(g)
 }
 
@@ -376,7 +409,7 @@ inline(
     def(LIST+(f), (*a +List(t) -- *b +List+(t)) *a -- *b List+(t), L0 thaw f freeze)
 )
 
-def List.==(eq) [ (*c a a -- *c Bool) *c List(a) List(a) -- *c Bool ] {
+def List.==(eq {==}) [ (*c a a -- *c Bool) *c List(a) List(a) -- *c Bool ] {
     True while (
         dip(dip(uncons) uncons dip(swap) dip2(==(eq)) rotl) &&
         over2 empty? over2 empty? && not over &&,
@@ -385,35 +418,35 @@ def List.==(eq) [ (*c a a -- *c Bool) *c List(a) List(a) -- *c Bool ] {
     dip(drop2)
 }
 
-def List+.==(eq) [ (*c a a -- *c Bool) *c List+(a) List+(a) -- *c Bool ] {
+def List+.==(eq {==}) [ (*c a a -- *c Bool) *c List+(a) List+(a) -- *c Bool ] {
     dip(>List) >List ==(eq)
 }
 
-def(List.lookup(p), (*c k a -- *c Bool) *c k List(a) -- *c Maybe(a),
+def(List.lookup(p {.key ==}), (*c k a -- *c Bool) *c k List(a) -- *c Maybe(a),
     find(over dip(p) swap) nip)
 
-def(List+.lookup(p), (*c k a -- *c Bool) *c k List+(a) -- *c Maybe(a),
+def(List+.lookup(p {.key ==}), (*c k a -- *c Bool) *c k List+(a) -- *c Maybe(a),
     find(over dip(p) swap) nip)
 
-def(List.reverse-lookup(p), (*c k a -- *c Bool) *c k List(a) -- *c Maybe(a),
+def(List.reverse-lookup(p {.key ==}), (*c k a -- *c Bool) *c k List(a) -- *c Maybe(a),
     reverse-find(over dip(p) swap) nip)
 
-def(List+.reverse-lookup(p), (*c k a -- *c Bool) *c k List+(a) -- *c Maybe(a),
+def(List+.reverse-lookup(p {.key ==}), (*c k a -- *c Bool) *c k List+(a) -- *c Maybe(a),
     reverse-find(over dip(p) swap) nip)
 
-def(List.member(p), (*c k a -- *c Bool) *c k List(a) -- *c Bool,
+def(List.member(p {==}), (*c k a -- *c Bool) *c k List(a) -- *c Bool,
     lookup(p) some?)
 
-def(List+.member(p), (*c k a -- *c Bool) *c k List+(a) -- *c Bool,
+def(List+.member(p {==}), (*c k a -- *c Bool) *c k List+(a) -- *c Bool,
     lookup(p) some?)
 
-def(List.difference(eq), (*c a a -- *c Bool) *c List(a) List(a) -- *c List(a),
+def(List.difference(eq {==}), (*c a a -- *c Bool) *c List(a) List(a) -- *c List(a),
     swap filter(over dip(swap member(eq) not) swap) nip)
 
-def(List.union(eq), (*c a a -- *c Bool) *c List(a) List(a) -- *c List(a),
+def(List.union(eq {==}), (*c a a -- *c Bool) *c List(a) List(a) -- *c List(a),
     over dip(swap difference(eq)) swap cat)
 
-def(List.unions(eq), (*c a a -- *c Bool) *c List(List(a)) -- *c List(a),
+def(List.unions(eq {==}), (*c a a -- *c Bool) *c List(List(a)) -- *c List(a),
     fold(union(eq)) unwrap(L0))
 
 def(List.map2(f), (*c x y -- *c z) *c List(x) List(y) -- *c List(z),
@@ -458,7 +491,7 @@ def(List.partition(p), (*a t -- *a Bool) *a List(t) -- *a List(t) List(t),
 def(List+.partition(p), (*a t -- *a Bool) *a List+(t) -- *a List(t) List(t),
     partition-either(dup dip(p) swap if(Right, Left)))
 
-def(List.show;(f), (t +Str -- +Str) List(t) +Str -- +Str,
+def(List.show;(f {show;}), (t +Str -- +Str) List(t) +Str -- +Str,
     "LIST( " ; for(f " ; " ;) ")" ;)
-def(List+.show;(f), (t +Str -- +Str) List+(t) +Str -- +Str,
+def(List+.show;(f {show;}), (t +Str -- +Str) List+(t) +Str -- +Str,
     "LIST+( " ; unsnoc dip:for(f " ; " ;) f " ;+ )" ;)

--- a/lib/std/map.mth
+++ b/lib/std/map.mth
@@ -19,8 +19,8 @@ def(Map.values, Map(k,v) -- List(v), Map -> map(value))
 def(Map.insert, KVPair(k,v) Map(k,v) -- Map(k,v),
     Map -> cons Map)
 
-def(Map.lookup-pair(k==), (*c k k -- *c Bool) *c k Map(k,v) -- *c Maybe(KVPair(k,v)),
-    Map -> lookup(key k==))
+def(Map.lookup-pair(keq {==}), (*c k k -- *c Bool) *c k Map(k,v) -- *c Maybe(KVPair(k,v)),
+    Map -> lookup(.key keq))
 
-def(Map.lookup(k==), (*c k k -- *c Bool) *c k Map(k,v) -- *c Maybe(v),
-    lookup-pair(k==) map(value))
+def(Map.lookup(keq {==}), (*c k k -- *c Bool) *c k Map(k,v) -- *c Maybe(v),
+    lookup-pair(keq) map(value))

--- a/lib/std/maybe.mth
+++ b/lib/std/maybe.mth
@@ -17,12 +17,12 @@ inline (
     def Maybe.if(f,g) { some? if(f,g) }
     def Maybe.then(f) { some? then(f) }
     def Maybe.else(f) { none? then(f) }
-    def Maybe.and(f)  { some? and(f) }
-    def Maybe.or(f)   { some? or(f) }
+    def Maybe.and(f) { some? and(f) }
+    def Maybe.or(f) { some? or(f) }
 
-    def Maybe.if-some(f,g)  { { Some -> f    } { None -> g     } }
-    def Maybe.or-some(f)    { { Some -> Some } { None -> f     } }
-    def Maybe.unwrap(f)     { { Some -> id } { None -> f } }
+    def Maybe.if-some(f,g)  { { Some -> f    } { None -> g } }
+    def Maybe.or-some(f)    { { Some -> Some } { None -> f } }
+    def Maybe.unwrap(f)     { { Some -> id   } { None -> f } }
 )
 
 def Maybe.>List [ Maybe(t) -- List(t) ] {
@@ -30,12 +30,12 @@ def Maybe.>List [ Maybe(t) -- List(t) ] {
     { Some -> L1 }
 }
 
-def Maybe.==(eq) [ (*c a a -- *c Bool) *c Maybe(a) Maybe(a) -- *c Bool ] {
+def Maybe.== (eq {==}) [ (*c a a -- *c Bool) *c Maybe(a) Maybe(a) -- *c Bool ] {
     { None -> none? }
     { Some -> swap if-some(swap eq, drop False) }
 }
 
-def Maybe.compare(cmp) [ (*c a a -- *c Comparison) *c Maybe(a) Maybe(a) -- *c Comparison ] {
+def Maybe.compare (cmp {compare}) [ (*c a a -- *c Comparison) *c Maybe(a) Maybe(a) -- *c Comparison ] {
     { None -> match {
         { None -> EQ }
         { Some -> drop GT }
@@ -80,11 +80,11 @@ def Maybe.map2(f) [ (*c x y -- *c z) *c Maybe(x) Maybe(y) -- *c Maybe(z) ] {
 
 def Maybe.zip [ Maybe(x) Maybe(y) -- Maybe([x y]) ] { map2(pack2) }
 
-def Maybe.show;(f) [ (t +Str -- +Str) Maybe(t) +Str -- +Str ] {
+def Maybe.show;(f {show;}) [ (t +Str -- +Str) Maybe(t) +Str -- +Str ] {
     { None -> "None" ; }
     { Some -> f " Some" ; }
 }
 
-def Maybe.show(f) [ (t +Str -- +Str) Maybe(t) -- Str ] {
+def Maybe.show(f {show;}) [ (t +Str -- +Str) Maybe(t) -- Str ] {
     Str( show;(f) )
 }

--- a/lib/std/prelude.mth
+++ b/lib/std/prelude.mth
@@ -82,12 +82,12 @@ inline(
 def(Bool.show, Bool -- Str, if("True", "False"))
 def(Bool.show;, Bool +Str -- +Str, show ;)
 
-data(OS,
-    OS_UNKNOWN,
-    OS_WINDOWS,
-    OS_LINUX,
-    OS_MACOS)
-
+data OS {
+    0 OS_UNKNOWN
+    1 OS_WINDOWS
+    2 OS_LINUX
+    3 OS_MACOS
+}
 def(Int.>OS, Int -- OS, dup 1 3 in-range if(OS.from-enum-value-unsafe, drop OS_UNKNOWN))
 inline(
     def(OS.>Int, OS -- Int, enum-value)
@@ -95,12 +95,12 @@ inline(
     def(RUNNING_OS, OS, prim-sys-os >OS)
 )
 
-data(Arch,
-    ARCH_UNKNOWN,
-    ARCH_I386,
-    ARCH_AMD64,
-    ARCH_ARM64)
-
+data Arch {
+    0 ARCH_UNKNOWN
+    1 ARCH_I386
+    2 ARCH_AMD64
+    3 ARCH_ARM64
+}
 def(Int.>Arch, Int -- Arch, dup 1 3 in-range if(Arch.from-enum-value-unsafe, drop ARCH_UNKNOWN))
 inline(
     def(Arch.>Int, Arch -- Int, enum-value)
@@ -200,6 +200,9 @@ inline(
     def drop4 [ a b c d     -- ] { drop drop drop drop           }
     def drop5 [ a b c d e   -- ] { drop drop drop drop drop      }
     def drop6 [ a b c d e f -- ] { drop drop drop drop drop drop }
+
+    def rdrop2 (rd1 {rdrop}, rd2 {rdrop}) [ ( +a --, +b -- ) +a +b -- ] { rd2 rd1 }
+    def rdrop3 (rd1 {rdrop}, rd2 {rdrop}, rd3 {rdrop}) [ ( +a --, +b --, +c -- ) +a +b +c -- ] { rd3 rd2 rd1 }
 
     def flip3 [ a b c   --   c b a ] { >x1 >x2 >x3     x1> x2> x3>     }
     def flip4 [ a b c d -- d c b a ] { >x1 >x2 >x3 >x4 x1> x2> x3> x4> }
@@ -899,34 +902,34 @@ inline(
     def(unpack5, [a b c d e] -- a b c d e, prim-tup-unpack5)
 
     def(pack0==, [] [] -- Bool, drop2 False)
-    def(pack1==(aeq), (a a -- Bool) [a] [a] -- Bool,
+    def(pack1==(aeq{==}), (a a -- Bool) [a] [a] -- Bool,
         on2:unpack1 aeq)
-    def(pack2==(aeq,beq), (a a -- Bool, b b -- Bool) [a b] [a b] -- Bool,
+    def(pack2==(aeq{==},beq{==}), (a a -- Bool, b b -- Bool) [a b] [a b] -- Bool,
         dip:unpack2 unpack2 dip:swap
         beq if(aeq, drop2 False))
-    def(pack3==(aeq,beq,ceq), (a a -- Bool, b b -- Bool, c c -- Bool)
+    def(pack3==(aeq{==},beq{==},ceq{==}), (a a -- Bool, b b -- Bool, c c -- Bool)
             [a b c] [a b c] -- Bool,
         dip:unpack3 unpack3 dip2:rotr dip:swap
         ceq if(beq if(aeq, drop2 False), drop4 False))
-    def(pack4==(aeq,beq,ceq,deq),
+    def(pack4==(aeq{==},beq{==},ceq{==},deq{==}),
             (a a -- Bool, b b -- Bool, c c -- Bool, d d -- Bool)
             [a b c d] [a b c d] -- Bool,
         dip:unpack4 unpack4 dip3:rot4r dip2:rotr dip:swap
         deq if(ceq if(beq if(aeq, drop2 False), drop4 False), drop2 drop4 False))
 
-    def(pack2-show;-contents(f,g), (a +Str -- +Str, b +Str -- +Str) [a b] +Str -- +Str,
+    def(pack2-show;-contents(f{show;},g{show;}), (a +Str -- +Str, b +Str -- +Str) [a b] +Str -- +Str,
         unpack2 dip(f) " " ; g)
-    def(pack3-show;-contents(f,g,h), (a +Str -- +Str, b +Str -- +Str, c +Str -- +Str) [a b c] +Str -- +Str,
+    def(pack3-show;-contents(f{show;},g{show;},h{show;}), (a +Str -- +Str, b +Str -- +Str, c +Str -- +Str) [a b c] +Str -- +Str,
         unpack3 dip2(f) " " ; dip(g) " " ; h)
-    def(pack4-show;-contents(f,g,h,i),
+    def(pack4-show;-contents(f{show;},g{show;},h{show;},i{show;}),
         (a +Str -- +Str, b +Str -- +Str, c +Str -- +Str, d +Str -- +Str) [a b c d] +Str -- +Str,
         unpack4 dip3(f) " " ; dip2(g) " " ; dip(h) " " ; i)
 
-    def(pack2-show;(f,g), (a +Str -- +Str, b +Str -- +Str) [a b] +Str -- +Str,
+    def(pack2-show;(f{show;},g{show;}), (a +Str -- +Str, b +Str -- +Str) [a b] +Str -- +Str,
         pack2-show;-contents(f,g) " pack2" ;)
-    def(pack3-show;(f,g,h), (a +Str -- +Str, b +Str -- +Str, c +Str -- +Str) [a b c] +Str -- +Str,
+    def(pack3-show;(f{show;},g{show;},h{show;}), (a +Str -- +Str, b +Str -- +Str, c +Str -- +Str) [a b c] +Str -- +Str,
         pack3-show;-contents(f,g,h) " pack3" ;)
-    def(pack4-show;(f,g,h,i), (a +Str -- +Str, b +Str -- +Str, c +Str -- +Str, d +Str -- +Str) [a b c d] +Str -- +Str,
+    def(pack4-show;(f{show;},g{show;},h{show;},i{show;}), (a +Str -- +Str, b +Str -- +Str, c +Str -- +Str, d +Str -- +Str) [a b c d] +Str -- +Str,
         pack4-show;-contents(f,g,h,i) " pack4" ;)
 )
 

--- a/lib/std/test.mth
+++ b/lib/std/test.mth
@@ -140,7 +140,7 @@ def(+Test.fail!, +Test -- +Test,
         True test-failed!
         test-name +world:print(show; " test failed" ;)
     ))
-def(+Test.check-equals!(feq,fshow), (a a -- Bool, a +Str -- +Str) a a +Test -- +Test,
+def(+Test.check-equals!(feq {==}, fshow {show;}), (a a -- Bool, a +Str -- +Str) a a +Test -- +Test,
     ||| Check two values for equality. If they're equal, do nothing.
     ||| If they're different, mark the test as failed (see [fail!])
     ||| and print the values.
@@ -153,17 +153,17 @@ def(+Test.check-equals!(feq,fshow), (a a -- Bool, a +Str -- +Str) a a +Test -- +
         +world:print("  expected: " ; fshow "\n" ;
                      "       got: " ; fshow "\n" ;)
     ))
-def(+Test.check-equals-2!(f1,f2,g1,g2),
+def(+Test.check-equals-2!(f1 {==},f2 {==}, g1 {show;}, g2 {show;}),
         (a a -- Bool, b b -- Bool,
          a +Str -- +Str, b +Str -- +Str)
         a b a b +Test -- +Test,
     pack2 dip:pack2 check-equals!(pack2==(f1,f2), pack2-show;(g1,g2)))
-def(+Test.check-equals-3!(f1,f2,f3,g1,g2,g3),
+def(+Test.check-equals-3!(f1 {==}, f2 {==}, f3 {==}, g1 {show;}, g2 {show;}, g3 {show;}),
         (a a -- Bool, b b -- Bool, c c -- Bool,
          a +Str -- +Str, b +Str -- +Str, c +Str -- +Str)
         a b c a b c +Test -- +Test,
     pack3 dip:pack3 check-equals!(pack3==(f1,f2,f3), pack3-show;-contents(g1,g2,g3)))
-def(+Test.check-equals-4!(f1,f2,f3,f4,g1,g2,g3,g4),
+def(+Test.check-equals-4!(f1 {==}, f2 {==}, f3 {==}, f4 {==}, g1 {show;}, g2 {show;}, g3 {show;}, g4 {show;}),
         (a a -- Bool, b b -- Bool, c c -- Bool, d d -- Bool,
          a +Str -- +Str, b +Str -- +Str, c +Str -- +Str, d +Str -- +Str)
         a b c d a b c d +Test -- +Test,

--- a/src/arrow.mth
+++ b/src/arrow.mth
@@ -212,10 +212,10 @@ def(Block.free-vars, +Mirth Block -- +Mirth List(Var),
     ) nip)
 
 def(Arrow.free-vars, +Mirth Arrow -- +Mirth List(Var),
-    atoms map(free-vars) unions(==))
+    atoms map(free-vars) unions)
 def(Atom.free-vars, +Mirth Atom -- +Mirth List(Var),
-    dup args map(free-vars) unions(==)
-    swap op free-vars union(==))
+    dup args map(free-vars) unions
+    swap op free-vars union)
 def(Arg.free-vars, +Mirth Arg -- +Mirth List(Var),
     ArgBlock -> free-vars)
 def Op.free-vars [ +Mirth Op -- +Mirth List(Var) ] {
@@ -247,12 +247,12 @@ def Op.free-vars [ +Mirth Op -- +Mirth List(Var) ] {
     { OpTableFromIndex -> drop L0 }
 }
 def(Match.free-vars, +Mirth Match -- +Mirth List(Var),
-    cases map(free-vars) unions(==))
+    cases map(free-vars) unions)
 def(Case.free-vars, +Mirth Case -- +Mirth List(Var),
     body free-vars)
 def(Lambda.free-vars, +Mirth Lambda -- +Mirth List(Var),
     dup body free-vars
-    swap params difference(==))
+    swap params difference)
 
 def(Arg.token, Arg -- Token,
     ArgBlock -> token)

--- a/src/c99.mth
+++ b/src/c99.mth
@@ -121,7 +121,7 @@ def run-output-c99! [ Arrow C99_Options +World +Mirth -- +World +Mirth ] {
         c99-word-defs!
         c99-block-defs!
         c99-end!
-    )   
+    )
 }
 
 field(Tag.~word-cname, Tag, Str)
@@ -939,9 +939,9 @@ def c99-smart-def! (f) [ (*a +C99Branch -- *b +C99Branch) *a C99API +C99 -- *b +
 }
 
 def c99-codip-arrow! [ Arrow +C99Branch -- +C99Branch ] {
-    dup +mirth:type unpack
-    split-parts >cod-parts >cod-base
-    split-parts >dom-parts >dom-base
+    dup +mirth:type /ArrowType
+    cod> split-parts >cod-parts >cod-base
+    dom> split-parts >dom-parts >dom-base
     cod-base> unit? dom-base> unit? && if(
         dom-parts> dip-parts( +stack(+SNil) )
         c99-arrow!

--- a/src/def.mth
+++ b/src/def.mth
@@ -67,19 +67,19 @@ def(Def.external?, Def -- Maybe(External), DefExternal -> Some, _ -> drop None)
 def(Def.field?, Def -- Maybe(Field), DefField -> Some, _ -> drop None)
 
 def(Def.==, Def Def -- Bool,
-    DefAlias -> Some swap alias? ==:==,
-    DefPackage -> Some swap package? ==:==,
-    DefModule -> Some swap module? ==:==,
-    DefBuffer -> Some swap buffer? ==:==,
-    DefPrim -> Some swap prim? ==:==,
-    DefData -> Some swap data? ==:==,
-    DefTable -> Some swap table? ==:==,
-    DefType -> Some swap typedef? ==:==,
-    DefExternal -> Some swap external? ==:==,
-    DefWord -> Some swap word? ==:==,
-    DefField -> Some swap field? ==:==,
-    DefTag -> Some swap tag? ==:==,
-    DefVariable -> Some swap variable? ==:==)
+    DefAlias -> Some swap alias? ==,
+    DefPackage -> Some swap package? ==,
+    DefModule -> Some swap module? ==,
+    DefBuffer -> Some swap buffer? ==,
+    DefPrim -> Some swap prim? ==,
+    DefData -> Some swap data? ==,
+    DefTable -> Some swap table? ==,
+    DefType -> Some swap typedef? ==,
+    DefExternal -> Some swap external? ==,
+    DefWord -> Some swap word? ==,
+    DefField -> Some swap field? ==,
+    DefTag -> Some swap tag? ==,
+    DefVariable -> Some swap variable? ==)
 
 def(Def.typecheck!, +Mirth Def -- +Mirth,
     DefAlias -> target typecheck!,

--- a/src/elab.mth
+++ b/src/elab.mth
@@ -346,7 +346,7 @@ def +ResolveDef.filter-sort(p) [
 
 def +ResolveDef.filter-arity [ +Mirth +ResolveDef -- +Mirth +ResolveDef ] {
     token num-args filter(
-        dup2 rdip:arity dip(>Int) arity-compatible?,
+        dup2 rdip:qname-hard arity dip(>Int) arity-compatible?,
         RD_WRONG_ARITY
     ) drop
 }
@@ -366,7 +366,7 @@ def +ResolveDef.filter-roots [ List(Namespace) +Mirth +ResolveDef -- +Mirth +Res
         { Left ->
             >name
             filter(
-                dup2 rdip:qname-hard namespace swap member(==)
+                dup2 rdip:qname-hard namespace swap member
                 or(token over rdip:def-is-imported-at-token?),
                 dup rdip:qname-hard namespace match(
                     NAMESPACE_TYCON ->
@@ -385,7 +385,7 @@ def +ResolveDef.filter-roots [ List(Namespace) +Mirth +ResolveDef -- +Mirth +Res
 
         { Right ->
             dup is-relative? and(ignore-last-name not) if(
-                filter(dup2 rdip:qname-hard climb-up-dname? has(over3 member(==)),
+                filter(dup2 rdip:qname-hard climb-up-dname? has(over3 member),
                     over2 empty? if(
                         RD_METHOD_NOT_AVAILABLE,
                         RD_METHOD_WRONG_TYPE
@@ -1000,6 +1000,18 @@ def elab-args! [ +Mirth +AB -- +Mirth +AB ] {
     ab-token@ args for(elab-block-at!)
 }
 
+def elab-word-args! [ Word +Mirth +AB -- Word +Mirth +AB ] {
+    elab-args!
+    ab-token@ num-args over arity < then(
+        ab-token@ num-args over rdip:params drop-slice for(
+            default if-some (
+                elab-block-at!,
+                ab-token@ "word parameter is missing, has no default implementation" rdip:emit-fatal-error!
+            )
+        )
+    )
+}
+
 def elab-no-args! [ +Mirth +AB -- +Mirth +AB ] {
     ab-token@ rdip:args-0
 }
@@ -1064,7 +1076,7 @@ def elab-atom-def! [ Def +Mirth +AB -- +Mirth +AB ] {
     DefVariable -> elab-no-args! ab-variable!,
     DefExternal -> elab-no-args! ab-external!,
     DefField -> elab-no-args! ab-field!,
-    DefWord -> elab-args! ab-word!,
+    DefWord -> elab-word-args! ab-word!,
     DefTag -> elab-args! ab-tag!,
     DefPrim -> elab-prim!,
     _ -> rdip:qname-hard elab-atom-not-a-word!
@@ -1168,7 +1180,7 @@ def elab-pattern-atom! [ Token +Mirth +Pattern -- +Mirth +Pattern ] {
             @+pat:pattern mid top-types-are-fine? then(
                 @+pat:pattern mid top-namespaces
                 token name? if(
-                    filter(dup2 rdip:qname-hard namespace swap member(==), RD_WRONG_CONSTRUCTOR) drop,
+                    filter(dup2 rdip:qname-hard namespace swap member, RD_WRONG_CONSTRUCTOR) drop,
                     filter-roots
                 )
             )
@@ -1295,7 +1307,7 @@ def check-module-path [ Token Module +World +Mirth -- +World +Mirth ] {
             ) drop3,
 
         Some ->
-            split-last-byte(BDOT ==) "mth" Some ==:==
+            split-last-byte(BDOT ==) "mth" Some ==
             else(over3 "expected .mth extension for mirth file" emit-warning!)
             over2 name >Str == else(over2 "expected module name to match file name" emit-fatal-error!)
             over package path! drop2
@@ -1739,13 +1751,13 @@ def create-projectors! [ +Mirth Tag -- +Mirth ] {
             @lbl_lens dup WordParams prop(
                 type dom top-type? unwrap("logic error: expected parameter" fatal-error!)
                 morphism? unwrap("logic error: expected morphism" fatal-error!)
-                "f" >Name Var.new-auto-run! L1
+                "f" >Name Var.new-auto-run! >var None >default Param L1
             ) @lbl_lens ~params !
 
             @dat @lbl_get @lbl_set @lbl_lens dup WordArrow prop4(
                 >lbl_lens >lbl_set >lbl_get >dat
                 @lbl_lens ab-build-word-arrow!(
-                    lbl_lens> rdip:params dup ab-lambda!(
+                    lbl_lens> rdip:params map(.var) dup ab-lambda!(
                         /L1 unwrap("Expected one parameter." rdip:fatal-error!) >f
                         dat> is-resource? if(
                             lbl_get> ab-word!
@@ -1908,7 +1920,7 @@ def elab-def! [ +Mirth Token -- +Mirth Token ] {
         dup dup ab-build-word-arrow!(
             swap rdip:params dup empty? if(
                 drop elab-def-body!,
-                ab-lambda!(elab-def-body!)
+                map(.var) ab-lambda!(elab-def-body!)
             )
         ) tuck check-inline-recursion-arrow!
     ) @word ~arrow !
@@ -1954,15 +1966,23 @@ def check-inline-recursion-failed! [ +Mirth Word -- +Mirth ] {
 }
 
 ||| Elaborate a word's parameters from its type and declaration.
-def elab-def-params! [ +Mirth Word -- +Mirth List(Var) ] {
+def elab-def-params! [ +Mirth Word -- +Mirth List(Param) ] {
     L0 over type
     rotl head dip(/ArrowType dom> cod>) nip
     args reverse-for(
         dup sig-param-name? unwrap("expected parameter name" emit-fatal-error!) >name
-        dup succ dup run-end? if(drop, "expected right paren or comma" emit-fatal-error!)
+        dup succ dup run-end? if(
+            drop None >default,
+            dup lcurly? if(
+                dup succ Some >default
+                next dup run-end? if(drop, "expected right paren or comma" emit-fatal-error!),
+
+                "expected right paren, left curly, or comma" emit-fatal-error!
+            )
+        )
         elab-expand-tensor!
         swap morphism? unwrap("need function type for param" emit-fatal-error!)
-        nip name> Var.new-auto-run!
+        nip name> Var.new-auto-run! >var Param
         rotr dip(cons)
     ) drop
 }
@@ -2079,7 +2099,7 @@ def elab-def-external-ctype [ +Mirth External -- +Mirth CTypeArrow ] {
 
         dup dom parts filter-some(label?)
         over cod parts filter-some(label?)
-        swap difference(==) for(
+        swap difference for(
             Str("Output label "; name >Str ; " not present in input";) error!
         )
     )
@@ -2278,7 +2298,7 @@ def table-new! [ +Mirth head:Token name:Name state:PropState(QName) -- +Mirth Ta
     @word WordType prop2
     @word ~ctx-type !
 
-    @vx L1
+    @vx >var None >default Param L1
     @word WordParams prop
     @word ~params !
     @word make-inline!
@@ -2349,8 +2369,7 @@ def resolve-def-namespace [ +Mirth Token name/dname:Name/DName -- +Mirth Maybe(N
     bind(as-namespace?)
 }
 
-def elab-qname-from-nonrelative-dname [ +Mirth Token DName Int -- +Mirth QName ] {
-    >arity
+def elab-qname-from-nonrelative-dname [ +Mirth Token DName arity:Int -- +Mirth QName ] {
     dup Right >name/dname
     dup root? else(drop "relative name not allowed" emit-fatal-error!)
     last-name >name
@@ -2369,13 +2388,18 @@ def def-visible-from-token? [ Token Def -- Bool ] {
     )
 }
 
+def Token.is-default-param? [ Token -- Bool ] {
+    dup name? and( dup succ lcurly? >Bool ) nip
+}
+
 ||| Elaborate the qname for a word definition.
 ||| Generally speaking this is going to use the module namespace.
 def elab-def-qname [ +Mirth Token -- +Mirth QName ] {
+    dup args dup has(is-default-param?) if(drop -1, len >Int) >arity
     dup name/dname? unwrap("expected name" emit-fatal-error!)
     match(
-        Left -> >name dup .module NAMESPACE_MODULE >namespace num-args >Int >arity MKQNAME,
-        Right -> over num-args >Int elab-qname-from-nonrelative-dname
+        Left -> >name .module NAMESPACE_MODULE >namespace MKQNAME,
+        Right -> elab-qname-from-nonrelative-dname
     )
 }
 

--- a/src/elab.mth
+++ b/src/elab.mth
@@ -587,8 +587,8 @@ def ab-build-hom!(f) [
     (*a StackType +Mirth +AB -- *b StackType +Mirth +AB)
     *a Ctx ArrowType Token Home +Mirth -- *b Arrow +Mirth
 ] {
-    dip2(unpack rotr)
-    ab-build!(f ab-unify-type!)
+    dip2(/ArrowType dom>)
+    ab-build!(cod> f ab-unify-type!)
 }
 
 ||| Build the arrow for a word. If the word type and context are available, use that.
@@ -618,15 +618,16 @@ def initial-ctx-type-body-home [ +Mirth Word -- +Mirth Ctx ArrowType Token Home 
 
 def finalize-word-arrow [ +Mirth Arrow Word -- +Mirth Arrow ] {
     >word >arrow
-    @word inferring-type? if(
+    @word inferring-type? then(
         @arrow Arrow.ctx-type rigidify-sig!
         dup2 pack2 @word WordType prop @word ~ctx-type !
         False @word ~inferring-type? !
-        unpack arrow> cod! dom! ctx!,
-
-        arrow>
+        /ArrowType
+        cod> @arrow:cod!
+        dom> @arrow:dom!
+        @arrow:ctx!
     )
-    word> drop
+    arrow> word> drop
 }
 
 def guess-initial-ctx-type [ +Mirth word:Word -- +Mirth Ctx ArrowType word:Word ] {
@@ -741,8 +742,10 @@ def ab-expand-opsig! [ OpSig +Mirth +AB -- StackType StackType +Mirth +AB ] {
     { OPSIG_ID -> ab-type@ dup }
     { OPSIG_PUSH -> dip(ab-type@ dup) STCons }
     { OPSIG_APPLY ->
-        dip(ab-type@) unpack
-        dip(ab-token@ rdip:elab-stack-type-unify! drop) }
+        /ArrowType
+        ab-type@
+        dom> ab-token@ rdip:elab-stack-type-unify! drop
+        cod> }
 }
 
 def ab-int! [ Int +Mirth +AB -- +Mirth +AB ] { OpInt ab-op! }
@@ -914,7 +917,7 @@ def elab-label-pop-r-sig! [ Label -- OpSig ] {
 }
 
 def elab-arrow! [ +Mirth Ctx ArrowType Token Home -- +Mirth Arrow ] {
-    dip2(unpack) elab-arrow-hom!
+    dip2(/ArrowType dom> cod>) elab-arrow-hom!
 }
 
 def elab-arrow-hom! [ +Mirth Ctx StackType StackType Token Home -- +Mirth Arrow ] {
@@ -1206,7 +1209,7 @@ def +Match.case!(mkpat,mkbod) [
     rotl
     +Match.home
     @pattern:dip:rdip(ab-build-hom!(dip(mkbod)))
-    >body CASE add-case
+    >body Case add-case
 }
 
 def elab-expand-tensor! [ +Mirth StackType Token -- +Mirth StackType Type Token ] {
@@ -1569,7 +1572,7 @@ def elab-data-done! [ +Mirth Data -- +Mirth ] {
         >tag
         @dat "/" @tag name >Str cat 0u data-word-new! >untag
         @untag Some @tag ~untag !
-        @tag @untag WordType prop(ctx-type unpack swap T-> pack2) @untag ~ctx-type !
+        @tag @untag WordType prop(ctx-type invert pack2) @untag ~ctx-type !
         @tag @untag @untag WordArrow prop2(
             >untag >tag
             untag> ab-build-word-arrow!(
@@ -1953,7 +1956,7 @@ def check-inline-recursion-failed! [ +Mirth Word -- +Mirth ] {
 ||| Elaborate a word's parameters from its type and declaration.
 def elab-def-params! [ +Mirth Word -- +Mirth List(Var) ] {
     L0 over type
-    rotl head dip(unpack) nip
+    rotl head dip(/ArrowType dom> cod>) nip
     args reverse-for(
         dup sig-param-name? unwrap("expected parameter name" emit-fatal-error!) >name
         dup succ dup run-end? if(drop, "expected right paren or comma" emit-fatal-error!)

--- a/src/match.mth
+++ b/src/match.mth
@@ -15,20 +15,22 @@ import(mirth.arrow)
 # Match #
 #########
 
-data(Match, Match ->
+struct Match {
     home:Home token:Token body:Token
     ctx:Ctx dom:StackType cod:StackType
-    cases:List(Case))
+    cases:List(Case)
+}
 
-data(+Match, +Match ->
+struct +Match {
     home:Home token:Token body:Token
     ctx:Ctx dom:StackType cod:StackType
-    cases:List(Case))
+    cases:List(Case)
+}
 
 def(Match.thaw, Match -- +Match, Match -> +Match)
 def(+Match.freeze, +Match -- Match, +Match -> Match)
 
-data(Case, CASE -> pattern:Pattern body:Arrow)
+struct Case { pattern:Pattern body:Arrow }
 def(Case.outer-ctx, Case -- Ctx, pattern outer-ctx)
 def(Case.inner-ctx, Case -- Ctx, pattern inner-ctx)
 
@@ -110,7 +112,7 @@ def(Case.is-default-case?, Case -- Bool, pattern is-default?)
 # Pattern #
 ###########
 
-data(Pattern, Pattern ->
+struct Pattern {
     home:Home
     token-start:Token
     token-end:Token
@@ -119,7 +121,8 @@ data(Pattern, Pattern ->
     saved:List(Type)    # List of types set aside by underscores.
     mid:StackType       # Stack type on the left of the pattern.
     cod:StackType       # Stack type coming from outside match.
-    atoms:List(PatternAtom))
+    atoms:List(PatternAtom)
+}
 def(Pattern.dom, Pattern -- StackType, sip:mid saved for(STCons))
 def(Pattern.thaw, Pattern -- +Pattern, >pattern +Pattern)
 
@@ -170,7 +173,7 @@ def(+Pattern.tag!, +Mirth +Pattern Tag -- +Mirth +Pattern,
     dup PatOpTag >op L0 >saved
     pattern token-start >token
     pattern inner-ctx >ctx
-    dip:SUBST_NIL rdip:type freshen-sig unpack
+    dip:SUBST_NIL rdip:type freshen-sig /ArrowType dom> cod>
     dip(pattern mid)
     pattern token-start >token +Gamma rdip':unify! rdrop >cod
     dup >dom pattern:mid!

--- a/src/module.mth
+++ b/src/module.mth
@@ -57,5 +57,5 @@ def(Module.source-path, Module -- Path,
 def(Module.visible, Module Module -- Bool,
     dup2 == if(
         drop2 True, # Module is always visible to itself.
-        imports member(==)
+        imports member
     ))

--- a/src/name.mth
+++ b/src/name.mth
@@ -212,7 +212,7 @@ def(QName.def-hard?, +Mirth QName -- +Mirth Maybe(Def), dup name defs lookup(qna
 def(QName.defined-hard?, +Mirth QName -- +Mirth Bool, def-hard? some?)
 def(QName.undefined-hard?, +Mirth QName -- +Mirth Bool, def-hard? none?)
 
-def(QName.def-soft?, +Mirth QName -- +Mirth Maybe(Def), dup name defs dip(Some) lookup(qname-soft ==:==))
+def(QName.def-soft?, +Mirth QName -- +Mirth Maybe(Def), dup name defs dip(Some) lookup(qname-soft ==))
 def(QName.defined-soft?, +Mirth QName -- +Mirth Bool, def-soft? some?)
 def(QName.undefined-soft?, +Mirth QName -- +Mirth Bool, def-soft? none?)
 

--- a/src/specializer.mth
+++ b/src/specializer.mth
@@ -288,26 +288,19 @@ def(+SPSynth.synth-op!, +Mirth +SPSynth Op -- +Mirth +SPSynth,
     OpVar -> synth-var!,
     _ -> ab:ab-op!)
 
-def(+SPSynth.synth-block!, +Mirth +SPSynth Block -- +Mirth +SPSynth,
+def +SPSynth.synth-block! [ +Mirth +SPSynth Block -- +Mirth +SPSynth ] {
     ab:ab-block!(+SPSYNTH synth-run! /+SPSYNTH)
-    # dup free-vars has(dup spmap lookup(==) some?) if(
-        # dup rdip:to-run-var bind(spmap lookup(==)) match(
-        #     None -> ab:ab-block!(+SPSYNTH synth-run! /+SPSYNTH),
-        #     Some -> nip OpBlockPush ab:ab-op!
-        # ),
-        # # OpBlockPush ab:ab-op!
-    # ))
-    )
+}
 
 def(+SPSynth.synth-run!, +Mirth +SPSynth Block -- +Mirth +SPSynth,
     rdip:arrow synth-arrow!)
 
-def(+SPSynth.synth-var!, +Mirth +SPSynth Var -- +Mirth +SPSynth,
-    dup spmap lookup(==) match(
-        Some -> nip synth-run!,
-        # Some -> nip arrow synth-arrow!,
-        None -> ab:ab-var!
-    ))
+def +SPSynth.synth-var! [ +Mirth +SPSynth Var -- +Mirth +SPSynth ] {
+    dup spmap lookup match {
+        { Some -> nip synth-run! }
+        { None -> ab:ab-var! }
+    }
+}
 
 def(+SPSynth.synth-match!, +Mirth +SPSynth Match -- +Mirth +SPSynth,
     MetaVar.new! STMeta >cod

--- a/src/specializer.mth
+++ b/src/specializer.mth
@@ -231,14 +231,15 @@ def(specialize-ctx-type, +Mirth SPKey Ctx ArrowType -- +Mirth Ctx ArrowType,
     /SPKEY
     dup first token >token +Gamma
     dip:SUBST_NIL nip
-    dip(ArrowType.unpack swap) reverse-for(
-        dip(force-cons?!
-            unwrap("unexpected domain in specialize-ctx-type" rdip:fatal-error!)
-            unpack2)
-        /ArgBlock type TMorphism unify! drop
+    swap dom (
+        swap reverse-for(
+            dip(force-cons?!
+                unwrap("unexpected domain in specialize-ctx-type" rdip:fatal-error!)
+                unpack2)
+            /ArgBlock type TMorphism unify! drop
+        )
     )
     rdrop
-    swap T->
     dip:Ctx0 rigidify-sig!)
 
 

--- a/src/type.mth
+++ b/src/type.mth
@@ -1129,10 +1129,6 @@ def ArrowType.invert [ ArrowType -- ArrowType ] {
     ArrowType
 }
 
-def ArrowType.unpack [ ArrowType -- StackType StackType ] {
-    sip:dom cod
-}
-
 def ArrowType.unify! [ +Mirth +Gamma ArrowType ArrowType -- +Mirth +Gamma ArrowType ] {
     dip(/ArrowType) /ArrowType
     dom> dom> unify! >dom
@@ -1209,18 +1205,13 @@ def ArrowType.rigidify! [ +Mirth Ctx ArrowType -- +Mirth Ctx ArrowType ] {
 }
 
 def(ArrowType.rigidify-sig!, +Mirth Ctx ArrowType -- +Mirth Ctx ArrowType,
-    dup
-    unpack linear-base-meta? if-some(
-        swap linear-base-meta? if-some(
-            over == if(
-                TYPE_UNIT Some swap ~type? !,
-                drop
-            ),
-            drop
-        ),
-        drop
+    >arrowtype
+    @arrowtype dom linear-base-meta? for(
+        @arrowtype cod linear-base-meta? for(
+            over == then(TYPE_UNIT Some over ~type? !)
+        ) drop
     )
-    rigidify!)
+    arrowtype> rigidify!)
 
 def(ArrowType.max-num-params, ArrowType -- Nat,
     dom num-morphisms-on-top)
@@ -1472,12 +1463,15 @@ def(StackType.ctype?, StackType +Mirth -- Maybe(CTypeStack) +Mirth,
         drop None
     ))
 
-data(CTypeArrow, CTypeArrow ->
+struct CTypeArrow {
     dom: CTypeStack
-    cod: CTypeStack)
+    cod: CTypeStack
+}
 
-def(ArrowType.ctype, ArrowType +Mirth -- CTypeArrow +Mirth,
-    unpack dip(ctype >dom) ctype >cod CTypeArrow)
+def ArrowType.ctype [ ArrowType +Mirth -- CTypeArrow +Mirth ] {
+    /ArrowType @dom:ctype @cod:ctype CTypeArrow
+}
 
-def(ArrowType.ctype?, ArrowType +Mirth -- Maybe(CTypeArrow) +Mirth,
-    unpack on2(ctype?) map2(>cod >dom CTypeArrow))
+def ArrowType.ctype? [ ArrowType +Mirth -- Maybe(CTypeArrow) +Mirth ] {
+    /ArrowType dom> ctype? cod> ctype? map2(>cod >dom CTypeArrow)
+}

--- a/src/type.mth
+++ b/src/type.mth
@@ -139,7 +139,7 @@ def +Mirth.init-types! [ +Mirth -- +Mirth ] {
 def(T+, StackType Resource -- StackType, STWith)
 def(T*, StackType Type -- StackType, STCons)
 def(T*+, StackType Type/Resource -- StackType, match(Left -> T*, Right -> T+))
-def(T->, StackType StackType -- ArrowType, ARROW_TYPE)
+def(T->, StackType StackType -- ArrowType, >cod >dom ArrowType)
 
 def(TT, List(Type) -- StackType, T0 swap for(T*))
 def(T0, StackType, STACK_TYPE_UNIT)
@@ -1116,69 +1116,97 @@ def StackType.linear-base-var? [ StackType -- Maybe(Var) ] {
 # Arrow TYPE #
 ##############
 
-data(ArrowType, ARROW_TYPE -> StackType StackType)
-def(ArrowType.>Type, ArrowType -- Type, TMorphism)
-def ArrowType.invert [ ArrowType -- ArrowType ] { ARROW_TYPE -> swap ARROW_TYPE }
-
-def(ArrowType.unpack, ArrowType -- StackType StackType, ARROW_TYPE -> id)
-def(ArrowType.dom, ArrowType -- StackType, unpack drop)
-def(ArrowType.cod, ArrowType -- StackType, unpack nip)
-def(ArrowType.unify!, +Mirth +Gamma ArrowType ArrowType -- +Mirth +Gamma ArrowType,
-    dip(unpack) unpack
-    dip(swap dip(unify!)) rotl
-    dip(unify!) swap
-    ARROW_TYPE)
-def(ArrowType.unify-error!, +Mirth +Gamma ArrowType -- +Mirth +Gamma ArrowType,
-    unpack dip(unify-error!) dip'(unify-error!) ARROW_TYPE)
-def(ArrowType.has-meta?, MetaVar ArrowType -- Bool,
-    unpack dip(over) has-meta? if(drop2 True, has-meta?))
-def ArrowType.has-var? [ Var ArrowType -- Bool ] {
-    unpack
-    dip(over) has-var? if(drop2 True, has-var?)
+struct ArrowType {
+    dom: StackType
+    cod: StackType
 }
 
-def(ArrowType.sig;, +Str ArrowType -- +Str,
-    unpack swap dom; "--"; cod;)
+inline ( def ArrowType.>Type [ ArrowType -- Type ] { TMorphism } )
+
+def ArrowType.invert [ ArrowType -- ArrowType ] {
+    /ArrowType
+    dom> cod> >dom >cod
+    ArrowType
+}
+
+def ArrowType.unpack [ ArrowType -- StackType StackType ] {
+    sip:dom cod
+}
+
+def ArrowType.unify! [ +Mirth +Gamma ArrowType ArrowType -- +Mirth +Gamma ArrowType ] {
+    dip(/ArrowType) /ArrowType
+    dom> dom> unify! >dom
+    cod> cod> unify! >cod
+    ArrowType
+}
+
+def ArrowType.unify-error! [ +Mirth +Gamma ArrowType -- +Mirth +Gamma ArrowType ] {
+    dom:unify-error!
+    cod:unify-error!
+}
+
+def ArrowType.has-meta? [ MetaVar ArrowType -- Bool ] {
+    /ArrowType cod> over dom>
+    has-meta? if(drop2 True, has-meta?)
+}
+
+def ArrowType.has-var? [ Var ArrowType -- Bool ] {
+    /ArrowType cod> over dom>
+    has-var? if(drop2 True, has-var?)
+}
+
+def ArrowType.sig; [ +Str ArrowType -- +Str ] {
+    /ArrowType
+    dom> dom; "--"; cod> cod;
+}
 
 ||| Replace the stack rest with a metavar, if they're both unit.
-def(ArrowType.semifreshen-sig, ArrowType -- ArrowType,
-    dup needs-fresh-stack-rest? then(semifreshen-aux))
+def ArrowType.semifreshen-sig [ ArrowType -- ArrowType ] {
+    dup needs-fresh-stack-rest? then(semifreshen-aux)
+}
 
-def(ArrowType.semifreshen-aux, ArrowType -- ArrowType,
-    MetaVar.new! STMeta swap unpack
-    dip(semifreshen) swap
-    dip(semifreshen) swap
-    ARROW_TYPE nip)
+def ArrowType.semifreshen-aux [ ArrowType -- ArrowType ] {
+    /ArrowType
+    MetaVar.new! STMeta
+    @cod:semifreshen
+    @dom:semifreshen
+    ArrowType nip
+}
 
-def(ArrowType.needs-fresh-stack-rest?, ArrowType -- Bool,
-    unpack base unit? if(
-        base unit?,
-        drop False
-    ))
+def ArrowType.needs-fresh-stack-rest? [ ArrowType -- Bool ] {
+    /ArrowType
+    dom> base unit? and(@cod base unit?)
+    cod> drop
+}
 
-def(ArrowType.freshen-sig, Subst ArrowType -- Subst ArrowType,
+def ArrowType.freshen-sig [ Subst ArrowType -- Subst ArrowType ] {
     dup needs-fresh-stack-rest? if(
         freshen-sig-aux,
         freshen
-    ))
+    )
+}
 
-def(ArrowType.freshen-sig-aux, Subst ArrowType -- Subst ArrowType,
-    MetaVar.new! STMeta rotr unpack
-    dip(freshen-aux) swap
-    dip(freshen-aux) swap
-    ARROW_TYPE dip(nip))
+def ArrowType.freshen-sig-aux [ Subst ArrowType -- Subst ArrowType ] {
+    /ArrowType
+    MetaVar.new! STMeta swap
+    @dom:freshen-aux
+    @cod:freshen-aux
+    ArrowType dip2:drop
+}
 
-def(ArrowType.freshen, Subst ArrowType -- Subst ArrowType,
-    unpack
-    dip(freshen) swap
-    dip(freshen) swap
-    ARROW_TYPE)
+def ArrowType.freshen [ Subst ArrowType -- Subst ArrowType ] {
+    /ArrowType
+    @dom:freshen
+    @cod:freshen
+    ArrowType
+}
 
-def(ArrowType.rigidify!, +Mirth Ctx ArrowType -- +Mirth Ctx ArrowType,
-    unpack
-    dip(rigidify!) swap
-    dip(rigidify!) swap
-    ARROW_TYPE)
+def ArrowType.rigidify! [ +Mirth Ctx ArrowType -- +Mirth Ctx ArrowType ] {
+    /ArrowType
+    @dom:rigidify!
+    @cod:rigidify!
+    ArrowType
+}
 
 def(ArrowType.rigidify-sig!, +Mirth Ctx ArrowType -- +Mirth Ctx ArrowType,
     dup

--- a/src/var.mth
+++ b/src/var.mth
@@ -79,7 +79,7 @@ def(Ctx.fresh-var!, Type Ctx -- Ctx Var,
     fresh-name! dip(swap) Var.new! sip(Ctx.new))
 
 def(Ctx.==, Ctx Ctx -- Bool,
-    both(vars) ==(==))
+    on2:vars ==)
 
 def(Var.unify!, +Mirth +Gamma Var Var -- +Mirth +Gamma Type,
     dup2 == if(drop TVar, both(TVar) unify-failed!))

--- a/src/word.mth
+++ b/src/word.mth
@@ -12,6 +12,11 @@ import(mirth.def)
 import(mirth.type)
 import(mirth.arrow)
 
+struct Param {
+    var: Var
+    default: Maybe(Token)
+}
+
 table(Word)
 field(Word.~name, Word, Name)
 field(Word.~arity, Word, Nat)
@@ -20,7 +25,7 @@ field(Word.~head, Word, Token)
 field(Word.~sig?, Word, Maybe(Token))
 field(Word.~body, Word, Token)
 field(Word.~ctx-type, Word, Prop([Ctx ArrowType]))
-field(Word.~params, Word, Prop(List(Var)))
+field(Word.~params, Word, Prop(List(Param)))
 field(Word.~arrow, Word, Prop(Arrow))
 field(Word.~prefer-inline?, Word, Bool)
 field(Word.~cname, Word, Str)
@@ -35,7 +40,7 @@ def(Word.head, Word -- Token, ~head @)
 def(Word.sig?, Word -- Maybe(Token), ~sig? @)
 def(Word.body, Word -- Token, ~body @)
 def(Word.arity, Word -- Nat, ~arity @)
-def(Word.params, Word +Mirth -- List(Var) +Mirth, ~params force!)
+def(Word.params, Word +Mirth -- List(Param) +Mirth, ~params dup mut-is-set if(force!, drop L0))
 def(Word.arrow, Word +Mirth -- Arrow +Mirth, ~arrow force!)
 def(Word.inferring-type?, Word -- Bool,
     ~inferring-type? @? unwrap(False))

--- a/test/default-word-param.mth
+++ b/test/default-word-param.mth
@@ -1,0 +1,26 @@
+module(test.default-word-param)
+
+import(std.prelude)
+import(std.maybe)
+import(std.list)
+import(std.world)
+
+def +World.foo (b {bar}) { "Foo" print b b }
+def +World.bar { "Bar" print }
+
+def main {
+    "Hello!" print
+    print(10 Some show;)
+    print(10 20 30 L3 show;)
+    foo
+    foo("Baz" print)
+}
+# mirth-test # pout # Hello!
+# mirth-test # pout # 10 Some
+# mirth-test # pout # LIST( 10 ; 20 ; 30 ; )
+# mirth-test # pout # Foo
+# mirth-test # pout # Bar
+# mirth-test # pout # Bar
+# mirth-test # pout # Foo
+# mirth-test # pout # Baz
+# mirth-test # pout # Baz

--- a/test/match-syntax.mth
+++ b/test/match-syntax.mth
@@ -4,10 +4,10 @@ import(std.prelude)
 import(std.maybe)
 import(std.list)
 
-def(Maybe.sum, Maybe(Int) -- Int, { None -> 0 } { Some -> id })
-def List.sum {
+def(Maybe.mysum, Maybe(Int) -- Int, { None -> 0 } { Some -> id })
+def List.mysum {
     { Nil -> 0 }
-    { Cons -> dip'(sum) + }
+    { Cons -> dip'(mysum) + }
 }
 
 def List.very-slow-reverse {


### PR DESCRIPTION
This PR adds the ability to define a default for parameters to higher-order words. The default is evaluated in the caller's environment, so this can be used to pass a type-aware equality, and things like that, automatically.

Example:

```
def foo (f { bar } ) { f f }
def bar { ... }
```
Here, if we call `foo` with no arguments, this is the same as calling `foo(bar)`.

More useful example, defining a higher-order equality word on generic types:

```
def Maybe.== (eq {==})  {
   { None -> none? }
   { Some -> swap match {
      { None -> drop False }
      { Some -> swap eq }
   }
}
```

Now when we call `==` on a Maybe value, the mirth compiler fills in the default argument so it is equivalent to writing `==(==)`. Therefore we can call `==` on Maybe to test equality for a bunch of different types, without having to pass in the function explicitly.

Things that can be improved: the diagnostics that arise from errors when a default parameter doesn't fit. The name resolution for words that have default parameters could also be tighter.