### PR TITLE
Add more std lib functions

### DIFF
--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -2169,6 +2169,20 @@ static FIELD mfld_mirth_data_Tag_ZTildevalueZ_show = {0};
 static FIELD mfld_mirth_data_Tag_ZTildewordZ_c99Z_api = {0};
 static FIELD mfld_mirth_data_Tag_ZTildepatZ_c99Z_api = {0};
 static FIELD mfld_mirth_word_Word_ZTildec99Z_api = {0};
+static void mtw_std_buffer_ZPlusBuffer_ZPlusBuffer (INT in_USizze_1, void* in_Ptr_2, TUP* *out_ZPlusBuffer_3) {
+	TUP* v4 = tup_new(2);
+	v4->size = 2;
+	v4->cells[1] = MKPTR(in_Ptr_2);
+	v4->cells[0] = MKINT(in_USizze_1);
+	*out_ZPlusBuffer_3 = v4;
+}
+static void mtp_std_buffer_ZPlusBuffer_ZPlusBuffer (TUP* in_ZPlusBuffer_1, INT *out_USizze_2, void* *out_Ptr_3) {
+	INT v4 = value_int(in_ZPlusBuffer_1->cells[0]);
+	void* v5 = value_ptr(in_ZPlusBuffer_1->cells[1]);
+	tup_decref_outer(in_ZPlusBuffer_1,2);
+	*out_Ptr_3 = v5;
+	*out_USizze_2 = v4;
+}
 static VAL mtw_std_either_Either_2_Left (VAL in_a_1) {
 	TUP* v3 = tup_new(2);
 	v3->size = 2;
@@ -2216,20 +2230,6 @@ static void mtp_std_either_ZPlusEither_2_ZPlusRight (VAL in_ZPlusEither_1, VAL *
 	VAL v3 = value_tup(in_ZPlusEither_1, 2)->cells[1];
 	tup_decref_outer(value_tup(in_ZPlusEither_1, 2),2);
 	*out_ZPlusb_2 = v3;
-}
-static void mtw_std_buffer_ZPlusBuffer_ZPlusBuffer (INT in_USizze_1, void* in_Ptr_2, TUP* *out_ZPlusBuffer_3) {
-	TUP* v4 = tup_new(2);
-	v4->size = 2;
-	v4->cells[1] = MKPTR(in_Ptr_2);
-	v4->cells[0] = MKINT(in_USizze_1);
-	*out_ZPlusBuffer_3 = v4;
-}
-static void mtp_std_buffer_ZPlusBuffer_ZPlusBuffer (TUP* in_ZPlusBuffer_1, INT *out_USizze_2, void* *out_Ptr_3) {
-	INT v4 = value_int(in_ZPlusBuffer_1->cells[0]);
-	void* v5 = value_ptr(in_ZPlusBuffer_1->cells[1]);
-	tup_decref_outer(in_ZPlusBuffer_1,2);
-	*out_Ptr_3 = v5;
-	*out_USizze_2 = v4;
 }
 static VAL mtw_std_list_List_1_Cons (VAL in_t_1, VAL in_List_2) {
 	TUP* v4 = tup_new(3);
@@ -5556,8 +5556,6 @@ static int64_t mext_std_world_posixZ_stat (void* in_CStr_1, void* in_Ptr_2) {
 	int64_t v7 = (int64_t)(Y);
 	return v7;
 }
-static VAL mw_std_either_Either_2_leftZAsk (VAL in_Either_1);
-static VAL mw_std_either_Either_2_rightZAsk (VAL in_Either_1);
 static STR* mw_std_byte_Byte_toZ_strZ_unsafe (int64_t in_Byte_1);
 static VAL mw_std_byte_Byte_toZ_asciiZ_str (int64_t in_Byte_1);
 static bool mw_std_byte_Byte_isZ_stringZ_end (int64_t in_Byte_1);
@@ -5605,6 +5603,8 @@ static void mw_std_prim_Str_reprZThen (STR* in_Str_1, STR* in_ZPlusStr_2, STR* *
 static void mw_std_prim_Str_zzencodeZThen (STR* in_ZPlusStr_1, STR* in_Str_2, STR* *out_ZPlusStr_3);
 static STR* mw_std_prim_Str_zzencode (STR* in_Str_1);
 static VAL mw_std_prim_Str_ZToF64ZAsk (STR* in_Str_1);
+static VAL mw_std_either_Either_2_leftZAsk (VAL in_Either_1);
+static VAL mw_std_either_Either_2_rightZAsk (VAL in_Either_1);
 static bool mw_std_list_List_1_emptyZAsk (VAL in_List_1);
 static VAL mw_std_list_List_1_singleZAsk (VAL in_List_1);
 static VAL mw_std_list_List_1_pairZAsk (VAL in_List_1);
@@ -7158,46 +7158,6 @@ int main (int argc, char** argv) {
 	push_resource(MKI64(0));
 	return 0;
 }
-static VAL mw_std_either_Either_2_leftZAsk (VAL in_Either_1) {
-	VAL branch_Maybe_3;
-	switch (get_data_tag(in_Either_1)) {
-		case 0LL: { // Left
-			VAL v4 = mtp_std_either_Either_2_Left(in_Either_1);
-			VAL v5 = mtw_std_maybe_Maybe_1_Some(v4);
-			branch_Maybe_3 = v5;
-		} break;
-		case 1LL: { // Right
-			VAL v6 = mtp_std_either_Either_2_Right(in_Either_1);
-			decref(v6);
-			VAL v7 = MKI64(0LL /* None */);
-			branch_Maybe_3 = v7;
-		} break;
-		default: {
-			do_panic(str_make("unexpected fallthrough in match\n", 32));
-		}
-	}
-	return branch_Maybe_3;
-}
-static VAL mw_std_either_Either_2_rightZAsk (VAL in_Either_1) {
-	VAL branch_Maybe_3;
-	switch (get_data_tag(in_Either_1)) {
-		case 0LL: { // Left
-			VAL v4 = mtp_std_either_Either_2_Left(in_Either_1);
-			decref(v4);
-			VAL v5 = MKI64(0LL /* None */);
-			branch_Maybe_3 = v5;
-		} break;
-		case 1LL: { // Right
-			VAL v6 = mtp_std_either_Either_2_Right(in_Either_1);
-			VAL v7 = mtw_std_maybe_Maybe_1_Some(v6);
-			branch_Maybe_3 = v7;
-		} break;
-		default: {
-			do_panic(str_make("unexpected fallthrough in match\n", 32));
-		}
-	}
-	return branch_Maybe_3;
-}
 static STR* mw_std_byte_Byte_toZ_strZ_unsafe (int64_t in_Byte_1) {
 	VAL v3 = MKI64(0LL /* Nil */);
 	VAL v4 = mw_std_list_List_1_cons(MKI64(in_Byte_1), v3);
@@ -8558,6 +8518,46 @@ static VAL mw_std_prim_Str_ZToF64ZAsk (STR* in_Str_1) {
 		branch_Maybe_7 = branch_Maybe_15;
 	}
 	return branch_Maybe_7;
+}
+static VAL mw_std_either_Either_2_leftZAsk (VAL in_Either_1) {
+	VAL branch_Maybe_3;
+	switch (get_data_tag(in_Either_1)) {
+		case 0LL: { // Left
+			VAL v4 = mtp_std_either_Either_2_Left(in_Either_1);
+			VAL v5 = mtw_std_maybe_Maybe_1_Some(v4);
+			branch_Maybe_3 = v5;
+		} break;
+		case 1LL: { // Right
+			VAL v6 = mtp_std_either_Either_2_Right(in_Either_1);
+			decref(v6);
+			VAL v7 = MKI64(0LL /* None */);
+			branch_Maybe_3 = v7;
+		} break;
+		default: {
+			do_panic(str_make("unexpected fallthrough in match\n", 32));
+		}
+	}
+	return branch_Maybe_3;
+}
+static VAL mw_std_either_Either_2_rightZAsk (VAL in_Either_1) {
+	VAL branch_Maybe_3;
+	switch (get_data_tag(in_Either_1)) {
+		case 0LL: { // Left
+			VAL v4 = mtp_std_either_Either_2_Left(in_Either_1);
+			decref(v4);
+			VAL v5 = MKI64(0LL /* None */);
+			branch_Maybe_3 = v5;
+		} break;
+		case 1LL: { // Right
+			VAL v6 = mtp_std_either_Either_2_Right(in_Either_1);
+			VAL v7 = mtw_std_maybe_Maybe_1_Some(v6);
+			branch_Maybe_3 = v7;
+		} break;
+		default: {
+			do_panic(str_make("unexpected fallthrough in match\n", 32));
+		}
+	}
+	return branch_Maybe_3;
 }
 static bool mw_std_list_List_1_emptyZAsk (VAL in_List_1) {
 	int64_t v3 = get_data_tag(in_List_1);

--- a/lib/std/either.mth
+++ b/lib/std/either.mth
@@ -2,6 +2,7 @@ module std.either
 
 import std.prelude
 import std.maybe
+import std.str
 
 alias Left Either.Left
 alias Right Either.Right
@@ -39,6 +40,7 @@ data Either(a,b) {
         { Right -> g }
     }
 
+
     def either(f,g) [ (*x a -- *y, *x b -- *y) *x Either(a,b) -- *y ] {
         { Left -> f }
         { Right -> g }
@@ -49,10 +51,33 @@ data Either(a,b) {
         { Right -> g }
     }
 
-    # Convert Rights into Lefts, and then unwrap
+    ||| Map Rights into Lefts, and then unwrap
     def left(f) [ (*x b -- *x a) *x Either(a, b) -- *x a] {
         { Left -> id }
         { Right -> f }
+    }
+
+    ||| Map Lefts into Rights, then unwrap
+    def right(f) [ (*x a -- *x b) *x Either(a,b) -- *x b ] {
+        { Left -> f }
+        { Right -> id }
+    }
+
+    ||| Turn left values into right ones if the predicate matches
+    def right?(predicate,f) [ (*x a -- *x Bool, *x a -- *x b) *x Either(a,b) -- *x Either(a,b) ] {
+        { Left -> dup dip:predicate swap if(f Right,Left) }
+        { Right -> Right }
+    }
+
+    ||| Turn left values into right ones if `value eq` is true
+    def case(value, f, eq {==}) [ (*x a -- *x a a, *x -- *x b, *x a a -- *x Bool) *x Either(a,b) -- *x Either(a,b) ] {
+        right?(value eq, drop f)
+    }
+
+
+    def repr;(f {repr;}, g {repr;}) [ (a +Str -- +Str, b +Str -- +Str) Either(a,b) +Str -- +Str ] {
+        { Left -> f " Left" ; }
+        { Right -> g " Right" ; }
     }
 }
 
@@ -102,4 +127,18 @@ def while-left(f) [ (*c a -- *c Either(a,b)) *c a -- *c b ] {
 def while-right(f) [ (*c b -- *c Either(a,b)) *c b -- *c a ] {
     Right while-some(dup right?, nip f)
     left? unwrap(impossible!)
+}
+
+
+
+||| Wrap a value as a Left to be used with `Either.case`:
+|||
+|||     switch(
+|||         case("value-1", 1)
+|||         case("value-2", 2)
+|||         case("value-3", 3),
+|||         drop 4
+|||     )
+def switch(f, default) [ (*x Either(a, b) -- *x Either(a, b), *x a -- *x b) *x a -- *x b ] {
+    Left f right(default)
 }

--- a/lib/std/maybe.mth
+++ b/lib/std/maybe.mth
@@ -61,6 +61,27 @@ data Maybe(t) {
     def has(f)  { { Some -> f      } { None -> False } }
     def all(f)  { { Some -> f      } { None -> True  } }
 
+
+    ||| Consume the value with `g` (replacing with `None`) if the predicate `f` returns true
+    |||
+    |||   for?(updated?, refresh!)
+    |||   for?(deleted?, clean-up!)
+    |||   
+    def for?(f, g) [ (*a b -- *a Bool, *a b -- *a) *a Maybe(b) -- *a Maybe(b) ] {
+        bind(dup dip:f swap if(g None, Some))
+    }
+
+
+    ||| Consume `Some` with `f` if `q eq` is true
+    ||| 
+    |||   @command Some
+    |||   case("parse" ==, run-parser!)
+    |||   case("help" ==, show-help!)
+    |||
+    def case(q, f, eq {==}) [ (*x a -- *x a a, *x -- *x, *x a a -- *x Bool) *x Maybe(a) -- *x Maybe(a) ] {
+        for?(q eq, drop f)
+    }
+
     def filter(f) [ (*a b -- *a Bool) *a Maybe(b) -- *a Maybe(b) ] {
         { Some -> dup dip(f) swap if(Some, drop None) }
         { None -> None }
@@ -113,6 +134,23 @@ def while-none(f,g) [ (*a -- *a Maybe(b), *a -- *a) *a -- *a b ] {
     unwrap(impossible!)
 }
 
+def while-none(f) [ (*a -- *a Maybe(b)) *a -- *a b ] {
+    None until(drop f dup some?) unwrap(impossible!)
+}
+
 inline def Bool.>Maybe (f) [ ( *a -- *a b ) *a Bool -- *a Maybe(b) ] {
     if(f Some, None)
+}
+
+
+
+||| Intended to be used with `Maybe.case` like:
+|||
+|||     switch?(
+|||         case("value-1", do-something)
+|||         case("value-2", do-other-thing),
+|||         do-default-action
+|||     )
+def switch?(f, d) [ (*x Maybe(a) -- *x Maybe(a), *x a -- *x) *x a -- *x ] {
+    Some f for(d)
 }

--- a/lib/std/prelude.mth
+++ b/lib/std/prelude.mth
@@ -70,6 +70,26 @@ inline def while(f) [ (*x -- *x Bool) *x -- *x ] {
     True while(dup, drop f) drop
 }
 
+||| The opposite of `while(f, g)` – repeat until True
+inline def until(f, g) [ (*x -- *x Bool, *x -- *x) *x -- *x ] {
+    while(f not, g)
+}
+
+||| The opposite of `while(f)` – repeat until True
+inline def until(f) [ (*x -- *x Bool)  *x -- *x ] {
+    False while(dup not, drop f) drop
+}
+
+||| Do either `g` or `h` based on predicate `f`, preserving the top of the stack
+|||
+|||   @value if("world" ==, 
+|||     print("hello "; ;), 
+|||     print("goodbye "; ;)
+|||   )
+inline def if(f, g, h) [ (*a b -- *a Bool, *a b -- *c, *a b -- *c) *a b -- *c ] {
+    dup dip:f swap if(g, h)
+}
+
 inline def or(f,g,h) { or(f,or(g,h)) }
 inline def or(f,g,h,i) { or(f,or(g,or(h,i))) }
 inline def and(f,g,h) { and(f,and(g,h)) }
@@ -81,6 +101,8 @@ min-mirth-revision 2025_01_26_003 {
     alias Bool.True  prim-bool-true
     alias Bool.False prim-bool-false
 }
+
+
 
 # Re-export Bool unqualified.
 alias True  Bool.True
@@ -1086,6 +1108,7 @@ struct USize {
         def Int.>USize-if (f,g) [ (*a USize -- *b, *a Int -- *b) *a Int -- *b ] { >Nat-if(USize f, g) }
         def Int.>USize-else (f) [ (*a Int -- *a USize) *a Int -- *a USize ] { >USize-if(id, f) }
         def Int.>USize-clamp [ Int -- USize ] { >Nat-clamp >USize }
+        def ISize.>USize-clamp [ ISize -- USize ] { >Int >Nat-clamp >USize }
 
         def >Nat [ USize -- Nat ] { /USize }
         def >Int [ USize -- Int ] { >Nat >Int }
@@ -1273,7 +1296,11 @@ inline(
 def(@?, Mut(t) -- Maybe(t),
     dup mut-is-set if(@ Some, drop None))
 
-inline:def(panic!, *a Str -- *b, prim-panic)
+inline def panic! [*a Str -- *b] { prim-panic }
+
+inline def panic!(s) [(*a +Str -- *b +Str) *a -- *b] { 
+    Str(s) panic! 
+}
 
 def(impossible!, *a -- *b, "Impossible! The impossible has occured!" panic!)
 def(expect!(f,g), (*a -- *a Bool, *a -- *b Str) *a -- *a,


### PR DESCRIPTION
Includes:
- `Maybe` and `Either` methods for doing more monadic flow control, including a `switch(case(predicate, f), default)` pattern for both.
- `until/1` and `until/2` for the inverse of `while` (it just reads better sometimes).
- `if/3` so you can factor out a `dup` that comes in front of an `if/2` (I find this is a really common pattern and it reads clearer to just include the predicate as part of the `if`)
- A few other random things