### PR TITLE
Add a custom merge driver for bin/mirth0.c

### DIFF
--- a/.gitattribute
+++ b/.gitattribute
@@ -1,1 +1,0 @@
-*.mth linguist-language=Mirth

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/bin/mirth0.c merge=keep-local-changes
+*.mth linguist-language=Mirth
+

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,4 @@
+[merge "keep-local-changes"]
+        name = Custom merge driver that keeps local changes
+        driver = true
+ 


### PR DESCRIPTION
When a conflict occurs, this merge driver keeps local changes.