### PR TITLE
Add rules to check compiler against origin/main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ jobs:
       run: make build
     - name: make check
       run: make check
+    - name: make check-origin
+      run: make check-origin
     - name: make test-verify
       run: make test-verify
     - name: make examples

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CCSAN=$(CC) -fsanitize=undefined -fsanitize=address
 
 SRCS=lib/std/* lib/arg-parser/* src/*
 
-.PHONY: default show showsan build buildsan debug update check checksan clean \
+.PHONY: default show showsan build buildsan debug update check checksan check-origin-fast check-origin clean \
  install-vim install-code install-atom install profile play-snake test-verify test-update \
  examples
 
@@ -39,6 +39,21 @@ checksan: bin/mirth0.c bin/mirth1.c bin/mirth2.c bin/mirth3san.c
 	diff --strip-trailing-cr bin/mirth0.c bin/mirth3san.c
 	diff --strip-trailing-cr bin/mirth1.c bin/mirth3san.c
 	diff --strip-trailing-cr bin/mirth2.c bin/mirth3san.c
+
+check-origin-fast:
+	touch bin/origin-mirth0.c
+	git show origin/main:bin/mirth0.c > bin/origin-mirth0-fast.c
+	diff -q bin/origin-mirth0.c bin/origin-mirth0-fast.c || ( cp bin/origin-mirth0-fast.c bin/origin-mirth0.c && $(CC) bin/origin-mirth0.c -o bin/origin-mirth0 && bin/origin-mirth0 src/main.mth -c )
+
+check-origin: bin/mirth3.c
+	git show origin/main:bin/mirth0.c > bin/origin-mirth0.c
+	$(CC) bin/origin-mirth0.c -o bin/origin-mirth0
+	bin/origin-mirth0 src/main.mth -o bin/origin-mirth1.c
+	$(CC) bin/origin-mirth1.c -o bin/origin-mirth1
+	bin/origin-mirth1 src/main.mth -o bin/origin-mirth2.c
+	$(CC) bin/origin-mirth2.c -o bin/origin-mirth2
+	bin/origin-mirth2 src/main.mth -o bin/origin-mirth3.c
+	diff bin/mirth3.c bin/origin-mirth3.c
 
 clean:
 	cp bin/mirth0.c mirth0.c

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -60,6 +60,7 @@ case "$DirName" in
         case "$BaseName" in
             *.mth )
                 bin/mirth2 -c "$1"
+                make check-origin-fast
                 ;;
         esac
         ;;


### PR DESCRIPTION
Adds `make check-origin` and `make check-origin-fast`. These will use the mirth compiler in `origin/main` in order to check the current compiler. This will ensure that we commit features into main before relying on them in the compiler. (We can still use those new features in tests and in the examples.)