### PR TITLE
Drop Array fill value.

### DIFF
--- a/lib/std/array.mth
+++ b/lib/std/array.mth
@@ -6,21 +6,30 @@ import std.maybe
 
 ||| An array of values, tightly packed in linear memory.
 ||| The array grows from left to right, and access to a
-||| particular array location takes constant time.
-|||
-||| Arrays also have a fill value, which is used to when expanding
-||| the array or accessing out of bounds elements.
+||| particular location takes constant time.
 patch Array {
-    ||| Create an array with the given fill value, and n elements
-    ||| that are copies of the fill value.
+    ||| Create an array with n copies of the given value.
     def New [ a Nat -- Array(a) ] { >U64-clamp prim-array-new }
 
-    ||| Build an array, piece by piece via `+ArrayBuilder`, and give
-    ||| a fill value. For example, `Array(10 ; 20 ; 30 ; 0)`
-    ||| creates an array with three `Int` elements `10`, `20`, `30`,
-    ||| and a fill value of `0`.
-    def Array(f) [ ( +ArrayBuilder(a) |- *x -- *y a ) *x -- *y Array(a) ] {
-        +Array(f) freeze
+    min-mirth-revision 2025_04_12_001 {
+        def Nil [ Array(a) ] { prim-array-nil }
+
+        ||| Build an array, piece by piece via `+ArrayBuilder`, and give
+        ||| a fill value. For example, `Array(10 ; 20 ; 30 ; 0)`
+        ||| creates an array with three `Int` elements `10`, `20`, `30`,
+        ||| and a fill value of `0`.
+        def Array(f) [ ( +ArrayBuilder(a) |- *x -- *y ) *x -- *y Array(a) ] {
+            +Array(f) freeze
+        }
+    }
+
+    max-mirth-revision 2025_04_12_000 {
+        ||| Build an array, piece by piece via `+ArrayBuilder`.
+        ||| example, `Array(10 ; 20 ; 30 ;)` creates an array with
+        ||| three `Int` elements: `10`, `20`, and `30`.
+        def Array(f) [ ( +ArrayBuilder(a) |- *x -- *y a ) *x -- *y Array(a) ] {
+            +Array(f) freeze
+        }
     }
 
     ||| Prepare array for mutation, turning it into a linear resource.
@@ -93,60 +102,62 @@ patch Array {
         sip(len swap - >Nat-else("Array access out of bounds." panic!)) set
     }
 
-    ||| Push a value at the end of the array.
-    ||| Expands the array size as needed.
+    ||| Push a value at the end of the array, expanding the array.
     def push [ a Array(a) -- Array(a) ] { swap prim-array-push }
 
-    ||| Push two values at the end of the array.
-    ||| Expands the array size as needed.
+    ||| Push two values at the end of the array, expanding the array.
     def push2 [ a a Array(a) -- Array(a) ] { thaw push2! freeze }
 
-    ||| Push three values at the end of the array.
-    ||| Expands the array size as needed.
+    ||| Push three values at the end of the array, expanding the array.
     def push3 [ a a a Array(a) -- Array(a) ] { thaw push3! freeze }
 
-    ||| Push four values at the end of the array.
-    ||| Expands the array size as needed.
+    ||| Push four values at the end of the array, expanding the array.
     def push4 [ a a a a Array(a) -- Array(a) ] { thaw push4! freeze }
 
-    ||| Push five values at the end of the array.
-    ||| Expands the array size as needed.
+    ||| Push five values at the end of the array, expanding the array.
     def push5 [ a a a a a Array(a) -- Array(a) ] { thaw push5! freeze }
 
     ||| Pop a value from the end of the array.
     ||| If the array is empty, panic.
-    ||| >>>                push pop === id
-    ||| >>> (dup len 1 >=) pop push === id
-    ||| >>> (dup len 1 < ) pop !!!
     def pop [ Array(a) -- a Array(a) ] { prim-array-pop swap }
 
     ||| Pop two values from the end of the array.
     ||| If the array has fewer than two elements, panic.
-    ||| >>>                push2 pop2 === id
-    ||| >>> (dup len 2 >=) pop2 push2 === id
-    ||| >>> (dup len 2 < ) pop2 !!!
     def pop2 [ Array(a) -- a a Array(a) ] { thaw pop2! freeze }
 
     ||| Pop three values from the end of the array.
     ||| If the array has fewer than three elements, panic.
-    ||| >>>                push3 pop3 === id
-    ||| >>> (dup len 3 >=) pop3 push3 === id
-    ||| >>> (dup len 3 < ) pop3 !!!
     def pop3 [ Array(a) -- a a a Array(a) ] { thaw pop3! freeze }
 
     ||| Pop four values from the end of the array.
     ||| If the array has fewer than four elements, panic.
-    ||| >>>                push4 pop4 === id
-    ||| >>> (dup len 4 >=) pop4 push4 === id
-    ||| >>> (dup len 4 < ) pop4 !!!
     def pop4 [ Array(a) -- a a a a Array(a) ] { thaw pop4! freeze }
 
     ||| Pop five values from the end of the array.
     ||| If the array has fewer than five elements, panic.
-    ||| >>>                push5 pop5 === id
-    ||| >>> (dup len 5 >=) pop5 push5 === id
-    ||| >>> (dup len 5 < ) pop5 !!!
     def pop5 [ Array(a) -- a a a a a Array(a) ] { thaw pop5! freeze }
+
+    min-mirth-revision 2025_04_12_001 {
+        ||| Expand array up to the given length, using the given value.
+        ||| This is a no-op if the array is big enough already.
+        def expand [ a Nat Array(a) -- Array(a) ] {
+            dip:>U64-clamp
+            swap rotl prim-array-expand
+        }
+
+        ||| Push n copies of a value at the end of the array.
+        ||| Like `Array.expand` but takes the number of copies to push, not the final length.
+        def push-many [ a Nat Array(a) -- Array(a) ] {
+            sip(len +) expand
+        }
+    }
+    max-mirth-revision 2025_04_12_000 {
+        ||| Expand array up the given length, using the fill value.
+        ||| No-op if array is already big enough.
+        def expand [ Nat Array(a) -- Array(a) ] {
+            dip:pred sip2:get set
+        }
+    }
 
     ||| Get a slice of an array between two indices.
     ||| This slice is inclusive of the first index, but exclusive of the last index.
@@ -158,12 +169,6 @@ patch Array {
         dup dip(len min over - >U64-clamp)
         dip2:>U64-clamp
         rotr prim-array-slice
-    }
-
-    ||| Expand array up the given length, using the fill value.
-    ||| No-op if array is already big enough.
-    def expand [ Nat Array(a) -- Array(a) ] {
-        dip:pred sip2:get set
     }
 
     ||| Get a prefix up to a certain index (exclusive).
@@ -262,46 +267,53 @@ patch Array {
         )
     }
 
-    ||| Get array fill value. The fill value is used
-    ||| when accessing out of bounds elements, and when
-    ||| expanding the array.
-    def get-fill-value [ Array(a) -- a ] {
-        prim-array-get-default
+    max-mirth-revision 2025_04_12_000 {
+        ||| Get array fill value. The fill value is used
+        ||| when accessing out of bounds elements, and when
+        ||| expanding the array.
+        def get-fill-value [ Array(a) -- a ] {
+            prim-array-get-default
+        }
+
+        ||| Set array fill value. The fill value is used
+        ||| when accessing out of bounds elements, and when
+        ||| expanding the array.
+        def set-fill-value [ a Array(a) -- Array(a) ] {
+            swap prim-array-set-default
+        }
+
+        ||| Create a new array by applying a function
+        ||| to each element of the original array.
+        ||| The fill value is also mapped.
+        def map(f) [ *x |- (a -- b) Array(a) -- Array(b) ] {
+            dup get-fill-value f 0u +Array.New
+            for(f push!)
+            freeze
+        }
     }
 
-    ||| Set array fill value. The fill value is used
-    ||| when accessing out of bounds elements, and when
-    ||| expanding the array.
-    def set-fill-value [ a Array(a) -- Array(a) ] {
-        swap prim-array-set-default
-    }
-
-    ||| Create a new array by applying a function
-    ||| to each element of the original array.
-    ||| The fill value is also mapped.
-    def map(f) [ *x |- (a -- b) Array(a) -- Array(b) ] {
-        dup get-fill-value f 0u +Array.New
-        for(f push!)
-        freeze
+    min-mirth-revision 2025_04_12_001 {
+        ||| Create a new array by applying a function
+        ||| to each element of the original array.
+        def map(f) [ *x |- (a -- b) Array(a) -- Array(b) ] {
+            Array(for(f ;))
+        }
     }
 
     ||| Emit a text representation for the array.
     def repr; (f{repr;}) [ *x +Str |- (a --) Array(a) -- ] {
         "Array( " ;
-        sip:for(f " ; ";)
-        get-fill-value f
-        " )" ;
+        for(f " ; ";)
+        ")" ;
     }
 
     ||| Check two arrays for equality. Equality means they have the
-    ||| same length, corresponding elements are equal, and their
-    ||| fill values are the same.
+    ||| same length, and corresponding elements are equal.
     def = (f{=}) [ *x |- ( a a -- Bool ) Array(a) Array(a) -- Bool ] {
         and2(on2:len =,
             \array2 \array1
             0u \i
-            @array1 get-fill-value
-            @array2 get-fill-value f \result
+            True \result
             while(
                 @result
                 @i @array1 len < and,
@@ -314,6 +326,13 @@ patch Array {
         )
     }
 
+    ||| Use the array base pointer. This operation will panic if the array is not flat data,
+    ||| i.e. the array elements must not be reference counted / garbage collected,
+    ||| and it will panic if the array is empty (rather than return a NULL pointer).
+    ||| Only access elements within the array bounds, i.e. with index < len, and
+    ||| only use the pointer to read unless you can guarantee that you own all
+    ||| references to this specific array. It is recommended you go through +Array
+    ||| instead, if you need a pointer to owned array.
     def with-base(f) [ +Unsafe |- (*x Ptr -- *y) *x Array(a) -- *y Array(a) ] {
         sip(prim-array-base f)
     }
@@ -325,15 +344,25 @@ data +Array(a) {
     Unsafe [ Array(a) ]
     --
     def New [ a Nat -- +Array(a) ] { Array.New +Array.Unsafe }
-    def +Array(f) [ ( +ArrayBuilder(a) |- *x -- *y a ) *x -- *y +Array(a) ] {
-        +ArrayBuilder.None f finish-array!
+
+    min-mirth-revision 2025_04_12_001 {
+        def Nil [ +Array(a) ] { Array.Nil +Array.Unsafe }
+        def +Array(f) [ (+ArrayBuilder(a) |- *x -- *y) *x -- *y +Array(a) ] {
+            +ArrayBuilder.None f finish-array!
+        }
     }
 
-    ||| Get the fill value for the array.
-    def fill-value@ [ +Array(a) |- a ] { array@ get-fill-value }
+    max-mirth-revision 2025_04_12_000 {
+        def +Array(f) [ ( +ArrayBuilder(a) |- *x -- *y a ) *x -- *y +Array(a) ] {
+            +ArrayBuilder.None f finish-array!
+        }
 
-    ||| Set the fill value for the array.
-    def fill-value! [ +Array(a) |- a -- ] { array:set-fill-value }
+        ||| Get the fill value for the array.
+        def fill-value@ [ +Array(a) |- a ] { array@ get-fill-value }
+
+        ||| Set the fill value for the array.
+        def fill-value! [ +Array(a) |- a -- ] { array:set-fill-value }
+    }
 
     ||| Freeze the array resource into an immutable value.
     def freeze [ +Array(a) -- Array(a) ] { /Unsafe }
@@ -356,13 +385,11 @@ data +Array(a) {
     def len@ [ +Array(a) |- Nat ] { array:sip:len }
 
     ||| Get value at certain index.
-    ||| If index is greater than length, return the fill value.
+    ||| If index is greater than length, panic.
     def value@ [ +Array(a) |- Nat -- a ] { array:sip:get }
 
     ||| Set value at certain index.
-    ||| If index is greater than length, expand the array with copies of
-    ||| the fill value until index equals length, then push the value
-    ||| at the end.
+    ||| If index is greater than length, panic.
     def value! [ +Array(a) |- a Nat -- ] { array:set }
 
     ||| Modify the value at a certain index.
@@ -388,7 +415,6 @@ data +Array(a) {
     def swap! [ +Array(a) |- Nat Nat -- ] { dip(sip:value@) swap dip(replace!) value! }
 
     ||| Concatenate the given array to the end of this array.
-    ||| The fill value is set to the second array's fill value.
     def cat! [ +Array(a) |- Array(a) -- ] { array(swap cat) }
 
     ||| Get a slice of the array between two indices.
@@ -404,14 +430,28 @@ data +Array(a) {
     ||| truncated array of the given length (if there are enough elements).
     def truncate! [ +Array(a) |- Nat -- ] { array:prefix }
 
-    ||| Increase size of the array until it is at least as big
-    ||| as the given length.
-    def expand! [ +Array(a) |- Nat -- ] { array:expand }
+    min-mirth-revision 2025_04_12_001 {
+        ||| Increase size of the array until it is at least as big
+        ||| as the given length.
+        def expand! [ +Array(a) |- a Nat -- ] { array:expand }
 
-    ||| Set the length of the array, truncating or expanding
-    ||| the array as necessary.
-    def resize! [ +Array(a) |- Nat -- ] {
-        dup len@ < if(truncate!, expand!)
+        ||| Set the length of the array, truncating or expanding
+        ||| the array as necessary.
+        def resize! [ +Array(a) |- a Nat -- ] {
+            dup len@ < if(nip truncate!, expand!)
+        }
+    }
+
+    max-mirth-revision 2025_04_12_000 {
+        ||| Increase size of the array until it is at least as big
+        ||| as the given length.
+        def expand! [ +Array(a) |- Nat -- ] { array:expand }
+
+        ||| Set the length of the array, truncating or expanding
+        ||| the array as necessary.
+        def resize! [ +Array(a) |- Nat -- ] {
+            dup len@ < if(truncate!, expand!)
+        }
     }
 
     ||| Split the array in two at a given index.
@@ -434,46 +474,60 @@ data +Array(a) {
     def push5! [ +Array(a) |- a a a a a -- ] { dip:push4! push! }
 
     ||| Pop an element from the end of the array.
-    ||| If the array is empty, returns the fill value instead.
+    ||| If the array is empty, panic.
     def pop! [ +Array(a) |- a ] { array:pop }
 
     ||| Pop two elements from the end of the array.
-    ||| If the array does not have enough elements, return copies of the fill value.
+    ||| If the array does not have enough elements, panic.
     def pop2! [ +Array(a) |- a a ] { pop! dip:pop! }
 
     ||| Pop three values from the end of the array.
-    ||| If the array does not have enough values, return copies of the fill value.
+    ||| If the array does not have enough values, panic.
     def pop3! [ +Array(a) |- a a a ] { pop! dip:pop2! }
 
     ||| Pop four values from the end of the array.
-    ||| If the array does not have enough values, return copies of the fill value.
+    ||| If the array does not have enough values, panic.
     def pop4! [ +Array(a) |- a a a a ] { pop! dip:pop3! }
 
     ||| Pop five values from the end of the array.
-    ||| If the array does not have enough values, return copies of the fill value.
+    ||| If the array does not have enough values, panic.
     def pop5! [ +Array(a) |- a a a a a ] { pop! dip:pop4! }
 
     ||| Get base pointer to array data. This operation only works when the array has
     ||| flat data that is not subject to garbage collection / reference counting,
     ||| like Bool, U8, U16, U32, U64, I8, I16, I32, I64, F32, F64, Ptr, enums,
     ||| and single-field structs containing flat data. Attempting to use it in
-    ||| other situations will result in a panic.
-    ||| Also using the pointer to access memory is unsafe. If you are not
-    ||| sure that the array is a unique reference, do not write to this
-    ||| pointer.
+    ||| other situations will result in a panic. Only access elements within
+    ||| the given size, and only write to the array while you hold ownership.
     def base [ +Unsafe +Array(a) |- Ptr ] { array:with-base:id }
 }
 
-data +ArrayBuilder(a) {
-    None [ ]
-    Some [ +Array(a) ]
-    --
-    def finish-array! [ +ArrayBuilder(a) a -- +Array(a) ] {
-        { None -> 0u +Array.New }
-        { Some -> fill-value! }
+max-mirth-revision 2025_04_12_000 {
+    data +ArrayBuilder(a) {
+        None [ ]
+        Some [ +Array(a) ]
+        --
+        def finish-array! [ +ArrayBuilder(a) a -- +Array(a) ] {
+            { None -> 0u +Array.New }
+            { Some -> fill-value! }
+        }
+        def ; [ +ArrayBuilder(a) |- a --] {
+            { None -> 1u +Array.New +ArrayBuilder.Some }
+            { Some -> push! +ArrayBuilder.Some }
+        }
     }
-    def ; [ +ArrayBuilder(a) |- a --] {
-        { None -> 1u +Array.New +ArrayBuilder.Some }
-        { Some -> push! +ArrayBuilder.Some }
+}
+
+min-mirth-revision 2025_04_12_001 {
+    struct +ArrayBuilder(a) {
+        +array: +Array(a)
+        --
+        def None [ +ArrayBuilder(a) ] { +Array.Nil >+array +ArrayBuilder }
+        def finish-array! [ +ArrayBuilder(a) -- +Array(a) ] {
+            /+ArrayBuilder +array>
+        }
+        def ; [ +ArrayBuilder(a) |- a -- ] {
+            +array:push!
+        }
     }
 }

--- a/lib/std/buffer.mth
+++ b/lib/std/buffer.mth
@@ -16,8 +16,15 @@ struct +Buffer {
     def size [ +Buffer |- Size ] { +array:len@ >Size }
     def base [ +Buffer |- Ptr  ] { +array:unsafe:base }
 
-    ||| Resive buffer to given size.
-    def resize! [ +Buffer |- Size -- ] { >Nat-clamp +array:resize! }
+    min-mirth-revision 2025_04_12_001 {
+        ||| Resive buffer to given size.
+        def resize! [ +Buffer |- Size -- ] { 0u8 swap >Nat-clamp +array:resize! }
+    }
+
+    max-mirth-revision 2025_04_12_000 {
+        ||| Resive buffer to given size.
+        def resize! [ +Buffer |- Size -- ] { >Nat-clamp +array:resize! }
+    }
 
     ||| Resize buffer only if the new size is larger,
     ||| and resize by a factor of at least two.

--- a/src/c99.mth
+++ b/src/c99.mth
@@ -2283,19 +2283,19 @@ def c99-prim! [ +Mirth +C99Branch |- Atom Prim -- ] {
     { StrToF64     -> args "str_to_f64"   Prim.StrToF64     type +c99:cname-type-to-c99-api c99-smart-call! }
     { StrToArray   -> args "str_to_arr"   Prim.StrToArray   type +c99:cname-type-to-c99-api c99-smart-call! }
 
-    { ArrayNew        -> args "arr_new"          Prim.ArrayNew        type +c99:cname-type-to-c99-api c99-smart-call! }
-    { ArrayThaw       -> args "arr_thaw"         Prim.ArrayThaw       type +c99:cname-type-to-c99-api c99-smart-call! }
-    { ArrayBase       -> args "arr_base"         Prim.ArrayBase       type +c99:cname-type-to-c99-api c99-smart-call! }
-    { ArrayLen        -> args "arr_len"          Prim.ArrayLen        type +c99:cname-type-to-c99-api c99-smart-call! }
-    { ArrayGet        -> args "arr_get"          Prim.ArrayGet        type +c99:cname-type-to-c99-api c99-smart-call! }
-    { ArraySet        -> args "arr_set"          Prim.ArraySet        type +c99:cname-type-to-c99-api c99-smart-call! }
-    { ArrayGetDefault -> args "arr_get_default"  Prim.ArrayGetDefault type +c99:cname-type-to-c99-api c99-smart-call! }
-    { ArraySetDefault -> args "arr_set_default"  Prim.ArraySetDefault type +c99:cname-type-to-c99-api c99-smart-call! }
-    { ArrayPush       -> args "arr_push"         Prim.ArrayPush       type +c99:cname-type-to-c99-api c99-smart-call! }
-    { ArrayPop        -> args "arr_pop"          Prim.ArrayPop        type +c99:cname-type-to-c99-api c99-smart-call! }
-    { ArrayCat        -> args "arr_cat"          Prim.ArrayCat        type +c99:cname-type-to-c99-api c99-smart-call! }
-    { ArraySlice      -> args "arr_slice"        Prim.ArraySlice      type +c99:cname-type-to-c99-api c99-smart-call! }
-    { ArrayToStr      -> args "arr_to_str"       Prim.ArrayToStr      type +c99:cname-type-to-c99-api c99-smart-call! }
+    { ArrayNil    -> drop C99ReprType.ARR push-value-expression!("NULL" put) }
+    { ArrayNew    -> args "arr_new"    Prim.ArrayNew    type +c99:cname-type-to-c99-api c99-smart-call! }
+    { ArrayExpand -> args "arr_expand" Prim.ArrayExpand type +c99:cname-type-to-c99-api c99-smart-call! }
+    { ArrayThaw   -> args "arr_thaw"   Prim.ArrayThaw   type +c99:cname-type-to-c99-api c99-smart-call! }
+    { ArrayBase   -> args "arr_base"   Prim.ArrayBase   type +c99:cname-type-to-c99-api c99-smart-call! }
+    { ArrayLen    -> args "arr_len"    Prim.ArrayLen    type +c99:cname-type-to-c99-api c99-smart-call! }
+    { ArrayGet    -> args "arr_get"    Prim.ArrayGet    type +c99:cname-type-to-c99-api c99-smart-call! }
+    { ArraySet    -> args "arr_set"    Prim.ArraySet    type +c99:cname-type-to-c99-api c99-smart-call! }
+    { ArrayPush   -> args "arr_push"   Prim.ArrayPush   type +c99:cname-type-to-c99-api c99-smart-call! }
+    { ArrayPop    -> args "arr_pop"    Prim.ArrayPop    type +c99:cname-type-to-c99-api c99-smart-call! }
+    { ArrayCat    -> args "arr_cat"    Prim.ArrayCat    type +c99:cname-type-to-c99-api c99-smart-call! }
+    { ArraySlice  -> args "arr_slice"  Prim.ArraySlice  type +c99:cname-type-to-c99-api c99-smart-call! }
+    { ArrayToStr  -> args "arr_to_str" Prim.ArrayToStr  type +c99:cname-type-to-c99-api c99-smart-call! }
 
     { SysOs   -> drop C99ReprType.I64 push-value-expression!("RUNNING_OS" put) }
     { SysArch -> drop C99ReprType.I64 push-value-expression!("RUNNING_ARCH" put) }

--- a/src/prim.mth
+++ b/src/prim.mth
@@ -209,14 +209,14 @@ data Prim {
     StrToF32
     StrToArray
 
+    ArrayNil
     ArrayNew
+    ArrayExpand
     ArrayThaw
     ArrayBase
     ArrayLen
     ArrayGet
     ArraySet
-    ArrayGetDefault
-    ArraySetDefault
     ArrayPush
     ArrayPop
     ArrayCat
@@ -443,14 +443,14 @@ data Prim {
         { StrToF64 -> "prim-str-to-f64" 0 }
         { StrToArray -> "prim-str-to-array" 0 }
 
+        { ArrayNil -> "prim-array-nil" 0 }
         { ArrayNew -> "prim-array-new" 0 }
+        { ArrayExpand -> "prim-array-expand" 0 }
         { ArrayThaw -> "prim-array-thaw" 0 }
         { ArrayBase -> "prim-array-base" 0 }
         { ArrayLen -> "prim-array-len" 0 }
         { ArrayGet -> "prim-array-get" 0 }
         { ArraySet -> "prim-array-set" 0 }
-        { ArrayGetDefault -> "prim-array-get-default" 0 }
-        { ArraySetDefault -> "prim-array-set-default" 0 }
         { ArrayPush -> "prim-array-push" 0 }
         { ArrayPop -> "prim-array-pop" 0 }
         { ArrayCat -> "prim-array-cat" 0 }
@@ -840,11 +840,22 @@ data Prim {
         { StrToF64 -> Ctx.L0 Type.Str T1 Type.F64 Type.Str T2 T-> }
         { StrToArray -> Ctx.L0 Type.Str T1 Type.U8 Type.Array T1 T-> }
 
+        { ArrayNil ->
+            Ctx.L0
+            "a" Type.NewInCtx \a
+            T0 @a Type.Array T1 T->
+        }
         { ArrayNew ->
             Ctx.L0
             "a" Type.NewInCtx \a
             @a
             Type.U64 T2
+            @a Type.Array T1 T->
+        }
+        { ArrayExpand ->
+            Ctx.L0
+            "a" Type.NewInCtx \a
+            @a Type.Array Type.U64 @a T3
             @a Type.Array T1 T->
         }
         { ArrayThaw ->
@@ -877,19 +888,6 @@ data Prim {
             @a Type.Array
             Type.U64
             @a T3
-            @a Type.Array T1 T->
-        }
-        { ArrayGetDefault ->
-            Ctx.L0
-            "a" Type.NewInCtx \a
-            @a Type.Array T1
-            @a T1 T->
-        }
-        { ArraySetDefault ->
-            Ctx.L0
-            "a" Type.NewInCtx \a
-            @a Type.Array
-            @a T2
             @a Type.Array T1 T->
         }
         { ArrayPush ->

--- a/src/version.mth
+++ b/src/version.mth
@@ -8,4 +8,4 @@ module mirth.version
 ||| DD is the date, and NNN is some number that goes up within a single day. The only
 ||| thing that matters is that the overall number never goes down, only up.
 
-def mirth-revision { 2025_04_11_001 }
+def mirth-revision { 2025_04_12_001 }

--- a/test/arrays.mth
+++ b/test/arrays.mth
@@ -10,146 +10,147 @@ def main {
 
     +Tests (
         "len, push, pop, get, set" test (
-            Array(0) \array
+            Nil@Int \array
             @array len =>: 0u
-            Str(@array repr;) =>: "Array( 0 )"
+            Str(@array repr;) =>: "Array( )"
 
             10 @array:push
             @array len =>: 1u
             0u @array get =>: 10
-            Str(@array repr;) =>: "Array( 10 ; 0 )"
+            Str(@array repr;) =>: "Array( 10 ; )"
 
             20 @array:push
             @array len =>: 2u
             0u @array get =>: 10
             1u @array get =>: 20
-            Str(@array repr;) =>: "Array( 10 ; 20 ; 0 )"
+            Str(@array repr;) =>: "Array( 10 ; 20 ; )"
 
             30 @array:push
             @array len =>: 3u
             0u @array get =>: 10
             1u @array get =>: 20
             2u @array get =>: 30
-            Str(@array repr;) =>: "Array( 10 ; 20 ; 30 ; 0 )"
+            Str(@array repr;) =>: "Array( 10 ; 20 ; 30 ; )"
 
             40 1u @array:set
             @array len =>: 3u
             0u @array get =>: 10
             1u @array get =>: 40
             2u @array get =>: 30
-            Str(@array repr;) =>: "Array( 10 ; 40 ; 30 ; 0 )"
+            Str(@array repr;) =>: "Array( 10 ; 40 ; 30 ; )"
 
             @array:pop =>: 30
             @array len =>: 2u
             0u @array get =>: 10
             1u @array get =>: 40
-            Str(@array repr;) =>: "Array( 10 ; 40 ; 0 )"
+            Str(@array repr;) =>: "Array( 10 ; 40 ; )"
 
             @array:pop =>: 40
             @array len =>: 1u
             0u @array get =>: 10
-            Str(@array repr;) =>: "Array( 10 ; 0 )"
+            Str(@array repr;) =>: "Array( 10 ; )"
 
             @array:pop =>: 10
             @array len =>: 0u
-            Str(@array repr;) =>: "Array( 0 )"
+            Str(@array repr;) =>: "Array( )"
         )
 
         "Array.Fill, prefix, suffix, slice" test (
             10 5u Array.New \array
-            @array repr =>: "Array( 10 ; 10 ; 10 ; 10 ; 10 ; 10 )"
+            @array repr =>: "Array( 10 ; 10 ; 10 ; 10 ; 10 ; )"
 
             30 2u @array:set
-            @array repr =>: "Array( 10 ; 10 ; 30 ; 10 ; 10 ; 10 )"
+            @array repr =>: "Array( 10 ; 10 ; 30 ; 10 ; 10 ; )"
 
             100 3u @array:set
-            @array repr =>: "Array( 10 ; 10 ; 30 ; 100 ; 10 ; 10 )"
+            @array repr =>: "Array( 10 ; 10 ; 30 ; 100 ; 10 ; )"
 
             0 1u @array:set
-            @array repr =>: "Array( 10 ; 0 ; 30 ; 100 ; 10 ; 10 )"
+            @array repr =>: "Array( 10 ; 0 ; 30 ; 100 ; 10 ; )"
 
-            0u @array prefix repr =>: "Array( 10 )"
-            1u @array prefix repr =>: "Array( 10 ; 10 )"
-            2u @array prefix repr =>: "Array( 10 ; 0 ; 10 )"
-            3u @array prefix repr =>: "Array( 10 ; 0 ; 30 ; 10 )"
-            4u @array prefix repr =>: "Array( 10 ; 0 ; 30 ; 100 ; 10 )"
-            5u @array prefix repr =>: "Array( 10 ; 0 ; 30 ; 100 ; 10 ; 10 )"
-            6u @array prefix repr =>: "Array( 10 ; 0 ; 30 ; 100 ; 10 ; 10 )"
+            0u @array prefix repr =>: "Array( )"
+            1u @array prefix repr =>: "Array( 10 ; )"
+            2u @array prefix repr =>: "Array( 10 ; 0 ; )"
+            3u @array prefix repr =>: "Array( 10 ; 0 ; 30 ; )"
+            4u @array prefix repr =>: "Array( 10 ; 0 ; 30 ; 100 ; )"
+            5u @array prefix repr =>: "Array( 10 ; 0 ; 30 ; 100 ; 10 ; )"
+            6u @array prefix repr =>: "Array( 10 ; 0 ; 30 ; 100 ; 10 ; )"
 
-            0u @array suffix repr =>: "Array( 10 ; 0 ; 30 ; 100 ; 10 ; 10 )"
-            1u @array suffix repr =>: "Array( 0 ; 30 ; 100 ; 10 ; 10 )"
-            2u @array suffix repr =>: "Array( 30 ; 100 ; 10 ; 10 )"
-            3u @array suffix repr =>: "Array( 100 ; 10 ; 10 )"
-            4u @array suffix repr =>: "Array( 10 ; 10 )"
-            5u @array suffix repr =>: "Array( 10 )"
-            6u @array suffix repr =>: "Array( 10 )"
+            0u @array suffix repr =>: "Array( 10 ; 0 ; 30 ; 100 ; 10 ; )"
+            1u @array suffix repr =>: "Array( 0 ; 30 ; 100 ; 10 ; )"
+            2u @array suffix repr =>: "Array( 30 ; 100 ; 10 ; )"
+            3u @array suffix repr =>: "Array( 100 ; 10 ; )"
+            4u @array suffix repr =>: "Array( 10 ; )"
+            5u @array suffix repr =>: "Array( )"
+            6u @array suffix repr =>: "Array( )"
         )
 
         "Array(;), cat" test (
-            Array(10 ; 20 ; 30 ; 0) repr =>: "Array( 10 ; 20 ; 30 ; 0 )"
-            Array(10 ; 20 ; 30 ; 0) Array(40 ; 50 ; 60 ; 0) cat repr
-                =>: "Array( 10 ; 20 ; 30 ; 40 ; 50 ; 60 ; 0 )"
-            Array(10 ; 20 ; 30 ; 40) Array(40 ; 50 ; 60 ; 0) cat repr
-                =>: "Array( 10 ; 20 ; 30 ; 40 ; 50 ; 60 ; 0 )"
-            Array(10 ; 20 ; 30 ; 40) Array(40 ; 50 ; 60 ; 70) cat repr
-                =>: "Array( 10 ; 20 ; 30 ; 40 ; 50 ; 60 ; 70 )"
-            Array(0) Array(1 ; 2 ; 3 ; 4 ; 5 ; 0) cat repr
-                =>: "Array( 1 ; 2 ; 3 ; 4 ; 5 ; 0 )"
-            Array(0) Array(1 ; 2 ; 3 ; 4 ; 5 ; 6) cat repr
-                =>: "Array( 1 ; 2 ; 3 ; 4 ; 5 ; 6 )"
-            Array(1 ; 2 ; 3 ; 4 ; 5 ; 0) Array(0) cat repr
-                =>: "Array( 1 ; 2 ; 3 ; 4 ; 5 ; 0 )"
-            Array(1 ; 2 ; 3 ; 4 ; 5 ; 0) Array(1) cat repr
-                =>: "Array( 1 ; 2 ; 3 ; 4 ; 5 ; 1 )"
-            Array(0) Array(0) cat repr =>: "Array( 0 )"
-            Array(0) Array(1) cat repr =>: "Array( 1 )"
-            Array(1) Array(0) cat repr =>: "Array( 0 )"
-            Array(1) Array(1) cat repr =>: "Array( 1 )"
+            Array(10 ; 20 ; 30 ;) repr =>: "Array( 10 ; 20 ; 30 ; )"
+            Array(10 ; 20 ; 30 ;) Array(40 ; 50 ; 60 ;) cat repr
+                =>: "Array( 10 ; 20 ; 30 ; 40 ; 50 ; 60 ; )"
+            Array(10 ; 20 ; 30 ;) Array(40 ; 50 ; 60 ;) cat repr
+                =>: "Array( 10 ; 20 ; 30 ; 40 ; 50 ; 60 ; )"
+            Array() Array(1 ; 2 ; 3 ; 4 ; 5 ;) cat repr
+                =>: "Array( 1 ; 2 ; 3 ; 4 ; 5 ; )"
+            Array(1 ; 2 ; 3 ; 4 ; 5 ;) Array() cat repr
+                =>: "Array( 1 ; 2 ; 3 ; 4 ; 5 ; )"
+            Nil@Int Array() cat repr =>: "Array( )"
         )
 
         "Array.=" test (
-            # values and defaults must match:
+            Nil@Int Nil@Int = =>: True
 
-            Array(0) Array(0) = =>: True
-            Array(0) Array(1) = =>: False
-            Array(1) Array(0) = =>: False
-            Array(1) Array(1) = =>: True
+            Array(0 ;) Array(0 ;) = =>: True
+            Array(0 ;) Array(1 ;) = =>: False
+            Array(1 ;) Array(0 ;) = =>: False
+            Array(1 ;) Array(1 ;) = =>: True
 
-            Array(0 ; 0) Array(0 ; 0) = =>: True
-            Array(0 ; 0) Array(0 ; 1) = =>: False
-            Array(0 ; 0) Array(1 ; 0) = =>: False
-            Array(0 ; 0) Array(1 ; 1) = =>: False
+            Array(0 ; 0 ;) Array(0 ; 0 ;) = =>: True
+            Array(0 ; 0 ;) Array(1 ; 0 ;) = =>: False
+            Array(1 ; 0 ;) Array(0 ; 0 ;) = =>: False
+            Array(1 ; 0 ;) Array(1 ; 0 ;) = =>: True
 
-            Array(0 ; 1) Array(0 ; 0) = =>: False
-            Array(0 ; 1) Array(0 ; 1) = =>: True
-            Array(0 ; 1) Array(1 ; 0) = =>: False
-            Array(0 ; 1) Array(1 ; 1) = =>: False
+            Array(0 ; 0 ;) Array(0 ; 1 ;) = =>: False
+            Array(0 ; 0 ;) Array(1 ; 1 ;) = =>: False
+            Array(1 ; 0 ;) Array(0 ; 1 ;) = =>: False
+            Array(1 ; 0 ;) Array(1 ; 1 ;) = =>: False
 
-            Array(1 ; 0) Array(0 ; 0) = =>: False
-            Array(1 ; 0) Array(0 ; 1) = =>: False
-            Array(1 ; 0) Array(1 ; 0) = =>: True
-            Array(1 ; 0) Array(1 ; 1) = =>: False
+            Array(0 ; 1 ;) Array(0 ; 0 ;) = =>: False
+            Array(0 ; 1 ;) Array(1 ; 0 ;) = =>: False
+            Array(1 ; 1 ;) Array(0 ; 0 ;) = =>: False
+            Array(1 ; 1 ;) Array(1 ; 0 ;) = =>: False
 
-            Array(1 ; 1) Array(0 ; 0) = =>: False
-            Array(1 ; 1) Array(0 ; 1) = =>: False
-            Array(1 ; 1) Array(1 ; 0) = =>: False
-            Array(1 ; 1) Array(1 ; 1) = =>: True
+            Array(0 ; 1 ;) Array(0 ; 1 ;) = =>: True
+            Array(0 ; 1 ;) Array(1 ; 1 ;) = =>: False
+            Array(1 ; 1 ;) Array(0 ; 1 ;) = =>: False
+            Array(1 ; 1 ;) Array(1 ; 1 ;) = =>: True
 
-            # different lengths are always False even if values match:
+            Nil@Int Array(0 ;) = =>: False
+            Nil@Int Array(1 ;) = =>: False
+            Array(0 ;) Nil@Int = =>: False
+            Array(1 ;) Nil@Int = =>: False
 
-            Array(0 ; 0) Array(0) = =>: False
-            Array(0 ; 1) Array(0) = =>: False
-            Array(1 ; 0) Array(0) = =>: False
-            Array(1 ; 1) Array(0) = =>: False
-
-            Array(0 ; 0) Array(1) = =>: False
-            Array(0 ; 1) Array(1) = =>: False
-            Array(1 ; 0) Array(1) = =>: False
-            Array(1 ; 1) Array(1) = =>: False
+            Array(0 ;) Array(0 ; 0 ;) = =>: False
+            Array(0 ;) Array(0 ; 1 ;) = =>: False
+            Array(0 ;) Array(1 ; 0 ;) = =>: False
+            Array(0 ;) Array(1 ; 1 ;) = =>: False
+            Array(1 ;) Array(0 ; 0 ;) = =>: False
+            Array(1 ;) Array(0 ; 1 ;) = =>: False
+            Array(1 ;) Array(1 ; 0 ;) = =>: False
+            Array(1 ;) Array(1 ; 1 ;) = =>: False
+            Array(0 ; 0 ;) Array(0 ;) = =>: False
+            Array(0 ; 1 ;) Array(0 ;) = =>: False
+            Array(1 ; 0 ;) Array(0 ;) = =>: False
+            Array(1 ; 1 ;) Array(0 ;) = =>: False
+            Array(0 ; 0 ;) Array(1 ;) = =>: False
+            Array(0 ; 1 ;) Array(1 ;) = =>: False
+            Array(1 ; 0 ;) Array(1 ;) = =>: False
+            Array(1 ; 1 ;) Array(1 ;) = =>: False
         )
 
         "Array(Bool)" test (
-            Array( True ; False ; True ; False ; False ) \array
+            Array( True ; False ; True ; False ; ) \array
             0u @array get =>: True
             1u @array get =>: False
             2u @array get =>: True
@@ -199,52 +200,50 @@ def main {
         )
 
         "Array(List(Int))" test (
-            Nil@ListInt repr =>: "Array( List( ) )"
+            Nil@ListInt repr =>: "Array( )"
 
             Nil@ListInt \array
             List(1 ; 2 ; 3 ;) @array:push
             List(4 ; 5 ;) @array:push
             @array repr
-                =>: "Array( List( 1 ; 2 ; 3 ; ) ; List( 4 ; 5 ; ) ; List( ) )"
+                =>: "Array( List( 1 ; 2 ; 3 ; ) ; List( 4 ; 5 ; ) ; )"
 
             List.Nil @array:push
             @array repr
-                =>: "Array( List( 1 ; 2 ; 3 ; ) ; List( 4 ; 5 ; ) ; List( ) ; List( ) )"
+                =>: "Array( List( 1 ; 2 ; 3 ; ) ; List( 4 ; 5 ; ) ; List( ) ; )"
             @array map(sum) repr
-                =>: "Array( 6 Some ; 9 Some ; None ; None )"
+                =>: "Array( 6 Some ; 9 Some ; None ; )"
             @array map(foldl(0,+))
-                =>: Array( 6 ; 9 ; 0 ; 0 )
+                =>: Array( 6 ; 9 ; 0 ; )
         )
 
         "Array.sort" test (
-            Array( 1 ; 2 ; 3 ; 4 ; -1 ) sort
-                =>: Array( 1 ; 2 ; 3 ; 4 ; -1 )
+            Array( 1 ; 2 ; 3 ; 4 ; ) sort
+                =>: Array( 1 ; 2 ; 3 ; 4 ; )
 
-            Array( 4 ; 3 ; 2 ; 1 ; -1 ) sort
-                =>: Array( 1 ; 2 ; 3 ; 4 ; -1 )
+            Array( 4 ; 3 ; 2 ; 1 ; ) sort
+                =>: Array( 1 ; 2 ; 3 ; 4 ; )
 
-            Array( 1 ; 3 ; 2 ; 5 ; 4 ; -1 ) sort
-                =>: Array( 1 ; 2 ; 3 ; 4 ; 5 ; -1 )
+            Array( 1 ; 3 ; 2 ; 5 ; 4 ; ) sort
+                =>: Array( 1 ; 2 ; 3 ; 4 ; 5 ; )
 
             "Hello, world!" prim-str-to-array sort prim-array-to-str
                 =>: " !,Hdellloorw"
         )
 
-        "expanding set, expand" test (
-            Array( 1 ; 2 ; 3 ; 4 ; 5 ; 0 ) \array
-            5 10u @array:set
-            @array repr =>: "Array( 1 ; 2 ; 3 ; 4 ; 5 ; 0 ; 0 ; 0 ; 0 ; 0 ; 5 ; 0 )"
+        "expand" test (
+            Array( 1 ; 2 ; 3 ; ) \array
+            0 6u @array:expand
+            @array repr =>: "Array( 1 ; 2 ; 3 ; 0 ; 0 ; 0 ; )"
+            4 10u @array:expand
+            @array repr =>: "Array( 1 ; 2 ; 3 ; 0 ; 0 ; 0 ; 4 ; 4 ; 4 ; 4 ; )"
 
-            Array( 1 ; 2 ; 3 ; 0 ) \array
-            6u @array:expand
-            @array repr =>: "Array( 1 ; 2 ; 3 ; 0 ; 0 ; 0 ; 0 )"
-
-            Array( 1 ) \array
-            100u @array:expand
+            Array.Nil \array
+            1 100u @array:expand
             0 @array for(+) =>: 100
 
-            Array( False ) \array
-            2560u @array:expand
+            Array( ) \array
+            False 2560u @array:expand
             @array show-bools => (
                 "0000000000"
                 dup cat dup cat dup cat dup cat
@@ -255,13 +254,13 @@ def main {
         "using buffer" test (
             Array( 0u8 ) \array
             4u @array:expand
-            @array repr =>: "Array( 0u8 ; 0u8 ; 0u8 ; 0u8 ; 0u8 )"
+            @array repr =>: "Array( 0u8 ; 0u8 ; 0u8 ; 0u8 ; )"
             10u8 unsafe:@array:with-base:!U8
-            @array repr =>: "Array( 10u8 ; 0u8 ; 0u8 ; 0u8 ; 0u8 )"
+            @array repr =>: "Array( 10u8 ; 0u8 ; 0u8 ; 0u8 ; )"
             20u8 unsafe:@array:with-base(1 bytes + !U8)
-            @array repr =>: "Array( 10u8 ; 20u8 ; 0u8 ; 0u8 ; 0u8 )"
+            @array repr =>: "Array( 10u8 ; 20u8 ; 0u8 ; 0u8 ; )"
             30u8 unsafe:@array:with-base(2 bytes + !U8)
-            @array repr =>: "Array( 10u8 ; 20u8 ; 30u8 ; 0u8 ; 0u8 )"
+            @array repr =>: "Array( 10u8 ; 20u8 ; 30u8 ; 0u8 ; )"
         )
     )
 }


### PR DESCRIPTION
Go back to not having a fill value for arrays.

This means out of bound array access results in panic once again. You can recreate the old functionality by checking the length yourself and/or calling `Array.expand` / `+Array.expand!` manually beforehand.

The problem of not knowing how to allocate an array without having a value ahead of time was solved by not allocating anything for an empty array, I.e. use a null pointer internally to represent an empty array. This PR makes it a panic if you attempt to access an empty array's base pointer. But since you wouldn't be able to do anything safely with a pointer to an empty array, this is fine actually.