### PR TITLE
Add Self and +Self type macros

### DIFF
--- a/src/c99.mth
+++ b/src/c99.mth
@@ -50,9 +50,9 @@ struct +C99 {
     +output: +Output
 }
 
-def +C99.put      [ +Mirth +C99 |- Str --  ] { put-enabled if(+output:put, drop) }
+def +C99.put      [ +Mirth +C99 |- Str  -- ] { put-enabled if(+output:put, drop)      }
 def +C99.put-byte [ +Mirth +C99 |- Byte -- ] { put-enabled if(+output:put-byte, drop) }
-def +C99.line     [ +Mirth +C99 |-         ] { put-enabled then(+output:line) }
+def +C99.line     [ +Mirth +C99 |-         ] { put-enabled then(+output:line)         }
 
 def run-output-c99! [ +World +Mirth |- Arrow C99_Options -- ] {
     num-errors 0> if(

--- a/src/def.mth
+++ b/src/def.mth
@@ -113,7 +113,7 @@ data Def {
         { Word -> drop False }
         { Field -> drop False }
         { Tag -> drop False }
-        { Macro -> drop False }
+        { Macro -> action defines-a-type? }
     }
 
     def exposed-tycon? [ +Mirth |- Def -- Maybe(Tycon) ] {

--- a/src/elab.mth
+++ b/src/elab.mth
@@ -217,21 +217,23 @@ struct +TypeElab {
             filter-qualifiers
             L0 filter-roots
         ) if? (
-            match(
-                Data -> sip:applied-type params,
-                Table -> Type.Table L0,
-                Type -> rdip(sip:target params), # TODO: this doesn't quite make sense.
-                _ ->
+            match {
+                { Data -> sip:applied-type params }
+                { Table -> Type.Table L0 }
+                { Type -> sip:target params } # TODO: this doesn't quite make sense.
+                { Macro -> action run-type! }
+                { _ ->
                     drop token "compiler bug: resolve-type-con-name! doesn't understand type"
-                    rdip:emit-error! Type.Error L0,
-            ),
+                    rdip:emit-error! Type.Error L0
+                }
+            },
             Type.Error L0
         )
     }
 
     def elab-type-con! [ +Mirth +TypeElab |- Name/DName -- Type ] {
-        dup left? rdip:has(>Str "Mut" =) if(
-            drop token rdip:next dip(
+        dup left? has(>Str "Mut" =) if(
+            drop token next dip(
                 token:args-1
                 elab-type-arg!
                 Type.Mut
@@ -244,6 +246,30 @@ struct +TypeElab {
 
     def elab-resource-con! [ +Mirth +TypeElab |- Name/DName -- Resource ] {
         elab-type-con! Resource
+    }
+
+    def elab-self! [ +Mirth +TypeElab |- Type/Resource List(Var) ] {
+        defining-tycon? if?(
+            sip:full-type params,
+            token sig-resource-con? if(
+                token "Not currently inside a type block, +Self is not bound." emit-error! Resource.Error Right,
+                token "Not currently inside a type block, Self is not bound." emit-error! Type.Error Left
+            ) L0
+        )
+    }
+
+    def elab-self-type! [ +Mirth +TypeElab |- Type List(Var) ] {
+        elab-self! dip:left(
+            token "Enclosing type block is a resource type, must use +Self instead of Self." emit-error!
+            drop Type.Error
+        )
+    }
+
+    def elab-self-resource!  [ +Mirth +TypeElab |- Resource List(Var) ] {
+        elab-self! dip:right(
+            token "Enclosing type block is a value type, must use Self instead of +Self." emit-error!
+            drop Resource.Error
+        )
     }
 
     def with-token(f) [ +TypeElab |- (*a -- *b) *a Token -- *b ] {

--- a/src/macro.mth
+++ b/src/macro.mth
@@ -2,6 +2,8 @@ module mirth.macro
 
 import std.prelude
 import std.maybe
+import std.list
+
 import mirth.mirth
 import mirth.name
 import mirth.token
@@ -14,6 +16,8 @@ import mirth.table
 import mirth.external
 import mirth.data
 import mirth.typedef
+import mirth.type
+import mirth.var
 
 table +Mirth |- Macro {
     head?: Maybe(Token)
@@ -39,12 +43,20 @@ table +Mirth |- Macro {
 }
 
 data MacroAction {
-    Decl  [[ +World +Mirth Token -- +World +Mirth Token ]]
-    Arrow [[        +Mirth +AB   -- +Mirth +AB          ]]
+    Decl  [[ +World +Mirth Token |- ]]
+    Type  [[ +Mirth +TypeElab    |- Type List(Var) ]]
+    Arrow [[ +Mirth +AB          |- ]]
     --
     def decl?  { Decl -> Some, _ -> drop None }
     def arrow? { Arrow -> Some, _ -> drop None }
+    def type?  { Type -> Some, _ -> drop None }
     def callable? { arrow? >Bool }
+    def defines-a-type? { type? >Bool }
+
+    def run-type! [ +Mirth +TypeElab |- MacroAction -- Type List(Var) ] {
+        { Type -> run }
+        { _ -> "Expected type macro!" fatal-error! }
+    }
 }
 
 def +Mirth.module-statement-error! [ +Mirth Token |- ] {
@@ -55,6 +67,7 @@ def +Mirth.import-statement-error! [ +Mirth Token |- ] {
 }
 
 def +Mirth.prim-decl-macro! { MacroAction.Decl  Macro.Prim Def.Macro register }
+def +Mirth.prim-type-macro! { MacroAction.Type  Macro.Prim Def.Macro register }
 def +Mirth.prim-word-macro! { MacroAction.Arrow Macro.Prim Def.Macro register }
 
 def +Mirth.init-macros! [ +Mirth |- ] {
@@ -75,6 +88,9 @@ def +Mirth.init-macros! [ +Mirth |- ] {
     "embed-str"          -1 [ elab-embed-str!          ] prim-decl-macro!
     "max-mirth-revision" -1 [ elab-max-mirth-revision! ] prim-decl-macro!
     "min-mirth-revision" -1 [ elab-min-mirth-revision! ] prim-decl-macro!
+
+    "Self"  -1 [ elab-self-type!               ] prim-type-macro!
+    "+Self" -1 [ elab-self-resource! dip:>Type ] prim-type-macro!
 
     "match" -1 [ elab-atom-match!    ] prim-word-macro!
     "\\"    -1 [ elab-atom-lambda!   ] prim-word-macro!

--- a/src/mirth.mth
+++ b/src/mirth.mth
@@ -29,6 +29,7 @@ import mirth.typedef
 import mirth.prim
 import mirth.name
 import mirth.macro
+import mirth.tycon
 
 struct Builtin {
     std: Package
@@ -229,6 +230,16 @@ struct +Mirth {
         lexical-state:defining-namespace:swap
         dip(f) lexical-state:defining-namespace!
     }
+
+    def defining-namespace? [ +Mirth |- Maybe(Namespace) ] {
+        lexical-state defining-namespace (
+            if?(compute Some, None None)
+        ) lexical-state!
+    }
+
+    def defining-tycon? [ +Mirth |- Maybe:Tycon ] {
+        defining-namespace? bind:enclosing-tycon?
+    }
 }
 
 struct Diagnostic {
@@ -255,8 +266,6 @@ data Severity {
         { Error   -> "error"   }
     }
 }
-
-
 
 #########
 # PROPS #

--- a/src/name.mth
+++ b/src/name.mth
@@ -170,6 +170,14 @@ data Namespace {
         { Word -> drop None }
     }
 
+    def enclosing-tycon? [ +Mirth |- Namespace -- Maybe(Tycon) ] {
+        { Root -> None }
+        { Package -> drop None }
+        { Module -> drop None }
+        { Tycon -> Some }
+        { Word -> namespace-hard enclosing-tycon? }
+    }
+
     def Prim [ +Mirth -- +Mirth Namespace ] {
         Module.Prim Namespace.Module
     }

--- a/src/table.mth
+++ b/src/table.mth
@@ -5,6 +5,7 @@ import std.maybe
 import std.str
 import std.list
 import std.byte
+import std.either
 
 import mirth.name
 import mirth.type
@@ -97,6 +98,10 @@ table +Mirth |- Table {
     def >Type [ Table -- Type ] { Type.Table }
     def >Tycon [ Table -- Tycon ] { Tycon.Table }
     def >Namespace [ Table -- Namespace ] { >Tycon >Namespace }
+
+    def params [ +Mirth |- Table -- List(Var) ] { drop L0 }
+    def applied-type [ +Mirth |- Table -- Type ] { >Type }
+    def full-type [ +Mirth |- Table -- Type/Resource ] { applied-type Left }
 
     def name;  [ +Mirth +Str |- Table -- ] { rdip:name name; }
     def qname; [ +Mirth +Str |- Table -- ] { rdip:qname-hard qname; }

--- a/src/tycon.mth
+++ b/src/tycon.mth
@@ -4,12 +4,14 @@ import std.prelude
 import std.maybe
 import std.either
 import std.str
+import std.list
 
 import mirth.name
 import mirth.data
 import mirth.table
 import mirth.type
 import mirth.mirth
+import mirth.var
 
 data Tycon {
     Data  [ Data ]
@@ -60,16 +62,17 @@ data Tycon {
         { Prim -> Type.Prim }
     }
 
-    def full-type-fresh [ +Mirth |- Tycon -- Type/Resource ] {
-        { Data -> dip:Subst.Nil full-type map(freshen, freshen) nip }
-        { Prim -> sip:Type.Prim is-resource? if(Resource Right, Left) }
-        { Table -> Type.Table Left }
-    }
-
     def can-own-state? [ +Mirth |- Tycon -- Bool ] {
         { Data -> can-own-state? }
         { Prim -> can-own-state? }
         { Table -> drop False }
     }
 
+    def params       [ +Mirth |- Tycon -- List(Var)     ] { Data -> params,       Table -> params,       Prim -> params       }
+    def applied-type [ +Mirth |- Tycon -- Type          ] { Data -> applied-type, Table -> applied-type, Prim -> applied-type }
+    def full-type    [ +Mirth |- Tycon -- Type/Resource ] { Data -> full-type,    Table -> full-type,    Prim -> full-type    }
+
+    def full-type-fresh [ +Mirth |- Tycon -- Type/Resource ] {
+        dip:Subst.Nil full-type map(freshen, freshen) nip
+    }
 }

--- a/src/type.mth
+++ b/src/type.mth
@@ -563,6 +563,14 @@ data PrimType {
         { Debug -> True }
         { _ -> drop False }
     }
+
+    field(+Mirth |- params, PrimType, List(Var), L0)
+    def applied-type [ +Mirth |- PrimType -- Type ] {
+        sip:Type.Prim params for(Type.Var Type.App)
+    }
+    def full-type [ +Mirth |- PrimType -- Type/Resource ] {
+        sip:applied-type is-resource? if(Resource Right, Left)
+    }
 }
 
 def +Mirth.def-prim-type! [ +Mirth |- PrimType List(Str) -- ] {
@@ -577,6 +585,7 @@ def +Mirth.def-prim-type-alias! [ +Mirth |- PrimType Str List(Str) -- ] {
         swap Var.New!
     ) >params
     Name over tycon-qname .name! >qname
+    @params over params!
     Type.Prim @params for(Type.Var Type.App) >type
     def-type!
 }
@@ -752,6 +761,7 @@ struct Resource {
     --
     def NewInCtx [ +Mirth Ctx |- Str -- Resource ] { dip:Type.RESOURCE Var.NewInCtx Type.Var Resource }
     def Fresh! [ +Mirth |- Resource ] { Kind.RESOURCE MetaVar.New! Type.Meta Resource }
+    def Error [ Resource ] { Type.Error Resource }
 
     def World [ Resource ] { Type.World Resource }
     def Debug [ Resource ] { Type.Debug Resource }

--- a/test/self-type.mth
+++ b/test/self-type.mth
@@ -1,0 +1,48 @@
+||| Test the Self value type and +Self resource type.
+module test.self-type
+
+import std.prelude
+import std.world
+
+struct Foo {
+    --
+    def name [ Self -- Str ] { drop "Foo" }
+}
+
+struct Bar(a) {
+    value: a
+    --
+    def map(f) [ (a -- b) Self(a) -- Self(b) ] { /Bar value> f >value Bar }
+}
+
+struct Baz(a,b) {
+    a b
+    --
+    def exchange [ Self(a,b) -- Self(b,a) ] { /Baz swap Baz }
+}
+
+struct +Foo {
+    --
+    def name [ +Self |- Str ] { "+Foo" }
+}
+
+struct +Bar(a) {
+    value: a
+    --
+    def value2 [ +Self(a) |- a a ] { value value }
+}
+
+struct +Baz(a,b) {
+    baz: Baz(a,b)
+    --
+    def exchange! [ +Self(a,b) -- +Self(b,a) ] {
+        /+Baz @baz:exchange +Baz
+    }
+}
+
+def main {
+    Foo name print
+    +Foo name print /+Foo
+}
+# mirth-test # pout # Foo
+# mirth-test # pout # +Foo


### PR DESCRIPTION
This PR adds `Self` and `+Self` as type macros that refer to the type constructor of the enclosing definition block. E.g.

```
struct Foo {
    -- 
    def foo [ Self -- Str ] { drop "foo" }
}
```

The `Self` refers to `Foo`.

For resource types, there is `+Self`.

Note that `Self` and `+Self` refer specifically to the type constructor, so if there are type parameters you must pass them explicitly,  e.g.
```
data List(a) {
    Nil
    Cons [ a List(a) ]
    --
    def map(f) [ (a -- b) Self(a) -- Self(b) ] { ... }
}
```
This is just a first implementation. Possible future improvements: making `Self` infer missing type parameters from context, make sure `Self` works in constructor/struct type signatures, using `Self` as a namespace for qualification purposes.

Also it would be good to ultimately decide whether `Self` refers to the tycon namespace of the current definition, or the type of the lexically enclosing definition block. Currently it's the latter. This distinction is only relevant for inline monkey patching style definitions, e.g. in `def Int.foo [ ... Self ... ]` the `Self` doesn't refer to `Int` but to whatever block this definition is in. I think the current approach is fine, is more consistent, but someone might expect that `Self` to refer to `Int` instead.