### PR TITLE
Fix a bug with building arrays from nothing.

### DIFF
--- a/bin/mirth0.c
+++ b/bin/mirth0.c
@@ -111,7 +111,7 @@ typedef struct TYPE {
     void (*trace_)(VAL v, int fd);
     void (*run)(VAL v);
     VAL (*peek_)(ARR* a, USIZE i);
-    VAL (*poke_)(ARR* a, USIZE i, VAL v);
+    void (*poke_)(ARR* a, USIZE i, VAL v);
 } TYPE;
 
 #define REFS_FLAG 0x0001
@@ -127,101 +127,101 @@ static void default_run    (VAL v);
 
 static void bool_trace_ (VAL v, int fd);
 static VAL  bool_peek_ (ARR* a, USIZE i);
-static VAL  bool_poke_ (ARR* a, USIZE i, VAL v);
+static void bool_poke_ (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_BOOL = { .name = "Bool", .trace_ = bool_trace_, .stride=0, .peek_=bool_peek_, .poke_=bool_poke_ };
 
 static void int_trace_ (VAL v, int fd);
 static void int_free   (VAL v);
 static VAL  int_peek_  (ARR* a, USIZE i);
-static VAL  int_poke_  (ARR* a, USIZE i, VAL v);
+static void int_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_INT = { .name = "Int", .trace_ = int_trace_, .free = int_free, .stride=8, .peek_=int_peek_, .poke_=int_poke_, };
 
 static void nat_trace_ (VAL v, int fd);
 static void nat_free   (VAL v);
 static VAL  nat_peek_  (ARR* a, USIZE i);
-static VAL  nat_poke_  (ARR* a, USIZE i, VAL v);
+static void nat_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_NAT = { .name = "Nat", .trace_ = nat_trace_, .free = nat_free, .stride=8, .peek_=nat_peek_, .poke_=nat_poke_, };
 
 static void i64_trace_ (VAL v, int fd);
 static VAL  i64_peek_  (ARR* a, USIZE i);
-static VAL  i64_poke_  (ARR* a, USIZE i, VAL v);
+static void i64_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_I64 = { .name = "I64", .trace_ = i64_trace_, .stride=8, .peek_=i64_peek_, .poke_=i64_poke_, };
 
 static void i32_trace_ (VAL v, int fd);
 static VAL  i32_peek_  (ARR* a, USIZE i);
-static VAL  i32_poke_  (ARR* a, USIZE i, VAL v);
+static void i32_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_I32 = { .name = "I32", .trace_ = i32_trace_, .stride=4, .peek_=i32_peek_, .poke_=i32_poke_, };
 
 static void i16_trace_ (VAL v, int fd);
 static VAL  i16_peek_  (ARR* a, USIZE i);
-static VAL  i16_poke_  (ARR* a, USIZE i, VAL v);
+static void i16_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_I16 = { .name = "I16", .trace_ = i16_trace_, .stride=2, .peek_=i16_peek_, .poke_=i16_poke_, };
 
 static void i8_trace_ (VAL v, int fd);
 static VAL  i8_peek_  (ARR* a, USIZE i);
-static VAL  i8_poke_  (ARR* a, USIZE i, VAL v);
+static void i8_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_I8 = { .name = "I8", .trace_ = i8_trace_, .stride=1, .peek_=i8_peek_, .poke_=i8_poke_, };
 
 static void u64_trace_ (VAL v, int fd);
 static VAL  u64_peek_  (ARR* a, USIZE i);
-static VAL  u64_poke_  (ARR* a, USIZE i, VAL v);
+static void u64_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_U64 = { .name = "U64", .trace_ = u64_trace_, .stride=8, .peek_=u64_peek_, .poke_=u64_poke_, };
 
 static void u32_trace_ (VAL v, int fd);
 static VAL  u32_peek_  (ARR* a, USIZE i);
-static VAL  u32_poke_  (ARR* a, USIZE i, VAL v);
+static void u32_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_U32 = { .name = "U32", .trace_ = u32_trace_, .stride=4, .peek_=u32_peek_, .poke_=u32_poke_, };
 
 static void u16_trace_ (VAL v, int fd);
 static VAL  u16_peek_  (ARR* a, USIZE i);
-static VAL  u16_poke_  (ARR* a, USIZE i, VAL v);
+static void u16_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_U16 = { .name = "U16", .trace_ = u16_trace_, .stride=2, .peek_=u16_peek_, .poke_=u16_poke_, };
 
 static void u8_trace_ (VAL v, int fd);
 static VAL  u8_peek_  (ARR* a, USIZE i);
-static VAL  u8_poke_  (ARR* a, USIZE i, VAL v);
+static void u8_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_U8 = { .name = "U8", .trace_ = u8_trace_, .stride=1, .peek_=u8_peek_, .poke_=u8_poke_, };
 
 static void f64_trace_ (VAL v, int fd);
 static VAL  f64_peek_  (ARR* a, USIZE i);
-static VAL  f64_poke_  (ARR* a, USIZE i, VAL v);
+static void f64_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_F64 = { .name = "F64", .trace_ = f64_trace_, .stride=8, .peek_=f64_peek_, .poke_=f64_poke_, };
 
 static void f32_trace_ (VAL v, int fd);
 static VAL  f32_peek_  (ARR* a, USIZE i);
-static VAL  f32_poke_  (ARR* a, USIZE i, VAL v);
+static void f32_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_F32 = { .name = "F32", .trace_ = f32_trace_, .stride=4, .peek_=f32_peek_, .poke_=f32_poke_, };
 
 static void ptr_trace_ (VAL v, int fd);
 static VAL  ptr_peek_  (ARR* a, USIZE i);
-static VAL  ptr_poke_  (ARR* a, USIZE i, VAL v);
+static void ptr_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_PTR = { .name = "Ptr", .trace_ = ptr_trace_, .stride=sizeof(void*), .peek_=ptr_peek_, .poke_=ptr_poke_, };
 
 static void fnptr_run (VAL v);
 static VAL  fnptr_peek_  (ARR* a, USIZE i);
-static VAL  fnptr_poke_  (ARR* a, USIZE i, VAL v);
+static void fnptr_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_FNPTR = { .name = "FnPtr", .run = fnptr_run, .stride=sizeof(FNPTR), .peek_=fnptr_peek_, .poke_=fnptr_poke_, };
 
 static void str_free (VAL v);
 static void str_trace_ (VAL v, int fd);
 static VAL  str_peek_  (ARR* a, USIZE i);
-static VAL  str_poke_  (ARR* a, USIZE i, VAL v);
+static void str_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_STR = { .name = "Str", .flags=REFS_FLAG, .trace_ = str_trace_, .free=str_free, .stride=sizeof(void*), .peek_=str_peek_, .poke_=str_poke_, };
 
 static void tup_free (VAL v);
 static void tup_trace_ (VAL v, int fd);
 static void tup_run (VAL v);
 static VAL  tup_peek_  (ARR* a, USIZE i);
-static VAL  tup_poke_  (ARR* a, USIZE i, VAL v);
+static void tup_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_TUP = { .name = "Tup", .flags = REFS_FLAG, .free = tup_free, .trace_ = tup_trace_, .run = tup_run, .stride=sizeof(void*), .peek_=tup_peek_, .poke_=tup_poke_, };
 
-static VAL arr_peek_ (ARR* a, USIZE i);
-static VAL arr_poke_ (ARR* a, USIZE i, VAL v);
+static VAL  arr_peek_ (ARR* a, USIZE i);
+static void arr_poke_ (ARR* a, USIZE i, VAL v);
 
 static void arr_free (VAL v);
 static void arr_trace_ (VAL v, int fd);
 static VAL  arr_arr_peek_  (ARR* a, USIZE i);
-static VAL  arr_arr_poke_  (ARR* a, USIZE i, VAL v);
+static void arr_arr_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_ARR = { .name = "Array", .flags = REFS_FLAG, .free = arr_free, .trace_ = arr_trace_, .stride=sizeof(void*), .peek_=arr_arr_peek_, .poke_=arr_arr_poke_, };
 
 #define TAG_BOOL  ((TAG)&TYPE_BOOL)
@@ -1869,22 +1869,23 @@ static VAL bool_peek_(ARR* arr, USIZE i) {
     return MKBOOL(b);
 }
 
-static VAL bool_poke_(ARR* arr, USIZE i, VAL v) {
-    uint32_t u32 = arr->data.u32s[i/32];
-    bool b = (u32 >> (i&31)) & 1;
-    bool b2 = VBOOL(v);
-    arr->data.u32s[i/32] ^= (b != b2) << (i&31);
-    return MKBOOL(b);
+static void bool_poke_(ARR* arr, USIZE i, VAL v) {
+    USIZE hi = i/32;
+    USIZE lo = i&31;
+    uint32_t u32 = arr->data.u32s[hi];
+    uint32_t flag = 1 << lo;
+    uint32_t mask = ~flag;
+    uint32_t b = (bool)VBOOL(v);
+    flag = b << lo;
+    arr->data.u32s[hi] = (u32 & mask) | flag;
 }
 
-#define gen_peek_poke(ty,mkmacro,vmacro,fld) \
-    static VAL ty##_peek_(ARR* arr, USIZE i) { \
+#define gen_peek_poke(pfx,mkmacro,vmacro,fld) \
+    static VAL pfx##_peek_(ARR* arr, USIZE i) { \
         return mkmacro(arr->data.fld[i]); \
     } \
-    static VAL ty##_poke_(ARR* arr, USIZE i, VAL v) { \
-        VAL u = mkmacro(arr->data.fld[i]); \
+    static void pfx##_poke_(ARR* arr, USIZE i, VAL v) { \
         arr->data.fld[i] = vmacro(v); \
-        return u; \
     }
 gen_peek_poke(int,MKINT,VINT,iints)
 gen_peek_poke(nat,MKNAT,VNAT,iints)
