### PR TITLE
Represent mirth structs as C structs.

### DIFF
--- a/lib/std/byte.mth
+++ b/lib/std/byte.mth
@@ -147,42 +147,27 @@ data Byte {
 
     def zencode [ Byte -- Str ] { str:zencode; }
     def zencode; [ +Str |- Byte -- ] {
-        ||| Encode byte as a readable string of alphanumeric or underscore characters.
-        ||| Alphanumeric ASCII characters other than 'z' and 'Z' are left as is.
-        ||| Otherwise, they are encoded as a string beginning with 'z' or 'Z'.
+        ||| Encode byte as a string of alphanumeric characters.
+        ||| Alphanumeric characters other than 'z' are left as is.
+        ||| Otherwise, they are encoded as a short string beginning with 'z'.
 
         # Important invariant: No string here should be the prefix of another.
         # With this invariant we can ensure that the z-encoding of any string
-        # is unique. To help enforce the invariant, keep these cases in
-        # lexicographical order.
+        # is unique. To help enforce the invariant, keep these cases in order.
 
-        { B'&' -> "ZAmp"; } { B'?' -> "ZAsk"; } { B'@' -> "ZAt"; }
-        { B'\' -> "ZBSlash"; } { B'!' -> "ZBang"; }
-        { B'^' -> "ZCaret"; } { BCOLON -> "ZColon"; } { BCOMMA -> "ZComma"; }
-        { B'/' -> "ZDiv"; } { B'$' -> "ZDollar"; } { BDOT -> "ZDot"; }
-        { B'=' -> "ZEqual"; }
-        { BHASH -> "ZHash"; }
-        { BLCURLY  -> "ZLCurly"; }
-        { BLPAREN  -> "ZLParen"; }
-        { BLSQUARE -> "ZLSquare"; }
-        { B'<'  -> "ZLess"; }
-        { B'%' -> "ZMod"; }
-        { B'*' -> "ZMul"; }
-        { B'|' -> "ZPipe"; }
-        { B'+' -> "ZPlus"; }
-        { BQUOTE -> "ZQuote"; }
-        { BRCURLY  -> "ZRCurly"; }
-        { BRPAREN  -> "ZRParen"; }
-        { BRSQUARE -> "ZRSquare"; }
-        { B';' -> "ZThen"; }
-        { BTICK -> "ZTick"; }
-        { B'~' -> "ZTilde"; }
-        { B'>' -> "ZTo"; }
+        { B'+'   -> "za"; } { B'\'   -> "zb"; } { B'^'   -> "zc"; } { B'='  -> "zd"; }
+        { B'-'   -> "ze"; } { B'/'   -> "zf"; } { B'>'   -> "zg"; } { BHASH -> "zh"; }
+        { BCOLON -> "zi"; } { B';'   -> "zj"; } { BCOMMA -> "zk"; } { B'<'  -> "zl"; }
+        { B'*'   -> "zm"; } { B'&'   -> "zn"; } { B'@'   -> "zo"; } { BDOT  -> "zp"; }
+        { BTICK  -> "zq"; } { B'%'   -> "zr"; } { B'$'   -> "zs"; } { B'~'  -> "zt"; }
+        { B'_'   -> "zu"; } { B'|'   -> "zv"; } { B'`'   -> "zw"; } { B'!'  -> "zx"; }
+        { B'?'   -> "zy"; } { B'z'   -> "zz"; }
 
-        { B'Z' -> "ZZ"; } { B'-'  -> "Z_"; }
-        { B'z' -> "zz"; } { B'_' -> "z_"; }
-
-        { _ -> dup is-alnum if(emit-unsafe; , "Z"; int; "U";) }
+        { BLSQUARE -> "zLB"; } { BRSQUARE -> "zRB"; }
+        { BLCURLY  -> "zLC"; } { BRCURLY  -> "zRC"; }
+        { BLPAREN  -> "zLP"; } { BRPAREN  -> "zRP"; }
+        { BQUOTE   -> "zQ"; }
+        { _ -> dup is-alnum if(emit-unsafe; , "z"; to-hexdigits dip:emit-unsafe; emit-unsafe;) }
     }
 
     def int; [ +Str Byte -- +Str ] {

--- a/lib/std/either.mth
+++ b/lib/std/either.mth
@@ -15,6 +15,9 @@ data Either(a,b) {
 
     --
 
+    def is-left?  [ Either(a,b) -- Bool ] { Left  -> drop True, Right -> drop False }
+    def is-right? [ Either(a,b) -- Bool ] { Right -> drop True, Left  -> drop False }
+
     def left? [ Either(a,b) -- Maybe(a) ] {
         { Left -> Some }
         { Right -> drop None }

--- a/src/c99.mth
+++ b/src/c99.mth
@@ -64,6 +64,7 @@ def run-output-c99! [ +World +Mirth |- Arrow C99_Options -- ] {
         c99-header!
         c99-label-defs!
         c99-field-defs!
+        c99-data-defs!
         c99-tag-defs!
         c99-buffers!
         c99-external-blocks!
@@ -137,6 +138,11 @@ def c99-buffer-call! [ +Mirth +C99Branch |- Buffer -- ] {
     C99ReprType.PTR push-value-expression!(cname put)
 }
 
+def c99-data-defs! [ +Mirth +C99 |- ] {
+    Data.for(c99-repr prepare-type-sigs!)
+    Data.for(c99-repr prepare-type-defs!)
+}
+
 def c99-tag-defs! [ +Mirth +C99 |- ] { Tag.for(c99-tag-def!) }
 def c99-tag-def! [ +Mirth +C99 |- Tag -- ] {
     \tag @tag prefer-inline? else(
@@ -187,7 +193,10 @@ def c99-tag-body! [ +Mirth +C99Branch |- Tag -- ] {
             push-value-expression!(put)
         ),
 
-        @tag c99-pack-tag! push-value/resource!
+        @tag data c99-repr struct? if?(
+            construct!,
+            @tag c99-pack-tag!
+        ) push-value/resource!
     ))
 }
 
@@ -219,7 +228,10 @@ def c99-reverse-tag-body! [ +Mirth +C99Branch |- Tag -- ] {
         @tag data pop-data! +C99Value/Resource.rdrop, # decref is unnecessary
 
         @tag data pop-data!
-        @tag c99-unpack-tag!
+        @tag data c99-repr struct? if?(
+            destruct!,
+            @tag c99-unpack-tag!
+        )
     ))
 }
 
@@ -336,26 +348,14 @@ def c99-tag-get-label! [ +Mirth +C99Branch |- TagField -- ] {
         @+datavar:rdup @tag data consume-as-data >datavar
         @fieldty match {
             { Left -> # field is value
-                type-to-c99-repr >fieldrepr
-                @fieldrepr value-expression!(
-                    fieldrepr> v-macro(
-                        "((TUP*)PTRPTR(" put
-                        @datavar put "))->cells[" put
-                        @tag @label c99-tag-label-index >Str put
-                        "]" put
-                    )
+                type-to-c99-repr value-expression!(
+                    @datavar put "->m" put @label name mangled put
                 ) keep-value! push-value!
                 +datavar> +for(drop-value!, push-resource!)
             }
             { Right -> # field and data are resources
-                resource-to-c99-repr >fieldrepr
-                @fieldrepr push-resource-expression!(
-                    fieldrepr> v-macro (
-                        "((TUP*)PTRPTR(" put
-                        @datavar put "))->cells[" put
-                        @tag @label c99-tag-label-index >Str put
-                        "]" put
-                    )
+                resource-to-c99-repr push-resource-expression!(
+                    @datavar put "->m" put @label name mangled put
                 )
                 +datavar> push-value/resource!
             }
@@ -395,19 +395,18 @@ def c99-tag-set-label! [ +Mirth +C99Branch |- TagField -- ] {
             }
         },
 
+        @tag data c99-repr struct? unwrap("Expected struct repr" fatal-error!) \struct-repr
         @tag data pop-data! >+datavar
         @fieldty match {
-            { Left -> type-to-c99-repr pop-value! consume-as-VAL }
-            { Right -> resource-to-c99-repr pop-resource! consume-as-VAL }
+            { Left -> type-to-c99-repr pop-value! consume }
+            { Right -> resource-to-c99-repr pop-resource! consume }
         } >fieldval
         +datavar> +for (
             # field and data are both values
-            consume-as-VAL >dataval
-            C99ReprType.VAL push-value-expression!(
-                "tup_replace(" put
+            consume >dataval
+            @tag data C99ReprType.Data push-value-expression!(
+                @struct-repr cname put "_set_" put @label name mangled put "(" put
                 dataval> put
-                ", " put
-                @tag @label c99-tag-label-index >Str put
                 ", " put
                 fieldval> put
                 ")" put
@@ -419,32 +418,20 @@ def c99-tag-set-label! [ +Mirth +C99Branch |- TagField -- ] {
             @+datavar:rdup @tag data consume-as-data >datavar
             fieldty> match {
                 { Left -> # field is value
-                    type-to-c99-repr >fieldrepr
+                    type-to-c99-repr \fieldrepr
                     @fieldrepr needs-refcounting? then (
-                        @fieldrepr dup value-expression! (
-                            v-macro (
-                                "((TUP*)PTRPTR(" put
-                                @datavar put
-                                "))->cells[" put
-                                @tag @label c99-tag-label-index >Str put
-                                "]" put
-                            )
+                        @fieldrepr value-expression! (
+                            @datavar put "->m" put @label name mangled put
                         ) drop-value!
                     )
-                    fieldrepr> drop
                 }
                 { Right -> # field is resource
                     drop
                 }
             }
             c99-line(
-                "((TUP*)PTRPTR(" put
-                @datavar put
-                "))->cells[" put
-                @tag @label c99-tag-label-index >Str put
-                "] = " put
-                fieldval> put
-                ";" put
+                @datavar put "->m" put @label name mangled put " = " put
+                fieldval> put ";" put
             )
             +datavar>
             push-resource!
@@ -1337,6 +1324,22 @@ data C99DataRepr {
         { Struct -> get-data-tag }
         { Sum    -> get-data-tag }
     }
+
+    def prepare-type-sigs! [ +Mirth +C99 |- C99DataRepr -- ] {
+        { Unit   -> prepare-type-sigs! }
+        { Enum   -> prepare-type-sigs! }
+        { Field  -> prepare-type-sigs! }
+        { Struct -> prepare-type-sigs! }
+        { Sum    -> prepare-type-sigs! }
+    }
+
+    def prepare-type-defs! [ +Mirth +C99 |- C99DataRepr -- ] {
+        { Unit   -> prepare-type-defs! }
+        { Enum   -> prepare-type-defs! }
+        { Field  -> prepare-type-defs! }
+        { Struct -> prepare-type-defs! }
+        { Sum    -> prepare-type-defs! }
+    }
 }
 
 struct C99DataUnitRepr {
@@ -1347,6 +1350,8 @@ struct C99DataUnitRepr {
     def v-macro-prefix-suffix { drop "" "" }
     def mk-macro { drop }
     def get-data-tag { nip tag value-show "LL" cat }
+    def prepare-type-sigs! [ +Mirth +C99 |- C99DataUnitRepr -- ] { drop }
+    def prepare-type-defs! [ +Mirth +C99 |- C99DataUnitRepr -- ] { drop }
 }
 
 struct C99DataEnumRepr {
@@ -1357,6 +1362,8 @@ struct C99DataEnumRepr {
     def v-macro-prefix-suffix { drop "VI64(" ")" }
     def mk-macro { drop Str( "MKI64(" ; ; ")" ; ) }
     def get-data-tag { drop }
+    def prepare-type-sigs! [ +Mirth +C99 |- C99DataEnumRepr -- ] { drop }
+    def prepare-type-defs! [ +Mirth +C99 |- C99DataEnumRepr -- ] { drop }
 }
 
 struct C99DataFieldRepr {
@@ -1369,16 +1376,252 @@ struct C99DataFieldRepr {
     def v-macro-prefix-suffix { c99-repr v-macro-prefix-suffix }
     def mk-macro { c99-repr mk-macro }
     def get-data-tag { nip tag value-show "LL" cat }
+    def prepare-type-sigs! [ +Mirth +C99 |- C99DataFieldRepr -- ] { drop }
+    def prepare-type-defs! [ +Mirth +C99 |- C99DataFieldRepr -- ] { drop }
 }
 
 struct C99DataStructRepr {
     tag: Tag
+    cname: Str
+    fields: List(C99DataStructField)
     --
+
+    def Make [ +Mirth |- Tag -- C99DataStructRepr ] {
+        >tag
+        @tag only-tag? if(@tag data cname, @tag qname mangled) >cname
+        @tag inputs c99-inputs-to-struct-fields >fields
+        C99DataStructRepr
+    }
+
+    def data [ +Mirth |- C99DataStructRepr -- Data ] { tag data }
+
     def needs-refcounting? { drop True }
-    def underlying-c99-type [ +Mirth |- C99DataStructRepr -- Str ] { drop "PTUP" }
-    def v-macro-prefix-suffix { drop "VTUP(" ")" }
-    def mk-macro { drop Str( "MKTUP(" ; ; ")" ; ) }
+    def underlying-c99-type [ +Mirth |- C99DataStructRepr -- Str ] {
+        Str("struct "; cname ; "*";)
+    }
+    def v-macro-prefix-suffix [ +Mirth |- C99DataStructRepr -- Str Str ] {
+        Str( "V_" ; cname ; "(" ; ) ")"
+    }
+    def mk-macro [ +Mirth |- Str C99DataStructRepr -- Str ] {
+        Str( "MK_" ; cname ; "(" ; ; ")" ; )
+    }
     def get-data-tag { nip tag value-show "LL" cat }
+    def prepare-type-sigs! [ +Mirth +C99 |- C99DataStructRepr -- ] {
+        \self
+        c99-line("struct " put @self cname put " { " put)
+        c99-nest(
+            c99-line("REFS refs;" put)
+            @self tag only-tag? else (
+                c99-line("enum " put @self data cname put " tag;" put)
+            )
+            @self fields for(
+                \field
+                c99-line(
+                    @field c99-repr underlying-c99-type put " "
+                    put @field cname put ";" put
+                )
+            )
+        )
+        c99-line("};" put)
+        c99-line(
+            "MKTYPE_REFS(" put
+            "TYPE_" put @self cname put "," put
+            @self tag data name >Str put-cstr "," put
+            @self cname put "," put
+            "sizeof(void*),);" put
+        )
+        c99-line(
+            "#define TAG_" put @self cname put
+            " (REFS_FLAG | (TAG)&TYPE_" put @self cname put ")" put
+        )
+        c99-line(
+            "#define MK_" put @self cname put "(x) " put
+            "((VAL){.tag=TAG_" put @self cname put ", .data.ptr=(x)})" put
+        )
+        c99-line(
+            "#define V_" put @self cname put "(v) " put
+            "((struct " put @self cname put "*)((v).data.ptr))" put
+        )
+    }
+    def prepare-type-defs! [ +Mirth +C99 |- C99DataStructRepr -- ] {
+        \self
+        c99-line(
+            "gen_peek_poke(" put
+            @self cname put "," put
+            "MK_" put @self cname put "," put
+            "V_" put @self cname put "," put
+            "ptrs)" put
+        )
+        c99-line("static void " put @self cname put "_free (VAL vself) {" put)
+        c99-nest(
+            c99-line("ASSERT(vself.tag == TAG_" put @self cname put ");" put)
+            c99-line(@self underlying-c99-type put " self = vself.data.ptr;" put)
+            @self fields for(
+                \field
+                @field c99-repr needs-refcounting? then(
+                    c99-line(
+                        "decref(" put
+                        Str("self->" ; @field cname ;)
+                        @field c99-repr mk-macro put
+                        ");" put
+                    )
+                )
+            )
+            c99-line("free(self);" put)
+        )
+        c99-line("}" put)
+
+        c99-line("static void " put @self cname put "_trace_ (VAL vself, int fd) {" put)
+        c99-nest(
+            Str("<" ; @self data name >Str ; ">" ;) \msg
+            c99-line("write(fd, " put @msg put-cstr ", " put @msg num-bytes >Str put ");" put)
+        )
+        c99-line("}" put)
+
+        @self fields for( \field
+            @field label? filter(
+                drop
+                @self data is-resource? not
+                @field is-resource? not and
+            ) for ( \label
+                c99-line(
+                    "static " put @self underlying-c99-type put " " put
+                    @self cname put "_set_" put @label name mangled put
+                    "(" put @self underlying-c99-type put " self, " put
+                        @field c99-repr underlying-c99-type put " x" put
+                    ") {" put
+                )
+                c99-nest(
+                    c99-line("if (self->refs == 1) {" put )
+                    c99-nest(
+                        @field c99-repr needs-refcounting? then(
+                            c99-line(
+                                "decref(" put
+                                Str("self->" ; @field cname ;)
+                                @field c99-repr mk-macro put
+                                ");" put
+                            )
+                        )
+                        c99-line("self->" put @field cname put " = x;" put)
+                        c99-line("return self;" put)
+                    )
+                    c99-line("}" put)
+                    c99-line(@self underlying-c99-type put " self2 = calloc(1, sizeof * self2);" put)
+                    c99-line("ASSERT(self2); memcpy(self2, self, sizeof * self2);" put)
+                    @self fields for(\field2
+                        @field cname @field2 cname = if(
+                            c99-line("self2->" put @field cname put " = x;" put),
+                            @field2 c99-repr needs-refcounting? then(
+                                c99-line(
+                                    "incref(" put
+                                    Str("self2->"; @field2 cname ;)
+                                    @field2 c99-repr mk-macro put
+                                    ");" put
+                                )
+                            )
+                        )
+                    )
+                    c99-line("self->refs--;" put)
+                    c99-line("return self2;" put)
+                )
+                c99-line("}" put)
+            )
+        )
+    }
+
+    def construct! [ +Mirth +C99Branch |- C99DataStructRepr -- +C99Value/Resource ] {
+        \self
+        +c99:fresh-name! \struct-ptr
+        c99-line(
+            "struct " put @self cname put "* " put
+            @struct-ptr put " = " put
+            "calloc(1, sizeof *" put @struct-ptr put ");" put
+        )
+        c99-line("ASSERT(" put @struct-ptr put ");" put)
+        c99-line(@struct-ptr put "->refs = 1;" put)
+        @self fields reverse-for(
+            \field
+            @field input pop-stack-part! consume \expr
+            c99-line(
+                @struct-ptr put "->" put @field cname put " = " put
+                @expr put ";" put
+            )
+        )
+        @struct-ptr >value-name
+        @self data C99ReprType.Data >value-repr +C99Value
+        @self data is-resource? if(
+            turn-into-resource! +C99Value/Resource.+Right,
+            +C99Value/Resource.+Left
+        )
+    }
+    def destruct! [ +Mirth +C99Branch |- C99DataStructRepr +C99Value/Resource -- ] {
+        \self
+        +c99:fresh-name! \struct-val
+        consume \struct-ptr
+        c99-line(
+            "struct " put @self cname put " " put
+            @struct-val put " = " put
+            "*" put @struct-ptr put ";" put
+        )
+        @self fields for(
+            \field
+            Str(@struct-val ; "." ; @field cname ;) >value-name
+            @field c99-repr >value-repr
+            +C99Value +C99Value/Resource.+Left
+            @field input push-stack-part!
+        )
+        c99-line("if (!--(" put @struct-ptr put "->refs)) {" put)
+        c99-nest:c99-line("free(" put @struct-ptr put ");" put)
+        c99-line("} else {" put)
+        c99-nest(
+            @self fields for(
+                \field
+                @field c99-repr needs-refcounting? then(
+                    c99-line(
+                        "incref(" put
+                        Str( @struct-val ; "." ; @field cname ; )
+                        @field c99-repr mk-macro put
+                        ");" put
+                    )
+                )
+            )
+        )
+        c99-line("}" put)
+    }
+}
+
+struct C99DataStructField {
+    input: StackTypePart
+    c99-repr: C99ReprType
+    cname: Str
+    --
+    def is-resource? [ +Mirth |- C99DataStructField -- Bool ] {
+        input type/resource is-right?
+    }
+    def label? [ +Mirth |- C99DataStructField -- Maybe(Label) ] {
+        input label
+    }
+}
+
+def c99-inputs-to-struct-fields [ +Mirth |- List(StackTypePart) -- List(C99DataStructField) ] {
+    0 \i
+    L0 \names
+    L0 \fields
+    reverse-for(
+        dup >input
+        match {
+            { Cons -> sip:c99-repr tycon? if?(name mangled, @i >Str @i:1+) }
+            { With -> sip:c99-repr tycon? if?(name mangled, @i >Str @i:1+) }
+            { ConsLabel -> dip:c99-repr name mangled }
+            { WithLabel -> dip:c99-repr name mangled }
+        }
+        \name >c99-repr
+        0 \j
+        @names for(@name = then(@j:1+))
+        "m" @j 0> if(@name "_" cat @j >Str cat, @name) cat >cname
+        C99DataStructField @fields:cons
+    )
+    @fields
 }
 
 struct C99DataSumRepr {
@@ -1389,6 +1632,8 @@ struct C99DataSumRepr {
     def v-macro-prefix-suffix { drop "VTUP(" ")" }
     def mk-macro { drop Str( "MKTUP(" ; ; ")" ; ) }
     def get-data-tag { drop Str( "PTREXTRA("  ; ; ")" ; ) }
+    def prepare-type-sigs! [ +Mirth +C99 |- C99DataSumRepr -- ] { drop }
+    def prepare-type-defs! [ +Mirth +C99 |- C99DataSumRepr -- ] { drop }
 }
 
 def StackTypePart.c99-repr [ +Mirth |- StackTypePart -- C99ReprType ] {
@@ -1412,8 +1657,7 @@ field(+Mirth |- Data.c99-repr, Data, C99DataRepr,
         @input type/resource either(c99-repr,c99-repr) >c99-repr
         C99DataFieldRepr C99DataRepr.Field,
     @self single-tag? if?(
-        >tag
-        C99DataStructRepr C99DataRepr.Struct,
+        C99DataStructRepr.Make C99DataRepr.Struct,
         @self >data
         C99DataSumRepr C99DataRepr.Sum
     ))))

--- a/src/c99.mth
+++ b/src/c99.mth
@@ -160,10 +160,6 @@ def c99-tag-def! [ +Mirth +C99 |- Tag -- ] {
     )
 }
 
-def pop-stack-part-name! [ +Mirth +C99Branch |- StackTypePart -- Str ] {
-    pop-stack-part! +for(consume,consume)
-}
-
 def pop-stack-part! [ +Mirth +C99Branch |- StackTypePart -- +C99Value/Resource ] {
     { ConsLabel -> dip:type-to-c99-repr pop-value-label! +C99Value/Resource.+Left }
     { WithLabel -> dip:resource-to-c99-repr pop-resource-label! +C99Value/Resource.+Right }
@@ -174,7 +170,7 @@ def pop-stack-part! [ +Mirth +C99Branch |- StackTypePart -- +C99Value/Resource ]
 def c99-tag-body! [ +Mirth +C99Branch |- Tag -- ] {
     \tag @tag semi-transparent? if?(
         input pop-stack-part!
-        @tag data C99ReprType.Data value/resource-repr!
+        @tag data C99ReprType.Data convert-value/resource!
         @tag outputs-resource? if(
             turn-into-resource! push-resource!,
             turn-into-value! push-value!
@@ -221,7 +217,7 @@ def push-stack-part! [ +Mirth +C99Branch |- +C99Value/Resource StackTypePart -- 
 def c99-reverse-tag-body! [ +Mirth +C99Branch |- Tag -- ] {
     \tag @tag semi-transparent? if?(
         @tag data pop-data!
-        input dup c99-repr value/resource-repr!
+        input dup c99-repr convert-value/resource!
         push-stack-part!,
 
     @tag num-total-inputs 0= if(
@@ -331,14 +327,14 @@ def c99-tag-get-label! [ +Mirth +C99Branch |- TagField -- ] {
                     # wrapper is value
                     @tagrepr pop-value!
                 )
-                @fieldrepr value-repr!
+                @fieldrepr convert-value!
                 push-value!
             }
 
             { Right -> # field and wrapper are both resources
                 resource-to-c99-repr \fieldrepr
                 @tagrepr pop-resource!
-                @fieldrepr resource-repr!
+                @fieldrepr convert-resource!
                 push-resource!
                 C99ReprType.Void push-resource-expression!("0" put)
             }
@@ -376,13 +372,13 @@ def c99-tag-set-label! [ +Mirth +C99Branch |- TagField -- ] {
                 @tag data pop-data! +for(
                     drop-value!
                     @fieldrepr pop-value!
-                    @tagrepr value-repr!
+                    @tagrepr convert-value!
                     push-value!,
 
                     drop-resource-as-value!
                     @fieldrepr pop-value!
                     turn-into-resource!
-                    @tagrepr resource-repr!
+                    @tagrepr convert-resource!
                     push-resource!
                 )
             }
@@ -390,7 +386,7 @@ def c99-tag-set-label! [ +Mirth +C99Branch |- TagField -- ] {
                 resource-to-c99-repr \fieldrepr
                 C99ReprType.Void pop-resource! +C99Resource.rdrop # vacant wrapper is unit
                 @fieldrepr pop-resource!
-                @tagrepr resource-repr!
+                @tagrepr convert-resource!
                 push-resource!
             }
         },
@@ -404,7 +400,7 @@ def c99-tag-set-label! [ +Mirth +C99Branch |- TagField -- ] {
         +datavar> +for (
             # field and data are both values
             @fieldrepr is-physical? if(
-                consume >dataval
+                @tag data consume-as-data >dataval
                 @tag data C99ReprType.Data push-value-expression!(
                     @struct-repr cname put "_set_" put @label name mangled put "(" put
                     dataval> put
@@ -451,13 +447,13 @@ def c99-tag-set-label! [ +Mirth +C99Branch |- TagField -- ] {
 
 def c99-table-to-index! [ +Mirth +C99Branch |- Table -- ] {
     C99ReprType.Table pop-value!
-    C99ReprType.U64 value-repr!
+    C99ReprType.U64 convert-value!
     push-value!
 }
 
 def c99-table-from-index! [ +Mirth +C99Branch |- Table -- ] {
     C99ReprType.U64 pop-value!
-    C99ReprType.Table value-repr!
+    C99ReprType.Table convert-value!
     push-value!
 }
 
@@ -566,16 +562,7 @@ def CType.>C99ReprType [ CType -- C99ReprType ] {
 }
 
 def to-ctype-expr [ +Mirth |- +C99Value/Resource CType -- Str ] {
-    { FnPtr -> drop C99ReprType.FNPTR consume-as }
-    { _ -> drop consume }
-}
-
-
-def CTypeStackPart.c99-ctype-pop [ +Mirth +C99Branch StackType |- CTypeStackPart -- Str ] {
-    { Cons -> drop pop-value-from-stack-type! consume }
-    { With -> drop pop-resource-from-stack-type! consume }
-    { ConsLabel -> nip swap pop-value-label-from-stack-type! consume }
-    { WithLabel -> nip swap pop-resource-label-from-stack-type! consume }
+    >C99ReprType consume-as
 }
 
 def CTypeStackPart.c99-ctype-push [ +Mirth +C99Branch List(StackTypePart) |- Str CTypeStackPart -- ] {
@@ -805,8 +792,7 @@ def +C99.cname-type-to-c99-api [ +Mirth +C99 |- Str ArrowType -- C99API ] {
 
 def C99APIArg.reserve-as-new-value! [ +Mirth +C99Branch |- C99APIArg -- C99APIArg ] {
     dup is-physical? if(
-        dup arg-repr new-value!
-        consume swap arg-name!,
+        dup arg-repr dup new-value! consume-as swap arg-name!,
         "0" swap arg-name!
     )
 }
@@ -1083,7 +1069,7 @@ def c99-from-enum-value! [ +Mirth +C99Branch |- Data -- ] {
     dup is-enum? else("from-enum-value-unsafe on non-enum data type" fatal-error!)
     dup is-resource? then("from-enum-value-unsafe on resource" fatal-error!)
     C99ReprType.I64 pop-value!
-    C99ReprType.Data value-repr!
+    C99ReprType.Data convert-value!
     push-value!
 }
 
@@ -1220,7 +1206,7 @@ def c99-nat! [ +Mirth +C99Branch |- Nat -- ] { >Int C99ReprType.Nat c99-int/nat!
 def c99-str! [ +Mirth +C99Branch |- Str -- ] {
     C99ReprType.STR new-value! >+str
     dup num-bytes 4090 bytes > if(
-        c99-line("STRLIT(" put @+str:rdup consume put "," put)
+        c99-line("STRLIT(" put @+str:value-name put "," put)
         c99-nest(
             c99-line(dup put-cstr-long "," put)
             c99-line(dup num-bytes >Str put)
@@ -1228,7 +1214,7 @@ def c99-str! [ +Mirth +C99Branch |- Str -- ] {
         c99-line(");" put),
 
         c99-line("STRLIT(" put
-            @+str:rdup consume put ", " put
+            @+str:value-name put ", " put
             dup put-cstr ", " put
             dup num-bytes >Str put ");" put)
     ) drop
@@ -1356,7 +1342,7 @@ struct C99DataUnitRepr {
     def needs-refcounting? { drop False }
     def underlying-c99-type { drop "void" }
     def v-macro-prefix-suffix { drop "" "" }
-    def mk-macro { drop }
+    def mk-macro { drop2 "MKI64(0)" }
     def get-data-tag { nip tag value-show "LL" cat }
     def prepare-type-sigs! [ +Mirth +C99 |- C99DataUnitRepr -- ] { drop }
     def prepare-type-defs! [ +Mirth +C99 |- C99DataUnitRepr -- ] { drop }
@@ -1549,7 +1535,7 @@ struct C99DataStructRepr {
         c99-line(@struct-ptr put "->refs = 1;" put)
         @self fields reverse-for(
             \field
-            @field input pop-stack-part! consume \expr
+            @field input pop-stack-part! @field c99-repr consume-as \expr
             @field is-physical? then(
                 c99-line(
                     @struct-ptr put "->" put @field cname put " = " put
@@ -1567,7 +1553,7 @@ struct C99DataStructRepr {
     def destruct! [ +Mirth +C99Branch |- C99DataStructRepr +C99Value/Resource -- ] {
         \self
         +c99:fresh-name! \struct-val
-        consume \struct-ptr
+        @self data consume-as-data \struct-ptr
         c99-line(
             "struct " put @self cname put " " put
             @struct-val put " = " put
@@ -2015,10 +2001,6 @@ def +C99Value.push-value-direct! [ +Mirth +C99Branch |- +C99Value -- ] {
     c99-line("push_value(" put put ");" put)
 }
 
-def +C99Value.consume [ +C99Value -- Str ] {
-    /+C99Value value-repr> drop value-name>
-}
-
 def +C99Value.consume-as-VAL [ +Mirth |- +C99Value -- Str ] {
     /+C99Value value-name> value-repr> mk-macro
 }
@@ -2032,30 +2014,59 @@ def +C99Value.consume-as-data [ +Mirth |- +C99Value Data -- Str ] {
 }
 
 def +C99Value.consume-as [ +Mirth |- C99ReprType +C99Value -- Str ] {
-    { VAL -> consume-as-VAL }
-    { Void -> rdrop "0" }
-    { _ ->
-        /+C99Value
-        @value-repr match {
-            { VAL -> Str( v-macro-prefix-suffix dip(; value-name> ;) ; ) }
-            { _ ->
-                over = if(
-                    drop value-name>,
-                    dup is-int-like? @value-repr is-int-like? and if(
-                        Str( "((" ; underlying-c99-type ; ")" ; value-name> ; ")" ; ),
-                        Str( "(\n#error \"attempted to cast " ; value-name> ; " to incompatible C99 repr type " ;
-                            underlying-c99-type ; "\"\n" ; )
+    strip-newtypes \wanted
+    @wanted match {
+        { VAL -> consume-as-VAL }
+        { Void -> rdrop "0" }
+        { _ -> drop
+            /+C99Value
+            @value-repr strip-newtypes \got
+            @got match {
+                { VAL -> Str( @wanted v-macro-prefix-suffix dip(; value-name> ;) ; ) }
+                { _ -> drop
+                    @wanted @got = if(
+                        value-name>,
+                        @wanted is-int-like? and(@got is-int-like?) if(
+                            Str( "((" ; @wanted underlying-c99-type ; ")" ; value-name> ; ")" ; ),
+                            Str( "(\n#error \"attempted to cast " ; value-name> ;
+                                " to incompatible C99 repr type " ;
+                                @wanted underlying-c99-type ; "\"\n" ; )
+                        )
                     )
-                )
+                }
             }
+            value-repr> drop
         }
-        value-repr> drop
     }
+}
+
+# Get C99-repr but see through newtypes,enums,units,etc
+field(+Mirth |- Data.strip-newtypes-c99-repr, Data, C99ReprType,
+    @self C99ReprType.Data \default
+    @default @self strip-newtypes-c99-repr!
+    @self c99-repr match {
+        { Unit   -> drop C99ReprType.Void }
+        { Enum   -> drop C99ReprType.I64 }
+        { Field  -> c99-repr strip-newtypes }
+        { Struct -> drop @default }
+        { Sum    -> drop @default }
+    }
+)
+
+def C99ReprType.strip-newtypes [ +Mirth |- C99ReprType -- C99ReprType ] {
+    { Data -> strip-newtypes-c99-repr }
+    { Table -> drop C99ReprType.U64 }
+    { _ -> id }
+}
+
+def C99ReprType.compatible? [ +Mirth |- C99ReprType C99ReprType -- Bool ] {
+    on2:strip-newtypes =
 }
 
 def +C99Value.keep-value! [ +Mirth +C99Branch +C99Value |- ] {
     value-repr needs-refcounting? then(
-        +C99Value.rdup consume-as-VAL +c99:c99-line("incref(" put put ");" put)
+        value-name value-repr mk-macro
+        +c99:c99-line("incref(" put put ");" put)
     )
 }
 
@@ -2087,7 +2098,7 @@ def +C99Resource.rdup [ +C99Resource |- +C99Resource ] {
 }
 
 def +C99Resource.rdrop [ +C99Resource -- ] {
-    consume drop
+    /+C99Resource ldrop
 }
 
 def +C99Value.turn-into-resource! [ +C99Value -- +C99Resource ] {
@@ -2110,12 +2121,6 @@ def +C99Resource.drop-resource-as-value! [ +Mirth +C99Branch |- +C99Resource -- 
 
 def +C99Resource.dup-resource-as-value! [ +Mirth +C99Branch +C99Resource |- +C99Value ] {
     rdup turn-into-value! rswap rdip(dup-value! rdrop) rswap
-}
-
-def +C99Resource.consume [ +C99Resource -- Str ] {
-    /+C99Resource
-    resource-repr> drop
-    resource-name>
 }
 
 def +C99Resource.consume-as [ +Mirth |- C99ReprType +C99Resource -- Str ] {
@@ -2177,7 +2182,6 @@ struct +C99Value/Resource {
 
     def push-value/resource! { +for(push-value!, push-resource!) }
     def peek-data-tag { +map(peek-data-tag, peek-data-tag) }
-    def consume { +for(consume, consume) }
     def consume-as { +for(consume-as, consume-as) }
     def consume-as-VAL { +for(consume-as-VAL, consume-as-VAL) }
     def consume-as-TUP { +for(consume-as-TUP, consume-as-TUP) }
@@ -2186,14 +2190,15 @@ struct +C99Value/Resource {
     def turn-into-resource! { +for(turn-into-resource!, id) }
     def value/resource-name { +map(value-name, resource-name) }
     def value/resource-repr { +map(value-repr, resource-repr) }
-    def value/resource-name! { +map(value-name!, resource-name!) }
-    def value/resource-repr! { +map(value-repr!, resource-repr!) }
+    # def value/resource-name! { +map(value-name!, resource-name!) }
+    # def value/resource-repr! { +map(value-repr!, resource-repr!) }
+    def convert-value/resource! { +map(convert-value!, convert-resource!) }
 }
 
 def +C99Branch.pop-data! [ +Mirth +C99Branch |- Data -- +C99Value/Resource ] {
     dup is-resource? if(
-        C99ReprType.Data pop-resource! +Right +C99Value/Resource,
-        C99ReprType.Data pop-value! +Left +C99Value/Resource
+        C99ReprType.Data dup pop-resource! convert-resource! +Right +C99Value/Resource,
+        C99ReprType.Data dup pop-value! convert-value! +Left +C99Value/Resource
     )
 }
 
@@ -2207,19 +2212,23 @@ def +C99Stack.refresh-all! [ +Mirth |- +C99 +C99Stack reachable:Bool env:C99Env 
     { +Nil -> start-branch! }
     { +Cons ->
         >+x refresh-all!
-        @+x:value-repr push-value-expression!(+x> consume put)
+        @+x:value-repr push-value-expression!(@+x:value-name put)
+        +x> +C99Value.rdrop
     }
     { +With ->
         >+x refresh-all!
-        @+x:resource-repr push-resource-expression!(+x> consume put)
+        @+x:resource-repr push-resource-expression!(@+x:resource-name put)
+        +x> +C99Resource.rdrop
     }
     { +ConsLabel ->
         >+x refresh-all!
-        @+x:value-repr swap push-label-expression!(+x> consume put)
+        @+x:value-repr swap push-label-expression!(@+x:value-name put)
+        +x> +C99Value.rdrop
     }
     { +WithLabel ->
         >+x refresh-all!
-        @+x:resource-repr swap push-label-expression!(+x> consume put)
+        @+x:resource-repr swap push-label-expression!(@+x:resource-name put)
+        +x> +C99Resource.rdrop
     }
 }
 
@@ -2435,28 +2444,28 @@ def +C99Branch.flush-cache! [ +Mirth +C99Branch |- ] {
 
 def +C99Branch.pop-value! [ +Mirth +C99Branch |- C99ReprType -- +C99Value ] {
     +stack(pop-value?) rswap match {
-        { +Some -> convert-value! }
+        { +Some -> drop }
         { +None -> pop-value-direct! }
     }
 }
 
 def +C99Branch.pop-value-label! [ +Mirth +C99Branch |- C99ReprType Label -- +C99Value ] {
     +stack(pop-value-label?) rswap match {
-        { +Some -> drop convert-value! }
+        { +Some -> drop2 }
         { +None -> pop-value-label-direct! }
     }
 }
 
 def +C99Branch.pop-resource! [ +Mirth +C99Branch |- C99ReprType -- +C99Resource ] {
     +stack(pop-resource?) rswap match {
-        { +Some -> convert-resource! }
+        { +Some -> drop }
         { +None -> pop-resource-direct! }
     }
 }
 
 def +C99Branch.pop-resource-label! [ +Mirth +C99Branch |- C99ReprType Label -- +C99Resource ] {
     +stack(pop-resource-label?) rswap match {
-        { +Some -> drop convert-resource! }
+        { +Some -> drop2 }
         { +None -> pop-resource-label-direct! }
     }
 }
@@ -2469,13 +2478,11 @@ def +C99Resource.push-resource! [ +Mirth +C99Branch |- +C99Resource -- ] {
     rswap +stack(rswap +C99Stack.+With)
 }
 
-def +C99Value.convert-value! [ +Mirth +C99Value |- C99ReprType -- ] {
-    { VAL -> }
-    { _ -> dup +C99Value.rdup consume-as value-name! value-repr! }
+def +C99Value.convert-value! [ +Mirth +C99Branch +C99Value |- C99ReprType -- ] {
+    dup consume-as >value-name >value-repr +C99Value
 }
-def +C99Resource.convert-resource! [ +Mirth +C99Resource |- C99ReprType -- ] {
-    { VAL -> }
-    { _ -> dup +C99Resource.rdup consume-as resource-name! resource-repr! }
+def +C99Resource.convert-resource! [ +Mirth +C99Branch +C99Resource |- C99ReprType -- ] {
+    dup consume-as >resource-name >resource-repr +C99Resource
 }
 
 def +C99Branch.type-to-c99-repr [ +Mirth +C99Branch |- Type -- C99ReprType ] { c99-repr }
@@ -3199,7 +3206,7 @@ def c99-field-call! [ +Mirth +C99Branch |- Field -- ] {
         "field_mut(&" put
         cname put
         ", " put
-        +index> consume put
+        +index> C99ReprType.U64 consume-as put
         ")" put
     )
 }

--- a/src/c99.mth
+++ b/src/c99.mth
@@ -398,20 +398,25 @@ def c99-tag-set-label! [ +Mirth +C99Branch |- TagField -- ] {
         @tag data c99-repr struct? unwrap("Expected struct repr" fatal-error!) \struct-repr
         @tag data pop-data! >+datavar
         @fieldty match {
-            { Left -> type-to-c99-repr pop-value! consume }
-            { Right -> resource-to-c99-repr pop-resource! consume }
-        } >fieldval
+            { Left -> type-to-c99-repr dup dup pop-value! consume-as }
+            { Right -> resource-to-c99-repr dup dup pop-resource! consume-as }
+        } >fieldval \fieldrepr
         +datavar> +for (
             # field and data are both values
-            consume >dataval
-            @tag data C99ReprType.Data push-value-expression!(
-                @struct-repr cname put "_set_" put @label name mangled put "(" put
-                dataval> put
-                ", " put
-                fieldval> put
-                ")" put
-            )
-            fieldty> drop,
+            @fieldrepr is-physical? if(
+                consume >dataval
+                @tag data C99ReprType.Data push-value-expression!(
+                    @struct-repr cname put "_set_" put @label name mangled put "(" put
+                    dataval> put
+                    ", " put
+                    fieldval> put
+                    ")" put
+                )
+                fieldty> drop,
+
+                fieldval> fieldty> drop2
+                push-value!
+            ),
 
             # data is resource
             >+datavar
@@ -429,9 +434,12 @@ def c99-tag-set-label! [ +Mirth +C99Branch |- TagField -- ] {
                     drop
                 }
             }
-            c99-line(
-                @datavar put "->m" put @label name mangled put " = " put
-                fieldval> put ";" put
+            @fieldrepr is-physical? if(
+                c99-line(
+                    @datavar put "->m" put @label name mangled put " = " put
+                    fieldval> put ";" put
+                ),
+                fieldval> drop
             )
             +datavar>
             push-resource!
@@ -1411,14 +1419,13 @@ struct C99DataStructRepr {
         c99-line("struct " put @self cname put " { " put)
         c99-nest(
             c99-line("REFS refs;" put)
-            @self tag only-tag? else (
-                c99-line("enum " put @self data cname put " tag;" put)
-            )
             @self fields for(
                 \field
-                c99-line(
-                    @field c99-repr underlying-c99-type put " "
-                    put @field cname put ";" put
+                @field is-physical? then(
+                    c99-line(
+                        @field c99-repr underlying-c99-type put " "
+                        put @field cname put ";" put
+                    )
                 )
             )
         )
@@ -1483,6 +1490,7 @@ struct C99DataStructRepr {
                 drop
                 @self data is-resource? not
                 @field is-resource? not and
+                @field is-physical? and
             ) for ( \label
                 c99-line(
                     "static " put @self underlying-c99-type put " " put
@@ -1542,9 +1550,11 @@ struct C99DataStructRepr {
         @self fields reverse-for(
             \field
             @field input pop-stack-part! consume \expr
-            c99-line(
-                @struct-ptr put "->" put @field cname put " = " put
-                @expr put ";" put
+            @field is-physical? then(
+                c99-line(
+                    @struct-ptr put "->" put @field cname put " = " put
+                    @expr put ";" put
+                )
             )
         )
         @struct-ptr >value-name
@@ -1565,7 +1575,7 @@ struct C99DataStructRepr {
         )
         @self fields for(
             \field
-            Str(@struct-val ; "." ; @field cname ;) >value-name
+            @field is-physical? if(Str(@struct-val ; "." ; @field cname ;), "0") >value-name
             @field c99-repr >value-repr
             +C99Value +C99Value/Resource.+Left
             @field input push-stack-part!
@@ -1595,12 +1605,9 @@ struct C99DataStructField {
     c99-repr: C99ReprType
     cname: Str
     --
-    def is-resource? [ +Mirth |- C99DataStructField -- Bool ] {
-        input type/resource is-right?
-    }
-    def label? [ +Mirth |- C99DataStructField -- Maybe(Label) ] {
-        input label
-    }
+    def is-physical? [ +Mirth |- C99DataStructField -- Bool ] { c99-repr is-physical? }
+    def is-resource? [ +Mirth |- C99DataStructField -- Bool ] { input type/resource is-right? }
+    def label? [ +Mirth |- C99DataStructField -- Maybe(Label) ] { input label }
 }
 
 def c99-inputs-to-struct-fields [ +Mirth |- List(StackTypePart) -- List(C99DataStructField) ] {
@@ -1711,7 +1718,7 @@ data C99ReprType {
     def is-void? [ C99ReprType -- Bool ] { Void -> True, _ -> drop False }
     def is-unit? [ +Mirth |- C99ReprType -- Bool ] {
         { Void -> True }
-        { Data -> is-unit? }
+        { Data -> c99-repr is-unit? }
         { _ -> drop False }
     }
     def is-physical? [ +Mirth |- C99ReprType -- Bool ] { is-unit? not }
@@ -2463,10 +2470,12 @@ def +C99Resource.push-resource! [ +Mirth +C99Branch |- +C99Resource -- ] {
 }
 
 def +C99Value.convert-value! [ +Mirth +C99Value |- C99ReprType -- ] {
-    dup +C99Value.rdup consume-as value-name! value-repr!
+    { VAL -> }
+    { _ -> dup +C99Value.rdup consume-as value-name! value-repr! }
 }
 def +C99Resource.convert-resource! [ +Mirth +C99Resource |- C99ReprType -- ] {
-    dup +C99Resource.rdup consume-as resource-name! resource-repr!
+    { VAL -> }
+    { _ -> dup +C99Resource.rdup consume-as resource-name! resource-repr! }
 }
 
 def +C99Branch.type-to-c99-repr [ +Mirth +C99Branch |- Type -- C99ReprType ] { c99-repr }

--- a/src/data.mth
+++ b/src/data.mth
@@ -265,12 +265,12 @@ table +Mirth |- Tag {
     def only-tag? [ +Mirth |- Tag -- Bool ] { .data tags single? >Bool }
 
     def label-inputs-from-sig [ +Mirth |- Tag -- List(Label) ] {
-        sig? if?(run-tokens filter-some(sig-label?), List.Nil)
+        sig? if?(sig-stack-tokens filter-some(sig-label?), List.Nil)
     }
 
     def num-type-inputs-from-sig [ +Mirth |- Tag -- Nat ] {
         dup sig? if?(
-            run-length
+            sig-stack-length
             over num-resource-inputs-from-sig sub-clamp
             swap label-inputs-from-sig len sub-clamp,
             drop 0u
@@ -279,7 +279,9 @@ table +Mirth |- Tag {
 
     def num-resource-inputs-from-sig [ +Mirth |- Tag -- Nat ] {
         sig? if?(
-            run-tokens filter(could-be-sig-label? not) filter-some(name?)
+            sig-stack-tokens
+            filter(could-be-sig-label? not)
+            filter-some(last-name?)
             filter(or(could-be-resource-var, could-be-resource-con))
             len,
             0u
@@ -551,7 +553,7 @@ def elab-data-tag! [ +Mirth Data |- SyntaxDataTag -- ] {
 
     @tag outputs-resource? not then(
         @tag sig? for(
-            run-tokens find(
+            sig-stack-tokens find(
                 or(sig-resource-con? >Bool, sig-resource-var? >Bool)
             ) for ("Value type cannot contain resource." emit-error!)
         )

--- a/src/data.mth
+++ b/src/data.mth
@@ -30,6 +30,7 @@ table +Mirth |- Data {
     ~qname: Prop(QName)
     ~params: Prop(List(Var))
     ~ctype?: Prop(Maybe(CType))
+    cname: Str { @self qname-hard mangled }
     is-resource?: Bool { @self name could-be-resource-con }
     unit?: Maybe(Tag) { @self tags single? filter(num-total-inputs 0=) }
     is-enum?: Bool { @self and(is-unit? not, tags all(num-total-inputs 0=)) }

--- a/src/mirth.h
+++ b/src/mirth.h
@@ -1,5 +1,5 @@
 /* MIRTH HEADER */
-#line 3 "src/mirth.h"
+// #line 3 "src/mirth.h"
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
 #define MIRTH_WINDOWS 1

--- a/src/token.mth
+++ b/src/token.mth
@@ -415,7 +415,7 @@ table +Mirth |- Token {
     }
 
     def run-length [ +Mirth |- Token -- Nat ] {
-        dip(0u) while(dup run-end? not, next dip(1+)) drop
+        run-tokens len
     }
 
     def run-arrow? [ +Mirth |- Token -- Maybe(Token) ] {
@@ -432,6 +432,14 @@ table +Mirth |- Token {
 
     def sig-next-stack-end [ +Mirth |- Token -- Token ] {
         while(dup sig-stack-end? not, next)
+    }
+
+    def sig-stack-tokens [ +Mirth |- Token -- List(Token) ] {
+        collect-while(dup sig-stack-end? not, sip(next)) nip
+    }
+
+    def sig-stack-length [ +Mirth |- Token -- Nat ] {
+        sig-stack-tokens len
     }
 
     def sig-has-vdash-or-dashes? [ +Mirth |- Token -- Bool ] {

--- a/test/struct-physical.mth
+++ b/test/struct-physical.mth
@@ -1,0 +1,528 @@
+||| Test whether a struct can handle a variety of physical & non-physical fields correctly.
+module test.struct-physical
+import std.prelude
+import std.world
+import std.test
+import std.str
+
+struct Fake {
+    --
+    def = [ Fake Fake -- Bool ] { drop2 True }
+    def repr; [ +Str |- Fake -- ] { drop "Fake"; }
+}
+struct Real {
+    Int
+    --
+    def = [ Real Real -- Bool ] { on2:/Real = }
+    def repr; [ +Str |- Real -- ] { Real -> repr; " Real"; }
+}
+struct +Cake {
+    --
+    def have [ +Cake |- Str ] { "cake" }
+    def eat  [ +Cake -- Str ] { +Cake -> "cake" }
+}
+
+struct F0R0 { }
+struct F0R1 { r1: Real }
+struct F0R2 { r1: Real r2: Real }
+
+struct F1R0 { f1: Fake }
+struct F1R1 { f1: Fake r1: Real }
+struct F1R2 { f1: Fake r1: Real r2: Real }
+
+struct F2R0 { f1: Fake f2: Fake }
+struct F2R1 { f1: Fake f2: Fake r1: Real }
+struct F2R2 { f1: Fake f2: Fake r1: Real r2: Real }
+
+struct +F0R0 { }
+struct +F0R1 { r1: Real }
+struct +F0R2 { r1: Real r2: Real }
+
+struct +F1R0 { f1: Fake }
+struct +F1R1 { f1: Fake r1: Real }
+struct +F1R2 { f1: Fake r1: Real r2: Real }
+
+struct +F2R0 { f1: Fake f2: Fake }
+struct +F2R1 { f1: Fake f2: Fake r1: Real }
+struct +F2R2 { f1: Fake f2: Fake r1: Real r2: Real }
+
+struct +C1F0R0 { +c1: +Cake }
+struct +C1F0R1 { +c1: +Cake r1: Real }
+struct +C1F0R2 { +c1: +Cake r1: Real r2: Real }
+
+struct +C1F1R0 { +c1: +Cake f1: Fake }
+struct +C1F1R1 { +c1: +Cake f1: Fake r1: Real }
+struct +C1F1R2 { +c1: +Cake f1: Fake r1: Real r2: Real }
+
+struct +C1F2R0 { +c1: +Cake f1: Fake f2: Fake }
+struct +C1F2R1 { +c1: +Cake f1: Fake f2: Fake r1: Real }
+struct +C1F2R2 { +c1: +Cake f1: Fake f2: Fake r1: Real r2: Real }
+
+def main {
+    +Tests (
+
+        "F0R0" test( F0R0 drop )
+        "F0R1" test(
+            10 Real >r1
+            F0R1 \x
+            @x r1 => ( 10 Real )
+            20 Real @x:r1!
+            @x r1 => ( 20 Real )
+        )
+        "F0R2" test (
+            11 Real >r1
+            12 Real >r2
+            F0R2 \x
+            @x r1 => ( 11 Real )
+            @x r2 => ( 12 Real )
+            21 Real @x:r1!
+            @x r1 => ( 21 Real )
+            @x r2 => ( 12 Real )
+            32 Real @x:r2!
+            @x r1 => ( 21 Real )
+            @x r2 => ( 32 Real )
+        )
+
+        "F1R0" test(
+            Fake >f1
+            F1R0 \x
+            @x f1 => ( Fake )
+            Fake @x:f1!
+            @x f1 => ( Fake )
+        )
+
+        "F1R1" test(
+            Fake >f1
+            11 Real >r1
+            F1R1 \x
+            @x f1 => ( Fake )
+            @x r1 => ( 11 Real )
+            Fake @x:f1!
+            @x f1 => ( Fake )
+            @x r1 => ( 11 Real )
+            21 Real @x:r1!
+            @x f1 => ( Fake )
+            @x r1 => ( 21 Real )
+        )
+
+        "F1R2" test(
+            Fake >f1
+            11 Real >r1
+            12 Real >r2
+            F1R2 \x
+            @x f1 => ( Fake )
+            @x r1 => ( 11 Real )
+            @x r2 => ( 12 Real )
+            Fake @x:f1!
+            @x f1 => ( Fake )
+            @x r1 => ( 11 Real )
+            @x r2 => ( 12 Real )
+            21 Real @x:r1!
+            @x f1 => ( Fake )
+            @x r1 => ( 21 Real )
+            @x r2 => ( 12 Real )
+            32 Real @x:r2!
+            @x f1 => ( Fake )
+            @x r1 => ( 21 Real )
+            @x r2 => ( 32 Real )
+        )
+
+        "F2R0" test(
+            Fake >f1
+            Fake >f2
+            F2R0 \x
+            @x f1 => ( Fake )
+            @x f2 => ( Fake )
+            Fake @x:f1!
+            @x f1 => ( Fake )
+            @x f2 => ( Fake )
+            Fake @x:f2!
+            @x f1 => ( Fake )
+            @x f2 => ( Fake )
+        )
+
+        "F2R1" test(
+            Fake >f1
+            Fake >f2
+            11 Real >r1
+            F2R1 \x
+            @x f1 => ( Fake )
+            @x f2 => ( Fake )
+            @x r1 => ( 11 Real )
+            Fake @x:f1!
+            @x f1 => ( Fake )
+            @x f2 => ( Fake )
+            @x r1 => ( 11 Real )
+            Fake @x:f2!
+            @x f1 => ( Fake )
+            @x f2 => ( Fake )
+            @x r1 => ( 11 Real )
+            21 Real @x:r1!
+            @x f1 => ( Fake )
+            @x f2 => ( Fake )
+            @x r1 => ( 21 Real )
+        )
+
+        "F2R2" test(
+            Fake >f1
+            Fake >f2
+            11 Real >r1
+            12 Real >r2
+            F2R2 \x
+            @x f1 => ( Fake )
+            @x f2 => ( Fake )
+            @x r1 => ( 11 Real )
+            @x r2 => ( 12 Real )
+            Fake @x:f1!
+            @x f1 => ( Fake )
+            @x f2 => ( Fake )
+            @x r1 => ( 11 Real )
+            @x r2 => ( 12 Real )
+            Fake @x:f2!
+            @x f1 => ( Fake )
+            @x f2 => ( Fake )
+            @x r1 => ( 11 Real )
+            @x r2 => ( 12 Real )
+            21 Real @x:r1!
+            @x f1 => ( Fake )
+            @x f2 => ( Fake )
+            @x r1 => ( 21 Real )
+            @x r2 => ( 12 Real )
+            32 Real @x:r2!
+            @x f1 => ( Fake )
+            @x f2 => ( Fake )
+            @x r1 => ( 21 Real )
+            @x r2 => ( 32 Real )
+        )
+
+        "+F0R0" test( +F0R0 /+F0R0 ldrop )
+        "+F0R1" test(
+            11 Real >r1
+            +F0R1
+            r1 => ( 11 Real )
+            21 Real r1!
+            r1 => ( 21 Real )
+            /+F0R1
+            r1> => ( 21 Real )
+        )
+        "+F0R2" test(
+            11 Real >r1
+            12 Real >r2
+            +F0R2
+            r1 => ( 11 Real )
+            r2 => ( 12 Real )
+            21 Real r1!
+            r1 => ( 21 Real )
+            r2 => ( 12 Real )
+            32 Real r2!
+            r1 => ( 21 Real )
+            r2 => ( 32 Real )
+            /+F0R2
+            r1> => ( 21 Real )
+            r2> => ( 32 Real )
+        )
+        "+F1R0" test(
+            Fake >f1
+            +F1R0
+            f1 => ( Fake )
+            Fake f1!
+            f1 => ( Fake )
+            /+F1R0
+            f1> => ( Fake )
+        )
+        "+F1R1" test(
+            Fake >f1
+            11 Real >r1
+            +F1R1
+            f1 => ( Fake )
+            r1 => ( 11 Real )
+            Fake f1!
+            f1 => ( Fake )
+            r1 => ( 11 Real )
+            21 Real r1!
+            f1 => ( Fake )
+            r1 => ( 21 Real )
+            /+F1R1
+            f1> => ( Fake )
+            r1> => ( 21 Real )
+        )
+        "+F1R2" test(
+            Fake >f1
+            11 Real >r1
+            12 Real >r2
+            +F1R2
+            f1 => ( Fake )
+            r1 => ( 11 Real )
+            r2 => ( 12 Real )
+            Fake f1!
+            f1 => ( Fake )
+            r1 => ( 11 Real )
+            r2 => ( 12 Real )
+            21 Real r1!
+            f1 => ( Fake )
+            r1 => ( 21 Real )
+            r2 => ( 12 Real )
+            32 Real r2!
+            f1 => ( Fake )
+            r1 => ( 21 Real )
+            r2 => ( 32 Real )
+            /+F1R2
+            f1> => ( Fake )
+            r1> => ( 21 Real )
+            r2> => ( 32 Real )
+        )
+        "+F2R0" test(
+            Fake >f1
+            Fake >f2
+            +F2R0
+            f1 => ( Fake )
+            f2 => ( Fake )
+            Fake f1!
+            f1 => ( Fake )
+            f2 => ( Fake )
+            /+F2R0
+            f1> => ( Fake )
+            f2> => ( Fake )
+        )
+        "+F2R1" test(
+            Fake >f1
+            Fake >f2
+            11 Real >r1
+            +F2R1
+            f1 => ( Fake )
+            f2 => ( Fake )
+            r1 => ( 11 Real )
+            Fake f1!
+            f1 => ( Fake )
+            f2 => ( Fake )
+            r1 => ( 11 Real )
+            21 Real r1!
+            f1 => ( Fake )
+            f2 => ( Fake )
+            r1 => ( 21 Real )
+            /+F2R1
+            f1> => ( Fake )
+            f2> => ( Fake )
+            r1> => ( 21 Real )
+        )
+        "+F2R2" test(
+            Fake >f1
+            Fake >f2
+            11 Real >r1
+            12 Real >r2
+            +F2R2
+            f1 => ( Fake )
+            f2 => ( Fake )
+            r1 => ( 11 Real )
+            r2 => ( 12 Real )
+            Fake f1!
+            f1 => ( Fake )
+            f2 => ( Fake )
+            r1 => ( 11 Real )
+            r2 => ( 12 Real )
+            21 Real r1!
+            f1 => ( Fake )
+            f2 => ( Fake )
+            r1 => ( 21 Real )
+            r2 => ( 12 Real )
+            32 Real r2!
+            f1 => ( Fake )
+            f2 => ( Fake )
+            r1 => ( 21 Real )
+            r2 => ( 32 Real )
+            /+F2R2
+            f1> => ( Fake )
+            f2> => ( Fake )
+            r1> => ( 21 Real )
+            r2> => ( 32 Real )
+        )
+
+        "+C1F0R0" test(
+            +Cake >+c1
+            +C1F0R0
+            +c1:have =>: "cake"
+            /+C1F0R0
+            +c1> eat =>: "cake"
+        )
+        "+C1F0R1" test(
+            +Cake >+c1
+            11 Real >r1
+            +C1F0R1
+            +c1:have =>: "cake"
+            r1 => ( 11 Real )
+            21 Real r1!
+            +c1:have =>: "cake"
+            r1 => ( 21 Real )
+            /+C1F0R1
+            +c1> eat =>: "cake"
+            r1> => ( 21 Real )
+        )
+        "+C1F0R2" test(
+            +Cake >+c1
+            11 Real >r1
+            12 Real >r2
+            +C1F0R2
+            +c1:have =>: "cake"
+            r1 => ( 11 Real )
+            r2 => ( 12 Real )
+            21 Real r1!
+            +c1:have =>: "cake"
+            r1 => ( 21 Real )
+            r2 => ( 12 Real )
+            32 Real r2!
+            +c1:have =>: "cake"
+            r1 => ( 21 Real )
+            r2 => ( 32 Real )
+            /+C1F0R2
+            +c1> eat =>: "cake"
+            r1> => ( 21 Real )
+            r2> => ( 32 Real )
+        )
+        "+C1F1R0" test(
+            +Cake >+c1
+            Fake >f1
+            +C1F1R0
+            +c1:have =>: "cake"
+            f1 => ( Fake )
+            Fake f1!
+            +c1:have =>: "cake"
+            f1 => ( Fake )
+            /+C1F1R0
+            +c1> eat =>: "cake"
+            f1> => ( Fake )
+        )
+        "+C1F1R1" test(
+            +Cake >+c1
+            Fake >f1
+            11 Real >r1
+            +C1F1R1
+            +c1:have =>: "cake"
+            f1 => ( Fake )
+            r1 => ( 11 Real )
+            Fake f1!
+            +c1:have =>: "cake"
+            f1 => ( Fake )
+            r1 => ( 11 Real )
+            21 Real r1!
+            +c1:have =>: "cake"
+            f1 => ( Fake )
+            r1 => ( 21 Real )
+            /+C1F1R1
+            +c1> eat =>: "cake"
+            f1> => ( Fake )
+            r1> => ( 21 Real )
+        )
+        "+C1F1R2" test(
+            +Cake >+c1
+            Fake >f1
+            11 Real >r1
+            12 Real >r2
+            +C1F1R2
+            +c1:have =>: "cake"
+            f1 => ( Fake )
+            r1 => ( 11 Real )
+            r2 => ( 12 Real )
+            Fake f1!
+            +c1:have =>: "cake"
+            f1 => ( Fake )
+            r1 => ( 11 Real )
+            r2 => ( 12 Real )
+            21 Real r1!
+            +c1:have =>: "cake"
+            f1 => ( Fake )
+            r1 => ( 21 Real )
+            r2 => ( 12 Real )
+            32 Real r2!
+            +c1:have =>: "cake"
+            f1 => ( Fake )
+            r1 => ( 21 Real )
+            r2 => ( 32 Real )
+            /+C1F1R2
+            +c1> eat =>: "cake"
+            f1> => ( Fake )
+            r1> => ( 21 Real )
+            r2> => ( 32 Real )
+        )
+        "+C1F2R0" test(
+            +Cake >+c1
+            Fake >f1
+            Fake >f2
+            +C1F2R0
+            +c1:have =>: "cake"
+            f1 => ( Fake )
+            f2 => ( Fake )
+            Fake f1!
+            +c1:have =>: "cake"
+            f1 => ( Fake )
+            f2 => ( Fake )
+            /+C1F2R0
+            +c1> eat =>: "cake"
+            f1> => ( Fake )
+            f2> => ( Fake )
+        )
+        "+C1F2R1" test(
+            +Cake >+c1
+            Fake >f1
+            Fake >f2
+            11 Real >r1
+            +C1F2R1
+            +c1:have =>: "cake"
+            f1 => ( Fake )
+            f2 => ( Fake )
+            r1 => ( 11 Real )
+            Fake f1!
+            +c1:have =>: "cake"
+            f1 => ( Fake )
+            f2 => ( Fake )
+            r1 => ( 11 Real )
+            21 Real r1!
+            +c1:have =>: "cake"
+            f1 => ( Fake )
+            f2 => ( Fake )
+            r1 => ( 21 Real )
+            /+C1F2R1
+            +c1> eat =>: "cake"
+            f1> => ( Fake )
+            f2> => ( Fake )
+            r1> => ( 21 Real )
+        )
+        "+C1F2R2" test(
+            +Cake >+c1
+            Fake >f1
+            Fake >f2
+            11 Real >r1
+            12 Real >r2
+            +C1F2R2
+            +c1:have =>: "cake"
+            f1 => ( Fake )
+            f2 => ( Fake )
+            r1 => ( 11 Real )
+            r2 => ( 12 Real )
+            Fake f1!
+            +c1:have =>: "cake"
+            f1 => ( Fake )
+            f2 => ( Fake )
+            r1 => ( 11 Real )
+            r2 => ( 12 Real )
+            21 Real r1!
+            +c1:have =>: "cake"
+            f1 => ( Fake )
+            f2 => ( Fake )
+            r1 => ( 21 Real )
+            r2 => ( 12 Real )
+            32 Real r2!
+            +c1:have =>: "cake"
+            f1 => ( Fake )
+            f2 => ( Fake )
+            r1 => ( 21 Real )
+            r2 => ( 32 Real )
+            /+C1F2R2
+            +c1> eat =>: "cake"
+            f1> => ( Fake )
+            f2> => ( Fake )
+            r1> => ( 21 Real )
+            r2> => ( 32 Real )
+        )
+    )
+}
+# mirth-test # pout # 27 tests passed.


### PR DESCRIPTION
Only structs for now. And they are still heap allocated & reference counted even in cases where they need not be. Sum types still have the generic tagged tuple representation for now.