### PR TITLE
String to float parsing primitives.

### DIFF
--- a/lib/std/prelude.mth
+++ b/lib/std/prelude.mth
@@ -51,6 +51,8 @@ alias(F32./, prim-f32-div)
 alias(F32.>F64, prim-f32-to-f64)
 alias(F32.>Int, prim-f32-to-int)
 alias(F32.>Str, prim-f32-to-str)
+inline def F32.show [ F32 -- Str ] { Str(show;) }
+inline def F32.show; [ +Str F32 -- +Str ] { >Str ; " >F32"; }
 
 alias(F64.+, prim-f64-add)
 alias(F64.-, prim-f64-sub)
@@ -59,6 +61,8 @@ alias(F64./, prim-f64-div)
 alias(F64.>F32, prim-f64-to-f32)
 alias(F64.>Int, prim-f64-to-int)
 alias(F64.>Str, prim-f64-to-str)
+inline def F64.show [ F64 -- Str ] { >Str }
+inline def F64.show; [ +Str F64 -- +Str ] { >Str ; }
 
 inline(
     alias(Bool.if(f,g), prim-if)

--- a/lib/std/str.mth
+++ b/lib/std/str.mth
@@ -236,3 +236,22 @@ def(+Str.push-show-byte!, +Str escape-hex:Bool Byte -- escape-hex:Bool +Str,
 
 def(Str.show;, Str +Str -- +Str,
     "\"" ; False >escape-hex bytes-for(push-show-byte!) escape-hex> drop "\"" ;)
+
+
+||| Convert the initial portion of a string into a 32-bit float.
+||| Returns the F32 and the rest of the string.
+inline def Str.parse-f32 [ Str -- F32 Str ] { prim-str-to-f32 }
+
+||| Convert the initial portion of a string into a 64-bit float.
+||| Returns the F64 and the rest of the string.
+inline def Str.parse-f64 [ Str -- F64 Str ] { prim-str-to-f64 }
+
+||| Try to parse a string (in its entirety) as a 32-bit float.
+def Str.>F32? [ Str -- Maybe(F32) ] {
+    dup empty? if(drop None, parse-f32 empty? if(Some, drop None))
+}
+
+||| Try to parse a full string (in its entirety) as a 64-bit float.
+def Str.>F64? [ Str -- Maybe(F64) ] {
+    dup empty? if(drop None, parse-f64 empty? if(Some, drop None))
+}

--- a/src/c99.mth
+++ b/src/c99.mth
@@ -1387,7 +1387,7 @@ def PrimType.c99-repr [ PrimType -- C99ReprType ] {
     { PRIM_TYPE_INT -> C99RT_I64 }
     { PRIM_TYPE_F32 -> C99RT_F32 }
     { PRIM_TYPE_F64 -> C99RT_F64 }
-    { PRIM_TYPE_STR -> C99RT_VAL }
+    { PRIM_TYPE_STR -> C99RT_STR }
     { PRIM_TYPE_PTR -> C99RT_PTR }
     { PRIM_TYPE_WORLD -> C99RT_UNIT }
 }
@@ -2204,6 +2204,9 @@ def c99-prim! [ Atom Prim +C99Branch -- +C99Branch ] {
     { PRIM_STR_GT   -> drop "(str_cmp(" C99RT_STR ", " C99RT_STR ") > 0)"  False C99RT_BOOL Some c99-binop! }
     { PRIM_STR_GE   -> drop "(str_cmp(" C99RT_STR ", " C99RT_STR ") >= 0)" False C99RT_BOOL Some c99-binop! }
     { PRIM_STR_NE   -> drop "(str_cmp(" C99RT_STR ", " C99RT_STR ") != 0)" False C99RT_BOOL Some c99-binop! }
+
+    { PRIM_STR_TO_F32 -> args "str_to_f32" PRIM_STR_TO_F32 +mirth:type +c99:cname-type-to-c99-api c99-smart-call! }
+    { PRIM_STR_TO_F64 -> args "str_to_f64" PRIM_STR_TO_F64 +mirth:type +c99:cname-type-to-c99-api c99-smart-call! }
 
     { PRIM_SYS_OS   -> drop C99RT_I64 push-value-expression!("RUNNING_OS" put) }
     { PRIM_SYS_ARCH -> drop C99RT_I64 push-value-expression!("RUNNING_ARCH" put) }

--- a/src/lexer.mth
+++ b/src/lexer.mth
@@ -311,23 +311,8 @@ def byte-sign-value-index-float [ Byte -- Byte UOffset ] {
     { _ -> drop B'+' 0u >UOffset }
 }
 
-external(
-    "double strtod(const char*, char**);"
-    "double string_to_float64(const char* float64_str) {"
-    "    return strtod(float64_str, 0);"
-    "}"
-    string_to_float64 [ CStr -- F64 ]
-)
-
 def(+Str.float?, +Str -- F64 +Str,
-    "" thaw rswap 0u >UOffset
-    float-sign rdip:dip:push-byte-ascii! +
-    while(dup num-bytes? >UOffset <,
-        sip(
-            byte@ rdip:push-byte-ascii!
-        )
-        1+)
-    drop rswap freeze with-cstr(string_to_float64))
+    freeze dup thaw >F64? unwrap(0.0))
 
 def(+Str.is-int?, +Str -- Bool +Str,
     is-dec-int?

--- a/src/prim.mth
+++ b/src/prim.mth
@@ -136,6 +136,8 @@ data Prim {
     PRIM_STR_GT
     PRIM_STR_GE
     PRIM_STR_NE
+    PRIM_STR_TO_F64
+    PRIM_STR_TO_F32
 
     PRIM_SYS_OS
     PRIM_SYS_ARCH
@@ -286,6 +288,8 @@ data Prim {
         { PRIM_STR_GT -> "prim-str-gt" 0 }
         { PRIM_STR_GE -> "prim-str-ge" 0 }
         { PRIM_STR_NE -> "prim-str-ne" 0 }
+        { PRIM_STR_TO_F32 -> "prim-str-to-f32" 0 }
+        { PRIM_STR_TO_F64 -> "prim-str-to-f64" 0 }
 
         { PRIM_SYS_OS   -> "prim-sys-os"   0 }
         { PRIM_SYS_ARCH -> "prim-sys-arch" 0 }
@@ -601,6 +605,8 @@ data Prim {
         { PRIM_STR_GT -> Ctx.L0 TYPE_STR TYPE_STR T2 TYPE_BOOL T1 T-> }
         { PRIM_STR_GE -> Ctx.L0 TYPE_STR TYPE_STR T2 TYPE_BOOL T1 T-> }
         { PRIM_STR_NE -> Ctx.L0 TYPE_STR TYPE_STR T2 TYPE_BOOL T1 T-> }
+        { PRIM_STR_TO_F32 -> Ctx.L0 TYPE_STR T1 TYPE_F32 TYPE_STR T2 T-> }
+        { PRIM_STR_TO_F64 -> Ctx.L0 TYPE_STR T1 TYPE_F64 TYPE_STR T2 T-> }
 
         { PRIM_SYS_OS   -> Ctx.L0 T0 TYPE_INT T1 T-> }
         { PRIM_SYS_ARCH -> Ctx.L0 T0 TYPE_INT T1 T-> }

--- a/test/str-to-x.mth
+++ b/test/str-to-x.mth
@@ -1,0 +1,25 @@
+module test.str-to-x
+
+import std.prelude
+import std.str
+import std.test
+
+def main {
+    +Tests.Start!
+
+    "prim-str-to-f32" test (
+        "0" prim-str-to-f32 => ("") => (0.0 >F32)
+        "0.1" prim-str-to-f32 => ("") => (0.1 >F32)
+    )
+
+    "prim-str-to-f64" test (
+        "0" prim-str-to-f64 => ("") => (0.0)
+        "0.1" prim-str-to-f64 => ("") => (0.1)
+        "0.123456789" prim-str-to-f64 => ("") => (0.123456789)
+        "-0.123456789" prim-str-to-f64 => ("") => (-0.123456789)
+    )
+
+    +Tests.end!
+}
+
+# mirth-test # pout # 2 tests passed.


### PR DESCRIPTION
This PR adds prim-str-to-f32 and prim-str-to-f64 primitives, which are wrappers around strtof and strtod respectively.

It exposes these in `std.str` as `Str.parse-f32` and `Str.parse-f64` for prefix parsing, and as `Str.>F32?` and `Str.>F64?` for full string parsing.