@@ -1911,21 +1912,24 @@ static VAL arr_peek_(ARR* arr, USIZE i) {
     return ty->peek_(arr, i);
 }
 
-static VAL arr_poke_(ARR* arr, USIZE i, VAL v) {
+static void arr_poke_(ARR* arr, USIZE i, VAL v) {
     ASSERT(arr); ASSERT(i < arr->size);
     ASSERT(arr->refs == 1);
     ASSERT(arr->tag == v.tag);
     const TYPE* ty = PTRPTR(arr->tag);
     ASSERT(ty && ty->poke_);
-    return ty->poke_(arr, i, v);
+    ty->poke_(arr, i, v);
 }
 
-static ARR* arr_thaw(ARR* arr, size_t new_size) {
+// Copy array over into a fresh array with minimum capacity.
+// No-op if array has a unique reference and enough capacity.
+static ARR* arr_thaw(ARR* arr, size_t need_cap) {
     ASSERT(arr);
-    if ((arr->refs == 1) && (arr->cap >= new_size)) return arr;
+    if ((arr->refs == 1) && (arr->cap >= need_cap)) return arr;
     USIZE stride = arr->stride;
     USIZE size = arr->size;
-    USIZE cap = new_size * 2 + 8 ;
+    if (need_cap < size) need_cap = size;
+    USIZE cap = need_cap * 2 + 8 ;
     USIZE mbytes = stride ? (size * stride) : (size/8 + 4);
     USIZE nbytes = stride ? (cap  * stride) : (cap /8 + 4);
     ARR* arr2 = calloc(1, sizeof(ARR) + nbytes);
@@ -1936,7 +1940,7 @@ static ARR* arr_thaw(ARR* arr, size_t new_size) {
     arr2->size = arr->size;
     arr2->tag = arr->tag;
     memcpy(arr2->data.u8s, arr->data.u8s, mbytes);
-    if ((arr->tag == 0) || (arr->tag & REFS_FLAG)) {
+    if (arr->tag & REFS_FLAG) {
         for (USIZE i = 0; i < arr->size; i++) {
             incref(arr_peek_(arr2,i));
         }
@@ -1947,15 +1951,18 @@ static ARR* arr_thaw(ARR* arr, size_t new_size) {
 
 
 static ARR* arr_new(USIZE cap) {
+    if (cap < 4) cap = 4;
     USIZE nbytes = cap * sizeof(VAL);
     ARR* arr = calloc(1, sizeof(ARR) + nbytes);
     ASSERT(arr);
     arr->refs = 1;
     arr->cap = cap;
+    arr->stride = sizeof(VAL);
     return arr;
 }
 
 static ARR* arr_new_of(TAG tag, USIZE cap) {
+    if (cap < 4) cap = 4;
     const TYPE* ty = PTRPTR(tag);
     USIZE stride = ty ? ty->stride : sizeof(VAL);
     USIZE nbytes = stride ? stride * cap : cap/8 + 4;
@@ -1970,17 +1977,25 @@ static ARR* arr_new_of(TAG tag, USIZE cap) {
 }
 
 static ARR* arr_new_fill(VAL v, USIZE n) {
-    ARR* arr = arr_new_of(v.tag, n);
+    ARR* arr = arr_new_of(v.tag, n+1);
     arr->size = n;
-    if (v.tag == TAG_U8) {
+    if (v.tag == TAG_BOOL) {
+        if (VBOOL(v)) {
+            memset(arr->data.u8s, 0xFF, n/8 + 1);
+        }
+    } else if (arr->stride == 1) {
         memset(arr->data.u8s, v.data.u8, n);
-    } else {
+    } else if (HAS_REFS(v)) {
         for (USIZE i = 0; i < n; i++) {
             arr_poke_(arr,i,v);
             if (i > 0) incref(v);
         }
+        if (n == 0) decref(v);
+    } else {
+        for (USIZE i = 0; i < n; i++) {
+            arr_poke_(arr,i,v);
+        }
     }
-    if (n == 0) decref(v);
     return arr;
 }
 
@@ -1992,6 +2007,8 @@ static USIZE arr_len(ARR* arr) {
 }
 
 static VAL arr_get(ARR* arr, USIZE i) {
+    ASSERT(arr);
+    ASSERT(i < arr->size);
     VAL v = arr_peek_(arr,i);
     incref(v);
     decref(MKARR(arr));
@@ -1999,35 +2016,45 @@ static VAL arr_get(ARR* arr, USIZE i) {
 }
 
 static ARR* arr_set(ARR* arr, USIZE i, VAL v) {
+    ASSERT(arr);
     ASSERT(arr->tag == v.tag);
+    ASSERT(i < arr->size);
     arr = arr_thaw(arr, arr->size);
-    VAL u = arr_poke_(arr,i,v);
+    VAL u = arr_peek_(arr,i);
+    arr_poke_(arr,i,v);
     decref(u);
     return arr;
 }
 
 static ARR* arr_push(ARR* arr, VAL v) {
     ASSERT(arr);
-    if (!arr->tag) {
-        const TYPE *ty = PTRPTR(v.tag);
-        arr->tag = v.tag;
-        arr->cap = ty->stride ?
-            (arr->cap * sizeof(VAL) / ty->stride):
-            (arr->cap * sizeof(VAL) * 8);
-    }
-    ASSERT(arr->tag == v.tag);
     USIZE n = arr->size;
     arr = arr_thaw(arr, n+1);
-    arr->size++;
+    if (!arr->tag) {
+        ASSERT(n == 0);
+        ASSERT(arr->cap > 0);
+        ASSERT(arr->cap * sizeof(VAL) > 4);
+        const TYPE *ty = PTRPTR(v.tag);
+        ASSERT(ty);
+        arr->tag = v.tag;
+        arr->cap = ty->stride
+            ? (arr->cap * sizeof(VAL) / ty->stride)
+            : ((arr->cap * sizeof(VAL) - 4) * 8);
+        arr->stride = ty->stride;
+    }
+    ASSERT(arr->tag == v.tag);
+    ASSERT(arr->cap > n);
+    arr->size = n+1;
     arr_poke_(arr,n,v);
     return arr;
 }
 
 static ARR* arr_pop(ARR* arr, VAL* vout) {
-    ASSERT(arr && arr->size > 0);
+    ASSERT(arr);
+    ASSERT(arr->size > 0);
     USIZE n = arr->size;
     *vout = arr_peek_(arr, n-1);
-    arr = arr_thaw(arr, n-1);
+    arr = arr_thaw(arr, n);
     arr->size--;
     return arr;
 }
@@ -2140,6 +2167,9 @@ static STACK lbl_f64 = {0};
 static STACK lbl_path = {0};
 static STACK lbl_mode = {0};
 static STACK lbl_flags = {0};
+static STACK lbl_i = {0};
+static STACK lbl_stack = {0};
+static STACK lbl_result = {0};
 static STACK lbl_str = {0};
 static STACK lbl_name = {0};
 static STACK lbl_flagZ_type = {0};
@@ -2156,7 +2186,6 @@ static STACK lbl_docZ_length = {0};
 static STACK lbl_oo = {0};
 static STACK lbl_ZPlusfd = {0};
 static STACK lbl_owned = {0};
-static STACK lbl_result = {0};
 static STACK lbl_ZPlusfile = {0};
 static STACK lbl_ZPlusbuffer = {0};
 static STACK lbl_length = {0};
@@ -2393,7 +2422,6 @@ static STACK lbl_sfx = {0};
 static STACK lbl_tuplen = {0};
 static STACK lbl_ZPlustup = {0};
 static STACK lbl_tup = {0};
-static STACK lbl_i = {0};
 static STACK lbl_ptup = {0};
 static STACK lbl_fieldty = {0};
 static STACK lbl_ZPlustuplevar = {0};
@@ -2461,7 +2489,6 @@ static STACK lbl_arg2 = {0};
 static STACK lbl_argZ_type = {0};
 static STACK lbl_ZPlusclosure = {0};
 static STACK lbl_ZPlusindex = {0};
-static STACK lbl_stack = {0};
 static STACK lbl_ZPlusset = {0};
 static STACK lbl_z_codip = {0};
 static STACK lbl_z_dip = {0};
@@ -69581,7 +69608,7 @@ static STR* mw_mirth_c99_c99Z_headerZ_str (void) {
 		"    void (*trace_)(VAL v, int fd);\n"
 		"    void (*run)(VAL v);\n"
 		"    VAL (*peek_)(ARR* a, USIZE i);\n"
-		"    VAL (*poke_)(ARR* a, USIZE i, VAL v);\n"
+		"    void (*poke_)(ARR* a, USIZE i, VAL v);\n"
 		"} TYPE;\n"
 		"\n"
 		"#define REFS_FLAG 0x0001\n"
@@ -69597,101 +69624,101 @@ static STR* mw_mirth_c99_c99Z_headerZ_str (void) {
 		"\n"
 		"static void bool_trace_ (VAL v, int fd);\n"
 		"static VAL  bool_peek_ (ARR* a, USIZE i);\n"
-		"static VAL  bool_poke_ (ARR* a, USIZE i, VAL v);\n"
+		"static void bool_poke_ (ARR* a, USIZE i, VAL v);\n"
 		"static TYPE TYPE_BOOL = { .name = \"Bool\", .trace_ = bool_trace_, .stride=0, .peek_=bool_peek_, .poke_=bool_poke_ };\n"
 		"\n"
 		"static void int_trace_ (VAL v, int fd);\n"
 		"static void int_free   (VAL v);\n"
 		"static VAL  int_peek_  (ARR* a, USIZE i);\n"
-		"static VAL  int_poke_  (ARR* a, USIZE i, VAL v);\n"
+		"static void int_poke_  (ARR* a, USIZE i, VAL v);\n"
 		"static TYPE TYPE_INT = { .name = \"Int\", .trace_ = int_trace_, .free = int_free, .stride=8, .peek_=int_peek_, .poke_=int_poke_, };\n"
 		"\n"
 		"static void nat_trace_ (VAL v, int fd);\n"
 		"static void nat_free   (VAL v);\n"
 		"static VAL  nat_peek_  (ARR* a, USIZE i);\n"
-		"static VAL  nat_poke_  (ARR* a, USIZE i, VAL v);\n"
+		"static void nat_poke_  (ARR* a, USIZE i, VAL v);\n"
 		"static TYPE TYPE_NAT = { .name = \"Nat\", .trace_ = nat_trace_, .free = nat_free, .stride=8, .peek_=nat_peek_, .poke_=nat_poke_, };\n"
 		"\n"
 		"static void i64_trace_ (VAL v, int fd);\n"
 		"static VAL  i64_peek_  (ARR* a, USIZE i);\n"
-		"static VAL  i64_poke_  (ARR* a, USIZE i, VAL v);\n"
+		"static void i64_poke_  (ARR* a, USIZE i, VAL v);\n"
 		"static TYPE TYPE_I64 = { .name = \"I64\", .trace_ = i64_trace_, .stride=8, .peek_=i64_peek_, .poke_=i64_poke_, };\n"
 		"\n"
 		"static void i32_trace_ (VAL v, int fd);\n"
 		"static VAL  i32_peek_  (ARR* a, USIZE i);\n"
-		"static VAL  i32_poke_  (ARR* a, USIZE i, VAL v);\n"
+		"static void i32_poke_  (ARR* a, USIZE i, VAL v);\n"
 		"static TYPE TYPE_I32 = { .name = \"I32\", .trace_ = i32_trace_, .stride=4, .peek_=i32_peek_, .poke_=i32_poke_, };\n"
 		"\n"
 		"static void i16_trace_ (VAL v, int fd);\n"
 		"static VAL  i16_peek_  (ARR* a, USIZE i);\n"
-		"static VAL  i16_poke_  (ARR* a, USIZE i, VAL v);\n"
+		"static void i16_poke_  (ARR* a, USIZE i, VAL v);\n"
 		"static TYPE TYPE_I16 = { .name = \"I16\", .trace_ = i16_trace_, .stride=2, .peek_=i16_peek_, .poke_=i16_poke_, };\n"
 		"\n"
 		"static void i8_trace_ (VAL v, int fd);\n"
 		"static VAL  i8_peek_  (ARR* a, USIZE i);\n"
-		"static VAL  i8_poke_  (ARR* a, USIZE i, VAL v);\n"
+		"static void i8_poke_  (ARR* a, USIZE i, VAL v);\n"
 		"static TYPE TYPE_I8 = { .name = \"I8\", .trace_ = i8_trace_, .stride=1, .peek_=i8_peek_, .poke_=i8_poke_, };\n"
 		"\n"
 		"static void u64_trace_ (VAL v, int fd);\n"
 		"static VAL  u64_peek_  (ARR* a, USIZE i);\n"
-		"static VAL  u64_poke_  (ARR* a, USIZE i, VAL v);\n"
+		"static void u64_poke_  (ARR* a, USIZE i, VAL v);\n"
 		"static TYPE TYPE_U64 = { .name = \"U64\", .trace_ = u64_trace_, .stride=8, .peek_=u64_peek_, .poke_=u64_poke_, };\n"
 		"\n"
 		"static void u32_trace_ (VAL v, int fd);\n"
 		"static VAL  u32_peek_  (ARR* a, USIZE i);\n"
-		"static VAL  u32_poke_  (ARR* a, USIZE i, VAL v);\n"
+		"static void u32_poke_  (ARR* a, USIZE i, VAL v);\n"
 		"static TYPE TYPE_U32 = { .name = \"U32\", .trace_ = u32_trace_, .stride=4, .peek_=u32_peek_, .poke_=u32_poke_, };\n"
 		"\n"
 		"static void u16_trace_ (VAL v, int fd);\n"
 		"static VAL  u16_peek_  (ARR* a, USIZE i);\n"
-		"static VAL  u16_poke_  (ARR* a, USIZE i, VAL v);\n"
+		"static void u16_poke_  (ARR* a, USIZE i, VAL v);\n"
 		"static TYPE TYPE_U16 = { .name = \"U16\", .trace_ = u16_trace_, .stride=2, .peek_=u16_peek_, .poke_=u16_poke_, };\n"
 		"\n"
 		"static void u8_trace_ (VAL v, int fd);\n"
 		"static VAL  u8_peek_  (ARR* a, USIZE i);\n"
-		"static VAL  u8_poke_  (ARR* a, USIZE i, VAL v);\n"
+		"static void u8_poke_  (ARR* a, USIZE i, VAL v);\n"
 		"static TYPE TYPE_U8 = { .name = \"U8\", .trace_ = u8_trace_, .stride=1, .peek_=u8_peek_, .poke_=u8_poke_, };\n"
 		"\n"
 		"static void f64_trace_ (VAL v, int fd);\n"
 		"static VAL  f64_peek_  (ARR* a, USIZE i);\n"
-		"static VAL  f64_poke_  (ARR* a, USIZE i, VAL v);\n"
+		"static void f64_poke_  (ARR* a, USIZE i, VAL v);\n"
 		"static TYPE TYPE_F64 = { .name = \"F64\", .trace_ = f64_trace_, .stride=8, .peek_=f64_peek_, .poke_=f64_poke_, };\n"
 		"\n"
 		"static void f32_trace_ (VAL v, int fd);\n"
 		"static VAL  f32_peek_  (ARR* a, USIZE i);\n"
-		"static VAL  f32_poke_  (ARR* a, USIZE i, VAL v);\n"
+		"static void f32_poke_  (ARR* a, USIZE i, VAL v);\n"
 		"static TYPE TYPE_F32 = { .name = \"F32\", .trace_ = f32_trace_, .stride=4, .peek_=f32_peek_, .poke_=f32_poke_, };\n"
 		"\n"
 		"static void ptr_trace_ (VAL v, int fd);\n"
 		"static VAL  ptr_peek_  (ARR* a, USIZE i);\n"
-		"static VAL  ptr_poke_  (ARR* a, USIZE i, VAL v);\n"
+		"static void ptr_poke_  (ARR* a, USIZE i, VAL v);\n"
 		"static TYPE TYPE_PTR = { .name = \"Ptr\", .trace_ = ptr_trace_, .stride=sizeof(void*), .peek_=ptr_peek_, .poke_=ptr_poke_, };\n"
 		"\n"
 		"static void fnptr_run (VAL v);\n"
 		"static VAL  fnptr_peek_  (ARR* a, USIZE i);\n"
-		"static VAL  fnptr_poke_  (ARR* a, USIZE i, VAL v);\n"
+		"static void fnptr_poke_  (ARR* a, USIZE i, VAL v);\n"
 		"static TYPE TYPE_FNPTR = { .name = \"FnPtr\", .run = fnptr_run, .stride=sizeof(FNPTR), .peek_=fnptr_peek_, .poke_=fnptr_poke_, };\n"
 		"\n"
 		"static void str_free (VAL v);\n"
 		"static void str_trace_ (VAL v, int fd);\n"
 		"static VAL  str_peek_  (ARR* a, USIZE i);\n"
-		"static VAL  str_poke_  (ARR* a, USIZE i, VAL v);\n"
+		"static void str_poke_  (ARR* a, USIZE i, VAL v);\n"
 		"static TYPE TYPE_STR = { .name = \"Str\", .flags=REFS_FLAG, .trace_ = str_trace_, .free=str_free, .stride=sizeof(void*), .peek_=str_peek_, .poke_=str_poke_, };\n"
 		"\n"
 		"static void tup_free (VAL v);\n"
 		"static void tup_trace_ (VAL v, int fd);\n"
 		"static void tup_run (VAL v);\n"
 		"static VAL  tup_peek_  (ARR* a, USIZE i);\n"
-		"static VAL  tup_poke_  (ARR* a, USIZE i, VAL v);\n"
+		"static void tup_poke_  (ARR* a, USIZE i, VAL v);\n"
 		"static TYPE TYPE_TUP = { .name = \"Tup\", .flags = REFS_FLAG, .free = tup_free, .trace_ = tup_trace_, .run = tup_run, .stride=sizeof(void*), .peek_=tup_peek_, .poke_=tup_poke_, };\n"
 		"\n"
-		"static VAL arr_peek_ (ARR* a, USIZE i);\n"
-		"static VAL arr_poke_ (ARR* a, USIZE i, VAL v);\n"
+		"static VAL  arr_peek_ (ARR* a, USIZE i);\n"
+		"static void arr_poke_ (ARR* a, USIZE i, VAL v);\n"
 		"\n"
 		"static void arr_free (VAL v);\n"
 		"static void arr_trace_ (VAL v, int fd);\n"
 		"static VAL  arr_arr_peek_  (ARR* a, USIZE i);\n"
-		"static VAL  arr_arr_poke_  (ARR* a, USIZE i, VAL v);\n"
+		"static void arr_arr_poke_  (ARR* a, USIZE i, VAL v);\n"
 		"static TYPE TYPE_ARR = { .name = \"Array\", .flags = REFS_FLAG, .free = arr_free, .trace_ = arr_trace_, .stride=sizeof(void*), .peek_=arr_arr_peek_, .poke_=arr_arr_poke_, };\n"
 		"\n"
 		"#define TAG_BOOL  ((TAG)&TYPE_BOOL)\n"
@@ -71339,22 +71366,23 @@ static STR* mw_mirth_c99_c99Z_headerZ_str (void) {
 		"    return MKBOOL(b);\n"
 		"}\n"
 		"\n"
-		"static VAL bool_poke_(ARR* arr, USIZE i, VAL v) {\n"
-		"    uint32_t u32 = arr->data.u32s[i/32];\n"
-		"    bool b = (u32 >> (i&31)) & 1;\n"
-		"    bool b2 = VBOOL(v);\n"
-		"    arr->data.u32s[i/32] ^= (b != b2) << (i&31);\n"
-		"    return MKBOOL(b);\n"
+		"static void bool_poke_(ARR* arr, USIZE i, VAL v) {\n"
+		"    USIZE hi = i/32;\n"
+		"    USIZE lo = i&31;\n"
+		"    uint32_t u32 = arr->data.u32s[hi];\n"
+		"    uint32_t flag = 1 << lo;\n"
+		"    uint32_t mask = ~flag;\n"
+		"    uint32_t b = (bool)VBOOL(v);\n"
+		"    flag = b << lo;\n"
+		"    arr->data.u32s[hi] = (u32 & mask) | flag;\n"
 		"}\n"
 		"\n"
-		"#define gen_peek_poke(ty,mkmacro,vmacro,fld) \\\n"
-		"    static VAL ty##_peek_(ARR* arr, USIZE i) { \\\n"
+		"#define gen_peek_poke(pfx,mkmacro,vmacro,fld) \\\n"
+		"    static VAL pfx##_peek_(ARR* arr, USIZE i) { \\\n"
 		"        return mkmacro(arr->data.fld[i]); \\\n"
 		"    } \\\n"
-		"    static VAL ty##_poke_(ARR* arr, USIZE i, VAL v) { \\\n"
-		"        VAL u = mkmacro(arr->data.fld[i]); \\\n"
+		"    static void pfx##_poke_(ARR* arr, USIZE i, VAL v) { \\\n"
 		"        arr->data.fld[i] = vmacro(v); \\\n"
-		"        return u; \\\n"
 		"    }\n"
 		"gen_peek_poke(int,MKINT,VINT,iints)\n"
 		"gen_peek_poke(nat,MKNAT,VNAT,iints)\n"
@@ -71381,21 +71409,24 @@ static STR* mw_mirth_c99_c99Z_headerZ_str (void) {
 		"    return ty->peek_(arr, i);\n"
 		"}\n"
 		"\n"
-		"static VAL arr_poke_(ARR* arr, USIZE i, VAL v) {\n"
+		"static void arr_poke_(ARR* arr, USIZE i, VAL v) {\n"
 		"    ASSERT(arr); ASSERT(i < arr->size);\n"
 		"    ASSERT(arr->refs == 1);\n"
 		"    ASSERT(arr->tag == v.tag);\n"
 		"    const TYPE* ty = PTRPTR(arr->tag);\n"
 		"    ASSERT(ty && ty->poke_);\n"
-		"    return ty->poke_(arr, i, v);\n"
+		"    ty->poke_(arr, i, v);\n"
 		"}\n"
 		"\n"
-		"static ARR* arr_thaw(ARR* arr, size_t new_size) {\n"
+		"// Copy array over into a fresh array with minimum capacity.\n"
+		"// No-op if array has a unique reference and enough capacity.\n"
+		"static ARR* arr_thaw(ARR* arr, size_t need_cap) {\n"
 		"    ASSERT(arr);\n"
-		"    if ((arr->refs == 1) && (arr->cap >= new_size)) return arr;\n"
+		"    if ((arr->refs == 1) && (arr->cap >= need_cap)) return arr;\n"
 		"    USIZE stride = arr->stride;\n"
 		"    USIZE size = arr->size;\n"
-		"    USIZE cap = new_size * 2 + 8 ;\n"
+		"    if (need_cap < size) need_cap = size;\n"
+		"    USIZE cap = need_cap * 2 + 8 ;\n"
 		"    USIZE mbytes = stride ? (size * stride) : (size/8 + 4);\n"
 		"    USIZE nbytes = stride ? (cap  * stride) : (cap /8 + 4);\n"
 		"    ARR* arr2 = calloc(1, sizeof(ARR) + nbytes);\n"
@@ -71406,7 +71437,7 @@ static STR* mw_mirth_c99_c99Z_headerZ_str (void) {
 		"    arr2->size = arr->size;\n"
 		"    arr2->tag = arr->tag;\n"
 		"    memcpy(arr2->data.u8s, arr->data.u8s, mbytes);\n"
-		"    if ((arr->tag == 0) || (arr->tag & REFS_FLAG)) {\n"
+		"    if (arr->tag & REFS_FLAG) {\n"
 		"        for (USIZE i = 0; i < arr->size; i++) {\n"
 		"            incref(arr_peek_(arr2,i));\n"
 		"        }\n"
@@ -71417,15 +71448,18 @@ static STR* mw_mirth_c99_c99Z_headerZ_str (void) {
 		"\n"
 		"\n"
 		"static ARR* arr_new(USIZE cap) {\n"
+		"    if (cap < 4) cap = 4;\n"
 		"    USIZE nbytes = cap * sizeof(VAL);\n"
 		"    ARR* arr = calloc(1, sizeof(ARR) + nbytes);\n"
 		"    ASSERT(arr);\n"
 		"    arr->refs = 1;\n"
 		"    arr->cap = cap;\n"
+		"    arr->stride = sizeof(VAL);\n"
 		"    return arr;\n"
 		"}\n"
 		"\n"
 		"static ARR* arr_new_of(TAG tag, USIZE cap) {\n"
+		"    if (cap < 4) cap = 4;\n"
 		"    const TYPE* ty = PTRPTR(tag);\n"
 		"    USIZE stride = ty ? ty->stride : sizeof(VAL);\n"
 		"    USIZE nbytes = stride ? stride * cap : cap/8 + 4;\n"
@@ -71440,17 +71474,25 @@ static STR* mw_mirth_c99_c99Z_headerZ_str (void) {
 		"}\n"
 		"\n"
 		"static ARR* arr_new_fill(VAL v, USIZE n) {\n"
-		"    ARR* arr = arr_new_of(v.tag, n);\n"
+		"    ARR* arr = arr_new_of(v.tag, n+1);\n"
 		"    arr->size = n;\n"
-		"    if (v.tag == TAG_U8) {\n"
+		"    if (v.tag == TAG_BOOL) {\n"
+		"        if (VBOOL(v)) {\n"
+		"            memset(arr->data.u8s, 0xFF, n/8 + 1);\n"
+		"        }\n"
+		"    } else if (arr->stride == 1) {\n"
 		"        memset(arr->data.u8s, v.data.u8, n);\n"
-		"    } else {\n"
+		"    } else if (HAS_REFS(v)) {\n"
 		"        for (USIZE i = 0; i < n; i++) {\n"
 		"            arr_poke_(arr,i,v);\n"
 		"            if (i > 0) incref(v);\n"
 		"        }\n"
+		"        if (n == 0) decref(v);\n"
+		"    } else {\n"
+		"        for (USIZE i = 0; i < n; i++) {\n"
+		"            arr_poke_(arr,i,v);\n"
+		"        }\n"
 		"    }\n"
-		"    if (n == 0) decref(v);\n"
 		"    return arr;\n"
 		"}\n"
 		"\n"
@@ -71462,6 +71504,8 @@ static STR* mw_mirth_c99_c99Z_headerZ_str (void) {
 		"}\n"
 		"\n"
 		"static VAL arr_get(ARR* arr, USIZE i) {\n"
+		"    ASSERT(arr);\n"
+		"    ASSERT(i < arr->size);\n"
 		"    VAL v = arr_peek_(arr,i);\n"
 		"    incref(v);\n"
 		"    decref(MKARR(arr));\n"
@@ -71469,35 +71513,45 @@ static STR* mw_mirth_c99_c99Z_headerZ_str (void) {
 		"}\n"
 		"\n"
 		"static ARR* arr_set(ARR* arr, USIZE i, VAL v) {\n"
+		"    ASSERT(arr);\n"
 		"    ASSERT(arr->tag == v.tag);\n"
+		"    ASSERT(i < arr->size);\n"
 		"    arr = arr_thaw(arr, arr->size);\n"
-		"    VAL u = arr_poke_(arr,i,v);\n"
+		"    VAL u = arr_peek_(arr,i);\n"
+		"    arr_poke_(arr,i,v);\n"
 		"    decref(u);\n"
 		"    return arr;\n"
 		"}\n"
 		"\n"
 		"static ARR* arr_push(ARR* arr, VAL v) {\n"
 		"    ASSERT(arr);\n"
-		"    if (!arr->tag) {\n"
-		"        const TYPE *ty = PTRPTR(v.tag);\n"
-		"        arr->tag = v.tag;\n"
-		"        arr->cap = ty->stride ?\n"
-		"            (arr->cap * sizeof(VAL) / ty->stride):\n"
-		"            (arr->cap * sizeof(VAL) * 8);\n"
-		"    }\n"
-		"    ASSERT(arr->tag == v.tag);\n"
 		"    USIZE n = arr->size;\n"
 		"    arr = arr_thaw(arr, n+1);\n"
-		"    arr->size++;\n"
+		"    if (!arr->tag) {\n"
+		"        ASSERT(n == 0);\n"
+		"        ASSERT(arr->cap > 0);\n"
+		"        ASSERT(arr->cap * sizeof(VAL) > 4);\n"
+		"        const TYPE *ty = PTRPTR(v.tag);\n"
+		"        ASSERT(ty);\n"
+		"        arr->tag = v.tag;\n"
+		"        arr->cap = ty->stride\n"
+		"            ? (arr->cap * sizeof(VAL) / ty->stride)\n"
+		"            : ((arr->cap * sizeof(VAL) - 4) * 8);\n"
+		"        arr->stride = ty->stride;\n"
+		"    }\n"
+		"    ASSERT(arr->tag == v.tag);\n"
+		"    ASSERT(arr->cap > n);\n"
+		"    arr->size = n+1;\n"
 		"    arr_poke_(arr,n,v);\n"
 		"    return arr;\n"
 		"}\n"
 		"\n"
 		"static ARR* arr_pop(ARR* arr, VAL* vout) {\n"
-		"    ASSERT(arr && arr->size > 0);\n"
+		"    ASSERT(arr);\n"
+		"    ASSERT(arr->size > 0);\n"
 		"    USIZE n = arr->size;\n"
 		"    *vout = arr_peek_(arr, n-1);\n"
-		"    arr = arr_thaw(arr, n-1);\n"
+		"    arr = arr_thaw(arr, n);\n"
 		"    arr->size--;\n"
 		"    return arr;\n"
 		"}\n"
@@ -71575,7 +71629,7 @@ static STR* mw_mirth_c99_c99Z_headerZ_str (void) {
 		"}\n"
 		"\n"
 		"/* GENERATED C99 */\n",
-		62607
+		63383
 	);
 	return v2;
 }

--- a/lib/std/array.mth
+++ b/lib/std/array.mth
@@ -2,124 +2,320 @@ module std.array
 
 import std.prelude
 import std.str
+import std.maybe
 
-min-mirth-revision 2025_04_04_001 {
-    patch Array {
+||| An array of values, tightly packed in linear memory.
+||| The array grows from left to right, and access to a
+||| particular array location takes constant time.
+patch Array {
+    ||| Build an array, piece by piece. Together with `+Array.;` this
+    ||| is intended as a kind of array literal syntax. For example,
+    ||| `Array(10 ; 20 ; 30 ; 40 ;)` creates an array of length 4
+    ||| with the `Int` elements `10`, `20`, `30`, and `40`.
+    def Array(f) [ ( +Array(a) |- *x -- *y ) *x -- *y Array(a) ] {
+        Array.Nil thaw f freeze
+    }
 
-        def Array(f) [ ( +Array(a) |- *x -- *y ) *x -- *y Array(a) ] {
-            +Array.Nil f freeze
-        }
-        def Nil  [ Array(a) ] { 4u Array.New }
-        def New  [ Nat -- Array(a) ] { >U64-clamp prim-array-new }
-        def Fill [ a Nat -- Array(a) ] { >U64-clamp prim-array-new-fill }
-        def len [ Array(a) -- Nat ] { prim-array-len >Nat }
-        def cat [ Array(a) Array(a) -- Array(a) ] { prim-array-cat }
+    ||| Create an empty array.
+    def Nil [ Array(a) ] { 4u Array.New }
 
-        def get  [ Nat Array(a) -- a Array(a) ] { dip:>U64-clamp sip(swap prim-array-get) }
-        def set  [ a Nat Array(a) -- Array(a) ] { swap >U64-clamp rotl prim-array-set }
-        def push [ a Array(a) -- Array(a) ] { swap prim-array-push }
-        def pop  [ Array(a) -- a Array(a) ] { prim-array-pop swap }
+    ||| Create an empty array with a capacity hint.
+    def New  [ Nat -- Array(a) ] { >U64-clamp prim-array-new }
 
-        ||| Get a slice of an array between two indices.
-        |||
-        def slice [ Nat Nat Array(a) -- Array(a) ] {
-            tuck dip2(len min)
-            dup dip(len min over - >U64-clamp)
-            dip2:>U64-clamp
-            rotr prim-array-slice
-        }
+    ||| Create an array with n elements that are all copies of some value.
+    def Fill [ a Nat -- Array(a) ] { >U64-clamp prim-array-new-fill }
 
-        ||| Get a prefix of a certain length.
-        def prefix [ Nat Array(a) -- Array(a) ] { dip2:0u slice }
+    ||| Get the number of elements in this array.
+    def len [ Array(a) -- Nat ] { prim-array-len >Nat }
 
-        ||| Get a suffix, from a starting index.
-        def suffix [ Nat Array(a) -- Array(a) ] { sip:len slice }
+    ||| Concatenate two arrays. If the first array is unique and has enough
+    ||| space to absorb the second array's elements, this is done in-place
+    ||| in the first array.
+    def cat [ Array(a) Array(a) -- Array(a) ] { prim-array-cat }
 
-        ||| Iterate over every element of the array.
-        def for(f) [ *x |- (a --) Array(a) -- ] {
-            \array
-            @array len count(@array:get f)
-        }
+    ||| Is this array empty?
+    def empty? [ Array(a) -- Bool ] { len 0= }
 
-        ||| Iterate over every element of the array, with a second action
-        ||| to perform between every element.
-        def for(f,g) [ *x |- (a --, --) Array(a) --] {
-            \array
-            @array len count(
-                dup 0> then(dip:g)
-                @array:get f
-            )
-        }
+    ||| Does this array contain a single element?
+    ||| If so, return that element.
+    ||| Else return None.
+    def single? [ Array(a) -- Maybe(a) ] {
+        dup len 1 = if(
+            0u swap get Some,
+            drop None
+        )
+    }
 
-        ||| Create a new array with the result of applying a function
-        ||| to each element of the original array.
-        def map(f) [ *x |- (a -- b) Array(a) -- Array(b) ] {
-            dup len +Array.New
-            for(f push!)
-            freeze
-        }
+    ||| Does this array contain exactly two elements?
+    ||| If so, return those two elements as a pair.
+    ||| Else return None.
+    def pair? [ Array(a) -- Maybe([a a]) ] {
+        dup len 2 = if(
+            dup 1u swap get dip(0u swap get) pack2 Some,
+            drop None
+        )
+    }
 
-        def repr; (f{repr;}) [ *x +Str |- (a --) Array(a) -- ] {
-            "Array( " ;
-            for(f " ; ";)
-            ")" ;
-        }
+    ||| Get a value from an array at the given index.
+    ||| If the index is out of bounds, return None.
+    def get? [ Nat Array(a) -- Maybe(a) ] {
+        dup2 len < if(
+            get Some,
+            drop2 None
+        )
+    }
 
-        def = (f{=}) [ *x |- ( a a -- Bool ) Array(a) Array(a) -- Bool ] {
-            and2(on2:len =,
-                \array2 \array1
-                0u \i
-                True \result
-                while(
-                    @result
-                    @i @array1 len < and,
-                    @i @array1:get
-                    @i @array2:get f
-                    !result
-                    @i:1+
+    ||| Get a value from an array at the given index.
+    ||| If the index is out of bounds, panic.
+    def get [ Nat Array(a) -- a ] { swap >U64-clamp prim-array-get }
+
+    ||| Set an array value at a given index.
+    ||| If the index is out of bounds, panic.
+    def set [ a Nat Array(a) -- Array(a) ] { swap >U64-clamp rotl prim-array-set }
+
+    ||| Get a value from an array at the given index from the right.
+    ||| If the index is out of bounds, return None.
+    def get-right? [ Nat Array(a) -- Maybe(a) ] {
+        dup2 len < if(get-right Some, drop2 None)
+    }
+
+    ||| Get a value from an array at the given index from the right.
+    ||| If the index is out of bounds, panic.
+    def get-right [ Nat Array(a) -- a ] {
+        sip(len swap - >Nat-else("Array access out of bounds." panic!)) get
+    }
+
+    ||| Set a value from an array at the given index from the right.
+    def set-right [ a Nat Array(a) -- Array(a) ] {
+        sip(len swap - >Nat-else("Array access out of bounds." panic!)) set
+    }
+
+    ||| Push a value at the end of the array.
+    ||| Expands the array size as needed.
+    def push [ a Array(a) -- Array(a) ] { swap prim-array-push }
+
+    ||| Push two values at the end of the array.
+    ||| Expands the array size as needed.
+    def push2 [ a a Array(a) -- Array(a) ] { thaw push2! freeze }
+
+    ||| Push three values at the end of the array.
+    ||| Expands the array size as needed.
+    def push3 [ a a a Array(a) -- Array(a) ] { thaw push3! freeze }
+
+    ||| Push four values at the end of the array.
+    ||| Expands the array size as needed.
+    def push4 [ a a a a Array(a) -- Array(a) ] { thaw push4! freeze }
+
+    ||| Push five values at the end of the array.
+    ||| Expands the array size as needed.
+    def push5 [ a a a a a Array(a) -- Array(a) ] { thaw push5! freeze }
+
+    ||| Pop a value from the end of the array.
+    ||| If the array is empty, panic.
+    ||| >>>                push pop === id
+    ||| >>> (dup len 1 >=) pop push === id
+    ||| >>> (dup len 1 < ) pop !!!
+    def pop [ Array(a) -- a Array(a) ] { prim-array-pop swap }
+
+    ||| Pop two values from the end of the array.
+    ||| If the array has fewer than two elements, panic.
+    ||| >>>                push2 pop2 === id
+    ||| >>> (dup len 2 >=) pop2 push2 === id
+    ||| >>> (dup len 2 < ) pop2 !!!
+    def pop2 [ Array(a) -- a a Array(a) ] { thaw pop2! freeze }
+
+    ||| Pop three values from the end of the array.
+    ||| If the array has fewer than three elements, panic.
+    ||| >>>                push3 pop3 === id
+    ||| >>> (dup len 3 >=) pop3 push3 === id
+    ||| >>> (dup len 3 < ) pop3 !!!
+    def pop3 [ Array(a) -- a a a Array(a) ] { thaw pop3! freeze }
+
+    ||| Pop four values from the end of the array.
+    ||| If the array has fewer than four elements, panic.
+    ||| >>>                push4 pop4 === id
+    ||| >>> (dup len 4 >=) pop4 push4 === id
+    ||| >>> (dup len 4 < ) pop4 !!!
+    def pop4 [ Array(a) -- a a a a Array(a) ] { thaw pop4! freeze }
+
+    ||| Pop five values from the end of the array.
+    ||| If the array has fewer than five elements, panic.
+    ||| >>>                push5 pop5 === id
+    ||| >>> (dup len 5 >=) pop5 push5 === id
+    ||| >>> (dup len 5 < ) pop5 !!!
+    def pop5 [ Array(a) -- a a a a a Array(a) ] { thaw pop5! freeze }
+
+    ||| Get a slice of an array between two indices.
+    ||| This slice is inclusive of the first index, but exclusive of the last index.
+    ||| So for example, `1u 2u @array slice` returns an array containing only the
+    ||| element at index `1u`, but not the element at index `2u`.
+    ||| And `1u 1u @array slice` returns an empty array.
+    def slice [ Nat Nat Array(a) -- Array(a) ] {
+        tuck dip2(len min)
+        dup dip(len min over - >U64-clamp)
+        dip2:>U64-clamp
+        rotr prim-array-slice
+    }
+
+    ||| Get a prefix of a certain length.
+    def prefix [ Nat Array(a) -- Array(a) ] { dip2:0u slice }
+
+    ||| Get a suffix, from a starting index.
+    def suffix [ Nat Array(a) -- Array(a) ] { sip:len slice }
+
+    ||| Reverse the array.
+    def reverse [ Array(a) -- Array(a) ] {
+        >array
+        @array len \n
+        @n 2u div count (
+            @n over sub-clamp @array:swap-index
+        )
+        array>
+    }
+
+    ||| Swap the elements at the given indexes.
+    ||| If either index is out of bounds, panics.
+    def swap-index [ Nat Nat Array(a) -- Array(a) ] {
+        >array \j \i
+        @i @array get
+        @j @array get
+        @i @array:set
+        @j @array:set
+        array>
+    }
+
+    ||| Sort the array.
+    def sort(lt{<}) [ *x |- (a a -- Bool) Array(a) -- Array(a) ] {
+        0u swap sip:len sort-slice:lt
+    }
+
+    ||| Sort the array by some key.
+    def sort-by(key, lt{<}) [
+        *x |- (a -- b, b b -- Bool) Array(a) -- Array(a)
+    ] {
+        sort(on2:key lt)
+    }
+
+    ||| Sort the array between two indices [i,j).
+    ||| This is an unstable quicksort that uses the center as pivot.
+    ||| Worst case is O(n^2) time, but O(n log n) is the typical case.
+    def sort-slice(lt{<}) [
+        *x |- (a a -- Bool) Nat Nat Array(a) -- Array(a)
+    ] {
+        >array
+        64u Array.New \stack
+        @stack:push2
+        while(
+            @stack empty? not,
+            @stack:pop2 \j \i
+            @i 1+ @j < then(
+                @i @i @j + 2u div @array:swap-index
+                @i @array get \pivot
+                @i 1+ \ki
+                @j \kj
+                while(@ki @kj <,
+                    @ki @array get @pivot lt if(
+                        @ki:succ,
+                        @kj:pred
+                        @ki @kj @array:swap-index
+                    )
                 )
-                @result
+                @ki:pred
+                @i @ki @array:swap-index
+                @i @ki @stack:push2
+                @kj @j @stack:push2
             )
-        }
+        )
+        array>
     }
 
-    inline struct +Array(a) {
-        Array(a)
-        --
-        def Nil [ +Array(a) ] { Array.Nil thaw }
-        def New [ Nat -- +Array(a) ] { Array.New thaw }
-        def Fill [ a Nat -- +Array(a) ] { Array.Fill thaw }
-
-        def freeze [ +Array(a) -- Array(a) ] { /+Array }
-        def Array.thaw [ Array(a) -- +Array(a) ] { +Array }
-
-        def get!  [ +Array(a) |- Nat -- a ] { +Array -> get +Array }
-        def set!  [ +Array(a) |- a Nat -- ] { +Array -> set +Array }
-        def cat!  [ +Array(a) |- Array(a) -- ] { +Array -> swap cat +Array }
-
-        def copy! [ +Array(a) |- Array(a) ] { +Array -> dup +Array }
-        def rdrop [ +Array(a) -- ] { freeze drop }
-        def rdup  [ +Array(a) -- +Array(a) +Array(a) ] { copy! +Array }
-
-        def push!  [ +Array(a) |- a -- ] { +Array -> push +Array }
-        def push2! [ +Array(a) |- a a -- ] { dip:push! push! }
-        def push3! [ +Array(a) |- a a a -- ] { dip:push2! push! }
-        def push4! [ +Array(a) |- a a a a -- ] { dip:push3! push! }
-        def push5! [ +Array(a) |- a a a a a -- ] { dip:push4! push! }
-
-        def pop!  [ +Array(a) |- a ] { +Array -> pop +Array }
-        def pop2! [ +Array(a) |- a a ] { pop! dip:pop! }
-        def pop3! [ +Array(a) |- a a a ] { pop! dip:pop2! }
-        def pop4! [ +Array(a) |- a a a a ] { pop! dip:pop3! }
-        def pop5! [ +Array(a) |- a a a a a ] { pop! dip:pop4! }
-
-        def ; [ +Array(a) |- a -- ] { push! }
+    ||| Iterate over every element of the array.
+    def for(f) [ *x |- (a --) Array(a) -- ] {
+        \array
+        @array len count(@array get f)
     }
 
-    def A0 [ Array(a) ] { Array.Nil }
-    def A1 [ a -- Array(a) ] { 1u Array.New push }
-    def A2 [ a a -- Array(a) ] { 2u +Array.New push2! freeze }
-    def A3 [ a a a -- Array(a) ] { 3u +Array.New push3! freeze }
-    def A4 [ a a a a -- Array(a) ] { 4u +Array.New push4! freeze }
-    def A5 [ a a a a a -- Array(a) ] { 5u +Array.New push5! freeze }
+    ||| Iterate over every element of the array, with a second action
+    ||| to perform between every element.
+    def for(f,g) [ *x |- (a --, --) Array(a) --] {
+        \array
+        @array len count(
+            dup 0> then(dip:g)
+            @array get f
+        )
+    }
+
+    ||| Create a new array with the result of applying a function
+    ||| to each element of the original array.
+    def map(f) [ *x |- (a -- b) Array(a) -- Array(b) ] {
+        dup len +Array.New
+        for(f push!)
+        freeze
+    }
+
+    ||| Emit a text representation for the array.
+    def repr; (f{repr;}) [ *x +Str |- (a --) Array(a) -- ] {
+        "Array( " ;
+        for(f " ; ";)
+        ")" ;
+    }
+
+    ||| Check two arrays for equality. Equality means they have the
+    ||| same number of elemnets, and corresponding elements are equal.
+    def = (f{=}) [ *x |- ( a a -- Bool ) Array(a) Array(a) -- Bool ] {
+        and2(on2:len =,
+            \array2 \array1
+            0u \i
+            True \result
+            while(
+                @result
+                @i @array1 len < and,
+                @i @array1 get
+                @i @array2 get f
+                !result
+                @i:1+
+            )
+            @result
+        )
+    }
 }
+
+inline struct +Array(a) {
+    array:Array(a)
+    --
+    def Nil [ +Array(a) ] { Array.Nil thaw }
+    def New [ Nat -- +Array(a) ] { Array.New thaw }
+    def Fill [ a Nat -- +Array(a) ] { Array.Fill thaw }
+
+    def freeze [ +Array(a) -- Array(a) ] { /+Array array> }
+    def Array.thaw [ Array(a) -- +Array(a) ] { >array +Array }
+
+    def get!  [ +Array(a) |- Nat -- a ] { array get }
+    def set!  [ +Array(a) |- a Nat -- ] { array:set }
+    def cat!  [ +Array(a) |- Array(a) -- ] { array(swap cat) }
+
+    def copy! [ +Array(a) |- Array(a) ] { array }
+    def rdrop [ +Array(a) -- ] { freeze drop }
+    def rdup  [ +Array(a) -- +Array(a) +Array(a) ] { copy! thaw }
+
+    def push!  [ +Array(a) |- a -- ] { array:push }
+    def push2! [ +Array(a) |- a a -- ] { dip:push! push! }
+    def push3! [ +Array(a) |- a a a -- ] { dip:push2! push! }
+    def push4! [ +Array(a) |- a a a a -- ] { dip:push3! push! }
+    def push5! [ +Array(a) |- a a a a a -- ] { dip:push4! push! }
+
+    def pop!  [ +Array(a) |- a ] { array:pop }
+    def pop2! [ +Array(a) |- a a ] { pop! dip:pop! }
+    def pop3! [ +Array(a) |- a a a ] { pop! dip:pop2! }
+    def pop4! [ +Array(a) |- a a a a ] { pop! dip:pop3! }
+    def pop5! [ +Array(a) |- a a a a a ] { pop! dip:pop4! }
+
+    def ; [ +Array(a) |- a -- ] { push! }
+}
+
+def A0 [ Array(a) ] { Array.Nil }
+def A1 [ a -- Array(a) ] { 1u Array.New push }
+def A2 [ a a -- Array(a) ] { 2u +Array.New push2! freeze }
+def A3 [ a a a -- Array(a) ] { 3u +Array.New push3! freeze }
+def A4 [ a a a a -- Array(a) ] { 4u +Array.New push4! freeze }
+def A5 [ a a a a a -- Array(a) ] { 5u +Array.New push5! freeze }

--- a/src/main.mth
+++ b/src/main.mth
@@ -4,6 +4,7 @@ import std.prelude
 import std.list
 import std.posix
 import std.terminal
+import std.array
 
 import mirth.options
 import mirth.mirth

--- a/src/mirth.h
+++ b/src/mirth.h
@@ -110,7 +110,7 @@ typedef struct TYPE {
     void (*trace_)(VAL v, int fd);
     void (*run)(VAL v);
     VAL (*peek_)(ARR* a, USIZE i);
-    VAL (*poke_)(ARR* a, USIZE i, VAL v);
+    void (*poke_)(ARR* a, USIZE i, VAL v);
 } TYPE;
 
 #define REFS_FLAG 0x0001
@@ -126,101 +126,101 @@ static void default_run    (VAL v);
 
 static void bool_trace_ (VAL v, int fd);
 static VAL  bool_peek_ (ARR* a, USIZE i);
-static VAL  bool_poke_ (ARR* a, USIZE i, VAL v);
+static void bool_poke_ (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_BOOL = { .name = "Bool", .trace_ = bool_trace_, .stride=0, .peek_=bool_peek_, .poke_=bool_poke_ };
 
 static void int_trace_ (VAL v, int fd);
 static void int_free   (VAL v);
 static VAL  int_peek_  (ARR* a, USIZE i);
-static VAL  int_poke_  (ARR* a, USIZE i, VAL v);
+static void int_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_INT = { .name = "Int", .trace_ = int_trace_, .free = int_free, .stride=8, .peek_=int_peek_, .poke_=int_poke_, };
 
 static void nat_trace_ (VAL v, int fd);
 static void nat_free   (VAL v);
 static VAL  nat_peek_  (ARR* a, USIZE i);
-static VAL  nat_poke_  (ARR* a, USIZE i, VAL v);
+static void nat_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_NAT = { .name = "Nat", .trace_ = nat_trace_, .free = nat_free, .stride=8, .peek_=nat_peek_, .poke_=nat_poke_, };
 
 static void i64_trace_ (VAL v, int fd);
 static VAL  i64_peek_  (ARR* a, USIZE i);
-static VAL  i64_poke_  (ARR* a, USIZE i, VAL v);
+static void i64_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_I64 = { .name = "I64", .trace_ = i64_trace_, .stride=8, .peek_=i64_peek_, .poke_=i64_poke_, };
 
 static void i32_trace_ (VAL v, int fd);
 static VAL  i32_peek_  (ARR* a, USIZE i);
-static VAL  i32_poke_  (ARR* a, USIZE i, VAL v);
+static void i32_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_I32 = { .name = "I32", .trace_ = i32_trace_, .stride=4, .peek_=i32_peek_, .poke_=i32_poke_, };
 
 static void i16_trace_ (VAL v, int fd);
 static VAL  i16_peek_  (ARR* a, USIZE i);
-static VAL  i16_poke_  (ARR* a, USIZE i, VAL v);
+static void i16_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_I16 = { .name = "I16", .trace_ = i16_trace_, .stride=2, .peek_=i16_peek_, .poke_=i16_poke_, };
 
 static void i8_trace_ (VAL v, int fd);
 static VAL  i8_peek_  (ARR* a, USIZE i);
-static VAL  i8_poke_  (ARR* a, USIZE i, VAL v);
+static void i8_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_I8 = { .name = "I8", .trace_ = i8_trace_, .stride=1, .peek_=i8_peek_, .poke_=i8_poke_, };
 
 static void u64_trace_ (VAL v, int fd);
 static VAL  u64_peek_  (ARR* a, USIZE i);
-static VAL  u64_poke_  (ARR* a, USIZE i, VAL v);
+static void u64_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_U64 = { .name = "U64", .trace_ = u64_trace_, .stride=8, .peek_=u64_peek_, .poke_=u64_poke_, };
 
 static void u32_trace_ (VAL v, int fd);
 static VAL  u32_peek_  (ARR* a, USIZE i);
-static VAL  u32_poke_  (ARR* a, USIZE i, VAL v);
+static void u32_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_U32 = { .name = "U32", .trace_ = u32_trace_, .stride=4, .peek_=u32_peek_, .poke_=u32_poke_, };
 
 static void u16_trace_ (VAL v, int fd);
 static VAL  u16_peek_  (ARR* a, USIZE i);
-static VAL  u16_poke_  (ARR* a, USIZE i, VAL v);
+static void u16_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_U16 = { .name = "U16", .trace_ = u16_trace_, .stride=2, .peek_=u16_peek_, .poke_=u16_poke_, };
 
 static void u8_trace_ (VAL v, int fd);
 static VAL  u8_peek_  (ARR* a, USIZE i);
-static VAL  u8_poke_  (ARR* a, USIZE i, VAL v);
+static void u8_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_U8 = { .name = "U8", .trace_ = u8_trace_, .stride=1, .peek_=u8_peek_, .poke_=u8_poke_, };
 
 static void f64_trace_ (VAL v, int fd);
 static VAL  f64_peek_  (ARR* a, USIZE i);
-static VAL  f64_poke_  (ARR* a, USIZE i, VAL v);
+static void f64_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_F64 = { .name = "F64", .trace_ = f64_trace_, .stride=8, .peek_=f64_peek_, .poke_=f64_poke_, };
 
 static void f32_trace_ (VAL v, int fd);
 static VAL  f32_peek_  (ARR* a, USIZE i);
-static VAL  f32_poke_  (ARR* a, USIZE i, VAL v);
+static void f32_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_F32 = { .name = "F32", .trace_ = f32_trace_, .stride=4, .peek_=f32_peek_, .poke_=f32_poke_, };
 
 static void ptr_trace_ (VAL v, int fd);
 static VAL  ptr_peek_  (ARR* a, USIZE i);
-static VAL  ptr_poke_  (ARR* a, USIZE i, VAL v);
+static void ptr_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_PTR = { .name = "Ptr", .trace_ = ptr_trace_, .stride=sizeof(void*), .peek_=ptr_peek_, .poke_=ptr_poke_, };
 
 static void fnptr_run (VAL v);
 static VAL  fnptr_peek_  (ARR* a, USIZE i);
-static VAL  fnptr_poke_  (ARR* a, USIZE i, VAL v);
+static void fnptr_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_FNPTR = { .name = "FnPtr", .run = fnptr_run, .stride=sizeof(FNPTR), .peek_=fnptr_peek_, .poke_=fnptr_poke_, };
 
 static void str_free (VAL v);
 static void str_trace_ (VAL v, int fd);
 static VAL  str_peek_  (ARR* a, USIZE i);
-static VAL  str_poke_  (ARR* a, USIZE i, VAL v);
+static void str_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_STR = { .name = "Str", .flags=REFS_FLAG, .trace_ = str_trace_, .free=str_free, .stride=sizeof(void*), .peek_=str_peek_, .poke_=str_poke_, };
 
 static void tup_free (VAL v);
 static void tup_trace_ (VAL v, int fd);
 static void tup_run (VAL v);
 static VAL  tup_peek_  (ARR* a, USIZE i);
-static VAL  tup_poke_  (ARR* a, USIZE i, VAL v);
+static void tup_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_TUP = { .name = "Tup", .flags = REFS_FLAG, .free = tup_free, .trace_ = tup_trace_, .run = tup_run, .stride=sizeof(void*), .peek_=tup_peek_, .poke_=tup_poke_, };
 
-static VAL arr_peek_ (ARR* a, USIZE i);
-static VAL arr_poke_ (ARR* a, USIZE i, VAL v);
+static VAL  arr_peek_ (ARR* a, USIZE i);
+static void arr_poke_ (ARR* a, USIZE i, VAL v);
 
 static void arr_free (VAL v);
 static void arr_trace_ (VAL v, int fd);
 static VAL  arr_arr_peek_  (ARR* a, USIZE i);
-static VAL  arr_arr_poke_  (ARR* a, USIZE i, VAL v);
+static void arr_arr_poke_  (ARR* a, USIZE i, VAL v);
 static TYPE TYPE_ARR = { .name = "Array", .flags = REFS_FLAG, .free = arr_free, .trace_ = arr_trace_, .stride=sizeof(void*), .peek_=arr_arr_peek_, .poke_=arr_arr_poke_, };
 
 #define TAG_BOOL  ((TAG)&TYPE_BOOL)
@@ -1868,22 +1868,23 @@ static VAL bool_peek_(ARR* arr, USIZE i) {
     return MKBOOL(b);
 }
 
-static VAL bool_poke_(ARR* arr, USIZE i, VAL v) {
-    uint32_t u32 = arr->data.u32s[i/32];
-    bool b = (u32 >> (i&31)) & 1;
-    bool b2 = VBOOL(v);
-    arr->data.u32s[i/32] ^= (b != b2) << (i&31);
-    return MKBOOL(b);
+static void bool_poke_(ARR* arr, USIZE i, VAL v) {
+    USIZE hi = i/32;
+    USIZE lo = i&31;
+    uint32_t u32 = arr->data.u32s[hi];
+    uint32_t flag = 1 << lo;
+    uint32_t mask = ~flag;
+    uint32_t b = (bool)VBOOL(v);
+    flag = b << lo;
+    arr->data.u32s[hi] = (u32 & mask) | flag;
 }
 
-#define gen_peek_poke(ty,mkmacro,vmacro,fld) \
-    static VAL ty##_peek_(ARR* arr, USIZE i) { \
+#define gen_peek_poke(pfx,mkmacro,vmacro,fld) \
+    static VAL pfx##_peek_(ARR* arr, USIZE i) { \
         return mkmacro(arr->data.fld[i]); \
     } \
-    static VAL ty##_poke_(ARR* arr, USIZE i, VAL v) { \
-        VAL u = mkmacro(arr->data.fld[i]); \
+    static void pfx##_poke_(ARR* arr, USIZE i, VAL v) { \
         arr->data.fld[i] = vmacro(v); \
-        return u; \
     }
 gen_peek_poke(int,MKINT,VINT,iints)
 gen_peek_poke(nat,MKNAT,VNAT,iints)
@@ -1910,21 +1911,24 @@ static VAL arr_peek_(ARR* arr, USIZE i) {
     return ty->peek_(arr, i);
 }
 
-static VAL arr_poke_(ARR* arr, USIZE i, VAL v) {
+static void arr_poke_(ARR* arr, USIZE i, VAL v) {
     ASSERT(arr); ASSERT(i < arr->size);
     ASSERT(arr->refs == 1);
     ASSERT(arr->tag == v.tag);
     const TYPE* ty = PTRPTR(arr->tag);
     ASSERT(ty && ty->poke_);
-    return ty->poke_(arr, i, v);
+    ty->poke_(arr, i, v);
 }
 
-static ARR* arr_thaw(ARR* arr, size_t new_size) {
+// Copy array over into a fresh array with minimum capacity.
+// No-op if array has a unique reference and enough capacity.
+static ARR* arr_thaw(ARR* arr, size_t need_cap) {
     ASSERT(arr);
-    if ((arr->refs == 1) && (arr->cap >= new_size)) return arr;
+    if ((arr->refs == 1) && (arr->cap >= need_cap)) return arr;
     USIZE stride = arr->stride;
     USIZE size = arr->size;
-    USIZE cap = new_size * 2 + 8 ;
+    if (need_cap < size) need_cap = size;
+    USIZE cap = need_cap * 2 + 8 ;
     USIZE mbytes = stride ? (size * stride) : (size/8 + 4);
     USIZE nbytes = stride ? (cap  * stride) : (cap /8 + 4);
     ARR* arr2 = calloc(1, sizeof(ARR) + nbytes);
@@ -1935,7 +1939,7 @@ static ARR* arr_thaw(ARR* arr, size_t new_size) {
     arr2->size = arr->size;
     arr2->tag = arr->tag;
     memcpy(arr2->data.u8s, arr->data.u8s, mbytes);
-    if ((arr->tag == 0) || (arr->tag & REFS_FLAG)) {
+    if (arr->tag & REFS_FLAG) {
         for (USIZE i = 0; i < arr->size; i++) {
             incref(arr_peek_(arr2,i));
         }
@@ -1946,15 +1950,18 @@ static ARR* arr_thaw(ARR* arr, size_t new_size) {
 
 
 static ARR* arr_new(USIZE cap) {
+    if (cap < 4) cap = 4;
     USIZE nbytes = cap * sizeof(VAL);
     ARR* arr = calloc(1, sizeof(ARR) + nbytes);
     ASSERT(arr);
     arr->refs = 1;
     arr->cap = cap;
+    arr->stride = sizeof(VAL);
     return arr;
 }
 
 static ARR* arr_new_of(TAG tag, USIZE cap) {
+    if (cap < 4) cap = 4;
     const TYPE* ty = PTRPTR(tag);
     USIZE stride = ty ? ty->stride : sizeof(VAL);
     USIZE nbytes = stride ? stride * cap : cap/8 + 4;
@@ -1969,17 +1976,25 @@ static ARR* arr_new_of(TAG tag, USIZE cap) {
 }
 
 static ARR* arr_new_fill(VAL v, USIZE n) {
-    ARR* arr = arr_new_of(v.tag, n);
+    ARR* arr = arr_new_of(v.tag, n+1);
     arr->size = n;
-    if (v.tag == TAG_U8) {
+    if (v.tag == TAG_BOOL) {
+        if (VBOOL(v)) {
+            memset(arr->data.u8s, 0xFF, n/8 + 1);
+        }
+    } else if (arr->stride == 1) {
         memset(arr->data.u8s, v.data.u8, n);
-    } else {
+    } else if (HAS_REFS(v)) {
         for (USIZE i = 0; i < n; i++) {
             arr_poke_(arr,i,v);
             if (i > 0) incref(v);
         }
+        if (n == 0) decref(v);
+    } else {
+        for (USIZE i = 0; i < n; i++) {
+            arr_poke_(arr,i,v);
+        }
     }
-    if (n == 0) decref(v);
     return arr;
 }
 
@@ -1991,6 +2006,8 @@ static USIZE arr_len(ARR* arr) {
 }
 
 static VAL arr_get(ARR* arr, USIZE i) {
+    ASSERT(arr);
+    ASSERT(i < arr->size);
     VAL v = arr_peek_(arr,i);
     incref(v);
     decref(MKARR(arr));
@@ -1998,35 +2015,45 @@ static VAL arr_get(ARR* arr, USIZE i) {
 }
 
 static ARR* arr_set(ARR* arr, USIZE i, VAL v) {
+    ASSERT(arr);
     ASSERT(arr->tag == v.tag);
+    ASSERT(i < arr->size);
     arr = arr_thaw(arr, arr->size);
-    VAL u = arr_poke_(arr,i,v);
+    VAL u = arr_peek_(arr,i);
+    arr_poke_(arr,i,v);
     decref(u);
     return arr;
 }
 
 static ARR* arr_push(ARR* arr, VAL v) {
     ASSERT(arr);
-    if (!arr->tag) {
-        const TYPE *ty = PTRPTR(v.tag);
-        arr->tag = v.tag;
-        arr->cap = ty->stride ?
-            (arr->cap * sizeof(VAL) / ty->stride):
-            (arr->cap * sizeof(VAL) * 8);
-    }
-    ASSERT(arr->tag == v.tag);
     USIZE n = arr->size;
     arr = arr_thaw(arr, n+1);
-    arr->size++;
+    if (!arr->tag) {
+        ASSERT(n == 0);
+        ASSERT(arr->cap > 0);
+        ASSERT(arr->cap * sizeof(VAL) > 4);
+        const TYPE *ty = PTRPTR(v.tag);
+        ASSERT(ty);
+        arr->tag = v.tag;
+        arr->cap = ty->stride
+            ? (arr->cap * sizeof(VAL) / ty->stride)
+            : ((arr->cap * sizeof(VAL) - 4) * 8);
+        arr->stride = ty->stride;
+    }
+    ASSERT(arr->tag == v.tag);
+    ASSERT(arr->cap > n);
+    arr->size = n+1;
     arr_poke_(arr,n,v);
     return arr;
 }
 
 static ARR* arr_pop(ARR* arr, VAL* vout) {
-    ASSERT(arr && arr->size > 0);
+    ASSERT(arr);
+    ASSERT(arr->size > 0);
     USIZE n = arr->size;
     *vout = arr_peek_(arr, n-1);
-    arr = arr_thaw(arr, n-1);
+    arr = arr_thaw(arr, n);
     arr->size--;
     return arr;
 }

--- a/test/arrays.mth
+++ b/test/arrays.mth
@@ -8,7 +8,6 @@ import std.test
 def main {
 
     +Tests (
-
         "Array(Int).New, len, push, pop, get, set" test (
             10u New@Int \array
             @array len =>: 0u
@@ -16,38 +15,38 @@ def main {
 
             10 @array:push
             @array len =>: 1u
-            0u @array:get =>: 10
+            0u @array get =>: 10
             Str(@array repr;) =>: "Array( 10 ; )"
 
             20 @array:push
             @array len =>: 2u
-            0u @array:get =>: 10
-            1u @array:get =>: 20
+            0u @array get =>: 10
+            1u @array get =>: 20
             Str(@array repr;) =>: "Array( 10 ; 20 ; )"
 
             30 @array:push
             @array len =>: 3u
-            0u @array:get =>: 10
-            1u @array:get =>: 20
-            2u @array:get =>: 30
+            0u @array get =>: 10
+            1u @array get =>: 20
+            2u @array get =>: 30
             Str(@array repr;) =>: "Array( 10 ; 20 ; 30 ; )"
 
             40 1u @array:set
             @array len =>: 3u
-            0u @array:get =>: 10
-            1u @array:get =>: 40
-            2u @array:get =>: 30
+            0u @array get =>: 10
+            1u @array get =>: 40
+            2u @array get =>: 30
             Str(@array repr;) =>: "Array( 10 ; 40 ; 30 ; )"
 
             @array:pop =>: 30
             @array len =>: 2u
-            0u @array:get =>: 10
-            1u @array:get =>: 40
+            0u @array get =>: 10
+            1u @array get =>: 40
             Str(@array repr;) =>: "Array( 10 ; 40 ; )"
 
             @array:pop =>: 40
             @array len =>: 1u
-            0u @array:get =>: 10
+            0u @array get =>: 10
             Str(@array repr;) =>: "Array( 10 ; )"
 
             @array:pop =>: 10
@@ -96,10 +95,10 @@ def main {
 
         "Array(Bool)" test (
             Array( True ; False ; True ; False ; ) \array
-            0u @array:get =>: True
-            1u @array:get =>: False
-            2u @array:get =>: True
-            3u @array:get =>: False
+            0u @array get =>: True
+            1u @array get =>: False
+            2u @array get =>: True
+            3u @array get =>: False
             @array @array = =>: True
             @array show-bools =>: "1010"
             @array @array cat !array
@@ -130,7 +129,6 @@ def main {
                 "0000000000100000000000000000000000010000"
                           "100000000000000000000000010000" cat
             )
-
         )
 
         "Array(List(Int))" test (
@@ -150,6 +148,20 @@ def main {
             @array map(foldl(0,+))
                 =>: Array( 6 ; 9 ; 0 ; )
         )
+
+        "Array.sort" test (
+            Array( 1 ; 2 ; 3 ; 4 ; ) sort
+                =>: Array( 1 ; 2 ; 3 ; 4 ; )
+
+            Array( 4 ; 3 ; 2 ; 1 ; ) sort
+                =>: Array( 1 ; 2 ; 3 ; 4 ; )
+
+            Array( 1 ; 3 ; 2 ; 5 ; 4 ; ) sort
+                =>: Array( 1 ; 2 ; 3 ; 4 ; 5 ; )
+
+            "Hello, world!" prim-str-to-array sort prim-array-to-str
+                =>: " !,Hdellloorw"
+        )
     )
 }
 
@@ -159,4 +171,4 @@ def New@ListInt [ Nat -- Array:List:Int ] { Array.New }
 def Nil@ListInt [ Array:List:Int ] { Array.Nil }
 def show-bools [ Array(Bool) -- Str ] { Str:for:if("1";,"0";) }
 
-# mirth-test # pout # 5 tests passed.
+# mirth-test # pout # 6 tests passed.


### PR DESCRIPTION
The stride field wasn't being updated properly after pushing to an empty array, which led to segfaults. This PR fixes that.